### PR TITLE
fix the dehacked string replacement behavior

### DIFF
--- a/Source/d_deh.c
+++ b/Source/d_deh.c
@@ -444,6 +444,7 @@ char* savegamename;
 typedef struct {
   char **ppstr;  // doubly indirect pointer to string
   char *lookup;  // pointer to lookup string name
+  const char *orig;
 } deh_strs;
 
 deh_strs deh_strlookup[] = {
@@ -2913,8 +2914,12 @@ boolean deh_procStringSub(char *key, char *lookfor, char *newstring, FILE *fpout
   found = false;
   for (i=0;i<deh_numstrlookup;i++)
     {
+      if (deh_strlookup[i].orig == NULL)
+      {
+        deh_strlookup[i].orig = *deh_strlookup[i].ppstr;
+      }
       found = lookfor ?
-        !stricmp(*deh_strlookup[i].ppstr,lookfor) :
+        !stricmp(deh_strlookup[i].orig,lookfor) :
         !stricmp(deh_strlookup[i].lookup,key);
 
       if (found)


### PR DESCRIPTION
Fixes this issue: [[doomworld]](https://www.doomworld.com/forum/topic/112333-this-is-woof-631-aug-13-2021-updated-winmbf/?do=findComment&comment=2387738)
Fix taken from PrBoom+: https://github.com/coelckers/prboom-plus/commit/1cf2a32551cb4def4459ae672015b3c006f8343f