### PR TITLE
split dirname and basename at both types of slashes on Windows

### DIFF
--- a/Source/m_misc2.c
+++ b/Source/m_misc2.c
@@ -189,15 +189,21 @@ boolean M_StrToInt(const char *str, int *result)
 
 char *M_DirName(const char *path)
 {
-    char *p, *result;
+    char *pf, *pb, *result;
 
-    p = strrchr(path, DIR_SEPARATOR);
-    if (p == NULL)
+    pf = strrchr(path, '/');
+#ifdef _WIN32
+    pb = strrchr(path, '\\');
+#else
+    pb = NULL;
+#endif
+    if (pf == NULL && pb == NULL)
     {
         return M_StringDuplicate(".");
     }
     else
     {
+        char *p = MAX(pf, pb);
         result = M_StringDuplicate(path);
         result[p - path] = '\0';
         return result;
@@ -210,15 +216,21 @@ char *M_DirName(const char *path)
 
 const char *M_BaseName(const char *path)
 {
-    const char *p;
+    const char *pf, *pb;
 
-    p = strrchr(path, DIR_SEPARATOR);
-    if (p == NULL)
+    pf = strrchr(path, '/');
+#ifdef _WIN32
+    pb = strrchr(path, '\\');
+#else
+    pb = NULL;
+#endif
+    if (pf == NULL && pb == NULL)
     {
         return path;
     }
     else
     {
+        const char *p = MAX(pf, pb);
         return p + 1;
     }
 }


### PR DESCRIPTION
User-supplied path names may still contain both types of slashes, i.e. forward and backward slashes.

Fixes #437