### PR TITLE
de-hardcode colored blood values

### DIFF
--- a/Source/d_main.c
+++ b/Source/d_main.c
@@ -1812,11 +1812,6 @@ static void D_InitTables(void)
   mobjinfo[MT_HEADSHOT].altspeed = 20 * FRACUNIT;
   mobjinfo[MT_TROOPSHOT].altspeed = 20 * FRACUNIT;
 
-  // [Woof!]
-  mobjinfo[MT_HEAD].bloodcolor = 3; // Blue
-  mobjinfo[MT_BRUISER].bloodcolor = 2; // Green
-  mobjinfo[MT_KNIGHT].bloodcolor = 2; // Green
-
   // DEHEXTRA
   mobjinfo[MT_WOLFSS].droppeditem = MT_CLIP;
   mobjinfo[MT_POSSESSED].droppeditem = MT_CLIP;

--- a/autoload/chex.wad/extchex.deh
+++ b/autoload/chex.wad/extchex.deh
@@ -4,12 +4,6 @@ Dropped item = 0
 Thing 3 (Shotgun guy)
 Dropped item = 0
 
-Thing 15 (Cacodemon)
-Blood color = 0
-
-Thing 16 (Baron of Hell)
-Blood color = 0
-
 [STRINGS]
 HUSTR_E1M6 = E1M5: Caverns of Bazoik
 HUSTR_E1M7 = E1M5: Caverns of Bazoik

--- a/autoload/doom-all/bloodcolor.deh
+++ b/autoload/doom-all/bloodcolor.deh
@@ -1,0 +1,8 @@
+Thing 15 (Cacodemon)
+Blood color = 3
+
+Thing 16 (Baron of Hell)
+Blood color = 2
+
+Thing 18 (Hell Knight)
+Blood color = 2

--- a/autoload/hacx.wad/bloodcolor.deh
+++ b/autoload/hacx.wad/bloodcolor.deh
@@ -1,8 +1,2 @@
-Thing 16 (Baron of Hell)
-Blood color = 0
-
-Thing 18 (Hell knight)
-Blood color = 0
-
 Thing 21 (Arachnotron)
 Blood color = 2

--- a/autoload/rekkr.wad/bloodcolor.deh
+++ b/autoload/rekkr.wad/bloodcolor.deh
@@ -1,5 +1,0 @@
-Thing 15 (Cacodemon)
-Blood color = 0
-
-Thing 16 (Baron of Hell)
-Blood color = 0

--- a/autoload/rekkrsa.wad/bloodcolor.deh
+++ b/autoload/rekkrsa.wad/bloodcolor.deh
@@ -1,5 +1,0 @@
-Thing 15 (Cacodemon)
-Blood color = 0
-
-Thing 16 (Baron of Hell)
-Blood color = 0


### PR DESCRIPTION
Apply them using the doom-all autoload instead. Much less values to set, reset and apply again.