### PR TITLE
fix scaled time interpolation

### DIFF
--- a/Source/doomtype.h
+++ b/Source/doomtype.h
@@ -76,6 +76,9 @@ typedef int64_t Long64;
 #ifndef MAX
  #define MAX(a,b) (((a)>(b))?(a):(b))
 #endif
+#ifndef BETWEEN
+ #define BETWEEN(l,u,x) ((l)>(x)?(l):(x)>(u)?(u):(x))
+#endif
 
 #if defined(_MSC_VER) && !defined(__cplusplus)
 #define inline __inline

--- a/Source/i_system.h
+++ b/Source/i_system.h
@@ -44,6 +44,8 @@ int I_GetTime_RealTime();     // killough
 int I_GetTime_Adaptive(void); // killough 4/10/98
 extern int GetTime_Scale;
 
+extern int (*I_TickElapsedTime)(void);
+
 // [FG] Same as I_GetTime, but returns time in milliseconds
 int I_GetTimeMS();
 // [FG] toggle demo warp mode

--- a/Source/i_video.c
+++ b/Source/i_video.c
@@ -939,7 +939,12 @@ void I_FinishUpdate(void)
    // [AM] Figure out how far into the current tic we're in as a fixed_t.
    if (uncapped)
    {
-	fractionaltic = I_GetTimeMS() * TICRATE % 1000 * FRACUNIT / 1000;
+        const double tics_per_msec = TICRATE / 1000.0f;
+
+        int tic_time = I_TickElapsedTime();
+
+        fractionaltic = (fixed_t) (tic_time * FRACUNIT * tics_per_msec);
+        fractionaltic = BETWEEN(0, FRACUNIT, fractionaltic);
    }
 
    I_RestoreDiskBackground();

--- a/Source/i_video.c
+++ b/Source/i_video.c
@@ -939,11 +939,9 @@ void I_FinishUpdate(void)
    // [AM] Figure out how far into the current tic we're in as a fixed_t.
    if (uncapped)
    {
-        const double tics_per_msec = TICRATE / 1000.0f;
-
         int tic_time = I_TickElapsedTime();
 
-        fractionaltic = (fixed_t) (tic_time * FRACUNIT * tics_per_msec);
+        fractionaltic = tic_time * FRACUNIT * TICRATE / 1000;
         fractionaltic = BETWEEN(0, FRACUNIT, fractionaltic);
    }
 


### PR DESCRIPTION
Taken from DSDA-Doom: https://github.com/kraflab/dsda-doom/pull/90

I wonder if this can help us fix the `newsync` interpolation.