### PR TITLE
umapinfo: fix default endpic

### DIFF
--- a/Source/f_finale.c
+++ b/Source/f_finale.c
@@ -847,9 +847,13 @@ void F_Drawer (void)
 {
   if (using_FMI)
   {
-    if (!finalestage || !gamemapinfo->endpic[0] || (strcmp(gamemapinfo->endpic, "-") == 0))
+    if (!finalestage)
     {
       F_TextWrite();
+      if (!gamemapinfo->endpic[0])
+      {
+        using_FMI = false;
+      }
     }
     else if (strcmp(gamemapinfo->endpic, "$BUNNY") == 0)
     {


### PR DESCRIPTION
Fixes the default ending of Episode 4 with [Ultimate MIDI Pack](https://www.doomworld.com/forum/topic/120788-released-ultimate-midi-pack-a-community-music-replacement-for-the-original-doom/)
