### PR TITLE
remove doomednum reset for MT_SCEPTRE and MT_BIBLE

### DIFF
--- a/Source/d_main.c
+++ b/Source/d_main.c
@@ -1497,8 +1497,8 @@ void D_DoomMain(void)
       mobjinfo[MT_SKULL].deathstate   = S_BSKUL_DIE1;
       mobjinfo[MT_SKULL].damage       = 1;
     }
-  else
-    mobjinfo[MT_SCEPTRE].doomednum = mobjinfo[MT_BIBLE].doomednum = -1;
+  // else
+  //   mobjinfo[MT_SCEPTRE].doomednum = mobjinfo[MT_BIBLE].doomednum = -1;
 
   // jff 1/24/98 set both working and command line value of play parms
   nomonsters = clnomonsters = M_CheckParm ("-nomonsters");

--- a/Source/d_main.c
+++ b/Source/d_main.c
@@ -1497,8 +1497,12 @@ void D_DoomMain(void)
       mobjinfo[MT_SKULL].deathstate   = S_BSKUL_DIE1;
       mobjinfo[MT_SKULL].damage       = 1;
     }
-  // else
-  //   mobjinfo[MT_SCEPTRE].doomednum = mobjinfo[MT_BIBLE].doomednum = -1;
+  // This code causes MT_SCEPTRE and MT_BIBLE to not spawn on the map,
+  // which causes desync in Eviternity.wad demos.
+  #if 0
+  else
+    mobjinfo[MT_SCEPTRE].doomednum = mobjinfo[MT_BIBLE].doomednum = -1;
+  #endif
 
   // jff 1/24/98 set both working and command line value of play parms
   nomonsters = clnomonsters = M_CheckParm ("-nomonsters");


### PR DESCRIPTION
This change fixes desync in EVIT04-542.lmp, EVIT05-231.lmp, and many other Eviternity demos. There are still a few desyncs left.