### PR TITLE
make keyed doors flash on the automap (from Crispy Doom)

### DIFF
--- a/Source/am_map.c
+++ b/Source/am_map.c
@@ -1498,22 +1498,22 @@ void AM_drawWalls(void)
               case 1:
                 /*bluekey*/
                 AM_drawMline(&l,
-                  mapcolor_bdor? mapcolor_bdor : mapcolor_cchg);
+                  leveltime & 16? (mapcolor_bdor? mapcolor_bdor : mapcolor_cchg) : mapcolor_grid);
                 break;
               case 2:
                 /*yellowkey*/
                 AM_drawMline(&l,
-                  mapcolor_ydor? mapcolor_ydor : mapcolor_cchg);
+                  leveltime & 16? (mapcolor_ydor? mapcolor_ydor : mapcolor_cchg) : mapcolor_grid);
                 break;
               case 0:
                 /*redkey*/
                 AM_drawMline(&l,
-                  mapcolor_rdor? mapcolor_rdor : mapcolor_cchg);
+                  leveltime & 16? (mapcolor_rdor? mapcolor_rdor : mapcolor_cchg) : mapcolor_grid);
                 break;
               case 3:
                 /*any or all*/
                 AM_drawMline(&l,
-                  mapcolor_clsd? mapcolor_clsd : mapcolor_cchg);
+                  leveltime & 16? (mapcolor_clsd? mapcolor_clsd : mapcolor_cchg) : mapcolor_grid);
                 break;
             }
           }

--- a/Source/am_map.c
+++ b/Source/am_map.c
@@ -64,6 +64,9 @@ int mapcolor_frnd;    // colors for friends of player
 
 //jff 3/9/98 add option to not show secret sectors until entered
 int map_secret_after;
+
+int map_keyed_door_flash; // keyed doors are flashing
+
 //jff 4/3/98 add symbols for "no-color" for disable and "black color" for black
 #define NC 0
 #define BC 247
@@ -1493,27 +1496,31 @@ void AM_drawWalls(void)
           if ((lines[i].backsector->floorheight==lines[i].backsector->ceilingheight) ||
               (lines[i].frontsector->floorheight==lines[i].frontsector->ceilingheight))
           {
-            switch (AM_DoorColor(lines[i].special)) // closed keyed door
+            if (map_keyed_door_flash && (leveltime & 16))
+            {
+               AM_drawMline(&l, mapcolor_clsd);
+            }
+            else switch (AM_DoorColor(lines[i].special)) // closed keyed door
             {
               case 1:
                 /*bluekey*/
                 AM_drawMline(&l,
-                  leveltime & 16? (mapcolor_bdor? mapcolor_bdor : mapcolor_cchg) : mapcolor_grid);
+                  mapcolor_bdor? mapcolor_bdor : mapcolor_cchg);
                 break;
               case 2:
                 /*yellowkey*/
                 AM_drawMline(&l,
-                  leveltime & 16? (mapcolor_ydor? mapcolor_ydor : mapcolor_cchg) : mapcolor_grid);
+                  mapcolor_ydor? mapcolor_ydor : mapcolor_cchg);
                 break;
               case 0:
                 /*redkey*/
                 AM_drawMline(&l,
-                  leveltime & 16? (mapcolor_rdor? mapcolor_rdor : mapcolor_cchg) : mapcolor_grid);
+                  mapcolor_rdor? mapcolor_rdor : mapcolor_cchg);
                 break;
               case 3:
                 /*any or all*/
                 AM_drawMline(&l,
-                  leveltime & 16? (mapcolor_clsd? mapcolor_clsd : mapcolor_cchg) : mapcolor_grid);
+                  mapcolor_clsd? mapcolor_clsd : mapcolor_cchg);
                 break;
             }
           }

--- a/Source/am_map.h
+++ b/Source/am_map.h
@@ -100,6 +100,8 @@ extern int mapcolor_frnd;     // killough 8/8/98: colors for friends
 //jff 3/9/98
 extern int map_secret_after;  // secrets do not appear til after bagged
 
+extern int map_keyed_door_flash; // keyed doors are flashing
+
 extern int map_point_coordinates;  // killough 10/98
 
 #endif

--- a/Source/hu_stuff.h
+++ b/Source/hu_stuff.h
@@ -86,6 +86,7 @@ extern int hud_active;      // hud mode 0=off, 1=small, 2=full
 extern int hud_nosecrets;   // status does not list secrets/items/kills
 extern int hud_secret_message; // "A secret is revealed!" message
 extern int map_player_coords, map_level_stats, map_level_time; // [FG] level stats and level time widgets
+extern int map_keyed_door_flash;
 
 #endif
 

--- a/Source/hu_stuff.h
+++ b/Source/hu_stuff.h
@@ -86,7 +86,6 @@ extern int hud_active;      // hud mode 0=off, 1=small, 2=full
 extern int hud_nosecrets;   // status does not list secrets/items/kills
 extern int hud_secret_message; // "A secret is revealed!" message
 extern int map_player_coords, map_level_stats, map_level_time; // [FG] level stats and level time widgets
-extern int map_keyed_door_flash;
 
 #endif
 

--- a/Source/m_menu.c
+++ b/Source/m_menu.c
@@ -3102,17 +3102,16 @@ setup_menu_t auto_settings1[] =  // 1st AutoMap Settings screen
   {"blue door"                          ,S_COLOR,m_null,AU_X,AU_Y+10*8, {"mapcolor_bdor"}},
   {"yellow door"                        ,S_COLOR,m_null,AU_X,AU_Y+11*8, {"mapcolor_ydor"}},
 
-  {"AUTOMAP LEVEL TITLE COLOR"      ,S_CRITEM,m_null,AU_X,AU_Y+13*8, {"hudcolor_titl"}},
-  {"AUTOMAP COORDINATES COLOR"      ,S_CRITEM,m_null,AU_X,AU_Y+14*8, {"hudcolor_xyco"}},
+  {"Show Secrets only after entering",S_YESNO,m_null,AU_X,AU_Y+13*8, {"map_secret_after"}},
 
-  {"Show Secrets only after entering",S_YESNO,m_null,AU_X,AU_Y+15*8, {"map_secret_after"}},
-
-  {"Show coordinates of automap pointer",S_YESNO,m_null,AU_X,AU_Y+16*8, {"map_point_coord"}},  // killough 10/98
+  {"Show coordinates of automap pointer",S_YESNO,m_null,AU_X,AU_Y+14*8, {"map_point_coord"}},  // killough 10/98
 
   // [FG] show level statistics and level time widgets
-  {"Show player coords", S_CHOICE,m_null,AU_X,AU_Y+17*8, {"map_player_coords"},0,0,NULL,show_widgets_strings},
-  {"Show level stats",   S_CHOICE,m_null,AU_X,AU_Y+18*8, {"map_level_stats"},0,0,NULL,show_widgets_strings},
-  {"Show level time",    S_CHOICE,m_null,AU_X,AU_Y+19*8, {"map_level_time"},0,0,NULL,show_widgets_strings},
+  {"Show player coords", S_CHOICE,m_null,AU_X,AU_Y+15*8, {"map_player_coords"},0,0,NULL,show_widgets_strings},
+  {"Show level stats",   S_CHOICE,m_null,AU_X,AU_Y+16*8, {"map_level_stats"},0,0,NULL,show_widgets_strings},
+  {"Show level time",    S_CHOICE,m_null,AU_X,AU_Y+17*8, {"map_level_time"},0,0,NULL,show_widgets_strings},
+
+  {"Keyed doors are flashing", S_YESNO,m_null,AU_X,AU_Y+18*8, {"map_keyed_door_flash"}},
 
   // Button for resetting to defaults
   {0,S_RESET,m_null,X_BUTTON,Y_BUTTON},
@@ -3141,6 +3140,9 @@ setup_menu_t auto_settings2[] =  // 2nd AutoMap Settings screen
   {"player 4 arrow"                 ,S_COLOR ,m_null,AU_X,AU_Y+11*8, {"mapcolor_ply4"}},
 
   {"friends"                        ,S_COLOR ,m_null,AU_X,AU_Y+12*8, {"mapcolor_frnd"}},        // killough 8/8/98
+
+  {"AUTOMAP LEVEL TITLE COLOR"      ,S_CRITEM,m_null,AU_X,AU_Y+14*8, {"hudcolor_titl"}},
+  {"AUTOMAP COORDINATES COLOR"      ,S_CRITEM,m_null,AU_X,AU_Y+15*8, {"hudcolor_xyco"}},
 
   {"<- PREV",S_SKIP|S_PREV,m_null,AU_PREV,AU_Y+20*8, {auto_settings1}},
 

--- a/Source/m_misc.c
+++ b/Source/m_misc.c
@@ -1569,6 +1569,13 @@ default_t defaults[] = {
     "1 to not show secret sectors till after entered"
   },
 
+  {
+    "map_keyed_door_flash",
+    (config_t *) &map_keyed_door_flash, NULL,
+    {1}, {0,1}, number, ss_auto, wad_no,
+    "1 to make keyed doors flash on the automap"
+  },
+
   // [FG] player coords widget (intentionally not shown outside Automap)
   {
     "map_player_coords",


### PR DESCRIPTION
Fixes #272 
Should we add a menu option for this? We have myriad automap options anyway.