### PR TITLE
umapinfo: update map entries instead of replacing

### DIFF
--- a/Source/u_mapinfo.c
+++ b/Source/u_mapinfo.c
@@ -311,6 +311,86 @@ static void ReplaceString(char **pptr, const char *newstring)
   *pptr = strdup(newstring);
 }
 
+static void UpdateMapEntry(mapentry_t *mape, mapentry_t *newe)
+{
+  if (newe->levelname)
+  {
+    ReplaceString(&mape->levelname, newe->levelname);
+  }
+  if (newe->label)
+  {
+    ReplaceString(&mape->label, newe->label);
+  }
+  if (newe->intertext)
+  {
+    ReplaceString(&mape->intertext, newe->intertext);
+  }
+  if (newe->intertextsecret)
+  {
+    ReplaceString(&mape->intertextsecret, newe->intertextsecret);
+  }
+  if (newe->levelpic[0])
+  {
+    strcpy(mape->levelpic, newe->levelpic);
+  }
+  if (newe->nextmap[0])
+  {
+    strcpy(mape->nextmap, newe->nextmap);
+  }
+  if (newe->music[0])
+  {
+    strcpy(mape->music, newe->music);
+  }
+  if (newe->skytexture[0])
+  {
+    strcpy(mape->skytexture, newe->skytexture);
+  }
+  if (newe->endpic[0])
+  {
+    strcpy(mape->endpic, newe->endpic);
+  }
+  if (newe->exitpic[0])
+  {
+    strcpy(mape->exitpic, newe->exitpic);
+  }
+  if (newe->enterpic[0])
+  {
+    strcpy(mape->enterpic, newe->enterpic);
+  }
+  if (newe->interbackdrop[0])
+  {
+    strcpy(mape->interbackdrop, newe->interbackdrop);
+  }
+  if (newe->intermusic[0])
+  {
+    strcpy(mape->intermusic, newe->intermusic);
+  }
+  if (newe->partime)
+  {
+    mape->partime = newe->partime;
+  }
+  if (newe->nointermission)
+  {
+    mape->nointermission = newe->nointermission;
+  }
+  if (newe->numbossactions)
+  {
+    mape->numbossactions = newe->numbossactions;
+    if (mape->numbossactions == -1)
+    {
+      if (mape->bossactions) free(mape->bossactions);
+      mape->bossactions = NULL;
+    }
+    else
+    {
+      mape->bossactions = (bossaction_t *)realloc(mape->bossactions,
+        sizeof(bossaction_t) * mape->numbossactions);
+      memcpy(mape->bossactions, newe->bossactions,
+        sizeof(bossaction_t) * mape->numbossactions);
+    }
+  }
+}
+
 
 // -----------------------------------------------
 // Parses a set of string and concatenates them
@@ -636,13 +716,12 @@ int U_ParseMapInfo(const char *buffer, size_t length)
       continue;
     }
 
-    // Does this property already exist? If yes, replace it.
+    // Does this property already exist? If yes, update it.
     for(i = 0; i < U_mapinfo.mapcount; i++)
     {
       if (!strcmp(parsed.mapname, U_mapinfo.maps[i].mapname))
       {
-        FreeMap(&U_mapinfo.maps[i]);
-        U_mapinfo.maps[i] = parsed;
+        UpdateMapEntry(&U_mapinfo.maps[i], &parsed);
         break;
       }
     }
@@ -657,8 +736,6 @@ int U_ParseMapInfo(const char *buffer, size_t length)
   U_ScanClose(&scanner);
   return 1;
 }
-
-
 
 void U_FreeMapInfo()
 {


### PR DESCRIPTION
Updates map records instead of replacing them when parsing multiple UMPAINFO lumps. This fixes an issue with the latest NRFL midipack.