### PR TITLE
Fix intro music not playing with older versions of Fluidsynth

### DIFF
--- a/Source/i_flmusic.c
+++ b/Source/i_flmusic.c
@@ -183,7 +183,7 @@ static void I_FL_ResumeSong(void *handle)
 
 static void I_FL_PlaySong(void *handle, boolean looping)
 {
-    fluid_player_set_loop(player, looping ? -1 : 0);
+    fluid_player_set_loop(player, looping ? -1 : 1);
     fluid_player_play(player);
 }
 


### PR DESCRIPTION
On older versions of Fluidsynth, passing a loop count of 0 can cause a track to not play at all. Passing 1 seems to be more reliable across different versions. Tested with Fluidsynth 2.1.1 and 2.2.5.

Fixes intro music not playing as described [here.](https://www.doomworld.com/forum/post/2468643)