### PR TITLE
umapinfo: fix parsing of the 'episode' field

### DIFF
--- a/Source/m_menu.c
+++ b/Source/m_menu.c
@@ -606,7 +606,7 @@ void M_AddEpisode(const char *map, const char *gfx, const char *txt, const char 
     EpiMenuMap[EpiDef.numitems] = mapnum;
     strncpy(EpisodeMenu[EpiDef.numitems].name, gfx, 8);
     EpisodeMenu[EpiDef.numitems].name[9] = 0;
-    EpisodeMenu[EpiDef.numitems].alttext = strdup(txt);
+    EpisodeMenu[EpiDef.numitems].alttext = txt ? strdup(txt) : NULL;
     EpisodeMenu[EpiDef.numitems].alphaKey = alpha ? *alpha : 0;
     EpiDef.numitems++;
   }

--- a/Source/m_menu.c
+++ b/Source/m_menu.c
@@ -581,7 +581,7 @@ short EpiMenuMap[8] = { 1, 1, 1, 1, -1, -1, -1, -1 }, EpiMenuEpi[8] = { 1, 2, 3,
 //
 int epiChoice;
 
-void M_AddEpisode(const char *map, char *def)
+void M_AddEpisode(const char *map, const char *gfx, const char *txt, const char *alpha)
 {
   if (!EpiCustom)
   {
@@ -592,16 +592,13 @@ void M_AddEpisode(const char *map, char *def)
           EpiDef.numitems = 0;
   }
 
-  if (*def == '-')	// means 'clear'
+  if (gfx[0] && gfx[0] == '-')	// means 'clear'
   {
     EpiDef.numitems = 0;
   }
   else
   {
     int epi, mapnum;
-    const char *gfx = strtok(def, "\n");
-    char *txt = strtok(NULL, "\n");
-    const char *alpha = strtok(NULL, "\n");
     if (EpiDef.numitems >= 8)
       return;
     G_ValidateMapName(map, &epi, &mapnum);
@@ -609,7 +606,7 @@ void M_AddEpisode(const char *map, char *def)
     EpiMenuMap[EpiDef.numitems] = mapnum;
     strncpy(EpisodeMenu[EpiDef.numitems].name, gfx, 8);
     EpisodeMenu[EpiDef.numitems].name[9] = 0;
-    EpisodeMenu[EpiDef.numitems].alttext = txt;
+    EpisodeMenu[EpiDef.numitems].alttext = strdup(txt);
     EpisodeMenu[EpiDef.numitems].alphaKey = alpha ? *alpha : 0;
     EpiDef.numitems++;
   }

--- a/Source/m_menu.c
+++ b/Source/m_menu.c
@@ -581,6 +581,11 @@ short EpiMenuMap[8] = { 1, 1, 1, 1, -1, -1, -1, -1 }, EpiMenuEpi[8] = { 1, 2, 3,
 //
 int epiChoice;
 
+void M_ClearEpisodes(void)
+{
+  EpiDef.numitems = 0;
+}
+
 void M_AddEpisode(const char *map, const char *gfx, const char *txt, const char *alpha)
 {
   if (!EpiCustom)
@@ -592,11 +597,6 @@ void M_AddEpisode(const char *map, const char *gfx, const char *txt, const char 
           EpiDef.numitems = 0;
   }
 
-  if (gfx[0] && gfx[0] == '-')	// means 'clear'
-  {
-    EpiDef.numitems = 0;
-  }
-  else
   {
     int epi, mapnum;
     if (EpiDef.numitems >= 8)

--- a/Source/u_mapinfo.c
+++ b/Source/u_mapinfo.c
@@ -423,12 +423,16 @@ static int ParseStandardProperty(u_scanner_t* s, mapentry_t *mape)
       char *key = NULL;
 
       ParseLumpName(s, lumpname);
-      U_MustGetToken(s, ',');
-      if (U_MustGetToken(s, TK_StringConst))
-        alttext = strdup(s->string);
-      U_MustGetToken(s, ',');
-      if (U_MustGetToken(s, TK_StringConst))
-        key = strdup(s->string);
+      if (U_CheckToken(s, ','))
+      {
+        if (U_MustGetToken(s, TK_StringConst))
+          alttext = strdup(s->string);
+        if (U_CheckToken(s, ','))
+        {
+          if (U_MustGetToken(s, TK_StringConst))
+            key = strdup(s->string);
+        }
+      }
 
       M_AddEpisode(mape->mapname, lumpname, alttext, key);
 

--- a/Source/u_mapinfo.c
+++ b/Source/u_mapinfo.c
@@ -34,6 +34,7 @@
 #include "u_mapinfo.h"
 
 void M_AddEpisode(const char *map, const char *gfx, const char *txt, const char *alpha);
+void M_ClearEpisodes(void);
 
 umapinfo_t U_mapinfo;
 
@@ -408,18 +409,19 @@ static int ParseStandardProperty(u_scanner_t* s, mapentry_t *mape)
   }
   else if (!strcasecmp(pname, "episode"))
   {
-    char lumpname[9] = {0};
-    char *alttext = NULL;
-    char *key = NULL;
     if (U_CheckToken(s, TK_Identifier))
     {
       if (!strcasecmp(s->string, "clear"))
-        lumpname[0] = '-';
+        M_ClearEpisodes();
       else
         U_Error(s, "Either 'clear' or string constant expected");
     }
     else
     {
+      char lumpname[9] = {0};
+      char *alttext = NULL;
+      char *key = NULL;
+
       ParseLumpName(s, lumpname);
       U_MustGetToken(s, ',');
       if (U_MustGetToken(s, TK_StringConst))
@@ -427,12 +429,12 @@ static int ParseStandardProperty(u_scanner_t* s, mapentry_t *mape)
       U_MustGetToken(s, ',');
       if (U_MustGetToken(s, TK_StringConst))
         key = strdup(s->string);
+
+      M_AddEpisode(mape->mapname, lumpname, alttext, key);
+
+      if (alttext) free(alttext);
+      if (key) free(key);
     }
-
-    M_AddEpisode(mape->mapname, lumpname, alttext, key);
-
-    if (alttext) free(alttext);
-    if (key) free(key);
   }
   else if (!strcasecmp(pname, "next"))
   {

--- a/Source/u_mapinfo.c
+++ b/Source/u_mapinfo.c
@@ -33,7 +33,7 @@
 
 #include "u_mapinfo.h"
 
-void M_AddEpisode(const char *map, char *def);
+void M_AddEpisode(const char *map, const char *gfx, const char *txt, const char *alpha);
 
 umapinfo_t U_mapinfo;
 
@@ -408,9 +408,31 @@ static int ParseStandardProperty(u_scanner_t* s, mapentry_t *mape)
   }
   else if (!strcasecmp(pname, "episode"))
   {
-    char *lname = ParseMultiString(s, 1);
-    if (lname)
-      M_AddEpisode(mape->mapname, lname);
+    char lumpname[9] = {0};
+    char *alttext = NULL;
+    char *key = NULL;
+    if (U_CheckToken(s, TK_Identifier))
+    {
+      if (!strcasecmp(s->string, "clear"))
+        lumpname[0] = '-';
+      else
+        U_Error(s, "Either 'clear' or string constant expected");
+    }
+    else
+    {
+      ParseLumpName(s, lumpname);
+      U_MustGetToken(s, ',');
+      if (U_MustGetToken(s, TK_StringConst))
+        alttext = strdup(s->string);
+      U_MustGetToken(s, ',');
+      if (U_MustGetToken(s, TK_StringConst))
+        key = strdup(s->string);
+    }
+
+    M_AddEpisode(mape->mapname, lumpname, alttext, key);
+
+    if (alttext) free(alttext);
+    if (key) free(key);
   }
   else if (!strcasecmp(pname, "next"))
   {


### PR DESCRIPTION
The previous code broke on this: `episode = "", "Test", "1"` .