### PR TITLE
configure: stop using AC_FUNC_MALLOC/REALLOC

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -54,8 +54,6 @@ AC_CHECK_TYPES([ptrdiff_t])
 # Checks for library functions.
 AC_FUNC_ALLOCA
 AC_FUNC_ERROR_AT_LINE
-AC_FUNC_MALLOC
-AC_FUNC_REALLOC
 AC_CHECK_FUNCS([atexit memmove memset mkdir pow putenv strcasecmp strchr strdup strerror strncasecmp strrchr strstr strtol])
 
 AC_ARG_ENABLE([dogs], AS_HELP_STRING([--disable-dogs], [Disable support for helper dogs]))


### PR DESCRIPTION
These are apparently mostly useless and worse, break
cross-compilation.  See:
https://sourceforge.net/p/mingw-w64/mailman/message/36424004/

Really resolves #50