### PR TITLE
Ignore sprite lumps smaller than 8 bytes

### DIFF
--- a/Source/w_wad.c
+++ b/Source/w_wad.c
@@ -264,12 +264,8 @@ static void W_CoalesceMarkedResource(const char *start_marker,
           is_marked = 0;                          // stop marking lumps
         }
       else
-        if (is_marked || lump->namespace == namespace)
-          {
-            // if we are marking lumps,
-            // move lump to marked list
-            // sf: check for namespace already set
-
+        if (is_marked)                            // if we are marking lumps,
+          {                                       // move lump to marked list
             // sf 26/10/99:
             // ignore sprite lumps smaller than 8 bytes (the smallest possible)
             // in size -- this was used by some dmadds wads

--- a/Source/w_wad.c
+++ b/Source/w_wad.c
@@ -264,10 +264,21 @@ static void W_CoalesceMarkedResource(const char *start_marker,
           is_marked = 0;                          // stop marking lumps
         }
       else
-        if (is_marked)                            // if we are marking lumps,
-          {                                       // move lump to marked list
-            marked[num_marked] = *lump;
-            marked[num_marked++].namespace = namespace;  // killough 4/17/98
+        if (is_marked || lump->namespace == namespace)
+          {
+            // if we are marking lumps,
+            // move lump to marked list
+            // sf: check for namespace already set
+
+            // sf 26/10/99:
+            // ignore sprite lumps smaller than 8 bytes (the smallest possible)
+            // in size -- this was used by some dmadds wads
+            // as an 'empty' graphics resource
+            if(namespace != ns_sprites || lump->size > 8)
+            {
+              marked[num_marked] = *lump;
+              marked[num_marked++].namespace = namespace;  // killough 4/17/98
+            }
           }
         else
           lumpinfo[num_unmarked++] = *lump;       // else move down THIS list


### PR DESCRIPTION
This change allows loading some malformed wads, for example [triplex.wad](https://www.doomworld.com/idgames/levels/doom2/Ports/s-u/triplex). Taken from PrBoom+.