### PR TITLE
m_menu: fix widescreen rendering of shareware HELP2 screen

### DIFF
--- a/Source/m_menu.c
+++ b/Source/m_menu.c
@@ -493,7 +493,7 @@ void M_DrawReadThis1(void)
 {
   inhelpscreens = true;
   if (gamemode == shareware)
-    V_DrawPatchDirect (0,0,0,W_CacheLumpName("HELP2",PU_CACHE));
+    V_DrawPatchFullScreen (0,W_CacheLumpName("HELP2",PU_CACHE));
   else
     M_DrawCredits();
 }


### PR DESCRIPTION
Trivial fix so a widescreen compatible HELP2 asset can also be drawn properly.