### PR TITLE
allow the DEH parser to skip blank lines

### DIFF
--- a/Source/d_deh.c
+++ b/Source/d_deh.c
@@ -1718,7 +1718,7 @@ void ProcessDehFile(const char *filename, char *outfilename, int lumpnum)
         { // process that same line again with the last valid block code handler
           i = last_i;
           if (!filein->lump)
-            dehfseek(filein, filepos, SEEK_SET);
+            dehfseek(filein, filepos);
         }
 
       if (fileout)


### PR DESCRIPTION
Fixes this issue: [[doomworld]](https://www.doomworld.com/forum/topic/112333-this-is-woof-810-nov-26-2021-updated-winmbf/?do=findComment&comment=2422224)

Taken from PrBoom+: https://github.com/coelckers/prboom-plus/pull/319 and https://github.com/coelckers/prboom-plus/commit/5d565192e8a65f9f205673623c36d57df601fc2c