### PR TITLE
fix extended help for Doom 2, load help screen from PWAD

### DIFF
--- a/Source/m_menu.c
+++ b/Source/m_menu.c
@@ -525,7 +525,7 @@ void M_DrawReadThis2(void)
   if (gamemode == shareware)
     M_DrawCredits();
   else
-    V_DrawPatchDirect (0,0,0,W_CacheLumpName("CREDIT",PU_CACHE));
+    V_DrawPatchFullScreen (0,W_CacheLumpName("CREDIT",PU_CACHE));
 }
 
 /////////////////////////////
@@ -4029,8 +4029,8 @@ void M_InitExtendedHelp(void)
 	  {
 	    if (gamemode == commercial)
 	      {
-		ExtHelpDef.prevMenu  = &ReadDef1; // previous menu
-		ReadMenu1[0].routine = M_ExtHelp;
+		ExtHelpDef.prevMenu  = &HelpDef; // previous menu
+		HelpMenu[0].routine = M_ExtHelp;
 	      }
 	    else
 	      {
@@ -4063,7 +4063,7 @@ void M_DrawExtHelp(void)
   inhelpscreens = true;              // killough 5/1/98
   namebfr[4] = extended_help_index/10 + 0x30;
   namebfr[5] = extended_help_index%10 + 0x30;
-  V_DrawPatchDirect(0,0,0,W_CacheLumpName(namebfr,PU_CACHE));
+  V_DrawPatchFullScreen(0,W_CacheLumpName(namebfr,PU_CACHE));
 }
 
 //
@@ -4379,10 +4379,23 @@ int M_GetPixelWidth(char* ch)
 
 void M_DrawHelp (void)
 {
+  int helplump;
+  if (gamemode == commercial)
+    helplump = W_CheckNumForName("HELP");
+  else
+    helplump = W_CheckNumForName("HELP1");
+
   inhelpscreens = true;                        // killough 10/98
+  if (helplump < 0 || W_IsIWADLump(helplump))
+  {
   M_DrawBackground("FLOOR4_6", screens[0]);
   V_MarkRect (0,0,SCREENWIDTH,SCREENHEIGHT);
   M_DrawScreenItems(helpstrings);
+  }
+  else
+  {
+    V_DrawPatchFullScreen(0, W_CacheLumpNum(helplump, PU_CACHE));
+  }
 }
   
 //

--- a/Source/m_menu.c
+++ b/Source/m_menu.c
@@ -4027,8 +4027,8 @@ void M_InitExtendedHelp(void)
 	{
 	  if (extended_help_count)
 	  {
-		ExtHelpDef.prevMenu  = &HelpDef; // previous menu
-		HelpMenu[0].routine = M_ExtHelp;
+	    ExtHelpDef.prevMenu  = &HelpDef; // previous menu
+	    HelpMenu[0].routine = M_ExtHelp;
 
 	    if (gamemode != commercial)
 	      {

--- a/Source/m_menu.c
+++ b/Source/m_menu.c
@@ -4027,12 +4027,13 @@ void M_InitExtendedHelp(void)
 	{
 	  if (extended_help_count)
 	  {
+	    // Restore extended help functionality
+	    // for all game versions
 	    ExtHelpDef.prevMenu  = &HelpDef; // previous menu
 	    HelpMenu[0].routine = M_ExtHelp;
 
 	    if (gamemode != commercial)
 	      {
-		ExtHelpDef.prevMenu  = &ReadDef2; // previous menu
 		ReadMenu2[0].routine = M_ExtHelp;
 	      }
 	  }
@@ -4377,6 +4378,7 @@ int M_GetPixelWidth(char* ch)
 
 void M_DrawHelp (void)
 {
+  // Display help screen from PWAD
   int helplump;
   if (gamemode == commercial)
     helplump = W_CheckNumForName("HELP");

--- a/Source/m_menu.c
+++ b/Source/m_menu.c
@@ -4027,12 +4027,10 @@ void M_InitExtendedHelp(void)
 	{
 	  if (extended_help_count)
 	  {
-	    if (gamemode == commercial)
-	      {
 		ExtHelpDef.prevMenu  = &HelpDef; // previous menu
 		HelpMenu[0].routine = M_ExtHelp;
-	      }
-	    else
+
+	    if (gamemode != commercial)
 	      {
 		ExtHelpDef.prevMenu  = &ReadDef2; // previous menu
 		ReadMenu2[0].routine = M_ExtHelp;


### PR DESCRIPTION
Inspired by this thread [[doomworld]](https://www.doomworld.com/forum/topic/111465-boom-extended-help-screens-an-undocumented-feature/) (thanks, Redneckerz), I've fixed the extended help screens for Doom 2. Tested with sherlock.wad

Also, I think we should load help screen from PWADs, they are useful sometimes (e.g. DBP27.wad [[idgames]](https://www.doomworld.com/idgames/levels/doom2/Ports/d-f/dbp27))