### PR TITLE
reuse existing renderer in TXT_Init()

### DIFF
--- a/textscreen/txt_sdl.c
+++ b/textscreen/txt_sdl.c
@@ -265,14 +265,8 @@ int TXT_Init(void)
     if (TXT_SDLWindow == NULL)
         return 0;
 
-    // Destroy the existing renderer, so we can create our own new one
-
-    if (renderer != NULL)
-    {
-        SDL_DestroyRenderer(renderer);
-    }
-
-    renderer = SDL_CreateRenderer(TXT_SDLWindow, -1, SDL_RENDERER_PRESENTVSYNC);
+    if (renderer == NULL)
+        renderer = SDL_CreateRenderer(TXT_SDLWindow, -1, SDL_RENDERER_PRESENTVSYNC);
 
     if (renderer == NULL)
         renderer = SDL_CreateRenderer(TXT_SDLWindow, -1, SDL_RENDERER_SOFTWARE);


### PR DESCRIPTION
instead of destroying it and creating a new one.

Fixes a crash on exit when ENDOOM is enabled.

Fixes #372, thanks @hackneyed-one.