### PR TITLE
apply scalefactor from command line only once during initialization

### DIFF
--- a/Source/i_video.c
+++ b/Source/i_video.c
@@ -1287,6 +1287,7 @@ static void I_InitGraphicsMode(void)
    static boolean firsttime = true;
    
    // haleyjd
+   static int old_v_w, old_v_h;
    int v_w, v_h;
    int flags = 0;
    int scalefactor = 0;
@@ -1408,6 +1409,7 @@ static void I_InitGraphicsMode(void)
    actualheight = useaspect ? (6 * v_h / 5) : v_h;
 
    SDL_SetWindowMinimumSize(screen, v_w, actualheight);
+   SDL_GetWindowSize(screen, &window_width, &window_height);
 
    // [FG] window size when returning from fullscreen mode
    if (scalefactor > 0)
@@ -1415,10 +1417,23 @@ static void I_InitGraphicsMode(void)
       window_width = scalefactor * v_w;
       window_height = scalefactor * actualheight;
    }
-   else if (window_height * v_w > window_width * actualheight)
+   else if (old_v_w > 0 && old_v_h > 0)
    {
-      window_width = window_height * v_w / actualheight;
+      int rendered_height;
+
+      // rendered height does not necessarily match window height
+      if (window_height * old_v_w > window_width * old_v_h)
+          rendered_height = window_width * old_v_h / old_v_w;
+      else
+          rendered_height = window_height;
+
+      // need to resize window width?
+      if (rendered_height * v_w > window_width * actualheight)
+          window_width = rendered_height * v_w / actualheight;
    }
+
+   old_v_w = v_w;
+   old_v_h = actualheight;
 
    if (!fullscreen)
    {

--- a/Source/i_video.c
+++ b/Source/i_video.c
@@ -1410,21 +1410,14 @@ static void I_InitGraphicsMode(void)
    SDL_SetWindowMinimumSize(screen, v_w, actualheight);
 
    // [FG] window size when returning from fullscreen mode
-   if (scalefactor == 0)
-   {
-      scalefactor = MIN(window_width / v_w, window_height / actualheight);
-      scalefactor = MAX(scalefactor, 1);
-   }
-   else
-   {
-      // [FG] trigger resetting window size below if scalefactor was set on the command line
-      window_width = 0;
-   }
-
-   if (scalefactor * v_w > window_width)
+   if (scalefactor > 0)
    {
       window_width = scalefactor * v_w;
       window_height = scalefactor * actualheight;
+   }
+   else if (window_height * v_w > window_width * actualheight)
+   {
+      window_width = window_height * v_w / actualheight;
    }
 
    if (!fullscreen)

--- a/Source/i_video.c
+++ b/Source/i_video.c
@@ -1310,6 +1310,17 @@ static void I_InitGraphicsMode(void)
          usehires = hires = true;
       else if(M_CheckParm("-nohires"))
          usehires = hires = false; // grrr...
+
+      if(M_CheckParm("-1"))
+         scalefactor = 1;
+      else if(M_CheckParm("-2"))
+         scalefactor = 2;
+      else if(M_CheckParm("-3"))
+         scalefactor = 3;
+      else if(M_CheckParm("-4"))
+         scalefactor = 4;
+      else if(M_CheckParm("-5"))
+         scalefactor = 5;
    }
 
    // haleyjd 10/09/05: from Chocolate DOOM
@@ -1398,19 +1409,19 @@ static void I_InitGraphicsMode(void)
 
    SDL_SetWindowMinimumSize(screen, v_w, actualheight);
 
-   if(M_CheckParm("-1"))
-      scalefactor = 1;
-   else if(M_CheckParm("-2"))
-      scalefactor = 2;
-   else if(M_CheckParm("-3"))
-      scalefactor = 3;
-   else if(M_CheckParm("-4"))
-      scalefactor = 4;
-   else if(M_CheckParm("-5"))
-      scalefactor = 5;
-
    // [FG] window size when returning from fullscreen mode
-   if (scalefactor > 0)
+   if (scalefactor == 0)
+   {
+      scalefactor = MIN(window_width / v_w, window_height / actualheight);
+      scalefactor = MAX(scalefactor, 1);
+   }
+   else
+   {
+      // [FG] trigger resetting window size below if scalefactor was set on the command line
+      window_width = 0;
+   }
+
+   if (scalefactor * v_w > window_width)
    {
       window_width = scalefactor * v_w;
       window_height = scalefactor * actualheight;


### PR DESCRIPTION
On subsequent calls of I_InitGraphicsMode(), e.g. when changing hires
or widescreen in-game, determine (coarse, integer) scalefactor from
current ratio of window and framebuffer size. Resize window only if
new size is going to be wider than previous size. Force resizing of
window if scalefactor was set on command line.