### PR TITLE
stretch short skies

### DIFF
--- a/Source/g_game.c
+++ b/Source/g_game.c
@@ -602,6 +602,8 @@ static void G_DoLoadLevel(void)
         break;
       }//jff 3/27/98 end sky setting fix
 
+  R_InitSkyMap(); // [FG] stretch short skies
+
   levelstarttic = gametic;        // for time calculation
 
   if (!demo_compatibility && demo_version < 203)   // killough 9/29/98

--- a/Source/m_menu.c
+++ b/Source/m_menu.c
@@ -56,6 +56,7 @@
 #include "p_saveg.h" // saveg_compat
 #include "m_input.h"
 #include "r_draw.h" // [FG] R_SetFuzzColumnMode
+#include "r_sky.h" // [FG] R_InitSkyMap()
 
 // [crispy] remove DOS reference from the game quit confirmation dialogs
 #include "SDL_platform.h"
@@ -3665,18 +3666,12 @@ enum {
 };
 
 enum {
-  general_wad1,
-  general_wad2,
-  general_deh1,
-  general_deh2
-};
-
-enum {
   general_corpse,
   general_realtic,
   general_skill,
   general_comp,
   general_endoom,
+  general_stretchsky,
   general_end
 };
 
@@ -3707,38 +3702,25 @@ setup_menu_t gen_settings2[] = { // General Settings screen2
   {"Double Click acts as \"Use\"", S_YESNO, m_null, G_X,
    G_Y + general_leds*8, {"dclick_use"}},
 
-#if 0
-  {"Keyboard LEDs Always Off", S_YESNO, m_null, G_X,
-   G_Y + general_leds*8, {"leds_always_off"}, 0, 0, I_ResetLEDs},
-#endif
-
-  {"Files Preloaded at Game Startup",S_SKIP|S_TITLE, m_null, G_X,
-   G_Y3 - 12},
-
-  {"WAD # 1", S_FILE, m_null, GF_X, G_Y3 + general_wad1*8, {"wadfile_1"}},
-
-  {"WAD #2", S_FILE, m_null, GF_X, G_Y3 + general_wad2*8, {"wadfile_2"}},
-
-  {"DEH/BEX # 1", S_FILE, m_null, GF_X, G_Y3 + general_deh1*8, {"dehfile_1"}},
-
-  {"DEH/BEX #2", S_FILE, m_null, GF_X, G_Y3 + general_deh2*8, {"dehfile_2"}},
-
-  {"Miscellaneous"  ,S_SKIP|S_TITLE, m_null, G_X, G_Y4 - 12},
+  {"Miscellaneous"  ,S_SKIP|S_TITLE, m_null, G_X, G_Y3 - 12},
 
   {"Maximum number of player corpses", S_NUM|S_PRGWARN, m_null, G_X,
-   G_Y4 + general_corpse*8, {"max_player_corpse"}},
+   G_Y3 + general_corpse*8, {"max_player_corpse"}},
 
   {"Game speed, percentage of normal", S_NUM|S_PRGWARN, m_null, G_X,
-   G_Y4 + general_realtic*8, {"realtic_clock_rate"}},
+   G_Y3 + general_realtic*8, {"realtic_clock_rate"}},
 
   {"Default skill level", S_CHOICE|S_LEVWARN, m_null, G_X,
-   G_Y4 + general_skill*8, {"default_skill"}, 0, NULL, default_skill_strings},
+   G_Y3 + general_skill*8, {"default_skill"}, 0, NULL, default_skill_strings},
 
   {"Default compatibility", S_CHOICE|S_LEVWARN, m_null, G_X,
-   G_Y4 + general_comp*8, {"default_complevel"}, 0, NULL, default_compatibility_strings},
+   G_Y3 + general_comp*8, {"default_complevel"}, 0, NULL, default_compatibility_strings},
 
   {"Show ENDOOM screen", S_CHOICE, m_null, G_X,
-   G_Y4 + general_endoom*8, {"show_endoom"}, 0, NULL, default_endoom_strings},
+   G_Y3 + general_endoom*8, {"show_endoom"}, 0, NULL, default_endoom_strings},
+
+  {"Stretch short Skies", S_YESNO, m_null, G_X,
+   G_Y3 + general_stretchsky*8, {"stretchsky"}, 0, R_InitSkyMap},
 
   {"<- PREV",S_SKIP|S_PREV, m_null, KB_PREV, KB_Y+20*8, {gen_settings1}},
 

--- a/Source/m_misc.c
+++ b/Source/m_misc.c
@@ -49,6 +49,7 @@
 #include "sounds.h"
 #include "d_main.h"
 #include "r_draw.h" // [FG] fuzzcolumn_mode
+#include "r_sky.h" // [FG] stretchsky
 
 #include "d_io.h"
 #include <errno.h>
@@ -171,6 +172,13 @@ default_t defaults[] = {
     (config_t *) &show_endoom, NULL,
     {0}, {0,2}, number, ss_gen, wad_no,
     "show ENDOOM 0=off, 1=on, 2=PWAD only"
+  },
+
+  {
+    "stretchsky",
+    (config_t *) &stretchsky, NULL,
+    {0}, {0,1}, number, ss_gen, wad_no,
+    "1 to stretch short skies"
   },
 
   { // killough 2/21/98

--- a/Source/r_plane.c
+++ b/Source/r_plane.c
@@ -398,6 +398,13 @@ static void do_draw_plane(visplane_t *pl)
         dc_texheight = textureheight[texture]>>FRACBITS; // killough
         dc_iscale = pspriteiscale;
 
+        // [FG] stretch short skies
+        if (stretchsky && dc_texheight < 200)
+        {
+          dc_iscale = dc_iscale * dc_texheight / SKYSTRETCH_HEIGHT;
+          dc_texturemid = dc_texturemid * dc_texheight / SKYSTRETCH_HEIGHT;
+        }
+
 	// killough 10/98: Use sky scrolling offset, and possibly flip picture
         for (x = pl->minx; (dc_x = x) <= pl->maxx; x++)
           if ((unsigned)(dc_yl = pl->top[x]) <= (dc_yh = pl->bottom[x])) // [FG] 32-bit integer math

--- a/Source/r_sky.c
+++ b/Source/r_sky.c
@@ -31,13 +31,17 @@
 //-----------------------------------------------------------------------------
 
 #include "r_sky.h"
+#include "r_state.h" // [FG] textureheight[]
+
+// [FG] stretch short skies
+boolean stretchsky;
 
 //
 // sky mapping
 //
 
 int skyflatnum;
-int skytexture;
+int skytexture = -1; // [crispy] initialize
 int skytexturemid;
 
 //
@@ -46,6 +50,14 @@ int skytexturemid;
 //
 void R_InitSkyMap (void)
 {
+  // [crispy] initialize
+  if (skytexture == -1)
+    return;
+
+  // [FG] stretch short skies
+  if (stretchsky && (textureheight[skytexture]>>FRACBITS) < 200)
+    skytexturemid = -28*FRACUNIT;
+  else
   skytexturemid = 100*FRACUNIT;
 }
 

--- a/Source/r_sky.c
+++ b/Source/r_sky.c
@@ -50,13 +50,19 @@ int skytexturemid;
 //
 void R_InitSkyMap (void)
 {
+  int skyheight;
+
   // [crispy] initialize
   if (skytexture == -1)
     return;
 
   // [FG] stretch short skies
-  if (stretchsky && (textureheight[skytexture]>>FRACBITS) < 200)
+  skyheight = textureheight[skytexture]>>FRACBITS;
+
+  if (stretchsky && skyheight < 200)
     skytexturemid = -28*FRACUNIT;
+  else if (skyheight >= 200)
+    skytexturemid = 200*FRACUNIT;
   else
   skytexturemid = 100*FRACUNIT;
 }

--- a/Source/r_sky.h
+++ b/Source/r_sky.h
@@ -37,6 +37,10 @@
 // The sky map is 256*128*4 maps.
 #define ANGLETOSKYSHIFT         22
 
+// [FG] stretch short skies
+#define SKYSTRETCH_HEIGHT 228
+extern boolean stretchsky;
+
 extern int skytexture;
 extern int skytexturemid;
 


### PR DESCRIPTION
While at it, remove the "Files Preloaded at Game Startup" section
from the General menu. More menu clean-up will be due with the follow-up
commits, though.

Unfortunately, I couldn't simplify the code path in do_draw_plane() any
further, because there are maps like Ancient Aliens MAP11 which have
a short F_SKY1 texture but tall PL_SKYFLAT textures,
which have to be taken into account.