### PR TITLE
major overhaul of the sound SFX system

### DIFF
--- a/Source/i_sound.c
+++ b/Source/i_sound.c
@@ -169,14 +169,13 @@ static boolean addsfx(sfxinfo_t *sfx, int channel, int pitch)
       return false;
 
    // [FG] always discard previous buffer if using randomly pitched sounds
-   if (pitched_sounds && sfx->data)
+   if(sfx->data != NULL && pitched_sounds)
    {
       Z_ChangeTag(sfx->data, PU_CACHE);
-      sfx->data = NULL;
    }
 
    // haleyjd 06/03/06: rewrote again to make sound data properly freeable
-   if(sfx->data == NULL)
+   if(sfx->data == NULL || pitched_sounds)
    {   
       byte *data;
       Uint32 samplerate, samplelen;

--- a/Source/i_sound.c
+++ b/Source/i_sound.c
@@ -322,24 +322,16 @@ static void updateSoundParams(int handle, int volume, int separation, int pitch)
 
    // SoM 7/1/02: forceFlipPan accounted for here
    if(forceFlipPan)
-      separation = 257 - separation;
+      separation = 254 - separation;
    
-   // Per left/right channel.
-   //  x^2 seperation,
-   //  adjust volume properly.
-   //volume *= 8;
+   leftvol = ((254 - separation) * volume) / 127;
+   rightvol = ((separation) * volume) / 127;
 
-   leftvol = volume - ((volume*separation*separation) >> 16);
-   separation = separation - 257;
-   rightvol= volume - ((volume*separation*separation) >> 16);  
+   if (leftvol < 0) leftvol = 0;
+   else if ( leftvol > 255) leftvol = 255;
+   if (rightvol < 0) rightvol = 0;
+   else if (rightvol > 255) rightvol = 255;
 
-   // Sanity check, clamp volume.
-   if(rightvol < 0 || rightvol > 127)
-      I_Error("rightvol out of bounds");
-   
-   if(leftvol < 0 || leftvol > 127)
-      I_Error("leftvol out of bounds");
-   
    Mix_SetPanning(handle, leftvol, rightvol);
 }
 

--- a/Source/i_sound.c
+++ b/Source/i_sound.c
@@ -383,7 +383,7 @@ void I_SetChannels(void)
    // This table provides step widths for pitch parameters.
    for(i=-128 ; i<128 ; i++)
    {
-      steptablemid[i] = (int)(pow(1.2, (double)i / 64.0) * 65536.0);
+      steptablemid[i] = (int)(pow(2., (double)i / 64.0) * 65536.0);
    }
 }
 

--- a/Source/i_sound.c
+++ b/Source/i_sound.c
@@ -99,6 +99,7 @@ static void stopchan(int handle)
 
    if(channelinfo[handle].data)
    {
+      Mix_HaltChannel(handle);
       channelinfo[handle].data = NULL;
 
       if(channelinfo[handle].id)
@@ -118,7 +119,6 @@ static void stopchan(int handle)
       }
    }
 
-   Mix_HaltChannel(handle);
    channelinfo[handle].id = NULL;
 }
 

--- a/Source/i_sound.c
+++ b/Source/i_sound.c
@@ -265,31 +265,29 @@ static boolean addsfx(sfxinfo_t *sfx, int channel, int pitch)
    else
       Z_ChangeTag(sfx->data, PU_STATIC); // reset to static cache level
 
+   // [FG] let SDL_Mixer do the actual sound mixing
+   channelinfo[channel].chunk.allocated = 1;
+   channelinfo[channel].chunk.volume = MIX_MAX_VOLUME;
+
    // [FG] do not connect pitch-shifted samples to a sound SFX
    if (pitch == NORM_PITCH)
    {
       channelinfo[channel].data = sfx->data;
 
-      // [FG] let SDL_Mixer do the actual sound mixing
       channelinfo[channel].chunk.abuf = sfx->data;
       channelinfo[channel].chunk.alen = sfx->alen;
-      channelinfo[channel].chunk.allocated = 1;
-      channelinfo[channel].chunk.volume = MIX_MAX_VOLUME;
 
       // Preserve sound SFX id
       channelinfo[channel].id = sfx;
    }
    else
    {
-      // [FG] let SDL_Mixer do the actual sound mixing
       channelinfo[channel].chunk.abuf = sfx_data;
       channelinfo[channel].chunk.alen = sfx_alen;
-      channelinfo[channel].chunk.allocated = 1;
-      channelinfo[channel].chunk.volume = MIX_MAX_VOLUME;
 
       channelinfo[channel].id = NULL;
    }
-   
+
    return true;
 }
 

--- a/Source/i_sound.h
+++ b/Source/i_sound.h
@@ -34,11 +34,11 @@
 
 #include "sounds.h"
 
-// UNIX hack, to be removed.
-#ifdef SNDSERV
-extern FILE* sndserver;
-extern char* sndserver_filename;
-#endif
+// Adjustable by menu.
+#define NORM_PITCH 128
+#define NORM_PRIORITY 64
+#define NORM_SEP 128
+#define S_STEREO_SWING (96<<FRACBITS)
 
 // Init at program start...
 void I_InitSound(void);

--- a/Source/i_sound.h
+++ b/Source/i_sound.h
@@ -35,6 +35,7 @@
 #include "sounds.h"
 
 // Adjustable by menu.
+// [FG] moved here from s_sound.c
 #define NORM_PITCH 128
 #define NORM_PRIORITY 64
 #define NORM_SEP 128

--- a/Source/s_sound.c
+++ b/Source/s_sound.c
@@ -52,12 +52,6 @@
 
 #define S_ATTENUATOR ((S_CLIPPING_DIST-S_CLOSE_DIST)>>FRACBITS)
 
-// Adjustable by menu.
-#define NORM_PITCH 128
-#define NORM_PRIORITY 64
-#define NORM_SEP 128
-#define S_STEREO_SWING (96<<FRACBITS)
-
 //jff 1/22/98 make sound enabling variables readable here
 extern boolean nosfxparm, nomusicparm;
 //jff end sound enabling variables readable here


### PR DESCRIPTION
This commit contains the following changes:

- let SDL_Mixer do the actual sound mixing
- do not connect pitch-shifted samples to a sound SFX
- immediately free samples not connected to a sound SFX
- linear stereo volume separation
- pimp pitch shifting amplitude

Hopefully this fixes #58 