### PR TITLE
remove from P_Move() parts that are incompatible with PrBoom+ complevel 11

### DIFF
--- a/Source/p_enemy.c
+++ b/Source/p_enemy.c
@@ -307,6 +307,112 @@ extern  int    numspechit;
 
 static boolean P_Move(mobj_t *actor, boolean dropoff) // killough 9/12/98
 {
+  fixed_t tryx, tryy, deltax, deltay, origx, origy;
+  boolean try_ok;
+  int movefactor = ORIG_FRICTION_FACTOR;    // killough 10/98
+  int friction = ORIG_FRICTION;
+  int speed;
+
+  if (actor->movedir == DI_NODIR)
+    return false;
+
+#ifdef RANGECHECK
+  if ((unsigned)actor->movedir >= 8)
+    I_Error ("P_Move: Weird actor->movedir!");
+#endif
+
+  // killough 10/98: make monsters get affected by ice and sludge too:
+
+  if (monster_friction)
+    movefactor = P_GetMoveFactor(actor, &friction);
+
+  speed = actor->info->speed;
+
+  if (friction < ORIG_FRICTION &&     // sludge
+      !(speed = ((ORIG_FRICTION_FACTOR - (ORIG_FRICTION_FACTOR-movefactor)/2)
+     * speed) / ORIG_FRICTION_FACTOR))
+    speed = 1;      // always give the monster a little bit of speed
+
+  tryx = (origx = actor->x) + (deltax = speed * xspeed[actor->movedir]);
+  tryy = (origy = actor->y) + (deltay = speed * yspeed[actor->movedir]);
+
+  try_ok = P_TryMove(actor, tryx, tryy, dropoff);
+
+  // killough 10/98:
+  // Let normal momentum carry them, instead of steptoeing them across ice.
+
+  if (try_ok && friction > ORIG_FRICTION)
+    {
+      actor->x = origx;
+      actor->y = origy;
+      movefactor *= FRACUNIT / ORIG_FRICTION_FACTOR / 4;
+      actor->momx += FixedMul(deltax, movefactor);
+      actor->momy += FixedMul(deltay, movefactor);
+    }
+
+  if (!try_ok)
+    {      // open any specials
+      int good;
+
+      if (actor->flags & MF_FLOAT && floatok)
+        {
+          if (actor->z < tmfloorz)          // must adjust height
+            actor->z += FLOATSPEED;
+          else
+            actor->z -= FLOATSPEED;
+
+          actor->flags |= MF_INFLOAT;
+
+          return true;
+        }
+
+      if (!numspechit)
+        return false;
+
+      actor->movedir = DI_NODIR;
+
+      /* if the special is not a door that can be opened, return false
+       *
+       * killough 8/9/98: this is what caused monsters to get stuck in
+       * doortracks, because it thought that the monster freed itself
+       * by opening a door, even if it was moving towards the doortrack,
+       * and not the door itself.
+       *
+       * killough 9/9/98: If a line blocking the monster is activated,
+       * return true 90% of the time. If a line blocking the monster is
+       * not activated, but some other line is, return false 90% of the
+       * time. A bit of randomness is needed to ensure it's free from
+       * lockups, but for most cases, it returns the correct result.
+       *
+       * Do NOT simply return false 1/4th of the time (causes monsters to
+       * back out when they shouldn't, and creates secondary stickiness).
+       */
+
+      for (good = false; numspechit--; )
+        if (P_UseSpecialLine(actor, spechit[numspechit], 0, false))
+          good |= spechit[numspechit] == blockline ? 1 : 2;
+
+      /* cph - compatibility maze here
+       * Boom v2.01 and orig. Doom return "good"
+       * Boom v2.02 and LxDoom return good && (P_Random(pr_trywalk)&3)
+       * MBF plays even more games
+       */
+      if (!good || comp[comp_doorstuck]) return good;
+      if (demo_version < 203)
+        return (P_Random(pr_trywalk)&3); /* jff 8/13/98 */
+      else /* finally, MBF code */
+        return ((P_Random(pr_opendoor) >= 230) ^ (good & 1));
+    }
+  else
+    actor->flags &= ~MF_INFLOAT;
+
+  /* killough 11/98: fall more slowly, under gravity, if felldown==true */
+  if (!(actor->flags & MF_FLOAT) &&
+      (!felldown || demo_version < 203))
+    actor->z = actor->floorz;
+
+  return true;
+/*
   fixed_t tryx, tryy, deltax, deltay;
   boolean try_ok;
   int movefactor = ORIG_FRICTION_FACTOR;    // killough 10/98
@@ -430,6 +536,7 @@ static boolean P_Move(mobj_t *actor, boolean dropoff) // killough 9/12/98
     actor->z = actor->floorz;
 
   return true;
+*/
 }
 
 //

--- a/Source/p_enemy.c
+++ b/Source/p_enemy.c
@@ -318,7 +318,7 @@ static boolean P_Move(mobj_t *actor, boolean dropoff) // killough 9/12/98
 
 #ifdef RANGECHECK
   if ((unsigned)actor->movedir >= 8)
-    I_Error ("P_Move: Weird actor->movedir!");
+    I_Error ("Weird actor->movedir!");
 #endif
 
   // killough 10/98: make monsters get affected by ice and sludge too:
@@ -330,7 +330,7 @@ static boolean P_Move(mobj_t *actor, boolean dropoff) // killough 9/12/98
 
   if (friction < ORIG_FRICTION &&     // sludge
       !(speed = ((ORIG_FRICTION_FACTOR - (ORIG_FRICTION_FACTOR-movefactor)/2)
-     * speed) / ORIG_FRICTION_FACTOR))
+		 * speed) / ORIG_FRICTION_FACTOR))
     speed = 1;      // always give the monster a little bit of speed
 
   tryx = (origx = actor->x) + (deltax = speed * xspeed[actor->movedir]);
@@ -348,130 +348,6 @@ static boolean P_Move(mobj_t *actor, boolean dropoff) // killough 9/12/98
       movefactor *= FRACUNIT / ORIG_FRICTION_FACTOR / 4;
       actor->momx += FixedMul(deltax, movefactor);
       actor->momy += FixedMul(deltay, movefactor);
-    }
-
-  if (!try_ok)
-    {      // open any specials
-      int good;
-
-      if (actor->flags & MF_FLOAT && floatok)
-        {
-          if (actor->z < tmfloorz)          // must adjust height
-            actor->z += FLOATSPEED;
-          else
-            actor->z -= FLOATSPEED;
-
-          actor->flags |= MF_INFLOAT;
-
-          return true;
-        }
-
-      if (!numspechit)
-        return false;
-
-      actor->movedir = DI_NODIR;
-
-      /* if the special is not a door that can be opened, return false
-       *
-       * killough 8/9/98: this is what caused monsters to get stuck in
-       * doortracks, because it thought that the monster freed itself
-       * by opening a door, even if it was moving towards the doortrack,
-       * and not the door itself.
-       *
-       * killough 9/9/98: If a line blocking the monster is activated,
-       * return true 90% of the time. If a line blocking the monster is
-       * not activated, but some other line is, return false 90% of the
-       * time. A bit of randomness is needed to ensure it's free from
-       * lockups, but for most cases, it returns the correct result.
-       *
-       * Do NOT simply return false 1/4th of the time (causes monsters to
-       * back out when they shouldn't, and creates secondary stickiness).
-       */
-
-      for (good = false; numspechit--; )
-        if (P_UseSpecialLine(actor, spechit[numspechit], 0, false))
-          good |= spechit[numspechit] == blockline ? 1 : 2;
-
-      /* cph - compatibility maze here
-       * Boom v2.01 and orig. Doom return "good"
-       * Boom v2.02 and LxDoom return good && (P_Random(pr_trywalk)&3)
-       * MBF plays even more games
-       */
-      if (!good || comp[comp_doorstuck]) return good;
-      if (demo_version < 203)
-        return (P_Random(pr_trywalk)&3); /* jff 8/13/98 */
-      else /* finally, MBF code */
-        return ((P_Random(pr_opendoor) >= 230) ^ (good & 1));
-    }
-  else
-    actor->flags &= ~MF_INFLOAT;
-
-  /* killough 11/98: fall more slowly, under gravity, if felldown==true */
-  if (!(actor->flags & MF_FLOAT) &&
-      (!felldown || demo_version < 203))
-    actor->z = actor->floorz;
-
-  return true;
-/*
-  fixed_t tryx, tryy, deltax, deltay;
-  boolean try_ok;
-  int movefactor = ORIG_FRICTION_FACTOR;    // killough 10/98
-  int friction = ORIG_FRICTION;
-  int speed;
-
-  if (actor->movedir == DI_NODIR)
-    return false;
-
-#ifdef RANGECHECK
-  if ((unsigned)actor->movedir >= 8)
-    I_Error ("Weird actor->movedir!");
-#endif
-  
-  // killough 10/98: make monsters get affected by ice and sludge too:
-
-  if (monster_friction)
-    movefactor = P_GetMoveFactor(actor, &friction);
-
-  speed = actor->info->speed;
-
-  if (friction < ORIG_FRICTION &&     // sludge
-      !(speed = ((ORIG_FRICTION_FACTOR - (ORIG_FRICTION_FACTOR-movefactor)/2)
-		 * speed) / ORIG_FRICTION_FACTOR))
-    speed = 1;      // always give the monster a little bit of speed
-
-  tryx = actor->x + (deltax = speed * xspeed[actor->movedir]);
-  tryy = actor->y + (deltay = speed * yspeed[actor->movedir]);
-
-  // killough 12/98: rearrange, fix potential for stickiness on ice
-
-  if (friction <= ORIG_FRICTION)
-    try_ok = P_TryMove(actor, tryx, tryy, dropoff);
-  else
-    {
-      fixed_t x = actor->x;
-      fixed_t y = actor->y;
-      fixed_t floorz = actor->floorz;
-      fixed_t ceilingz = actor->ceilingz;
-      fixed_t dropoffz = actor->dropoffz;
-
-      try_ok = P_TryMove(actor, tryx, tryy, dropoff);
-
-      // killough 10/98:
-      // Let normal momentum carry them, instead of steptoeing them across ice.
-
-      if (try_ok)
-	{
-	  P_UnsetThingPosition(actor);
-	  actor->x = x;
-	  actor->y = y;
-	  actor->floorz = floorz;
-	  actor->ceilingz = ceilingz;
-	  actor->dropoffz = dropoffz;
-	  P_SetThingPosition(actor);
-	  movefactor *= FRACUNIT / ORIG_FRICTION_FACTOR / 4;
-	  actor->momx += FixedMul(deltax, movefactor);
-	  actor->momy += FixedMul(deltay, movefactor);
-	}
     }
 
   if (!try_ok)
@@ -536,7 +412,6 @@ static boolean P_Move(mobj_t *actor, boolean dropoff) // killough 9/12/98
     actor->z = actor->floorz;
 
   return true;
-*/
 }
 
 //

--- a/Source/p_enemy.c
+++ b/Source/p_enemy.c
@@ -355,22 +355,22 @@ static boolean P_Move(mobj_t *actor, boolean dropoff) // killough 9/12/98
       // Let normal momentum carry them, instead of steptoeing them across ice.
 
       if (try_ok)
-        {
+	{
 #if 0
-          P_UnsetThingPosition(actor);
+	  P_UnsetThingPosition(actor);
 #endif
-          actor->x = x;
-          actor->y = y;
+	  actor->x = x;
+	  actor->y = y;
 #if 0
-          actor->floorz = floorz;
-          actor->ceilingz = ceilingz;
-          actor->dropoffz = dropoffz;
-          P_SetThingPosition(actor);
+	  actor->floorz = floorz;
+	  actor->ceilingz = ceilingz;
+	  actor->dropoffz = dropoffz;
+	  P_SetThingPosition(actor);
 #endif
-          movefactor *= FRACUNIT / ORIG_FRICTION_FACTOR / 4;
-          actor->momx += FixedMul(deltax, movefactor);
-          actor->momy += FixedMul(deltay, movefactor);
-        }
+	  movefactor *= FRACUNIT / ORIG_FRICTION_FACTOR / 4;
+	  actor->momx += FixedMul(deltax, movefactor);
+	  actor->momy += FixedMul(deltay, movefactor);
+	}
     }
 
   if (!try_ok)

--- a/Source/p_enemy.c
+++ b/Source/p_enemy.c
@@ -350,6 +350,7 @@ static boolean P_Move(mobj_t *actor, boolean dropoff) // killough 9/12/98
       fixed_t ceilingz = actor->ceilingz;
       fixed_t dropoffz = actor->dropoffz;
 #endif
+
       try_ok = P_TryMove(actor, tryx, tryy, dropoff);
 
       // killough 10/98:

--- a/Source/p_enemy.c
+++ b/Source/p_enemy.c
@@ -320,7 +320,7 @@ static boolean P_Move(mobj_t *actor, boolean dropoff) // killough 9/12/98
   if ((unsigned)actor->movedir >= 8)
     I_Error ("Weird actor->movedir!");
 #endif
-
+  
   // killough 10/98: make monsters get affected by ice and sludge too:
 
   if (monster_friction)
@@ -337,6 +337,7 @@ static boolean P_Move(mobj_t *actor, boolean dropoff) // killough 9/12/98
   tryy = actor->y + (deltay = speed * yspeed[actor->movedir]);
 
   // killough 12/98: rearrange, fix potential for stickiness on ice
+  // Removed parts incompatible with PrBoom+ complevel 11
 
   if (friction <= ORIG_FRICTION)
     try_ok = P_TryMove(actor, tryx, tryy, dropoff);


### PR DESCRIPTION
This change fixes desync in Evitenity map14 demos and many others.
P_Move() is a quite convoluted function, so I suggest just replace it. This is the last known desync in complevel 11 demos.