### PR TITLE
set demo_insurance = 0

### DIFF
--- a/Source/doomstat.h
+++ b/Source/doomstat.h
@@ -93,7 +93,7 @@ extern int pitched_sounds;
 
 extern int general_translucency;
 
-extern int demo_insurance, default_demo_insurance;      // killough 4/5/98
+extern int demo_insurance;      // killough 4/5/98
 
 // -------------------------------------------
 // killough 10/98: compatibility vector

--- a/Source/g_game.c
+++ b/Source/g_game.c
@@ -2562,7 +2562,7 @@ void G_ReloadDefaults(void)
     G_MBFComp();
 
   // killough 3/31/98, 4/5/98: demo sync insurance
-  demo_insurance = 0; // (default_demo_insurance == 1);
+  demo_insurance = 0;
 
   // haleyjd
   rngseed = time(NULL);
@@ -2804,7 +2804,7 @@ void G_RecordDemo(char *name)
     orig_demoname = name;
   }
 
-  demo_insurance = 0; // (default_demo_insurance!=0);     // killough 12/98
+  demo_insurance = 0;
       
   usergame = false;
   if (demoname) (free)(demoname);

--- a/Source/g_game.c
+++ b/Source/g_game.c
@@ -2562,7 +2562,7 @@ void G_ReloadDefaults(void)
     G_MBFComp();
 
   // killough 3/31/98, 4/5/98: demo sync insurance
-  demo_insurance = (default_demo_insurance == 1);
+  demo_insurance = 0;
 
   // haleyjd
   rngseed = time(NULL);
@@ -2804,7 +2804,7 @@ void G_RecordDemo(char *name)
     orig_demoname = name;
   }
 
-  demo_insurance = mbf21 ? 0 : (default_demo_insurance!=0);     // killough 12/98
+  demo_insurance = 0; // (default_demo_insurance!=0);     // killough 12/98
       
   usergame = false;
   if (demoname) (free)(demoname);

--- a/Source/g_game.c
+++ b/Source/g_game.c
@@ -2562,7 +2562,7 @@ void G_ReloadDefaults(void)
     G_MBFComp();
 
   // killough 3/31/98, 4/5/98: demo sync insurance
-  demo_insurance = 0;
+  demo_insurance = 0; // (default_demo_insurance == 1);
 
   // haleyjd
   rngseed = time(NULL);

--- a/Source/m_misc.c
+++ b/Source/m_misc.c
@@ -209,14 +209,7 @@ default_t defaults[] = {
     {1}, {0,1}, number, ss_gen, wad_yes,
     "1 to enable flashing HOM indicator"
   },
-#if 0
-  { // killough 3/31/98
-    "demo_insurance",
-    (config_t *) &default_demo_insurance, NULL,
-    {2}, {0,2},number, ss_none, wad_no,
-    "1=take special steps ensuring demo sync, 2=only during recordings"
-  },
-#endif
+
   { // phares
     "weapon_recoil",
     (config_t *) &default_weapon_recoil, (config_t *) &weapon_recoil,

--- a/Source/m_misc.c
+++ b/Source/m_misc.c
@@ -209,14 +209,14 @@ default_t defaults[] = {
     {1}, {0,1}, number, ss_gen, wad_yes,
     "1 to enable flashing HOM indicator"
   },
-
+#if 0
   { // killough 3/31/98
     "demo_insurance",
     (config_t *) &default_demo_insurance, NULL,
     {2}, {0,2},number, ss_none, wad_no,
     "1=take special steps ensuring demo sync, 2=only during recordings"
   },
-
+#endif
   { // phares
     "weapon_recoil",
     (config_t *) &default_weapon_recoil, (config_t *) &weapon_recoil,


### PR DESCRIPTION
In the netgame complevel boom or mbf, if one of the players is recording a demo, it gets out of sync because `demo_insurance == 2`. Since `demo_insurance` is always 0 in PrBoom+ and MBF21, I suggest setting it to 0 too. Alternatively, we can sync the `demo_insurance` option in netgame.