### PR TITLE
Add support for 16-bit WAV sound lumps

### DIFF
--- a/Source/i_sound.c
+++ b/Source/i_sound.c
@@ -133,7 +133,7 @@ static void stopchan(int handle)
    channelinfo[handle].id = NULL;
 }
 
-#define SOUNDHDRSIZE 8
+static int SOUNDHDRSIZE;
 
 //
 // addsfx
@@ -228,7 +228,7 @@ static boolean addsfx(sfxinfo_t *sfx, int channel, int pitch)
          if (bits != 16 && bits != 8)
             return false;
 
-         data += 44 - 8;
+         SOUNDHDRSIZE = 44;
       }
       // Check the header, and ensure this is a valid sound
       else if(data[0] == 0x03 || data[1] == 0x00)
@@ -238,6 +238,8 @@ static boolean addsfx(sfxinfo_t *sfx, int channel, int pitch)
 
          // All Doom sounds are 8-bit
          bits = 8;
+
+         SOUNDHDRSIZE = 8;
       }
       else
       {
@@ -327,7 +329,7 @@ static boolean addsfx(sfxinfo_t *sfx, int channel, int pitch)
       sfx_alen *= 4;
 
       // haleyjd 06/03/06: don't need original lump data any more
-      //Z_ChangeTag(data, PU_CACHE);
+      Z_ChangeTag(data, PU_CACHE);
    }
    else
    if (!precache_sounds)

--- a/Source/i_sound.c
+++ b/Source/i_sound.c
@@ -187,7 +187,7 @@ static boolean addsfx(sfxinfo_t *sfx, int channel, int pitch)
    if(sfx->data == NULL || pitch != NORM_PITCH)
    {   
       byte *data;
-      Uint32 samplerate, samplelen;
+      Uint32 samplerate, samplelen, samplecount;
 
       // haleyjd: this should always be called (if lump is already loaded,
       // W_CacheLumpNum handles that for us).
@@ -252,10 +252,11 @@ static boolean addsfx(sfxinfo_t *sfx, int channel, int pitch)
          return false;
       }
 
+      samplecount = samplelen / (bits / 8);
+
       // [FG] do not connect pitch-shifted samples to a sound SFX
       if (pitch == NORM_PITCH)
       {
-         unsigned int samplecount = samplelen / (bits / 8);
          sfx_alen = (Uint32)(((ULong64)samplecount * snd_samplerate) / samplerate);
          // [FG] double up twice: 8 -> 16 bit and mono -> stereo
          sfx->alen = 4 * sfx_alen;
@@ -266,7 +267,6 @@ static boolean addsfx(sfxinfo_t *sfx, int channel, int pitch)
       {
          // [FG] spoof sound samplerate if using randomly pitched sounds
          samplerate = (Uint32)(((ULong64)samplerate * steptable[pitch]) >> 16);
-         unsigned int samplecount = samplelen / (bits / 8);
          sfx_alen = (Uint32)(((ULong64)samplecount * snd_samplerate) / samplerate);
          // [FG] double up twice: 8 -> 16 bit and mono -> stereo
          channelinfo[channel].data = Z_Malloc(4 * sfx_alen, PU_STATIC, (void **)&channelinfo[channel].data);

--- a/Source/i_sound.c
+++ b/Source/i_sound.c
@@ -133,7 +133,7 @@ static void stopchan(int handle)
    channelinfo[handle].id = NULL;
 }
 
-static int SOUNDHDRSIZE;
+static int SOUNDHDRSIZE = 8;
 
 //
 // addsfx


### PR DESCRIPTION
Based on Crispy Doom. Tested it with Doom Sound Bulb [[doomworld]](https://www.doomworld.com/forum/topic/110822-doom-sound-bulb-hd-sounds-that-stay-true-to-the-original/).


Fixes #101