### PR TITLE
force M_SaveDefaults() to always write the help string

### DIFF
--- a/Source/m_misc.c
+++ b/Source/m_misc.c
@@ -2014,6 +2014,8 @@ void M_SaveDefaults (void)
       int brackets = 0;
       config_t value;
 
+      // Always write a help string to avoid
+      // incorrect entries in the user config
 /*
       for (;line < comment && comments[line].line <= dp-defaults; line++)
         if (*comments[line].text != '[' || (brackets = 1, config_help))

--- a/Source/m_misc.c
+++ b/Source/m_misc.c
@@ -1983,7 +1983,7 @@ void M_SaveDefaults (void)
 {
   char tmpfile[PATH_MAX+1];
   register default_t *dp;
-  int line, blanks;
+  int blanks;
   FILE *f;
 
   // killough 10/98: for when exiting early
@@ -2009,7 +2009,7 @@ void M_SaveDefaults (void)
 
   // killough 10/98: output comment lines which were read in during input
 
-  for (blanks = 1, line = 0, dp = defaults; ; dp++, blanks = 0)
+  for (blanks = 1, dp = defaults; ; dp++, blanks = 0)
     {
       int brackets = 0;
       config_t value;

--- a/Source/m_misc.c
+++ b/Source/m_misc.c
@@ -2014,6 +2014,7 @@ void M_SaveDefaults (void)
       int brackets = 0;
       config_t value;
 
+/*
       for (;line < comment && comments[line].line <= dp-defaults; line++)
         if (*comments[line].text != '[' || (brackets = 1, config_help))
 
@@ -2026,6 +2027,7 @@ void M_SaveDefaults (void)
 			     putc('\n',f) == EOF)) ||
 		fputs(comments[line].text, f) == EOF)
 	      goto error;
+*/
 
       // If we still haven't seen any blanks,
       // Output a blank line for separation


### PR DESCRIPTION
This change fixes incorrect help strings in the user config when we add new entries in the middle of the `defaults[]`. I hope I read this code correctly :)