### PR TITLE
fix automap overlay mode stay on screen after wipe

### DIFF
--- a/Source/d_main.c
+++ b/Source/d_main.c
@@ -298,7 +298,7 @@ void D_Display (void)
   inhelpscreensstate = inhelpscreens;
   oldgamestate = wipegamestate = gamestate;
 
-  if (automapactive && automapoverlay)
+  if (gamestate == GS_LEVEL && automapactive && automapoverlay)
     {
       AM_Drawer();
       HU_Drawer();


### PR DESCRIPTION
Fixes this bug:
![doom01](https://user-images.githubusercontent.com/5077629/121781714-4c611900-cbd0-11eb-942e-a9274394744b.png)

Not sure if this fix is correct.