### PR TITLE
Remove player->centermessage code

### DIFF
--- a/Source/d_player.h
+++ b/Source/d_player.h
@@ -170,7 +170,7 @@ typedef struct player_s
   boolean             didsecret;      
 
   // [crispy] show centered "Secret Revealed!" message
-  char*               centermessage;
+  //char*               centermessage;
 
   // [AM] Previous position of viewz before think.
   //      Used to interpolate between camera positions.

--- a/Source/hu_stuff.c
+++ b/Source/hu_stuff.c
@@ -1320,17 +1320,18 @@ void HU_Ticker(void)
   // this allows the notification of turning messages off to be seen
   // display message if necessary
 
-  if ((showMessages || message_dontfuckwithme) && plr->centermessage)
+  if (showMessages || message_dontfuckwithme)
+    if (plr->message && !strncmp(plr->message, HUSTR_SECRETFOUND, 21))
     {
       extern int M_StringWidth(const char *string);
-      w_secret.l[0].x = ORIGWIDTH/2 - M_StringWidth(plr->centermessage)/2;
+      w_secret.l[0].x = ORIGWIDTH/2 - M_StringWidth(plr->message)/2;
 
-      HUlib_addMessageToSText(&w_secret, 0, plr->centermessage);
-      plr->centermessage = NULL;
+      HUlib_addMessageToSText(&w_secret, 0, plr->message);
+      plr->message = NULL;
       secret_on = true;
       secret_counter = 5*TICRATE/2; // [crispy] 2.5 seconds
     }
-  else if ((showMessages || message_dontfuckwithme) && plr->message &&
+    else if (plr->message &&
       (!message_nottobefuckedwith || message_dontfuckwithme))
     {
       //post the message to the message widget

--- a/Source/p_spec.c
+++ b/Source/p_spec.c
@@ -2071,7 +2071,7 @@ void P_PlayerInSpecialSector (player_t *player)
           if (showMessages && hud_secret_message && player == &players[consoleplayer])
           {
             int sfx_id;
-            player->centermessage = HUSTR_SECRETFOUND;
+            player->message = HUSTR_SECRETFOUND;
 
             sfx_id = I_GetSfxLumpNum(&S_sfx[sfx_secret]) != -1 ? sfx_secret :
                I_GetSfxLumpNum(&S_sfx[sfx_itmbk]) != -1 ? sfx_itmbk : -1;


### PR DESCRIPTION
`centermessage` field in `player_t` broke savegame compatibility. I didn't realize that Chocolate Doom save game code is so different. Perhaps this feature should be reworked in prboom+ style: https://github.com/coelckers/prboom-plus/commit/47e36c30e60e3d7bfd489bf222c1e771a8c310eb