### PR TITLE
back to Crispy Doom formula for fractionaltic calculation

### DIFF
--- a/Source/i_system.h
+++ b/Source/i_system.h
@@ -44,7 +44,7 @@ int I_GetTime_RealTime();     // killough
 int I_GetTime_Adaptive(void); // killough 4/10/98
 extern int GetTime_Scale;
 
-extern int (*I_TickElapsedTime)(void);
+extern int (*I_GetFracTime)(void);
 
 // [FG] Same as I_GetTime, but returns time in milliseconds
 int I_GetTimeMS();

--- a/Source/i_video.c
+++ b/Source/i_video.c
@@ -938,10 +938,7 @@ void I_FinishUpdate(void)
    // [AM] Figure out how far into the current tic we're in as a fixed_t.
    if (uncapped)
    {
-        int tic_time = I_TickElapsedTime();
-
-        fractionaltic = tic_time * FRACUNIT * TICRATE / 1000;
-        fractionaltic = BETWEEN(0, FRACUNIT, fractionaltic);
+        fractionaltic = I_GetFracTime();
    }
 
    I_RestoreDiskBackground();


### PR DESCRIPTION
Is there a way to simplify `I_GetFracScaledTime`?