### PR TITLE
emulate 'no fog on spawn west' vanilla bug

### DIFF
--- a/Source/g_game.c
+++ b/Source/g_game.c
@@ -1913,7 +1913,6 @@ static boolean G_CheckSpot(int playernum, mapthing_t *mthing)
 {
   fixed_t     x,y;
   subsector_t *ss;
-  unsigned    an;
   mobj_t      *mo;
   int         i;
 


### PR DESCRIPTION
I don't know if we need to emulate the bug, but the original Woof code crash in the Alien Vindetta demo reel.