### PR TITLE
When drawing introductory levelname, use height of entering patch

### DIFF
--- a/Source/wi_stuff.c
+++ b/Source/wi_stuff.c
@@ -509,7 +509,8 @@ static void WI_drawEL(void)
   if (wbs->next < num_lnames)
   {
   // draw level
-  y += (5*SHORT(lnames[wbs->next]->height))/4;
+  // haleyjd: corrected to use height of entering, not map name
+  y += (5 * SHORT(entering->height)) / 4;
 
   V_DrawPatch((ORIGWIDTH - SHORT(lnames[wbs->next]->width))/2,
               y, FB, lnames[wbs->next]);


### PR DESCRIPTION
This fixes entering screen in Eviternity.wad, taken from Eternity. Bug report: [[doomworld]](https://www.doomworld.com/forum/topic/112333-this-is-woof-700-sep-27-2021-updated-winmbf/?do=findComment&comment=2407528)