### PR TITLE
workaround for SDL_Mixer 2.0.4 mp3 header check

### DIFF
--- a/Source/i_sdlmusic.c
+++ b/Source/i_sdlmusic.c
@@ -272,6 +272,8 @@ static void *I_SDL_RegisterSong(void *data, int size)
       else
    #endif
       {
+         // Workaround for SDL_mixer doesn't always detect mp3s
+         // https://github.com/libsdl-org/SDL_mixer/issues/288
          const SDL_version *ver = Mix_Linked_Version();
          if (ver->major == 2 && ver->minor == 0 && ver->patch == 4)
          {

--- a/Source/i_sdlmusic.c
+++ b/Source/i_sdlmusic.c
@@ -272,6 +272,12 @@ static void *I_SDL_RegisterSong(void *data, int size)
       else
    #endif
       {
+         const SDL_version *ver = Mix_Linked_Version();
+         if (ver->major == 2 && ver->minor == 0 && ver->patch == 4)
+         {
+          if (size >= 2 && memcmp(data, "\xff\xf3", 2) == 0)
+            memcpy(data, "\xff\xfa", 2);
+         }
          rw    = SDL_RWFromMem(data, size);
          music = Mix_LoadMUS_RW(rw, false);
       }


### PR DESCRIPTION
Fixes mp3 music in PREACHER.WAD https://doomwiki.org/wiki/Preacher
This is a workaround for the issue discussed here: https://github.com/libsdl-org/SDL_mixer/issues/288