### PR TITLE
correction of fuzz sprite extra line code from Crispy Doom

### DIFF
--- a/Source/r_draw.c
+++ b/Source/r_draw.c
@@ -381,7 +381,7 @@ void R_DrawFuzzColumn(void)
   // draw one extra line using only pixels of that line and the one above
   if (cutoff)
   {
-    *dest = fullcolormap[6*256+dest[linesize*(fuzzoffset[fuzzpos]-1)/2]];
+    *dest = fullcolormap[6*256+dest[linesize*fuzzoffset[fuzzpos]]];
   }
 }
 


### PR DESCRIPTION
Due to the differences in the `fuzzoffset` table, we don't need to subtract 1 and divide by 2, if I understand correctly. The old code works fine anyway. Sorry, I didn't read this code too closely.