### PR TITLE
when -complevel mbf is set, ignore MBF21 options in OPTIONS lump

### DIFF
--- a/Source/g_game.c
+++ b/Source/g_game.c
@@ -2752,6 +2752,9 @@ void G_InitNew(skill_t skill, int episode, int map)
   if (demo_version >= 203)
     M_LoadOptions();     // killough 11/98: read OPTIONS lump from wad
 
+  if (demo_version == 203)
+    G_MBFComp();
+
   G_DoLoadLevel();
 }
 


### PR DESCRIPTION
Hopefully fixes this: [[doomworld]](https://www.doomworld.com/forum/topic/118074-dsda-doom-source-port-v0213/?do=findComment&comment=2404784)
I will test this more. Also, I think we need to refactor compatibility options, it became very confusing.