### PR TITLE
Disable MBF codepointers for BOOM demo compatibility

### DIFF
--- a/Source/p_enemy.c
+++ b/Source/p_enemy.c
@@ -2102,13 +2102,12 @@ void A_Detonate(mobj_t *mo)
 void A_Mushroom(mobj_t *actor)
 {
   int i, j, n = actor->info->damage;
-
-  if (demo_version < 203)
-    return;
-
   // Mushroom parameters are part of code pointer's state
   fixed_t misc1 = actor->state->misc1 ? actor->state->misc1 : FRACUNIT*4;
   fixed_t misc2 = actor->state->misc2 ? actor->state->misc2 : FRACUNIT/2;
+
+  if (demo_version < 203)
+    return;
 
   A_Explode(actor);               // make normal explosion
 

--- a/Source/p_enemy.c
+++ b/Source/p_enemy.c
@@ -2069,6 +2069,8 @@ void A_Fall(mobj_t *actor)
 // killough 11/98: kill an object
 void A_Die(mobj_t *actor)
 {
+  if (demo_version < 203)
+    return;
   P_DamageMobj(actor, NULL, NULL, actor->health);
 }
 
@@ -2087,6 +2089,8 @@ void A_Explode(mobj_t *thingy)
 
 void A_Detonate(mobj_t *mo)
 {
+  if (demo_version < 203)
+    return;
   P_RadiusAttack(mo, mo->target, mo->info->damage);
 }
 
@@ -2098,6 +2102,9 @@ void A_Detonate(mobj_t *mo)
 void A_Mushroom(mobj_t *actor)
 {
   int i, j, n = actor->info->damage;
+
+  if (demo_version < 203)
+    return;
 
   // Mushroom parameters are part of code pointer's state
   fixed_t misc1 = actor->state->misc1 ? actor->state->misc1 : FRACUNIT*4;
@@ -2538,6 +2545,8 @@ void A_KeenDie(mobj_t* mo)
 
 void A_Spawn(mobj_t *mo)
 {
+  if (demo_version < 203)
+    return;
   if (mo->state->misc1)
     {
       mobj_t *newmobj = P_SpawnMobj(mo->x, mo->y, 
@@ -2550,16 +2559,22 @@ void A_Spawn(mobj_t *mo)
 
 void A_Turn(mobj_t *mo)
 {
+  if (demo_version < 203)
+    return;
   mo->angle += (angle_t)(((ULong64) mo->state->misc1 << 32) / 360);
 }
 
 void A_Face(mobj_t *mo)
 {
+  if (demo_version < 203)
+    return;
   mo->angle = (angle_t)(((ULong64) mo->state->misc1 << 32) / 360);
 }
 
 void A_Scratch(mobj_t *mo)
 {
+  if (demo_version < 203)
+    return;
   mo->target && (A_FaceTarget(mo), P_CheckMeleeRange(mo)) ?
     mo->state->misc2 ? S_StartSound(mo, mo->state->misc2) : (void) 0,
     P_DamageMobj(mo->target, mo, mo, mo->state->misc1) : (void) 0;
@@ -2567,6 +2582,8 @@ void A_Scratch(mobj_t *mo)
 
 void A_PlaySound(mobj_t *mo)
 {
+  if (demo_version < 203)
+    return;
   S_StartSound(mo->state->misc2 ? NULL : mo, mo->state->misc1);
 }
 

--- a/Source/p_enemy.c
+++ b/Source/p_enemy.c
@@ -2572,6 +2572,8 @@ void A_PlaySound(mobj_t *mo)
 
 void A_RandomJump(mobj_t *mo)
 {
+  if (demo_version < 203)
+    return;
   if (P_Random(pr_randomjump) < mo->state->misc2)
     P_SetMobjState(mo, mo->state->misc1);
 }
@@ -2582,6 +2584,8 @@ void A_RandomJump(mobj_t *mo)
 
 void A_LineEffect(mobj_t *mo)
 {
+  if (demo_version < 203)
+    return;
   if (!(mo->intflags & MIF_LINEDONE))                // Unless already used up
     {
       line_t junk = *lines;                          // Fake linedef set to 1st


### PR DESCRIPTION
Disabling these two fixes desync in rush.wad [demos](https://dsdarchive.com/wads/rush). I guess I should disable other codepointers too. Do we introduce complevels for gameplay/demo recording?