### PR TITLE
unicode paths on Windows

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -96,7 +96,8 @@ set(WOOF_SOURCES
 if(MSVC)
     list(APPEND
       WOOF_SOURCES
-      win_opendir.c win_opendir.h)
+      win_opendir.c win_opendir.h
+      ../win32/win_fopen.c ../win32/win_fopen.h)
 endif()
 
 # Some platforms require standard libraries to be linked against.

--- a/Source/d_deh.c
+++ b/Source/d_deh.c
@@ -42,6 +42,10 @@
 #include "d_think.h"
 #include "w_wad.h"
 
+#ifdef _WIN32
+#include "../win32/win_fopen.h"
+#endif
+
 
 // killough 10/98: new functions, to allow processing DEH files in-memory
 // (e.g. from wads)

--- a/Source/d_main.c
+++ b/Source/d_main.c
@@ -69,6 +69,10 @@
 #include "u_mapinfo.h" // U_ParseMapInfo()
 #include "i_glob.h" // [FG] I_StartMultiGlob()
 
+#ifdef _WIN32
+#include "../win32/win_fopen.h"
+#endif
+
 // DEHacked support - Ty 03/09/97
 // killough 10/98:
 // Add lump number as third argument, for use when filename==NULL

--- a/Source/m_menu.c
+++ b/Source/m_menu.c
@@ -54,6 +54,10 @@
 #include "p_setup.h" // [FG] maplumpnum
 #include "w_wad.h" // [FG] W_IsIWADLump() / W_WadNameForLump()
 
+#ifdef _WIN32
+#include "../win32/win_fopen.h"
+#endif
+
 extern patch_t* hu_font[HU_FONTSIZE];
 extern boolean  message_dontfuckwithme;
           

--- a/Source/m_misc.c
+++ b/Source/m_misc.c
@@ -50,6 +50,10 @@
 #include "d_io.h"
 #include <errno.h>
 
+#ifdef _WIN32
+#include "../win32/win_fopen.h"
+#endif
+
 //
 // DEFAULTS
 //

--- a/Source/m_misc2.c
+++ b/Source/m_misc2.c
@@ -461,3 +461,32 @@ int M_snprintf(char *buf, size_t buf_len, const char *s, ...)
     va_end(args);
     return result;
 }
+
+#ifdef _WIN32
+FILE* D_fopen(const char *filename, const char *mode)
+{
+  wchar_t wpath[MAX_PATH];
+  wchar_t wmode[MAX_PATH];
+  int fn_len = strlen(filename);
+  int m_len  = strlen(mode);
+  int w_fn_len = 0;
+  int w_m_len = 0;
+
+  if (fn_len == 0) 
+    return NULL;
+  if (m_len == 0)
+    return NULL;
+
+  w_fn_len = MultiByteToWideChar(CP_UTF8, 0, filename, fn_len, wpath, fn_len);
+  if (w_fn_len >= MAX_PATH)
+    return NULL;
+  wpath[w_fn_len] = L'\0';
+
+  w_m_len = MultiByteToWideChar(CP_UTF8, 0, mode, m_len, wmode, m_len);
+  if(w_m_len >= MAX_PATH)
+    return NULL;
+  wmode[w_m_len] = L'\0';
+
+  return _wfopen(wpath, wmode);
+}
+#endif

--- a/Source/m_misc2.c
+++ b/Source/m_misc2.c
@@ -38,6 +38,10 @@
 #include "i_system.h"
 #include "m_misc2.h"
 
+#ifdef _WIN32
+#include "../win32/win_fopen.h"
+#endif
+
 //
 // Create a directory
 //
@@ -461,32 +465,3 @@ int M_snprintf(char *buf, size_t buf_len, const char *s, ...)
     va_end(args);
     return result;
 }
-
-#ifdef _WIN32
-FILE* D_fopen(const char *filename, const char *mode)
-{
-  wchar_t wpath[MAX_PATH];
-  wchar_t wmode[MAX_PATH];
-  int fn_len = strlen(filename);
-  int m_len  = strlen(mode);
-  int w_fn_len = 0;
-  int w_m_len = 0;
-
-  if (fn_len == 0) 
-    return NULL;
-  if (m_len == 0)
-    return NULL;
-
-  w_fn_len = MultiByteToWideChar(CP_UTF8, 0, filename, fn_len, wpath, fn_len);
-  if (w_fn_len >= MAX_PATH)
-    return NULL;
-  wpath[w_fn_len] = L'\0';
-
-  w_m_len = MultiByteToWideChar(CP_UTF8, 0, mode, m_len, wmode, m_len);
-  if(w_m_len >= MAX_PATH)
-    return NULL;
-  wmode[w_m_len] = L'\0';
-
-  return _wfopen(wpath, wmode);
-}
-#endif

--- a/Source/m_misc2.h
+++ b/Source/m_misc2.h
@@ -42,13 +42,4 @@ char *M_StringJoin(const char *s, ...);
 boolean M_StringEndsWith(const char *s, const char *suffix);
 int M_snprintf(char *buf, size_t buf_len, const char *s, ...) PRINTF_ATTR(3, 4);
 
-#ifdef _WIN32
-  #include <stdio.h>
-
-  FILE* D_fopen(const char *filename, const char *mode);
-
-  #undef  fopen
-  #define fopen(n, m) D_fopen(n, m)
-#endif
-
 #endif

--- a/Source/m_misc2.h
+++ b/Source/m_misc2.h
@@ -42,4 +42,13 @@ char *M_StringJoin(const char *s, ...);
 boolean M_StringEndsWith(const char *s, const char *suffix);
 int M_snprintf(char *buf, size_t buf_len, const char *s, ...) PRINTF_ATTR(3, 4);
 
+#ifdef _WIN32
+  #include <stdio.h>
+
+  FILE* D_fopen(const char *filename, const char *mode);
+
+  #undef  fopen
+  #define fopen(n, m) D_fopen(n, m)
+#endif
+
 #endif

--- a/Source/mmus2mid.c
+++ b/Source/mmus2mid.c
@@ -28,6 +28,10 @@
 #include <sys/stat.h>
 #include "mmus2mid.h"
 
+#ifdef _WIN32
+#include "../win32/win_fopen.h"
+#endif
+
 //#define STANDALONE  /* uncomment this to make MMUS2MID.EXE */
 #ifndef STANDALONE
 #include "z_zone.h"

--- a/Source/r_data.c
+++ b/Source/r_data.c
@@ -34,6 +34,10 @@
 #include "r_sky.h"
 #include "d_io.h"
 
+#ifdef _WIN32
+#include "../win32/win_fopen.h"
+#endif
+
 //
 // Graphics.
 // DOOM graphics for walls and sprites

--- a/Source/statdump.c
+++ b/Source/statdump.c
@@ -29,6 +29,10 @@
 
 #include "statdump.h"
 
+#ifdef _WIN32
+#include "../win32/win_fopen.h"
+#endif
+
 /* Par times for E1M1-E1M9. */
 static const int doom1_par_times[] =
 {

--- a/Source/w_wad.c
+++ b/Source/w_wad.c
@@ -35,6 +35,10 @@
 #include "m_misc2.h" // [FG] M_BaseName()
 #include "d_main.h" // [FG] wadfiles
 
+#ifdef _WIN32
+#include "../win32/win_fopen.h"
+#endif
+
 //
 // GLOBALS
 //

--- a/win32/win_fopen.c
+++ b/win32/win_fopen.c
@@ -1,0 +1,51 @@
+//  This program is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU General Public License
+//  as published by the Free Software Foundation; either version 2
+//  of the License, or (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 
+//  02111-1307, USA.
+//
+// DESCRIPTION:
+//      unicode paths for fopen() on Windows
+
+#include "win_fopen.h"
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+FILE* D_fopen(const char *filename, const char *mode)
+{
+  wchar_t wpath[MAX_PATH];
+  wchar_t wmode[MAX_PATH];
+  int fn_len = strlen(filename);
+  int m_len  = strlen(mode);
+  int w_fn_len = 0;
+  int w_m_len = 0;
+
+  if (fn_len == 0) 
+    return NULL;
+  if (m_len == 0)
+    return NULL;
+
+  w_fn_len = MultiByteToWideChar(CP_UTF8, 0, filename, fn_len, wpath, fn_len);
+  if (w_fn_len >= MAX_PATH)
+    return NULL;
+  wpath[w_fn_len] = L'\0';
+
+  w_m_len = MultiByteToWideChar(CP_UTF8, 0, mode, m_len, wmode, m_len);
+  if(w_m_len >= MAX_PATH)
+    return NULL;
+  wmode[w_m_len] = L'\0';
+
+  return _wfopen(wpath, wmode);
+}
+#endif

--- a/win32/win_fopen.h
+++ b/win32/win_fopen.h
@@ -1,0 +1,31 @@
+//  This program is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU General Public License
+//  as published by the Free Software Foundation; either version 2
+//  of the License, or (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 
+//  02111-1307, USA.
+//
+// DESCRIPTION:
+//      unicode paths for fopen() on Windows
+
+#ifndef __WIN_D_FOPEN__
+#define __WIN_D_FOPEN__
+
+#ifdef _WIN32
+#include <stdio.h>
+
+FILE* D_fopen(const char *filename, const char *mode);
+
+#undef  fopen
+#define fopen(n, m) D_fopen(n, m)
+#endif
+
+#endif


### PR DESCRIPTION
I tested it with MSVC and MSYS2. I don’t know how to organize this, we may need a special `win32_ *` file/dir for such hacks.

By the way, PrBoom+ and Choco don't support non-latin paths in Windows, only Eternity and GZDoom from my testing.