### PR TITLE
win midi: fix songs that forget to terminate notes held over loop point

### DIFF
--- a/Source/i_winmusic.c
+++ b/Source/i_winmusic.c
@@ -101,6 +101,20 @@ static void MidiErrorMessageBox(DWORD dwError)
     }
 }
 
+static void AllNotesOff(void)
+{
+    int i;
+
+    for (i = 0; i < MIDI_CHANNELS_PER_TRACK; ++i)
+    {
+        DWORD msg = 0;
+
+        msg = MIDI_EVENT_CONTROLLER | i | (MIDI_CONTROLLER_ALL_NOTES_OFF << 8);
+
+        midiOutShortMsg((HMIDIOUT)hMidiStream, msg);
+    }
+}
+
 // Fill the buffer with MIDI events, adjusting the volume as needed.
 
 static void FillBuffer(void)
@@ -115,6 +129,9 @@ static void FillBuffer(void)
         {
             if (song.looping)
             {
+                // Fix buggy songs that forget to terminate notes held over loop
+                // point.
+                AllNotesOff();
                 song.position = 0;
             }
             else


### PR DESCRIPTION
Fixes this issue: [[doomwold]](https://www.doomworld.com/forum/topic/112333-this-is-woof-810-nov-26-2021-updated-winmbf/?do=findComment&comment=2430070)

Here is a quote from https://doomwiki.org/wiki/Doom_II_music:
> The final note in the song's lead melody is the correct length in D_DDTBLU, while in D_DDTBL2 and D_DDTBL3 it appears to be of infinite length (in General MIDI this is defined as 546 bars and 15 tics). In-game it will either play for the length of the whole final measure, or hang indefinitely; in the latter cases it will either prevent the song from looping, or the note will persist across all further loops of the song.

Not sure if should fix that in OPL player.