### PR TITLE
fix load game during multiplayer demo playback (AV.WAD demo1)

### DIFF
--- a/Source/g_game.c
+++ b/Source/g_game.c
@@ -1822,10 +1822,12 @@ static void G_DoLoadGame(void)
   // [crispy] loaded game must always be single player.
   // Needed for ability to use a further game loading, as well as
   // cheat codes and other single player only specifics.
-  // if (startloadgame == -1)
-  netdemo = false;
-  netgame = false;
-  deathmatch = false;
+  if (!command_loadgame)
+  {
+    netdemo = false;
+    netgame = false;
+    deathmatch = false;
+  }
 
   gameaction = ga_nothing;
 

--- a/Source/g_game.c
+++ b/Source/g_game.c
@@ -1819,6 +1819,14 @@ static void G_DoLoadGame(void)
   char vcheck[VERSIONSIZE];
   byte saveg_complevel = MBFVERSION;
 
+  // [crispy] loaded game must always be single player.
+  // Needed for ability to use a further game loading, as well as
+  // cheat codes and other single player only specifics.
+  // if (startloadgame == -1)
+  netdemo = false;
+  netgame = false;
+  deathmatch = false;
+
   gameaction = ga_nothing;
 
   length = M_ReadFile(savename, &savebuffer);


### PR DESCRIPTION
Woof has the same issue: https://github.com/coelckers/prboom-plus/issues/352, except it outright crashes.

Maybe we should wait for multiplayer branch integration?