### PR TITLE
fix missing gamepad graphics in the menu

### DIFF
--- a/Source/m_menu.c
+++ b/Source/m_menu.c
@@ -1371,7 +1371,7 @@ menuitem_t MouseMenu[]=
   {-1,"",0},
   {2,"M_VERSEN",M_MouseVert,'v', "VERTICAL"},
   {-1,"",0},
-  {2,"",M_ControllerTurn,'g',"GAMEPAD"},
+  {2,"M_PADSEN",M_ControllerTurn,'g',"GAMEPAD"},
   {-1,"",0}
 };
 


### PR DESCRIPTION
Fixes this issue: [[doomworld]](https://www.doomworld.com/forum/topic/112333-this-is-woof-810-nov-26-2021-updated-winmbf/?do=findComment&comment=2424171)