### PR TITLE
free video resources on shut down

### DIFF
--- a/Source/i_system.c
+++ b/Source/i_system.c
@@ -338,6 +338,8 @@ void I_Quit (void)
 {
    has_exited=1;   /* Prevent infinitely recursive exits -- killough */
    
+   I_QuitVideo(0);
+
    if (*errmsg)
       puts(errmsg);   // killough 8/8/98
    else
@@ -346,6 +348,8 @@ void I_Quit (void)
    if (demorecording)
       G_CheckDemoStatus();
    M_SaveDefaults();
+
+   I_QuitVideo(1);
 
    SDL_QuitSubSystem(SDL_INIT_VIDEO);
 

--- a/Source/i_system.h
+++ b/Source/i_system.h
@@ -84,6 +84,7 @@ ticcmd_t* I_BaseTiccmd (void);
 // atexit handler -- killough
 
 void I_Quit (void);
+void I_QuitVideo (int);
 
 // Allocates from low memory under dos, just mallocs under unix
 

--- a/Source/i_video.c
+++ b/Source/i_video.c
@@ -1566,6 +1566,41 @@ static void I_InitGraphicsMode(void)
    I_SetPalette(W_CacheLumpName("PLAYPAL",PU_CACHE));
 }
 
+void I_QuitVideo (int phase)
+{
+  if (phase == 0)
+  {
+    if (argbbuffer != NULL)
+    {
+      SDL_FreeSurface(argbbuffer);
+      argbbuffer = NULL;
+    }
+    if (sdlscreen != NULL)
+    {
+      SDL_FreeSurface(sdlscreen);
+      sdlscreen = NULL;
+    }
+    if (texture != NULL)
+    {
+      SDL_DestroyTexture(texture);
+      texture = NULL;
+    }
+  }
+  else
+  {
+    if (renderer != NULL)
+    {
+      SDL_DestroyRenderer(renderer);
+      renderer = NULL;
+    }
+    if (screen != NULL)
+    {
+      SDL_DestroyWindow(screen);
+      screen = NULL;
+    }
+  }
+}
+
 void I_ResetScreen(void)
 {
    if(!in_graphics_mode)


### PR DESCRIPTION
Consider that the window and renderer get reused by I_EndDoom() and thus
delay their destruction. Fixes #353, fixes #355.