### PR TITLE
undo new_sync interpolation fix

### DIFF
--- a/Source/d_loop.c
+++ b/Source/d_loop.c
@@ -692,8 +692,12 @@ void TryRunTics (void)
     int	availabletics;
     int	counts;
 
+    // [AM] If we've uncapped the framerate and there are no tics
+    //      to run, return early instead of waiting around.
+    #define return_early (uncapped && counts == 0 && leveltime > oldleveltime)
+
     // get real tics
-    entertic = (I_GetTime() - basetic) / ticdup;
+    entertic = I_GetTime() / ticdup;
     realtics = entertic - oldentertics;
     oldentertics = entertic;
 
@@ -721,7 +725,7 @@ void TryRunTics (void)
 
         // [AM] If we've uncapped the framerate and there are no tics
         //      to run, return early instead of waiting around.
-        if (uncapped && realtics == 0 && leveltime > oldleveltime)
+        if (return_early)
             return;
     }
     else
@@ -736,7 +740,7 @@ void TryRunTics (void)
 
         // [AM] If we've uncapped the framerate and there are no tics
         //      to run, return early instead of waiting around.
-        if (uncapped && counts == 0 && leveltime > oldleveltime)
+        if (return_early)
             return;
 
         if (counts < 1)


### PR DESCRIPTION
I think this fix is wrong anyway. Alternatively, we can use the interpolation method from earlier versions of PrBoom/Eternity, but it depends on vsync and is not as smooth for some reason.