### PR TITLE
fix reset of MBF21 options for complevel mbf demo recording

### DIFF
--- a/Source/g_game.c
+++ b/Source/g_game.c
@@ -2912,6 +2912,8 @@ byte *G_WriteOptions(byte *demo_p)
       *demo_p++ = comp[i] != 0;
   }
 
+  G_MBFComp();
+
   //----------------
   // Padding at end
   //----------------


### PR DESCRIPTION
Fixes the issue reported here: [[doomworld]](https://www.doomworld.com/forum/topic/118074-dsda-doom-source-port-v0213/?do=findComment&comment=2404784)