### PR TITLE
fix player mobj is always in S_PLAY_RUN1 state in complevel boom

### DIFF
--- a/Source/p_user.c
+++ b/Source/p_user.c
@@ -225,6 +225,8 @@ void P_MovePlayer (player_t* player)
 	      P_Thrust(player,mo->angle-ANG90,cmd->sidemove*movefactor);
 	    }
 	}
+      // Add (cmd-> forwardmove || cmd-> sidemove) check to prevent the players
+      // always in S_PLAY_RUN1 animation in complevel Boom.
       if ((cmd->forwardmove || cmd->sidemove) &&
           (mo->state == states+S_PLAY))
 	P_SetMobjState(mo,S_PLAY_RUN1);

--- a/Source/p_user.c
+++ b/Source/p_user.c
@@ -225,7 +225,8 @@ void P_MovePlayer (player_t* player)
 	      P_Thrust(player,mo->angle-ANG90,cmd->sidemove*movefactor);
 	    }
 	}
-      if (mo->state == states+S_PLAY)
+      if ((cmd->forwardmove || cmd->sidemove) &&
+          (mo->state == states+S_PLAY))
 	P_SetMobjState(mo,S_PLAY_RUN1);
     }
 }


### PR DESCRIPTION
This bug is also present in PrBoom+. The original Boom 2.02 is fine.: https://github.com/Doom-Utils/historic-ports/blob/3ae2d25740b9d4ea896f0fde0c73f6b112135ce5/p_user.c#L177-L188
Not sure if this fix is demo compatible. I recorded several demos, it seems to work.