### PR TITLE
fix e*m0 maps, draw INTERPIC for episodes >= 3

### DIFF
--- a/Source/d_main.c
+++ b/Source/d_main.c
@@ -1562,7 +1562,7 @@ static void D_ProcessDehInWad(int i)
                                                        ("dehacked") % (unsigned) numlumps].index);
 
 // [FG] fast-forward demo to the desired map
-int demowarp = 0;
+int demowarp = -1;
 
 //
 // D_DoomMain
@@ -1999,7 +1999,7 @@ void D_DoomMain(void)
 	}
 	else
 	  // [FG] no demo playback
-	  demowarp = 0;
+	  demowarp = -1;
 
   if (slot && ++slot < myargc)
     {

--- a/Source/g_game.c
+++ b/Source/g_game.c
@@ -3083,7 +3083,7 @@ void G_DeferedPlayDemo(char* name)
   gameaction = ga_playdemo;
 
   // [FG] fast-forward demo to the desired map
-  if (demowarp)
+  if (demowarp >= 0)
   {
     I_EnableWarp(true);
   }

--- a/Source/p_setup.c
+++ b/Source/p_setup.c
@@ -1403,7 +1403,7 @@ void P_SetupLevel(int episode, int map, int playermask, skill_t skill)
   if (demowarp == map)
   {
     I_EnableWarp(false);
-    demowarp = 0;
+    demowarp = -1;
   }
 
   // Make sure all sounds are stopped before Z_FreeTags.

--- a/Source/wi_stuff.c
+++ b/Source/wi_stuff.c
@@ -1924,7 +1924,7 @@ void WI_DrawBackground(void)
     strcpy(name, enterpic);
   else if (exitpic)
     strcpy(name, exitpic);
-  else if (gamemode == commercial || (gamemode == retail && wbs->epsd == 3))
+  else if (gamemode == commercial || (gamemode == retail && wbs->epsd >= 3))
     strcpy(name, "INTERPIC");
   else 
     sprintf(name, "WIMAP%d", wbs->epsd);

--- a/Source/wi_stuff.c
+++ b/Source/wi_stuff.c
@@ -1924,6 +1924,7 @@ void WI_DrawBackground(void)
     strcpy(name, enterpic);
   else if (exitpic)
     strcpy(name, exitpic);
+  // with UMAPINFO it is possible that wbs->epsd > 3
   else if (gamemode == commercial || (gamemode == retail && wbs->epsd >= 3))
     strcpy(name, "INTERPIC");
   else 


### PR DESCRIPTION
I made UMAPINFO file for DTWID-LE [[idgames]](https://www.doomworld.com/idgames/levels/doom/Ports/megawads/dtwid-le) and find a few bugs:
1. Due to `demowarp` code e*m0 maps don't work
2. `INTERPIC` is not displayed in episodes 5, 6

Test WAD: [DTWID-LE_um.zip](https://github.com/fabiangreffrath/woof/files/6493509/DTWID-LE_um.zip)
