### PR TITLE
automake: go down into the data directory

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,6 +7,7 @@ dist_pkgdata_DATA = \
 
 SUBDIRS = \
 	configs \
+	data \
 	docs \
 	examples \
 	pkg \


### PR DESCRIPTION
Should make both `make dist` and `make install` include these files
properly.