### PR TITLE
pkg: get needed ldflags and copy woof.exe to staging

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,5 +9,6 @@ SUBDIRS = \
 	configs \
 	docs \
 	examples \
+	pkg \
 	Source \
 	toolsrc

--- a/configure.ac
+++ b/configure.ac
@@ -84,6 +84,7 @@ examples/Makefile
 Source/Makefile
 Source/resource.rc
 toolsrc/Makefile
+pkg/Makefile
 pkg/config.make
 ])
 AC_OUTPUT

--- a/pkg/Makefile.am
+++ b/pkg/Makefile.am
@@ -1,8 +1,7 @@
 
 WIN32_FILES=                                                            \
 win32/GNUmakefile                                                       \
-win32/cp-with-libs                                                      \
-win32/README
+win32/cp-with-libs
 
 EXTRA_DIST=$(WIN32_FILES)
 

--- a/pkg/config.make.in
+++ b/pkg/config.make.in
@@ -6,9 +6,8 @@
 # Tools needed:
 
 CC = @CC@
-OBJDUMP = @OBJDUMP@
 STRIP = @STRIP@
-LDFLAGS = @LDFLAGS@
+LDFLAGS = @SDL_LIBS@
 
 # Package name and version number:
 

--- a/pkg/win32/GNUmakefile
+++ b/pkg/win32/GNUmakefile
@@ -3,7 +3,7 @@ include ../config.make
 
 TOPLEVEL=../..
 
-ZIP=$(PACKAGE)$(PACKAGE_VERSION)-win32.zip
+ZIP=$(PACKAGE)-$(PACKAGE_VERSION)-win32.zip
 
 all: $(ZIP)
 
@@ -12,7 +12,7 @@ $(ZIP): staging
 
 staging:
 	mkdir $@
-	LC_ALL=C ./cp-with-libs --ldflags="$(LDFLAGS)" "$(TOPLEVEL)/Source/woof.exe"
+	LC_ALL=C ./cp-with-libs --ldflags="$(LDFLAGS)" "$(TOPLEVEL)/Source/woof.exe" $@
 
 	$(STRIP) $@/*.exe $@/*.dll
 


### PR DESCRIPTION
Repairs actual operation of the win32 packaging script