### PR TITLE
check for Win32 and either MSVC or cross-buildind

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ check_symbol_exists(strsignal "string.h" HAVE_STRSIGNAL)
 # SDL2.  On Windows, we use the official development library.
 find_package(SDL2 2.0.7)
 if(NOT SDL2_FOUND)
-    if(WIN32 AND NOT MSYS)
+    if(WIN32 AND (MSVC OR CMAKE_CROSSCOMPILING))
         message(STATUS "Downloading SDL2 Development Library...")
         if(MSVC)
             file(DOWNLOAD
@@ -86,7 +86,7 @@ endif()
 # SDL2_mixer.  On Windows, we use the official development library.
 find_package(SDL2_mixer 2.0.2)
 if(NOT SDL2_MIXER_FOUND)
-    if(WIN32 AND NOT MSYS)
+    if(WIN32 AND (MSVC OR CMAKE_CROSSCOMPILING))
         message(STATUS "Downloading SDL2_mixer Development Library...")
         if(MSVC)
             file(DOWNLOAD
@@ -113,7 +113,7 @@ endif()
 # SDL2_net.  On Windows, we use the official development library.
 find_package(SDL2_net)
 if(NOT SDL2_NET_FOUND)
-    if(WIN32 AND NOT MSYS)
+    if(WIN32 AND (MSVC OR CMAKE_CROSSCOMPILING))
         message(STATUS "Downloading SDL2_net Development Library...")
         if(MSVC)
             file(DOWNLOAD

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -180,7 +180,7 @@ target_compile_definitions(woof PRIVATE MINIZ_NO_ARCHIVE_APIS)
 
 # Assemble library files.
 set(WOOF_DLLS "")
-if(WIN32 AND NOT MSYS)
+if(WIN32 AND SDL2_DIR)
     # SDL2
     list(APPEND WOOF_DLLS "${SDL2_DLL_DIR}/SDL2.dll")
 
@@ -215,7 +215,7 @@ endif()
 install(FILES ${WOOF_DLLS} DESTINATION .)
 
 # Try get dependencies in MSYS2 environment.
-if(MSYS)
+if(WIN32 AND NOT SDL2_DIR)
     find_program(DLLTOOL_EXECUTABLE
         NAMES dlltool dlltool.exe
     )

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -180,7 +180,7 @@ target_compile_definitions(woof PRIVATE MINIZ_NO_ARCHIVE_APIS)
 
 # Assemble library files.
 set(WOOF_DLLS "")
-if(WIN32 AND SDL2_DIR)
+if(WIN32 AND (MSVC OR CMAKE_CROSSCOMPILING))
     # SDL2
     list(APPEND WOOF_DLLS "${SDL2_DLL_DIR}/SDL2.dll")
 
@@ -215,7 +215,7 @@ endif()
 install(FILES ${WOOF_DLLS} DESTINATION .)
 
 # Try get dependencies in MSYS2 environment.
-if(WIN32 AND NOT SDL2_DIR)
+if(WIN32 AND NOT MSVC AND NOT CMAKE_CROSSCOMPILING)
     find_program(DLLTOOL_EXECUTABLE
         NAMES dlltool dlltool.exe
     )


### PR DESCRIPTION
I think this covers all the cases that we officially, i.e. per
README.md, support:

  * Build for Windows
    * Native
      * MSVC
        - Download libraries
      * MinGW
        - Do not download libraries
    * Cross-build
      - Download libraries
  * Build for anything else
    - Do not download libraries