### PR TITLE
change config defaults, fix savegame header

### DIFF
--- a/Source/d_net.c
+++ b/Source/d_net.c
@@ -506,7 +506,10 @@ void D_ArbitrateNetStart (void)
 	// killough 11/98: NOTE: this code produces no inconsistency errors.
 	// However, TeamTNT's code =does= produce inconsistencies. Go figur.
 
-        G_ReadOptions((byte *) netbuffer->cmds);
+        if (mbf21)
+          G_ReadOptionsMBF21((byte *) netbuffer->cmds);
+        else
+          G_ReadOptions((byte *) netbuffer->cmds);
 
 	// killough 12/98: removed obsolete compatibility flag and
 	// removed printf()'s, since there are too many options to

--- a/Source/g_game.c
+++ b/Source/g_game.c
@@ -2369,8 +2369,10 @@ static int G_GetDefaultComplevel()
       return 109;
     case 1:
       return 202;
-    default:
+    case 2:
       return MBFVERSION;
+    default:
+      return MBF21VERSION;
   }
 }
 
@@ -2497,8 +2499,6 @@ void G_ReloadDefaults(void)
     demo_insurance = 0;
     classic_bfg = 0;
     beta_emulation = 0;
-
-    comp[comp_pursuit] = 1;
   }
 }
 

--- a/Source/g_game.c
+++ b/Source/g_game.c
@@ -1688,7 +1688,7 @@ static void G_DoLoadGame(void)
 
   save_p += VERSIONSIZE;
 
-  if (saveg_compat == saveg_current)
+  if (saveg_compat > saveg_woof510)
   {
     saveg_complevel = *save_p++;
   }

--- a/Source/g_game.c
+++ b/Source/g_game.c
@@ -1350,7 +1350,11 @@ static void G_DoPlayDemo(void)
       if (demover >= 203)
 	option_p = demo_p;
 
-      demo_p = G_ReadOptions(demo_p);  // killough 3/1/98: Read game options
+      // killough 3/1/98: Read game options
+      if (mbf21)
+        demo_p = G_ReadOptionsMBF21(demo_p);
+      else
+        demo_p = G_ReadOptions(demo_p);
 
       if (demover == 200)        // killough 6/3/98: partially fix v2.00 demos
         demo_p += 256-G_GameOptionSize();
@@ -1388,7 +1392,12 @@ static void G_DoPlayDemo(void)
       // the same as during recording.
       
       if (option_p)
-	G_ReadOptions(option_p);
+      {
+        if (mbf21)
+          G_ReadOptionsMBF21(option_p);
+        else
+          G_ReadOptions(option_p);
+      }
     }
 
   precache = true;
@@ -1560,6 +1569,8 @@ static void G_DoSaveGame(void)
   memcpy (save_p, name2, VERSIONSIZE);
   save_p += VERSIONSIZE;
 
+  *save_p++ = complevel;
+
   // killough 2/14/98: save old compatibility flag:
   *save_p++ = compatibility;
 
@@ -1650,6 +1661,7 @@ static void G_DoLoadGame(void)
 {
   int  length, i;
   char vcheck[VERSIONSIZE];
+  byte saveg_complevel = MBFVERSION;
 
   gameaction = ga_nothing;
 
@@ -1675,6 +1687,11 @@ static void G_DoLoadGame(void)
     }
 
   save_p += VERSIONSIZE;
+
+  if (saveg_compat == saveg_current)
+  {
+    saveg_complevel = *save_p++;
+  }
 
   // killough 2/14/98: load compatibility mode
   compatibility = *save_p++;
@@ -1714,7 +1731,10 @@ static void G_DoLoadGame(void)
   idmusnum = *(signed char *) save_p++;
 
   /* cph 2001/05/23 - Must read options before we set up the level */
-  G_ReadOptions(save_p);
+  if (saveg_complevel == MBF21VERSION)
+    G_ReadOptionsMBF21(save_p);
+  else
+    G_ReadOptions(save_p);
 
   // load a base level
   G_InitNew(gameskill, gameepisode, gamemap);
@@ -1723,7 +1743,10 @@ static void G_DoLoadGame(void)
   // killough 11/98: move down to here
   /* cph - MBF needs to reread the savegame options because G_InitNew
    * rereads the WAD options. The demo playback code does this too. */
-  save_p = G_ReadOptions(save_p);
+  if (saveg_complevel == MBF21VERSION)
+    save_p = G_ReadOptionsMBF21(save_p);
+  else
+    save_p = G_ReadOptions(save_p);
 
   // get the times
   // killough 11/98: save entire word
@@ -2705,7 +2728,7 @@ static int G_GameOptionSize(void) {
   return mbf21 ? MBF21_GAME_OPTION_SIZE : GAME_OPTION_SIZE;
 }
 
-static byte* mbf21_WriteOptions(byte* demo_p)
+static byte* G_WriteOptionsMBF21(byte* demo_p)
 {
   int i;
   byte *target = demo_p + MBF21_GAME_OPTION_SIZE;
@@ -2753,7 +2776,7 @@ byte *G_WriteOptions(byte *demo_p)
 
   if (mbf21)
   {
-    return mbf21_WriteOptions(demo_p);
+    return G_WriteOptionsMBF21(demo_p);
   }
 
   *demo_p++ = monsters_remember;  // part of monster AI
@@ -2825,7 +2848,7 @@ byte *G_WriteOptions(byte *demo_p)
 
 // Same, but read instead of write
 
-static byte *mbf21_ReadOption(byte *demo_p)
+byte *G_ReadOptionsMBF21(byte *demo_p)
 {
   int i, count;
 
@@ -2879,11 +2902,6 @@ static byte *mbf21_ReadOption(byte *demo_p)
 byte *G_ReadOptions(byte *demo_p)
 {
   byte *target = demo_p + GAME_OPTION_SIZE;
-
-  if (mbf21)
-  {
-    return mbf21_ReadOption(demo_p);
-  }
 
   monsters_remember = *demo_p++;
 

--- a/Source/g_game.h
+++ b/Source/g_game.h
@@ -63,6 +63,7 @@ void G_SetFastParms(int);        // killough 4/10/98: sets -fast parameters
 void G_DoNewGame(void);
 void G_DoReborn(int playernum);
 byte *G_ReadOptions(byte *demo_p);         // killough 3/1/98
+byte *G_ReadOptionsMBF21(byte *demo_p);
 byte *G_WriteOptions(byte *demo_p);        // killough 3/1/98
 void G_PlayerReborn(int player);
 void G_DoVictory(void);

--- a/Source/m_menu.c
+++ b/Source/m_menu.c
@@ -3493,7 +3493,7 @@ enum {
 };
 
 static const char *default_compatibility_strings[] = {
-  "Vanilla", "Boom", "MBF", NULL
+  "Vanilla", "Boom", "MBF", "MBF21", NULL
 };
 
 setup_menu_t gen_settings2[] = { // General Settings screen2

--- a/Source/m_misc.c
+++ b/Source/m_misc.c
@@ -59,6 +59,7 @@
 // DEFAULTS
 //
 
+static char* config_version;
 static int config_help;         //jff 3/3/98
 int usemouse;
 int usejoystick;
@@ -114,6 +115,13 @@ extern char *chat_macros[], *wad_files[], *deh_files[];  // killough 10/98
 // from wads, and to consolidate with menu code
 
 default_t defaults[] = {
+  {
+    "config_version",
+    (config_t *) &config_version, NULL,
+    {.s = "Woof 5.1.0"}, {0}, string, ss_none, wad_no,
+    "current config version"
+  },
+
   { //jff 3/3/98
     "config_help",
     (config_t *) &config_help, NULL,
@@ -1968,8 +1976,8 @@ default_t defaults[] = {
   {
     "default_complevel",
     (config_t *) &default_complevel, NULL,
-    {2}, {0,2}, number, ss_none, wad_no,
-    "0 Vanilla, 1 Boom, 2 MBF"
+    {3}, {0,3}, number, ss_none, wad_no,
+    "0 Vanilla, 1 Boom, 2 MBF, 3 MBF21"
   },
 
   {NULL}         // last entry
@@ -2336,6 +2344,17 @@ void M_LoadDefaults (void)
             comments[comment++].text = strdup(p);
           }
       fclose (f);
+    }
+
+  // Change defaults for new config version
+  if (strcmp(config_version, "Woof 5.1.0") == 0)
+    {
+      strcpy(config_version, "Woof 6.0.0");
+
+      default_comp[comp_zombie] = 1;
+      default_comp[comp_pursuit] = 1;
+      if (default_complevel == 2)
+        default_complevel = 3;
     }
 
   defaults_loaded = true;            // killough 10/98


### PR DESCRIPTION
MBF21 changes comp_pursuit: 1 (was 0), so I propose config versioning with forced new defaults to users with old configs. Also, changed the default complevel to MBF21.

Due to MBF21 changes in the demo header [[spec]](https://github.com/kraflab/mbf21/blob/master/docs/developer_spec.md#demo-format--header) we need to change savegame header loading.