### PR TITLE
add centermessage field to player_t

### DIFF
--- a/Source/d_player.h
+++ b/Source/d_player.h
@@ -175,6 +175,9 @@ typedef struct player_s
   //      Used to interpolate between camera positions.
   angle_t		oldviewz;
 
+  // [Woof!] show centered "A secret is revealed!" message
+  char*               centermessage;
+
 } player_t;
 
 

--- a/Source/hu_stuff.c
+++ b/Source/hu_stuff.c
@@ -1344,13 +1344,13 @@ void HU_Ticker(void)
   if (showMessages || message_dontfuckwithme)
   {
     // [Woof!] "A secret is revealed!" message
-    if (plr->message == s_HUSTR_SECRETFOUND)
+    if (plr->centermessage)
     {
       extern int M_StringWidth(const char *string);
-      w_secret.l[0].x = ORIGWIDTH/2 - M_StringWidth(plr->message)/2;
+      w_secret.l[0].x = ORIGWIDTH/2 - M_StringWidth(plr->centermessage)/2;
 
-      HUlib_addMessageToSText(&w_secret, 0, plr->message);
-      plr->message = NULL;
+      HUlib_addMessageToSText(&w_secret, 0, plr->centermessage);
+      plr->centermessage = NULL;
       secret_on = true;
       secret_counter = 5*TICRATE/2; // [crispy] 2.5 seconds
     }

--- a/Source/p_mobj.c
+++ b/Source/p_mobj.c
@@ -1019,6 +1019,7 @@ void P_SpawnPlayer (mapthing_t* mthing)
   p->playerstate   = PST_LIVE;
   p->refire        = 0;
   p->message       = NULL;
+  p->centermessage = NULL;
   p->damagecount   = 0;
   p->bonuscount    = 0;
   p->extralight    = 0;

--- a/Source/p_saveg.c
+++ b/Source/p_saveg.c
@@ -874,6 +874,9 @@ static void saveg_read_player_t(player_t *str)
         saveg_read_pspdef_t(&str->psprites[i]);
     }
 
+    // [Woof!] char* centermessage;
+    str->centermessage = NULL;
+
     // boolean didsecret;
     str->didsecret = saveg_read32();
 

--- a/Source/p_spec.c
+++ b/Source/p_spec.c
@@ -2093,11 +2093,14 @@ void P_PlayerInSpecialSector (player_t *player)
 
           if (showMessages && hud_secret_message && player == &players[consoleplayer])
           {
-            int sfx_id;
-            player->message = s_HUSTR_SECRETFOUND;
+            static int sfx_id = -1;
+            player->centermessage = s_HUSTR_SECRETFOUND;
 
+            if (sfx_id == -1)
+            {
             sfx_id = I_GetSfxLumpNum(&S_sfx[sfx_secret]) != -1 ? sfx_secret :
                I_GetSfxLumpNum(&S_sfx[sfx_itmbk]) != -1 ? sfx_itmbk : -1;
+            }
 
             if (sfx_id != -1)
                 S_StartSound(NULL, sfx_id);


### PR DESCRIPTION
I think sometimes the  "A Secret Revealed" message gets overridden with the pickup message. We now have backwards compatible saves and can safely add a new field to player_t.