### PR TITLE
immediately redraw status bar after help screens have been shown

### DIFF
--- a/Source/st_stuff.c
+++ b/Source/st_stuff.c
@@ -43,6 +43,9 @@
 #include "sounds.h"
 #include "dstrings.h"
 
+// [crispy] immediately redraw status bar after help screens have been shown
+extern boolean inhelpscreens;
+
 //
 // STATUS BAR DATA
 //
@@ -839,7 +842,8 @@ void ST_diffDraw(void)
 void ST_Drawer(boolean fullscreen, boolean refresh)
 {
   st_statusbaron = !fullscreen || (automapactive && !automapoverlay);
-  st_firsttime = st_firsttime || refresh;
+  // [crispy] immediately redraw status bar after help screens have been shown
+  st_firsttime = st_firsttime || refresh || inhelpscreens;
 
   ST_doPaletteStuff();  // Do red-/gold-shifts from damage/items
 


### PR DESCRIPTION
Fix this bug:
![doom00](https://user-images.githubusercontent.com/5077629/137261232-51c35520-2f7b-48ca-a919-bb767dab7a49.png)
