### PR TITLE
remove compatibility options from setup menu if complevel != mbf

### DIFF
--- a/Source/m_menu.c
+++ b/Source/m_menu.c
@@ -6081,6 +6081,7 @@ void M_Init(void)
     }
 
   M_ResetMenu();        // killough 10/98
+  M_ResetSetupMenu();
   M_InitHelpScreen();   // init the help screen       // phares 4/08/98
   M_InitExtendedHelp(); // init extended help screens // phares 3/30/98
 
@@ -6107,6 +6108,21 @@ void M_ResetMenu(void)
       MainMenu[options]  = MainMenu[savegame];
       MainMenu[savegame] = t;
     }
+}
+
+void M_ResetSetupMenu(void)
+{
+  if (demo_version < 203)
+  {
+    SetupDef.numitems--;
+    SetupMenu[set_compat] = SetupMenu[set_key_bindings];
+    SetupMenu[set_key_bindings] = SetupMenu[set_weapons];
+    SetupMenu[set_weapons] = SetupMenu[set_statbar];
+    SetupMenu[set_statbar] = SetupMenu[set_automap];
+    SetupMenu[set_automap] = SetupMenu[set_enemy];
+    SetupMenu[set_enemy] = SetupMenu[set_messages];
+    SetupMenu[set_messages] = SetupMenu[set_chatstrings];
+  }
 }
 //
 // End of General Routines

--- a/Source/m_menu.h
+++ b/Source/m_menu.h
@@ -70,6 +70,8 @@ void M_Trans(void);          // killough 11/98: reset translucency
 
 void M_ResetMenu(void);      // killough 11/98: reset main menu ordering
 
+void M_ResetSetupMenu(void);
+
 void M_DrawBackground(char *patch, byte *screen);  // killough 11/98
 
 void M_DrawCredits(void);    // killough 11/98

--- a/Source/m_misc.c
+++ b/Source/m_misc.c
@@ -2220,6 +2220,7 @@ void M_LoadOptions(void)
 
   M_Trans();           // reset translucency in case of change
   M_ResetMenu();       // reset menu in case of change
+  M_ResetSetupMenu();
 }
 
 //


### PR DESCRIPTION
I think the "Doom Compatibility" menu only makes sense in `complevel mbf`. Otherwise, it's just confusing.