### PR TITLE
do not override numerical values already set for MBF21 Bits fields

### DIFF
--- a/Source/d_deh.c
+++ b/Source/d_deh.c
@@ -1829,8 +1829,10 @@ void deh_procThing(DEHFILE *fpin, FILE* fpout, char *line)
           if (!strcasecmp(key,deh_mobjinfo[ix]))  // killough 8/98
             {
               // mbf21: process thing flags
-              if (!strcasecmp(key, "MBF21 Bits") && !value)
+              if (!strcasecmp(key, "MBF21 Bits"))
                 {
+                 if (!value)
+                 {
                   for (value = 0; (strval = strtok(strval, ",+| \t\f\r")); strval = NULL)
                    {
                      size_t iy;
@@ -1849,6 +1851,7 @@ void deh_procThing(DEHFILE *fpin, FILE* fpout, char *line)
                          fprintf(fpout, "Could not find MBF21 bit mnemonic %s\n", strval);
                        }
                     }
+                 }
 
                   mobjinfo[indexnum].flags2 = value;
                 }
@@ -2068,6 +2071,8 @@ void deh_procFrame(DEHFILE *fpin, FILE* fpout, char *line)
                                     // mbf21: process state flags
                                     if (!strcasecmp(key,deh_state[15]))  // MBF21 Bits
                                       {
+                                       if (!value)
+                                       {
                                         for (value = 0; (strval = strtok(strval, ",+| \t\f\r")); strval = NULL)
                                           {
                                             const struct deh_flag_s *flag;
@@ -2086,6 +2091,7 @@ void deh_procFrame(DEHFILE *fpin, FILE* fpout, char *line)
                                                 fprintf(fpout, "Could not find MBF21 frame bit mnemonic %s\n", strval);
                                               }
                                           }
+                                       }
 
                                         states[indexnum].flags = value;
                                       }
@@ -2346,6 +2352,8 @@ void deh_procWeapon(DEHFILE *fpin, FILE* fpout, char *line)
                    // mbf21: process weapon flags
                    if (!strcasecmp(key,deh_weapon[7]))  // MBF21 Bits
                     {
+                     if (!value)
+                     {
                       for (value = 0; (strval = strtok(strval, ",+| \t\f\r")); strval = NULL)
                       {
                         const struct deh_flag_s *flag;
@@ -2361,6 +2369,7 @@ void deh_procWeapon(DEHFILE *fpin, FILE* fpout, char *line)
                         if (!flag->name && fpout)
                           fprintf(fpout, "Could not find MBF21 weapon bit mnemonic %s\n", strval);
                       }
+                     }
 
                       weaponinfo[indexnum].flags = value;
                     }

--- a/Source/p_enemy.c
+++ b/Source/p_enemy.c
@@ -2905,7 +2905,8 @@ void A_MonsterMeleeAttack(mobj_t *actor)
   if (!P_CheckRange(actor, range))
     return;
 
-  S_StartSound(actor, hitsound);
+  if (hitsound > 0)
+    S_StartSound(actor, hitsound);
 
   damage = (P_Random(pr_mbf21) % damagemod + 1) * damagebase;
   P_DamageMobj(actor->target, actor, actor, damage);

--- a/Source/p_enemy.c
+++ b/Source/p_enemy.c
@@ -2905,8 +2905,7 @@ void A_MonsterMeleeAttack(mobj_t *actor)
   if (!P_CheckRange(actor, range))
     return;
 
-  if (hitsound > 0)
-    S_StartSound(actor, hitsound);
+  S_StartSound(actor, hitsound);
 
   damage = (P_Random(pr_mbf21) % damagemod + 1) * damagebase;
   P_DamageMobj(actor->target, actor, actor, damage);


### PR DESCRIPTION
Fixes #236

@kraflab @XaserAcheron There is still a potential divide-by-zero crash if `damagemod` is set to `0` in either `A_MonsterBulletAttack()` or `A_MonsterMeleeAttack()`. How should we deal with this?