### PR TITLE
fix handling music lumps with 0 length

### DIFF
--- a/Source/s_sound.c
+++ b/Source/s_sound.c
@@ -673,6 +673,7 @@ void S_StopMusic(void)
    
    I_StopSong(mus_playing->handle);
    I_UnRegisterSong(mus_playing->handle);
+   if (mus_playing->data != NULL) // for wads with "empty" music lumps (Nihility.wad)
    Z_ChangeTag(mus_playing->data, PU_CACHE);
    
    mus_playing->data = NULL;


### PR DESCRIPTION
For example Nihility.wad [[doomworld]](https://www.doomworld.com/forum/topic/85591-nihility-infinite-teeth-shareware-episode-v121/)

Related issue https://github.com/coelckers/prboom-plus/issues/208