### PR TITLE
win midi: non-linear volume control

### DIFF
--- a/Source/i_winmusic.c
+++ b/Source/i_winmusic.c
@@ -83,6 +83,24 @@ typedef struct
 
 static buffer_t buffer;
 
+static int volume_correction[] = {
+    0,   4,   7,  11,  13,  14,  16,  18,
+   21,  22,  23,  24,  24,  24,  25,  25,
+   25,  26,  26,  27,  27,  27,  28,  28,
+   29,  29,  29,  30,  30,  31,  31,  32,
+   32,  32,  33,  33,  34,  34,  35,  35,
+   36,  37,  37,  38,  38,  39,  39,  40,
+   40,  41,  42,  42,  43,  43,  44,  45,
+   45,  46,  47,  47,  48,  49,  49,  50,
+   51,  52,  52,  53,  54,  55,  56,  56,
+   57,  58,  59,  60,  61,  62,  62,  63,
+   64,  65,  66,  67,  68,  69,  70,  71,
+   72,  73,  74,  75,  77,  78,  79,  80,
+   81,  82,  84,  85,  86,  87,  89,  90,
+   91,  92,  94,  95,  96,  98,  99, 101,
+  102, 104, 105, 107, 108, 110, 112, 113,
+  115, 117, 118, 120, 122, 123, 125, 127 };
+
 // Message box for midiStream errors.
 
 static void MidiErrorMessageBox(DWORD dwError)
@@ -133,6 +151,8 @@ static void FillBuffer(void)
             channel_volume[MIDIEVENT_CHANNEL(event->dwEvent)] = volume;
 
             volume *= volume_factor;
+
+            volume = volume_correction[volume];
 
             event->dwEvent = (event->dwEvent & 0xFF00FFFF) |
                              ((volume & 0x7F) << 16);
@@ -361,6 +381,8 @@ void I_WIN_SetMusicVolume(int volume)
     for (i = 0; i < MIDI_CHANNELS_PER_TRACK; ++i)
     {
         int value = channel_volume[i] * volume_factor;
+
+        value = volume_correction[value];
 
         DWORD msg = MIDI_EVENT_CONTROLLER | i |
                     (MIDI_CONTROLLER_MAIN_VOLUME << 8) |

--- a/Source/i_winmusic.c
+++ b/Source/i_winmusic.c
@@ -83,7 +83,7 @@ typedef struct
 
 static buffer_t buffer;
 
-static int volume_correction[] = {
+static const int volume_correction[] = {
     0,   4,   7,  11,  13,  14,  16,  18,
    21,  22,  23,  24,  24,  24,  25,  25,
    25,  26,  26,  27,  27,  27,  28,  28,


### PR DESCRIPTION
`volume_correction` table is taken from https://www.native-instruments.com/forum/threads/change-the-instrument-midi-cc-attenuation-mapping.333383/page-2
Without it, setting volume to 1 just seemed near-uselessly quiet, compared to SDL_mixer before it.