### PR TITLE
INTERCEPTS overflow emulation from Chocolate Doom

### DIFF
--- a/Source/p_maputl.c
+++ b/Source/p_maputl.c
@@ -500,13 +500,13 @@ boolean PIT_AddLineIntercepts(line_t *ld)
   intercept_p->frac = frac;
   intercept_p->isaline = true;
   intercept_p->d.line = ld;
-  intercept_p++;
   InterceptsOverrun(intercept_p - intercepts, intercept_p);
   if (intercept_p - intercepts == MAXINTERCEPTS_ORIGINAL + 1)
   {
     // [crispy] print a warning
     fprintf(stderr, "PIT_AddLineIntercepts: Triggered INTERCEPTS overflow!\n");
   }
+  intercept_p++;
 
   return true;  // continue
 }
@@ -561,6 +561,12 @@ boolean PIT_AddThingIntercepts(mobj_t *thing)
   intercept_p->frac = frac;
   intercept_p->isaline = false;
   intercept_p->d.thing = thing;
+  InterceptsOverrun(intercept_p - intercepts, intercept_p);
+  if (intercept_p - intercepts == MAXINTERCEPTS_ORIGINAL + 1)
+  {
+    // [crispy] print a warning
+    fprintf(stderr, "PIT_AddThingIntercepts: Triggered INTERCEPTS overflow!\n");
+  }
   intercept_p++;
 
   return true;          // keep going
@@ -693,7 +699,7 @@ static void InterceptsOverrun(int num_intercepts, intercept_t *intercept)
 {
     int location;
 
-    if (num_intercepts <= MAXINTERCEPTS_ORIGINAL)
+    if (!demo_compatibility || num_intercepts <= MAXINTERCEPTS_ORIGINAL)
     {
         // No overrun
 

--- a/Source/p_maputl.c
+++ b/Source/p_maputl.c
@@ -501,11 +501,6 @@ boolean PIT_AddLineIntercepts(line_t *ld)
   intercept_p->isaline = true;
   intercept_p->d.line = ld;
   InterceptsOverrun(intercept_p - intercepts, intercept_p);
-  if (intercept_p - intercepts == MAXINTERCEPTS_ORIGINAL + 1)
-  {
-    // [crispy] print a warning
-    fprintf(stderr, "PIT_AddLineIntercepts: Triggered INTERCEPTS overflow!\n");
-  }
   intercept_p++;
 
   return true;  // continue
@@ -562,11 +557,6 @@ boolean PIT_AddThingIntercepts(mobj_t *thing)
   intercept_p->isaline = false;
   intercept_p->d.thing = thing;
   InterceptsOverrun(intercept_p - intercepts, intercept_p);
-  if (intercept_p - intercepts == MAXINTERCEPTS_ORIGINAL + 1)
-  {
-    // [crispy] print a warning
-    fprintf(stderr, "PIT_AddThingIntercepts: Triggered INTERCEPTS overflow!\n");
-  }
   intercept_p++;
 
   return true;          // keep going
@@ -704,6 +694,12 @@ static void InterceptsOverrun(int num_intercepts, intercept_t *intercept)
         // No overrun
 
         return;
+    }
+
+    if (num_intercepts == MAXINTERCEPTS_ORIGINAL + 1)
+    {
+        // [crispy] print a warning
+        fprintf(stderr, "Triggered INTERCEPTS overflow!\n");
     }
 
     location = (num_intercepts - MAXINTERCEPTS_ORIGINAL - 1) * 12;

--- a/Source/p_pspr.c
+++ b/Source/p_pspr.c
@@ -806,7 +806,7 @@ void A_FirePlasma(player_t *player, pspdef_t *psp)
 // the height of the intended target
 //
 
-static fixed_t bulletslope;
+fixed_t bulletslope;
 
 static void P_BulletSlope(mobj_t *mo)
 {


### PR DESCRIPTION
I didn't mean that I want to do it but oh well :smile:
1. I coudn't find demos with INTERCEPTS overflow that listed here: [[doomworld]](https://www.doomworld.com/forum/topic/35214-spechits-reject-and-intercepts-overflow-lists/) Do you know archive with these kind of demos?
2. Should we implement menu or config entries for various overflow emulations?