### PR TITLE
Workaround for SDL 2.0.14 alt-tab bug

### DIFF
--- a/Source/i_video.c
+++ b/Source/i_video.c
@@ -1209,7 +1209,14 @@ static void I_InitGraphicsMode(void)
                                v_w, v_h);
 
    // Workaround for SDL 2.0.14 alt-tab bug (taken from Doom Retro)
-   SDL_SetHintWithPriority(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "1", SDL_HINT_OVERRIDE);
+#if defined(_WIN32)
+   SDL_version ver;
+   SDL_GetVersion(&ver);
+   if (ver.major == 2 && ver.minor == 0 && ver.patch == 14)
+   {
+      SDL_SetHintWithPriority(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "1", SDL_HINT_OVERRIDE);
+   }
+#endif
 
    V_Init();
 

--- a/Source/i_video.c
+++ b/Source/i_video.c
@@ -1210,11 +1210,13 @@ static void I_InitGraphicsMode(void)
 
    // Workaround for SDL 2.0.14 alt-tab bug (taken from Doom Retro)
 #if defined(_WIN32)
-   SDL_version ver;
-   SDL_GetVersion(&ver);
-   if (ver.major == 2 && ver.minor == 0 && ver.patch == 14)
    {
-      SDL_SetHintWithPriority(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "1", SDL_HINT_OVERRIDE);
+      SDL_version ver;
+      SDL_GetVersion(&ver);
+      if (ver.major == 2 && ver.minor == 0 && ver.patch == 14)
+      {
+         SDL_SetHintWithPriority(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "1", SDL_HINT_OVERRIDE);
+      }
    }
 #endif
 

--- a/Source/i_video.c
+++ b/Source/i_video.c
@@ -1208,6 +1208,9 @@ static void I_InitGraphicsMode(void)
                                SDL_TEXTUREACCESS_STREAMING,
                                v_w, v_h);
 
+   // Workaround for SDL 2.0.14 alt-tab bug (taken from Doom Retro)
+   SDL_SetHintWithPriority(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "1", SDL_HINT_OVERRIDE);
+
    V_Init();
 
    UpdateGrab();


### PR DESCRIPTION
Taken from Doom Retro https://github.com/bradharding/doomretro/commit/45addf3e0408bd80713ff638a90ffd2513612e7f