### PR TITLE
enable cosmetic compatibility options for all complevels

### DIFF
--- a/Source/m_menu.c
+++ b/Source/m_menu.c
@@ -6305,7 +6305,18 @@ void M_ResetSetupMenu(void)
 {
   int i;
 
-  SetupMenu[set_compat].status = (demo_version < 203) ? 0 : 1;
+  for (i = compat_telefrag; i < compat_blazing; ++i)
+  {
+    FLAG_SET_BOOM(comp_settings1[i].m_flags, S_DISABLE);
+  }
+  for (i = compat_god; i < compat_skymap; ++i)
+  {
+    FLAG_SET_BOOM(comp_settings2[i].m_flags, S_DISABLE);
+  }
+  for (i = compat_stairs; i < compat_menu; ++i)
+  {
+    FLAG_SET_BOOM(comp_settings2[i].m_flags, S_DISABLE);
+  }
   FLAG_SET_BOOM(enem_settings1[enem_infighting].m_flags, S_DISABLE);
   for (i = enem_backing; i < enem_colored_blood; ++i)
   {

--- a/Source/p_doors.c
+++ b/Source/p_doors.c
@@ -133,7 +133,7 @@ void T_VerticalDoor (vldoor_t *door)
             door->sector->ceilingdata = NULL;  //jff 2/22/98
             P_RemoveThinker (&door->thinker);  // unlink and free
             // killough 4/15/98: remove double-closing sound of blazing doors
-            if (comp[comp_blazing])
+            if (default_comp[comp_blazing])
               S_StartSound((mobj_t *)&door->sector->soundorg,sfx_bdcls);
             break;
 
@@ -525,7 +525,7 @@ int EV_VerticalDoor(line_t *line, mobj_t *thing)
   door->line = line; // jff 1/31/98 remember line that triggered us
 
   // killough 10/98: use gradual lighting changes if nonzero tag given
-  door->lighttag = comp[comp_doorlight] ? 0 : line->tag; // killough 10/98
+  door->lighttag = default_comp[comp_doorlight] ? 0 : line->tag; // killough 10/98
 
   // set the type of door from the activating linedef type
   switch(line->special)

--- a/Source/p_genlin.c
+++ b/Source/p_genlin.c
@@ -971,7 +971,7 @@ manual_locked:
     door->direction = 1;
 
     // killough 10/98: implement gradual lighting
-    door->lighttag = !comp[comp_doorlight] && (line->special&6) == 6 && 
+    door->lighttag = !default_comp[comp_doorlight] && (line->special&6) == 6 && 
       line->special > GenLockedBase ? line->tag : 0;
 
     // setup speed of door motion
@@ -1110,7 +1110,7 @@ manual_door:
     door->line = line; // jff 1/31/98 remember line that triggered us
 
     // killough 10/98: implement gradual lighting
-    door->lighttag = !comp[comp_doorlight] && (line->special&6) == 6 && 
+    door->lighttag = !default_comp[comp_doorlight] && (line->special&6) == 6 && 
       line->special > GenLockedBase ? line->tag : 0;
 
     // set kind of door, whether it opens then close, opens, closes etc.

--- a/Source/r_plane.c
+++ b/Source/r_plane.c
@@ -392,7 +392,7 @@ static void do_draw_plane(visplane_t *pl)
 	//
 	// killough 7/19/98: fix hack to be more realistic:
 
-	if (comp[comp_skymap] || !(dc_colormap = fixedcolormap))
+	if (default_comp[comp_skymap] || !(dc_colormap = fixedcolormap))
 	  dc_colormap = fullcolormap;          // killough 3/20/98
 
         dc_texheight = textureheight[texture]>>FRACBITS; // killough


### PR DESCRIPTION
Fixes #265 
Not sure about `comp_doorlight` ("Tagged doors don't trigger special lighting")