### PR TITLE
add demo footer

### DIFF
--- a/Source/d_deh.c
+++ b/Source/d_deh.c
@@ -95,6 +95,8 @@ int dehfgetc(DEHFILE *fp)
 // variables used in other routines
 boolean deh_pars = FALSE; // in wi_stuff to allow pars in modified games
 
+char *dehfiles = NULL;  // filenames of .deh files for demo footer
+
 // #include "d_deh.h" -- we don't do that here but we declare the
 // variables.  This externalizes everything that there is a string
 // set for in the language files.  See d_deh.h for detailed comments,
@@ -1581,11 +1583,15 @@ void ProcessDehFile(const char *filename, char *outfilename, int lumpnum)
 
   if (filename)
     {
+      char *tmp = NULL;
       if (!(infile.inp = (void *) fopen(filename,"rt")))
         {
           printf("-deh file %s not found\n",filename);
           return;  // should be checked up front anyway
         }
+      tmp = M_StringJoin("\"", M_BaseName(filename), "\" ", NULL);
+      M_StringAdd(&dehfiles, tmp);
+      (free)(tmp);
       infile.lump = NULL;
     }
   else  // DEH file comes from lump indicated by third argument

--- a/Source/d_main.c
+++ b/Source/d_main.c
@@ -1140,6 +1140,11 @@ static void InitGameVersion(void)
     }
 }
 
+const char* GetGameVersionCmdline(void)
+{
+  return gameversions[gameversion].cmdline;
+}
+
 // killough 5/3/98: old code removed
 
 //

--- a/Source/g_game.c
+++ b/Source/g_game.c
@@ -3379,7 +3379,7 @@ void G_DeferedPlayDemo(char* name)
 extern const char* GetGameVersionCmdline(void);
 extern char *dehfiles;
 
-void G_AddDemoFooter(void)
+static void G_AddDemoFooter(void)
 {
   ptrdiff_t position = demo_p - demobuffer;
   char *str = NULL;

--- a/Source/g_game.c
+++ b/Source/g_game.c
@@ -3399,9 +3399,11 @@ static void G_AddDemoFooter(void)
     (free)(tmp);
   }
 
-  tmp = M_StringJoin("-deh ", dehfiles, NULL);
-  M_StringAdd(&str, tmp);
-  (free)(tmp);
+  if (dehfiles)
+  {
+    M_StringAdd(&str, "-deh ");
+    M_StringAdd(&str, dehfiles);
+  }
 
   switch(complevel)
   {

--- a/Source/g_game.c
+++ b/Source/g_game.c
@@ -3405,23 +3405,12 @@ static void G_AddDemoFooter(void)
     M_StringAdd(&str, dehfiles);
   }
 
-  switch(complevel)
+  if (demo_compatibility)
   {
-    case 109:
-      M_StringAdd(&str, "-complevel vanilla ");
-      tmp = M_StringJoin("-gameversion ", GetGameVersionCmdline(), " ", NULL);
-      M_StringAdd(&str, tmp);
-      (free)(tmp);
-      break;
-    case 202:
-      M_StringAdd(&str, "-complevel boom ");
-      break;
-    case 203:
-      M_StringAdd(&str, "-complevel mbf ");
-      break;
-    case 221:
-      M_StringAdd(&str, "-complevel mbf21 ");
-      break;
+    M_StringAdd(&str, "-complevel vanilla ");
+    tmp = M_StringJoin("-gameversion ", GetGameVersionCmdline(), " ", NULL);
+    M_StringAdd(&str, tmp);
+    (free)(tmp);
   }
 
   M_StringAdd(&str, DEMO_FOOTER_SEPARATOR);

--- a/Source/m_misc2.c
+++ b/Source/m_misc2.c
@@ -471,7 +471,7 @@ void M_StringAdd(char **dest, const char *src)
     size_t size;
 
     if (!dest || !src)
-       return 0;
+       return;
 
     if (*dest)
     {

--- a/Source/m_misc2.c
+++ b/Source/m_misc2.c
@@ -465,3 +465,24 @@ int M_snprintf(char *buf, size_t buf_len, const char *s, ...)
     va_end(args);
     return result;
 }
+
+void M_StringAdd(char **dest, const char *src)
+{
+    size_t size;
+
+    if (!dest || !src)
+       return 0;
+
+    if (*dest)
+    {
+        size = strlen(*dest) + strlen(src) + 1;
+        *dest = realloc(*dest, size);
+        M_StringConcat(*dest, src, size);
+    }
+    else
+    {
+        size = strlen(src) + 1;
+        *dest = malloc(size);
+        M_StringCopy(*dest, src, size);
+    }
+}

--- a/Source/m_misc2.h
+++ b/Source/m_misc2.h
@@ -42,4 +42,6 @@ char *M_StringJoin(const char *s, ...);
 boolean M_StringEndsWith(const char *s, const char *suffix);
 int M_snprintf(char *buf, size_t buf_len, const char *s, ...) PRINTF_ATTR(3, 4);
 
+void M_StringAdd(char **dest, const char *src);
+
 #endif


### PR DESCRIPTION
Add demo footer based on PrBoom+. It was discussed on speedrunners discord with @kraflab. The demo footer was very useful during the testing of the DSDA demo archive. Example:
```
Woof 6.3.0
-iwad "doom2.wad" -file "D2SPFX19.WAD" "doom2_ws.wad" -deh "D2DEHFIX.DEH" -complevel vanilla -gameversion 1.9 

```
Note that the current demo footer of PrBoom+/DSDA-Doom does not save the autoload wads/deh filenames.