### PR TITLE
add 'Dropped item' support

### DIFF
--- a/Source/d_deh.c
+++ b/Source/d_deh.c
@@ -977,7 +977,7 @@ typedef struct
 // killough 8/9/98: make DEH_BLOCKMAX self-adjusting
 #define DEH_BLOCKMAX (sizeof deh_blocks/sizeof*deh_blocks)  // size of array
 #define DEH_MAXKEYLEN 32 // as much of any key as we'll look at
-#define DEH_MOBJINFOMAX 31 // number of mobjinfo configuration keys
+#define DEH_MOBJINFOMAX 32 // number of mobjinfo configuration keys
 
 // Put all the block header values, and the function to be called when that
 // one is encountered, in this array:
@@ -1048,6 +1048,9 @@ char *deh_mobjinfo[DEH_MOBJINFOMAX] =
 
   // [Woof!]
   "Blood color",         // .bloodcolor
+
+  // DEHEXTRA
+  "Dropped item",        // .droppeditem
 };
 
 // Strings that are used to indicate flags ("Bits" in mobjinfo)
@@ -1911,6 +1914,11 @@ void deh_procThing(DEHFILE *fpin, FILE* fpout, char *line)
                     return;
                   }
                   mi->splash_group = mi->splash_group + SG_END;
+                }
+              else if (ix == 31)
+                {
+                  mobjinfo_t *mi = &mobjinfo[indexnum];
+                  mi->droppeditem = (int)(value - 1); // make it base zero (deh is 1-based)
                 }
               else
               {

--- a/Source/d_main.c
+++ b/Source/d_main.c
@@ -1718,6 +1718,8 @@ void D_DoomMain(void)
         mobjinfo[i].meleerange       = MELEERANGE;
         // [Woof!]
         mobjinfo[i].bloodcolor       = 0; // Normal
+        // DEHEXTRA
+        mobjinfo[i].droppeditem      = MT_NULL;
       }
 
     mobjinfo[MT_VILE].flags2    = MF2_SHORTMRANGE | MF2_DMGIGNORED | MF2_NOTHRESHOLD;
@@ -1742,6 +1744,12 @@ void D_DoomMain(void)
     mobjinfo[MT_HEAD].bloodcolor = 3; // Blue
     mobjinfo[MT_BRUISER].bloodcolor = 2; // Green
     mobjinfo[MT_KNIGHT].bloodcolor = 2; // Green
+
+    // DEHEXTRA
+    mobjinfo[MT_WOLFSS].droppeditem = MT_CLIP;
+    mobjinfo[MT_POSSESSED].droppeditem = MT_CLIP;
+    mobjinfo[MT_SHOTGUY].droppeditem = MT_SHOTGUN;
+    mobjinfo[MT_CHAINGUY].droppeditem = MT_CHAINGUN;
 
     for (i = S_SARG_RUN1; i <= S_SARG_PAIN2; ++i)
       states[i].flags |= STATEF_SKILL5FAST;

--- a/Source/info.h
+++ b/Source/info.h
@@ -1289,6 +1289,7 @@ extern char *sprnames[];             // 1/17/98 killough
 // Note that many of these are generically named for the ornamentals
 //
 typedef enum {
+  MT_NULL = -1, // null/invalid mobj (zero is reserved for MT_PLAYER)
   MT_PLAYER,
   MT_POSSESSED,
   MT_SHOTGUY,
@@ -1545,6 +1546,8 @@ typedef struct
 
     // [Woof!]
     int bloodcolor;   // [FG] colored blood and gibs
+    // DEHEXTRA
+    mobjtype_t droppeditem; // mobj to drop after death
 } mobjinfo_t;
 
 #define NO_ALTSPEED -1

--- a/Source/p_inter.c
+++ b/Source/p_inter.c
@@ -722,24 +722,11 @@ static void P_KillMobj(mobj_t *source, mobj_t *target)
   // This determines the kind of object spawned
   // during the death frame of a thing.
 
-  switch (target->type)
-    {
-    case MT_WOLFSS:
-    case MT_POSSESSED:
-      item = MT_CLIP;
-      break;
-
-    case MT_SHOTGUY:
-      item = MT_SHOTGUN;
-      break;
-
-    case MT_CHAINGUY:
-      item = MT_CHAINGUN;
-      break;
-
-    default:
-      return;
-    }
+  if (target->info->droppeditem != MT_NULL)
+  {
+    item = target->info->droppeditem;
+  }
+  else return;
 
   mo = P_SpawnMobj (target->x,target->y,ONFLOORZ, item);
   mo->flags |= MF_DROPPED;    // special versions of items


### PR DESCRIPTION
This dehacked thing field is part of DEHEXTRA according to DECOHack:
https://github.com/MTrop/DoomTools/blob/00006d2c9def8036fe6b48d1dbc89e153a2b17b5/docs/DECOHack%20Help.txt#L730-L731
Also, compatible with Eternity, PrBoom+, Doom Retro.