### PR TITLE
fix menu selection for items with alphaKey == 0

### DIFF
--- a/Source/m_menu.c
+++ b/Source/m_menu.c
@@ -5818,6 +5818,8 @@ boolean M_Responder (event_t* ev)
   
   else
     {
+      if (ch) // fix items with alphaKey == 0
+      {
       for (i = itemOn+1;i < currentMenu->numitems;i++)
 	if (currentMenu->menuitems[i].alphaKey == ch)
 	  {
@@ -5832,6 +5834,7 @@ boolean M_Responder (event_t* ev)
 	    S_StartSound(NULL,sfx_pstop);
 	    return true;
 	  }
+      }
     }
   return false;
 }


### PR DESCRIPTION
Fixes this issue: [[doomworld]](https://www.doomworld.com/forum/topic/112333-this-is-woof-810-nov-26-2021-updated-winmbf/?do=findComment&comment=2439112)
> By using any mouse commands (Left/right/middle click or wheel up/down) on the Options menus, the next available thermometer (not the text above it as usual) will be selected, but it can't be interacted with, be it through mouse or keyboard commands (occurs on the Options menu itself, Mouse Sensitivity and Sound Volume menus). Otherwise, if there are no thermometers, a sound will play but nothing will happen (occurs on the General and Setup screens).