### PR TITLE
use SDL functions to load a WAV lump

### DIFF
--- a/Source/i_sound.c
+++ b/Source/i_sound.c
@@ -230,9 +230,9 @@ static boolean addsfx(sfxinfo_t *sfx, int channel, int pitch)
          }
 
          samplerate = data[24] | (data[25] << 8) | (data[26] << 16) | (data[27] << 24);
-         samplelen = data[40] | (data[41] << 8) | (data[42] << 16) | (data[43] << 24);
+         //samplelen = data[40] | (data[41] << 8) | (data[42] << 16) | (data[43] << 24);
 
-         if (samplelen > lumplen - 44)
+         //if (samplelen > lumplen - 44)
             samplelen = lumplen - 44;
 
          bits = data[34] | (data[35] << 8);

--- a/Source/i_sound.c
+++ b/Source/i_sound.c
@@ -215,23 +215,16 @@ static boolean addsfx(sfxinfo_t *sfx, int channel, int pitch)
         }
         else
         {
-          SDL_AudioFormat fmt;
-
           if (wav_spec.channels != 1)
           {
             SDL_FreeWAV(wav_buffer);
             return false;
           }
 
-          fmt = wav_spec.format;
-
-          if (SDL_AUDIO_ISINT(fmt))
+          if (SDL_AUDIO_ISINT(wav_spec.format))
           {
-            if (SDL_AUDIO_BITSIZE(fmt) == 8)
-              bits = 8;
-            else if (SDL_AUDIO_BITSIZE(fmt) == 16)
-              bits = 16;
-            else
+            bits = SDL_AUDIO_BITSIZE(wav_spec.format);
+            if (bits != 8 && bits != 16)
             {
               SDL_FreeWAV(wav_buffer);
               return false;
@@ -242,6 +235,7 @@ static boolean addsfx(sfxinfo_t *sfx, int channel, int pitch)
             SDL_FreeWAV(wav_buffer);
             return false;
           }
+
           samplerate = wav_spec.freq;
           data = wav_buffer;
           SOUNDHDRSIZE = 0;


### PR DESCRIPTION
Fix pistol sound in UACrebellion.wad [[idgames]](https://www.doomworld.com/idgames/levels/doom2/Ports/s-u/uacrbln)
The same problem exists in Crispy Doom/PrBoom+.