### PR TITLE
fix musinfo lumpnum reset

### DIFF
--- a/Source/s_sound.c
+++ b/Source/s_sound.c
@@ -568,6 +568,7 @@ void S_ChangeMusic(int musicnum, int looping)
    musicinfo_t *music;
 
    musinfo.current_item = -1;
+   S_music[mus_musinfo].lumpnum = -1;
    
    //jff 1/22/98 return if music is not enabled
    if(!mus_card || nomusicparm)


### PR DESCRIPTION
Fixes this issue: [[doomworld]](https://www.doomworld.com/forum/topic/112333-this-is-woof-700-sep-27-2021-updated-winmbf/?do=findComment&comment=2407820)