### PR TITLE
remove PATH_MAX, more Unicode compatibility on Windows

### DIFF
--- a/Source/d_io.h
+++ b/Source/d_io.h
@@ -37,9 +37,6 @@
   #define S_ISDIR(x) (((sbuf.st_mode & S_IFDIR)==S_IFDIR)?1:0)
   #define strcasecmp _stricmp
   #define strncasecmp _strnicmp
-  #ifndef PATH_MAX
-     #define PATH_MAX _MAX_PATH
-  #endif
 #elif !defined (_WIN32)
   #include <unistd.h>
   #include <ctype.h> // tolower()

--- a/Source/d_main.c
+++ b/Source/d_main.c
@@ -964,13 +964,12 @@ void IdentifyVersion (void)
 
   // get config file from same directory as executable
   // killough 10/98
-  //sprintf(basedefault,"%s/%s.cfg", D_DoomPrefDir(), D_DoomExeName());
   if (basedefault) (free)(basedefault);
   basedefault = M_StringJoin(D_DoomPrefDir(), DIR_SEPARATOR_S, D_DoomExeName(), ".cfg", NULL);
 
   // set save path to -save parm or current dir
 
-  basesavegame = M_StringDuplicate(D_DoomPrefDir());
+  basesavegame = M_StringDuplicate(D_DoomPrefDir());       //jff 3/27/98 default to current dir
   if ((i=M_CheckParm("-save")) && i<myargc-1) //jff 3/24/98 if -save present
     {
       if (!stat(myargv[i+1],&sbuf) && S_ISDIR(sbuf.st_mode)) // and is a dir

--- a/Source/d_main.c
+++ b/Source/d_main.c
@@ -128,7 +128,7 @@ FILE    *debugfile;
 
 boolean advancedemo;
 
-char    *basedefault = NULL;//[PATH_MAX+1];   // default file
+char    *basedefault = NULL;   // default file
 char    *basesavegame = NULL;  // killough 2/16/98: savegame directory
 
 //jff 4/19/98 list of standard IWAD names
@@ -1400,7 +1400,7 @@ static void D_ProcessDehCommandLine(void)
         else
           if (deh)
             {
-              char file[PATH_MAX+1];      // killough
+              char *file = (malloc)(strlen(myargv[p]) + 5);      // killough
               AddDefaultExtension(strcpy(file, myargv[p]), ".bex");
               if (access(file, F_OK))  // nope
                 {
@@ -1412,6 +1412,7 @@ static void D_ProcessDehCommandLine(void)
               // during the beta we have debug output to dehout.txt
               // (apparently, this was never removed after Boom beta-killough)
               ProcessDehFile(file, D_dehout(), 0);  // killough 10/98
+              (free)(file);
             }
     }
   // ty 03/09/98 end of do dehacked stuff
@@ -1486,12 +1487,13 @@ static void D_ProcessWadPreincludes(void)
               s++;
             if (*s)
               {
-                char file[PATH_MAX+1];
+                char *file = (malloc)(strlen(s) + 5);
                 AddDefaultExtension(strcpy(file, s), ".wad");
                 if (!access(file, R_OK))
                   D_AddFile(file);
                 else
                   printf("\nWarning: could not open %s\n", file);
+                (free)(file);
               }
           }
     }
@@ -1566,7 +1568,7 @@ static void D_ProcessDehPreincludes(void)
               s++;
             if (*s)
               {
-                char file[PATH_MAX+1];
+                char *file = (malloc)(strlen(s) + 5);
                 AddDefaultExtension(strcpy(file, s), ".bex");
                 if (!access(file, R_OK))
                   ProcessDehFile(file, D_dehout(), 0);
@@ -1578,6 +1580,7 @@ static void D_ProcessDehPreincludes(void)
                     else
                       printf("\nWarning: could not open %s .deh or .bex\n", s);
                   }
+                (free)(file);
               }
           }
     }

--- a/Source/d_main.c
+++ b/Source/d_main.c
@@ -128,10 +128,7 @@ FILE    *debugfile;
 
 boolean advancedemo;
 
-//char    wadfile[PATH_MAX+1];       // primary wad file
-//char    mapdir[PATH_MAX+1];        // directory of development maps
 char    *basedefault = NULL;//[PATH_MAX+1];   // default file
-//char    baseiwad[PATH_MAX+1];      // jff 3/23/98: iwad directory
 char    *basesavegame = NULL;  // killough 2/16/98: savegame directory
 
 //jff 4/19/98 list of standard IWAD names
@@ -831,7 +828,7 @@ char *FindIWADFile(void)
   int i,j;
   char *p;
 
-  int lbuf = 1024;
+  int lbuf = 512;
   int lcustomiwad = 0;
 
   //jff 3/24/98 get -iwad parm if specified else use .
@@ -1849,12 +1846,12 @@ void D_DoomMain(void)
 
   if (p && p < myargc-1)
     {
-      char *file = malloc(strlen(myargv[p+1]) + 5);
+      char *file = (malloc)(strlen(myargv[p+1]) + 5);
       strcpy(file,myargv[p+1]);
       AddDefaultExtension(file,".lmp");     // killough
       D_AddFile(file);
       printf("Playing demo %s\n",file);
-      free(file);
+      (free)(file);
     }
 
   // get skill / episode / map from parms

--- a/Source/d_main.h
+++ b/Source/d_main.h
@@ -39,7 +39,7 @@ void D_AddFile(const char *file);
 
 char *D_DoomExeDir(void);       // killough 2/16/98: path to executable's dir
 char *D_DoomExeName(void);      // killough 10/98: executable's name
-extern char basesavegame[];     // killough 2/16/98: savegame path
+extern char *basesavegame;     // killough 2/16/98: savegame path
 char *D_DoomPrefDir(void);      // [FG] default configuration dir
 
 //jff 1/24/98 make command line copies of play modes available

--- a/Source/doomstat.h
+++ b/Source/doomstat.h
@@ -276,7 +276,7 @@ extern wbstartstruct_t wminfo;
 //
 
 // File handling stuff.
-extern  char    basedefault[];
+extern  char   *basedefault;
 extern  FILE   *debugfile;
 
 // if true, load all graphics at level load

--- a/Source/g_game.c
+++ b/Source/g_game.c
@@ -1532,7 +1532,7 @@ ULong64 G_Signature(void)
 
 static void G_DoSaveGame(void)
 {
-  char *name;//[PATH_MAX+1];
+  char *name = NULL;
   char name2[VERSIONSIZE];
   char *description;
   int  length, i;
@@ -1640,7 +1640,7 @@ static void G_DoSaveGame(void)
   gameaction = ga_nothing;
   savedescription[0] = 0;
 
-  (free)(name);
+  if (name) (free)(name);
 }
 
 static void G_DoLoadGame(void)

--- a/Source/g_game.c
+++ b/Source/g_game.c
@@ -1496,13 +1496,6 @@ char* G_SaveGameName(int slot)
     return M_StringJoin(basesavegame, DIR_SEPARATOR_S, buf, NULL);
 }
 
-char* G_MBFSaveGameName(int slot)
-{
-   char buf[16] = {0};
-   sprintf(buf, "MBFSAV%d.dsg", slot);
-   return M_StringJoin(basesavegame, DIR_SEPARATOR_S, buf, NULL);
-}
-
 // killough 12/98:
 // This function returns a signature for the current wad.
 // It is used to distinguish between wads, for the purposes

--- a/Source/g_game.c
+++ b/Source/g_game.c
@@ -67,7 +67,7 @@
 #define SAVESTRINGSIZE  24
 
 static size_t   savegamesize = SAVEGAMESIZE; // killough
-static char     demoname[PATH_MAX];
+static char     *demoname = NULL;
 static boolean  netdemo;
 static byte     *demobuffer;   // made some static -- killough
 static size_t   maxdemosize;
@@ -1413,7 +1413,7 @@ static void G_DoPlayDemo(void)
 // killough 2/22/98: version id string format for savegames
 #define VERSIONID "MBF %d"
 
-static char savename[PATH_MAX+1];
+static char *savename = NULL;
 
 //
 // killough 5/15/98: add forced loadgames, which allow user to override checks
@@ -1433,7 +1433,8 @@ void G_ForcedLoadGame(void)
 
 void G_LoadGame(char *name, int slot, boolean command)
 {
-  strcpy(savename, name);
+  if (savename) (free)(savename);
+  savename = M_StringDuplicate(name);
   savegameslot = slot;
   gameaction = ga_loadgame;
   forced_loadgame = false;
@@ -2672,6 +2673,8 @@ void G_RecordDemo(char *name)
   demo_insurance = mbf21 ? 0 : (default_demo_insurance!=0);     // killough 12/98
       
   usergame = false;
+  if (demoname) (free)(demoname);
+  demoname = (malloc)(strlen(name) + 5);
   AddDefaultExtension(strcpy(demoname, name), ".lmp");  // 1/18/98 killough
   i = M_CheckParm ("-maxdemo");
   if (i && i<myargc-1)

--- a/Source/g_game.c
+++ b/Source/g_game.c
@@ -1480,17 +1480,26 @@ void CheckSaveGame(size_t size)
 // killough 3/22/98: form savegame name in one location
 // (previously code was scattered around in multiple places)
 
-void G_SaveGameName(char *name, int slot)
+char* G_SaveGameName(int slot)
 {
   // Ty 05/04/98 - use savegamename variable (see d_deh.c)
   // killough 12/98: add .7 to truncate savegamename
+  char buf[16] = {0};
+  sprintf(buf, "%.7s%d.dsg", savegamename, slot);
 
 #ifdef _WIN32
   if (M_CheckParm("-cdrom"))
-    sprintf(name, "c:/doomdata/%.7s%d.dsg", savegamename, slot);
+    return M_StringJoin("c:\\doomdata\\", buf, NULL);
   else
 #endif
-    sprintf(name, "%s/%.7s%d.dsg", basesavegame, savegamename, slot);
+    return M_StringJoin(basesavegame, DIR_SEPARATOR_S, buf, NULL);
+}
+
+char* G_MBFSaveGameName(int slot)
+{
+   char buf[16] = {0};
+   sprintf(buf, "MBFSAV%d.dsg", slot);
+   return M_StringJoin(basesavegame, DIR_SEPARATOR_S, buf, NULL);
 }
 
 // killough 12/98:
@@ -1523,12 +1532,12 @@ ULong64 G_Signature(void)
 
 static void G_DoSaveGame(void)
 {
-  char name[PATH_MAX+1];
+  char *name;//[PATH_MAX+1];
   char name2[VERSIONSIZE];
   char *description;
   int  length, i;
 
-  G_SaveGameName(name,savegameslot);
+  name = G_SaveGameName(savegameslot);
 
   description = savedescription;
 
@@ -1630,6 +1639,8 @@ static void G_DoSaveGame(void)
 
   gameaction = ga_nothing;
   savedescription[0] = 0;
+
+  (free)(name);
 }
 
 static void G_DoLoadGame(void)

--- a/Source/g_game.h
+++ b/Source/g_game.h
@@ -57,7 +57,7 @@ void G_WorldDone(void);
 void G_Ticker(void);
 void G_ScreenShot(void);
 void G_ReloadDefaults(void);     // killough 3/1/98: loads game defaults
-void G_SaveGameName(char *,int); // killough 3/22/98: sets savegame filename
+char* G_SaveGameName(int); // killough 3/22/98: sets savegame filename
 void G_SetFastParms(int);        // killough 4/10/98: sets -fast parameters
 void G_DoNewGame(void);
 void G_DoReborn(int playernum);

--- a/Source/m_menu.c
+++ b/Source/m_menu.c
@@ -53,6 +53,7 @@
 #include "m_misc2.h" // [FG] M_StringDuplicate()
 #include "p_setup.h" // [FG] maplumpnum
 #include "w_wad.h" // [FG] W_IsIWADLump() / W_WadNameForLump()
+#include "p_saveg.h" // saveg_compat
 
 #ifdef _WIN32
 #include "../win32/win_fopen.h"
@@ -805,12 +806,12 @@ static void M_DrawDelVerify(void);
 
 static void M_DeleteGame(int i)
 {
-  char name[PATH_MAX+1];
-
-  G_SaveGameName(name, i);
+  char *name = G_SaveGameName(i);
   remove(name);
 
   M_ReadSaveStrings();
+
+  if (name) (free)(name);
 }
 
 //
@@ -858,13 +859,14 @@ void M_DrawSaveLoadBorder(int x,int y)
 
 void M_LoadSelect(int choice)
 {
-  char name[PATH_MAX+1];     // killough 3/22/98
+  char *name = NULL;     // killough 3/22/98
 
-  G_SaveGameName(name,choice);
+  name = G_SaveGameName(choice);
 
   G_LoadGame(name, choice, false); // killough 3/16/98, 5/15/98: add slot, cmd
 
   M_ClearMenus ();
+  if (name) (free)(name);
 }
 
 //
@@ -952,11 +954,12 @@ void M_ReadSaveStrings(void)
 
   for (i = 0 ; i < load_end ; i++)
     {
-      char name[PATH_MAX+1];    // killough 3/22/98
       FILE *fp;  // killough 11/98: change to use stdio
 
-      G_SaveGameName(name,i);    // killough 3/22/98
+      char *name = G_SaveGameName(i);    // killough 3/22/98
       fp = fopen(name,"rb");
+      if (name) (free)(name);
+
       if (!fp)
 	{   // Ty 03/27/98 - externalized:
 	  strcpy(&savegamestrings[i][0],s_EMPTYSTRING);

--- a/Source/m_misc.c
+++ b/Source/m_misc.c
@@ -43,6 +43,7 @@
 #include "st_stuff.h"
 #include "dstrings.h"
 #include "m_misc.h"
+#include "m_misc2.h"
 #include "s_sound.h"
 #include "sounds.h"
 #include "d_main.h"
@@ -1985,7 +1986,7 @@ default_t *M_LookupDefault(const char *name)
 
 void M_SaveDefaults (void)
 {
-  char tmpfile[PATH_MAX+1];
+  char *tmpfile;
   register default_t *dp;
   int line, blanks;
   FILE *f;
@@ -1994,7 +1995,7 @@ void M_SaveDefaults (void)
   if (!defaults_loaded || !defaultfile)
     return;
 
-  sprintf(tmpfile, "%s/tmp%.5s.cfg", D_DoomPrefDir(), D_DoomExeName());
+  tmpfile = M_StringJoin(D_DoomPrefDir(), DIR_SEPARATOR_S, "tmp", D_DoomExeName(), ".cfg", NULL);
   NormalizeSlashes(tmpfile);
 
   errno = 0;
@@ -2094,6 +2095,8 @@ void M_SaveDefaults (void)
   if (rename(tmpfile, defaultfile))
     I_Error("Could not write defaults to %s: %s\n", defaultfile,
 	    errno ? strerror(errno): "(Unknown Error)");
+
+  (free)(tmpfile);
 }
 
 //
@@ -2647,7 +2650,7 @@ void M_ScreenShot (void)
   if (!access(".",2))
     {
       static int shot;
-      char lbmname[PATH_MAX+1];
+      char lbmname[16] = {0};
       int tries = 10000;
 
       do

--- a/Source/r_data.c
+++ b/Source/r_data.c
@@ -847,13 +847,14 @@ void R_InitTranMap(int progress)
   else
     {   // Compose a default transparent filter map based on PLAYPAL.
       unsigned char *playpal = W_CacheLumpName("PLAYPAL", PU_STATIC);
-      char fname[PATH_MAX+1], *D_DoomPrefDir(void);
+      extern char *D_DoomPrefDir(void);
+      extern char *M_StringJoin(const char *s, ...);
+      char *fname = M_StringJoin(D_DoomPrefDir(), DIR_SEPARATOR_S, "tranmap.dat", NULL);
       struct {
         unsigned char pct;
         unsigned char playpal[256*3]; // [FG] a palette has 256 colors saved as byte triples
       } cache;
-      FILE *cachefp = fopen(strcat(strcpy(fname, D_DoomPrefDir()),
-                                   "/tranmap.dat"),"r+b");
+      FILE *cachefp = fopen(fname,"r+b");
 
       main_tranmap = Z_Malloc(256*256, PU_STATIC, 0);  // killough 4/11/98
 
@@ -945,6 +946,7 @@ void R_InitTranMap(int progress)
 	fclose(cachefp);
 
       Z_ChangeTag(playpal, PU_CACHE);
+      (free)(fname);
     }
 }
 

--- a/Source/w_wad.c
+++ b/Source/w_wad.c
@@ -538,7 +538,7 @@ void *W_CacheLumpNum(int lump, int tag)
 void WritePredefinedLumpWad(const char *filename)
 {
    FILE *file;
-   char fn[PATH_MAX + 1];  // we may have to add ".wad" to the name they pass
+   char *fn = (malloc)(strlen(filename) + 5);  // we may have to add ".wad" to the name they pass
    
    if(!filename || !*filename)  // check for null pointer or empty name
       return;  // early return
@@ -581,6 +581,7 @@ void WritePredefinedLumpWad(const char *filename)
       I_Error("Predefined lumps wad, %s written, exiting\n", filename);
    }
    I_Error("Cannot open predefined lumps wad %s for output\n", filename);
+   (free)(fn);
 }
 
 // [FG] name of the WAD file that contains the lump

--- a/win32/win_fopen.c
+++ b/win32/win_fopen.c
@@ -66,6 +66,22 @@ int D_remove(const char *path)
   return ret;
 }
 
+int D_rename(const char *oldname, const char *newname)
+{
+  wchar_t *wold = NULL;
+  wchar_t *wnew = NULL;
+  int ret;
+
+  wold = ConvertToUtf8(oldname);
+  wnew = ConvertToUtf8(newname);
+
+  ret = _wrename(wold, wnew);
+
+  if (wold) free(wold);
+  if (wnew) free(wnew);
+  return ret;
+}
+
 int D_stat(const char *path, struct stat *buf)
 {
   wchar_t *wpath = NULL;

--- a/win32/win_fopen.c
+++ b/win32/win_fopen.c
@@ -65,4 +65,47 @@ int D_remove(const char *path)
   if (wpath) free(wpath);
   return ret;
 }
+
+int D_stat(const char *path, struct stat *buf)
+{
+  wchar_t *wpath = NULL;
+  struct _stat wbuf;
+  int ret;
+
+  wpath = ConvertToUtf8(path);
+
+  ret = _wstat(wpath, &wbuf);
+
+  buf->st_mode = wbuf.st_mode;
+
+  if (wpath) free(wpath);
+  return ret;
+}
+
+int D_open(const char *filename, int oflag)
+{
+  wchar_t *wname;
+  int ret;
+
+  wname = ConvertToUtf8(filename);
+
+  ret = _wopen(wname, oflag);
+
+  if (wname) free(wname);
+  return ret;
+}
+
+int D_access(const char *path, int mode)
+{
+  wchar_t *wpath;
+  int ret;
+
+  wpath = ConvertToUtf8(path);
+
+  ret = _waccess(wpath, mode);
+
+  if (wpath) free(wpath);
+  return ret;
+}
+
 #endif

--- a/win32/win_fopen.c
+++ b/win32/win_fopen.c
@@ -23,7 +23,7 @@
 #include <windows.h>
 #include <stdlib.h>
 
-wchar_t* ConvertToUtf8(const char *str)
+static wchar_t* ConvertToUtf8(const char *str)
 {
   wchar_t *wstr = NULL;
   int wlen = 0;
@@ -121,6 +121,19 @@ int D_access(const char *path, int mode)
   ret = _waccess(wpath, mode);
 
   if (wpath) free(wpath);
+  return ret;
+}
+
+int D_mkdir(const char *dirname)
+{
+  wchar_t *wdir;
+  int ret;
+
+  wdir = ConvertToUtf8(dirname);
+
+  ret = _wmkdir(wdir);
+
+  if (wdir) free(wdir);
   return ret;
 }
 

--- a/win32/win_fopen.c
+++ b/win32/win_fopen.c
@@ -21,48 +21,48 @@
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include <stdlib.h>
+
+wchar_t* ConvertToUtf8(const char *str)
+{
+  wchar_t *wstr = NULL;
+  int wlen = 0;
+
+  wlen = MultiByteToWideChar(CP_UTF8, 0, str, -1, NULL, 0);
+
+  wstr = (wchar_t *) malloc(sizeof(wchar_t) * wlen);
+
+  MultiByteToWideChar(CP_UTF8, 0, str, -1, wstr, wlen);
+
+  return wstr;
+}
 
 FILE* D_fopen(const char *filename, const char *mode)
 {
-  wchar_t wpath[MAX_PATH];
-  wchar_t wmode[MAX_PATH];
-  int fn_len = strlen(filename);
-  int m_len  = strlen(mode);
-  int w_fn_len = 0;
-  int w_m_len = 0;
+  FILE *f;
+  wchar_t *wname = NULL;
+  wchar_t *wmode = NULL;
 
-  if (fn_len == 0) 
-    return NULL;
-  if (m_len == 0)
-    return NULL;
+  wname = ConvertToUtf8(filename);
+  wmode = ConvertToUtf8(mode);
 
-  w_fn_len = MultiByteToWideChar(CP_UTF8, 0, filename, fn_len, wpath, fn_len);
-  if (w_fn_len >= MAX_PATH)
-    return NULL;
-  wpath[w_fn_len] = L'\0';
+  f = _wfopen(wname, wmode);
 
-  w_m_len = MultiByteToWideChar(CP_UTF8, 0, mode, m_len, wmode, m_len);
-  if(w_m_len >= MAX_PATH)
-    return NULL;
-  wmode[w_m_len] = L'\0';
-
-  return _wfopen(wpath, wmode);
+  if (wname) free(wname);
+  if (wmode) free(wmode);
+  return f;
 }
 
 int D_remove(const char *path)
 {
-  wchar_t wpath[MAX_PATH];
-  int len = strlen(path);
-  int wlen = 0;
+  wchar_t *wpath = NULL;
+  int ret;
 
-  if (len == 0)
-    return -1;
+  wpath = ConvertToUtf8(path);
 
-  wlen = MultiByteToWideChar(CP_UTF8, 0, path, len, wpath, len);
-  if (wlen >= MAX_PATH)
-    return -1;
-  wpath[wlen] = L'\0';
+  ret = _wremove(wpath);
 
-  return _wremove(wpath);
+  if (wpath) free(wpath);
+  return ret;
 }
 #endif

--- a/win32/win_fopen.h
+++ b/win32/win_fopen.h
@@ -21,15 +21,29 @@
 
 #ifdef _WIN32
 #include <stdio.h>
+#include <io.h>
+#include <sys/stat.h>
 
 FILE* D_fopen(const char *filename, const char *mode);
 int D_remove(const char *path);
+int D_stat(const char *path, struct stat *buffer);
+int D_open(const char *filename, int oflag);
+int D_access(const char *path, int mode);
 
 #undef  fopen
 #define fopen(n, m) D_fopen(n, m)
 
 #undef  remove
 #define remove(p) D_remove(p)
+
+#undef  stat
+#define stat(p, b) D_stat(p, b)
+
+#undef  open
+#define open(n, of) D_open(n, of)
+
+#undef  access
+#define _access(p, m) D_access(p, m)
 #endif
 
 #endif

--- a/win32/win_fopen.h
+++ b/win32/win_fopen.h
@@ -47,7 +47,7 @@ int D_access(const char *path, int mode);
 #define open(n, of) D_open(n, of)
 
 #undef  access
-#define _access(p, m) D_access(p, m)
+#define access(p, m) D_access(p, m)
 #endif
 
 #endif

--- a/win32/win_fopen.h
+++ b/win32/win_fopen.h
@@ -26,6 +26,7 @@
 
 FILE* D_fopen(const char *filename, const char *mode);
 int D_remove(const char *path);
+int D_rename(const char *oldname, const char *newname);
 int D_stat(const char *path, struct stat *buffer);
 int D_open(const char *filename, int oflag);
 int D_access(const char *path, int mode);
@@ -35,6 +36,9 @@ int D_access(const char *path, int mode);
 
 #undef  remove
 #define remove(p) D_remove(p)
+
+#undef  rename
+#define rename(o, n) D_rename(o, n)
 
 #undef  stat
 #define stat(p, b) D_stat(p, b)

--- a/win32/win_fopen.h
+++ b/win32/win_fopen.h
@@ -23,6 +23,7 @@
 #include <stdio.h>
 #include <io.h>
 #include <sys/stat.h>
+#include <direct.h>
 
 FILE* D_fopen(const char *filename, const char *mode);
 int D_remove(const char *path);
@@ -30,6 +31,7 @@ int D_rename(const char *oldname, const char *newname);
 int D_stat(const char *path, struct stat *buffer);
 int D_open(const char *filename, int oflag);
 int D_access(const char *path, int mode);
+int D_mkdir(const char *dirname);
 
 #undef  fopen
 #define fopen(n, m) D_fopen(n, m)
@@ -48,6 +50,9 @@ int D_access(const char *path, int mode);
 
 #undef  access
 #define access(p, m) D_access(p, m)
+
+#undef  mkdir
+#define mkdir(d) D_mkdir(d)
 #endif
 
 #endif


### PR DESCRIPTION
`PATH_MAX == 260` is on Windows for compatibility reasons, many paths are much longer on modern systems. Also, add missed functions for Unicode support.