### PR TITLE
mbf21: demo format/header

### DIFF
--- a/Source/doomstat.h
+++ b/Source/doomstat.h
@@ -117,6 +117,7 @@ enum {
   comp_infcheat,
   comp_zerotags,
 
+  // from PrBoom+/Eternity Engine (part of mbf21 spec)
   comp_respawn,
   comp_soul,
 

--- a/Source/doomstat.h
+++ b/Source/doomstat.h
@@ -117,20 +117,14 @@ enum {
   comp_infcheat,
   comp_zerotags,
 
-  // PrBoom+
-  comp_placeholder_20, // comp_moveblock
-  comp_respawn,  /* cph - alias of comp_respawnfix from eternity */
-  comp_placeholder_22, // comp_sound
-  comp_placeholder_23, // comp_666
+  comp_respawn,
   comp_soul,
-  comp_placeholder_25, // comp_maskedanim
-  comp_placeholder_26, // comp_ouchface
-  comp_placeholder_27, // comp_maxhealth
-  comp_placeholder_28, // comp_translucency
 
   // mbf21
   comp_ledgeblock,
   comp_friendlyspawn,
+
+  MBF21_COMP_TOTAL,
 
   COMP_TOTAL=32  // Some extra room for additional variables
 };

--- a/Source/doomstat.h
+++ b/Source/doomstat.h
@@ -79,6 +79,8 @@ extern int demo_version;           // killough 7/19/98: Version of demo
 
 #define demo_compatibility (demo_version < 200) /* killough 11/98: macroized */
 
+#define mbf21 (demo_version == 221)
+
 // killough 7/19/98: whether monsters should fight against each other
 extern int monster_infighting, default_monster_infighting;
 
@@ -114,6 +116,22 @@ enum {
   comp_stairs,
   comp_infcheat,
   comp_zerotags,
+
+  // PrBoom+
+  comp_placeholder_20, // comp_moveblock
+  comp_respawn,  /* cph - alias of comp_respawnfix from eternity */
+  comp_placeholder_22, // comp_sound
+  comp_placeholder_23, // comp_666
+  comp_soul,
+  comp_placeholder_25, // comp_maskedanim
+  comp_placeholder_26, // comp_ouchface
+  comp_placeholder_27, // comp_maxhealth
+  comp_placeholder_28, // comp_translucency
+
+  // mbf21
+  comp_ledgeblock,
+  comp_friendlyspawn,
+
   COMP_TOTAL=32  // Some extra room for additional variables
 };
 

--- a/Source/g_game.c
+++ b/Source/g_game.c
@@ -1257,7 +1257,7 @@ static void G_DoPlayDemo(void)
   demover = *demo_p++;
 
   // [FG] PrBoom's own demo format starts with demo version 210
-  if (demover >= 210)
+  if (demover >= 210 && demover != 221)
   {
     fprintf(stderr,"G_DoPlayDemo: Unknown demo format %d.\n", demover);
     gameaction = ga_nothing;
@@ -1327,6 +1327,11 @@ static void G_DoPlayDemo(void)
     {
       demo_p += 6;               // skip signature;
 
+      if (demover == 221)
+      {
+        longtics = true;
+      }
+
       compatibility = *demo_p++;       // load old compatibility flag
       skill = *demo_p++;
       episode = *demo_p++;
@@ -1390,6 +1395,7 @@ static void G_DoPlayDemo(void)
 
   // [FG] report compatibility mode
   fprintf(stderr, "G_DoPlayDemo: Playing demo with %s (%d) compatibility.\n",
+    demover == 221 ? "MBF21" :
     demover >= 203 ? "MBF" :
     demover >= 200 ? (compatibility ? "Boom compatibility" : "Boom") :
     gameversion == exe_final ? "Final Doom" :
@@ -2315,6 +2321,8 @@ static int G_GetNamedComplevel (const char *arg)
     {202, "9",       -1},
     {203, "mbf",     -1},
     {203, "11",      -1},
+    {221, "mbf21",   -1},
+    {221, "21",      -1},
   };
 
   for (i = 0; i < sizeof(named_complevel)/sizeof(*named_complevel); i++)
@@ -2840,9 +2848,17 @@ void G_BeginRecording(void)
 
   demo_p = demobuffer;
 
-  if (complevel == MBFVERSION)
+  if (complevel == MBFVERSION || complevel == 221)
   {
+    if (complevel == 221)
+    {
+      longtics = true;
+      *demo_p++ = 221;
+    }
+    else
+    {
   *demo_p++ = MBFVERSION;
+    }
 
   // signature
   *demo_p++ = 0x1d;
@@ -2855,7 +2871,7 @@ void G_BeginRecording(void)
   // killough 2/22/98: save compatibility flag in new demos
   *demo_p++ = compatibility;       // killough 2/22/98
 
-  demo_version = MBFVERSION;     // killough 7/19/98: use this version's id
+  demo_version = complevel;
 
   *demo_p++ = gameskill;
   *demo_p++ = gameepisode;

--- a/Source/g_game.c
+++ b/Source/g_game.c
@@ -76,7 +76,7 @@ static short    consistancy[MAXPLAYERS][BACKUPTICS];
 
 static mapentry_t *G_LookupMapinfo(int episode, int map);
 
-static int mbf21_GameOptionSize(void);
+static int G_GameOptionSize(void);
 
 gameaction_t    gameaction;
 gamestate_t     gamestate;
@@ -1259,7 +1259,7 @@ static void G_DoPlayDemo(void)
   demover = *demo_p++;
 
   // [FG] PrBoom's own demo format starts with demo version 210
-  if (demover >= 210 && demover != 221)
+  if (demover >= 210 && demover != MBF21VERSION)
   {
     fprintf(stderr,"G_DoPlayDemo: Unknown demo format %d.\n", demover);
     gameaction = ga_nothing;
@@ -1329,14 +1329,13 @@ static void G_DoPlayDemo(void)
     {
       demo_p += 6;               // skip signature;
 
-      if (demover == 221)
+      if (demover == MBF21VERSION)
       {
         longtics = true;
         compatibility = 0;
       }
       else
       {
-
       compatibility = *demo_p++;       // load old compatibility flag
       }
       skill = *demo_p++;
@@ -1352,7 +1351,7 @@ static void G_DoPlayDemo(void)
       demo_p = G_ReadOptions(demo_p);  // killough 3/1/98: Read game options
 
       if (demover == 200)        // killough 6/3/98: partially fix v2.00 demos
-        demo_p += 256-mbf21_GameOptionSize();
+        demo_p += 256-G_GameOptionSize();
     }
 
   if (demo_compatibility)  // only 4 players can exist in old demos
@@ -1401,7 +1400,7 @@ static void G_DoPlayDemo(void)
 
   // [FG] report compatibility mode
   fprintf(stderr, "G_DoPlayDemo: Playing demo with %s (%d) compatibility.\n",
-    demover == 221 ? "MBF21" :
+    demover == MBF21VERSION ? "MBF21" :
     demover >= 203 ? "MBF" :
     demover >= 200 ? (compatibility ? "Boom compatibility" : "Boom") :
     gameversion == exe_final ? "Final Doom" :
@@ -1570,7 +1569,7 @@ static void G_DoSaveGame(void)
     save_p += strlen((char *) save_p)+1;
   }
 
-  CheckSaveGame(mbf21_GameOptionSize()+MIN_MAXPLAYERS+10);
+  CheckSaveGame(G_GameOptionSize()+MIN_MAXPLAYERS+10);
 
   for (i=0 ; i<MAXPLAYERS ; i++)
     *save_p++ = playeringame[i];
@@ -2680,7 +2679,7 @@ void G_RecordDemo(char *name)
 // byte(s) should still be skipped over or padded with 0's.
 // Lee Killough 3/1/98
 
-static int mbf21_GameOptionSize(void) {
+static int G_GameOptionSize(void) {
   return mbf21 ? MBF21_GAME_OPTION_SIZE : GAME_OPTION_SIZE;
 }
 
@@ -2728,14 +2727,12 @@ static byte* mbf21_WriteOptions(byte* demo_p)
 
 byte *G_WriteOptions(byte *demo_p)
 {
-  byte *target;
+  byte *target = demo_p + GAME_OPTION_SIZE;
 
   if (mbf21)
   {
     return mbf21_WriteOptions(demo_p);
   }
-
-  target = demo_p + GAME_OPTION_SIZE;
 
   *demo_p++ = monsters_remember;  // part of monster AI
 
@@ -2859,14 +2856,12 @@ static byte *mbf21_ReadOption(byte *demo_p)
 
 byte *G_ReadOptions(byte *demo_p)
 {
-  byte *target;
+  byte *target = demo_p + GAME_OPTION_SIZE;
 
   if (mbf21)
   {
     return mbf21_ReadOption(demo_p);
   }
-
-  target = demo_p + GAME_OPTION_SIZE;
 
   monsters_remember = *demo_p++;
 
@@ -2975,12 +2970,12 @@ void G_BeginRecording(void)
 
   demo_p = demobuffer;
 
-  if (complevel == MBFVERSION || complevel == 221)
+  if (complevel == MBFVERSION || complevel == MBF21VERSION)
   {
-    if (complevel == 221)
+    if (complevel == MBF21VERSION)
     {
       longtics = true;
-      *demo_p++ = 221;
+      *demo_p++ = MBF21VERSION;
     }
     else
     {
@@ -2995,7 +2990,7 @@ void G_BeginRecording(void)
   *demo_p++ = 0xe6;
   *demo_p++ = '\0';
 
-  if (complevel != 221)
+  if (complevel != MBF21VERSION)
   {
   // killough 2/22/98: save compatibility flag in new demos
   *demo_p++ = compatibility;       // killough 2/22/98

--- a/Source/g_game.h
+++ b/Source/g_game.h
@@ -37,6 +37,8 @@
 // killough 5/2/98: number of bytes reserved for saving options
 #define GAME_OPTION_SIZE 64
 
+#define MBF21_GAME_OPTION_SIZE (21 + MBF21_COMP_TOTAL)
+
 boolean G_Responder(event_t *ev);
 boolean G_CheckDemoStatus(void);
 void G_DeathMatchSpawnPlayer(int playernum);

--- a/Source/version.h
+++ b/Source/version.h
@@ -29,7 +29,7 @@
 #include "z_zone.h"  /* memory allocation wrappers -- killough */
 
 // DOOM version
-enum { MBFVERSION =  203 };
+enum { MBFVERSION =  203, MBF21VERSION = 221 };
 
 extern const char version_date[];
 


### PR DESCRIPTION
<s>The dsda-doom version of this is more complex, it changes the demo header by removing some fields from it https://github.com/kraflab/dsda-doom/blob/0b7e5f228a559ce57daaa0c750bfc9bc5ae038af/prboom2/src/dsda/options.c#L294-L382
I think this is unnecessary, and hope @kraflab changes his mind.</s>

edit: updated to current spec.