### PR TITLE
render the beta plasma ball sprites translucent

### DIFF
--- a/Source/info.c
+++ b/Source/info.c
@@ -4989,7 +4989,7 @@ mobjinfo_t original_mobjinfo[NUMMOBJTYPES] = {
     100,    // mass
     4,    // damage
     sfx_None,   // activesound
-    MF_NOBLOCKMAP|MF_MISSILE|MF_DROPOFF|MF_NOGRAVITY|MF_BOUNCES|MF_TRANSLUCENT,
+    MF_NOBLOCKMAP|MF_MISSILE|MF_DROPOFF|MF_NOGRAVITY|MF_BOUNCES|MF_TRANSLUCENT, // [FG] translucent
     S_NULL    // raisestate
   },
   
@@ -5016,7 +5016,7 @@ mobjinfo_t original_mobjinfo[NUMMOBJTYPES] = {
     100,    // mass
     4,    // damage
     sfx_None,   // activesound
-    MF_NOBLOCKMAP|MF_MISSILE|MF_DROPOFF|MF_NOGRAVITY|MF_BOUNCES|MF_TRANSLUCENT,
+    MF_NOBLOCKMAP|MF_MISSILE|MF_DROPOFF|MF_NOGRAVITY|MF_BOUNCES|MF_TRANSLUCENT, // [FG] translucent
     S_NULL    // raisestate
   },
 

--- a/Source/info.c
+++ b/Source/info.c
@@ -4989,7 +4989,7 @@ mobjinfo_t original_mobjinfo[NUMMOBJTYPES] = {
     100,    // mass
     4,    // damage
     sfx_None,   // activesound
-    MF_NOBLOCKMAP|MF_MISSILE|MF_DROPOFF|MF_NOGRAVITY|MF_BOUNCES,
+    MF_NOBLOCKMAP|MF_MISSILE|MF_DROPOFF|MF_NOGRAVITY|MF_BOUNCES|MF_TRANSLUCENT,
     S_NULL    // raisestate
   },
   
@@ -5016,7 +5016,7 @@ mobjinfo_t original_mobjinfo[NUMMOBJTYPES] = {
     100,    // mass
     4,    // damage
     sfx_None,   // activesound
-    MF_NOBLOCKMAP|MF_MISSILE|MF_DROPOFF|MF_NOGRAVITY|MF_BOUNCES,
+    MF_NOBLOCKMAP|MF_MISSILE|MF_DROPOFF|MF_NOGRAVITY|MF_BOUNCES|MF_TRANSLUCENT,
     S_NULL    // raisestate
   },
 


### PR DESCRIPTION
I know they were of course not translucent in the original beta
release, but we are using completely different plasma ball sprites
anyway - and they just look neat with some translucency added.

Alternative implementations would be to set this flag in
D_InitTables() instead, or to set it in a DEHACKED patch in
autoload/doom-all. What do you think?