### PR TITLE
initialize I_ErrorMsg earlier

### DIFF
--- a/Source/i_main.c
+++ b/Source/i_main.c
@@ -110,6 +110,8 @@ int main(int argc, char **argv)
    I_AtExitPrio(I_QuitFirst, true,  "I_QuitFirst", exit_priority_first);
    I_AtExitPrio(I_QuitLast,  false, "I_QuitLast",  exit_priority_last);
    I_AtExitPrio(I_Quit,      true,  "I_Quit",      exit_priority_last);
+
+   I_AtExitPrio(I_ErrorMsg, true, "I_ErrorMsg", exit_priority_verylast);
    
    // 2/2/98 Stan
    // Must call this here.  It's required by both netgames and i_video.c.

--- a/Source/i_system.c
+++ b/Source/i_system.c
@@ -220,7 +220,6 @@ void I_InitKeyboard(void)
 }
 
 extern boolean nomusicparm, nosfxparm;
-static void I_ErrorMsg();
 
 void I_Init(void)
 {
@@ -260,7 +259,6 @@ void I_Init(void)
   // killough 3/6/98: end of keyboard / autorun state changes
 
    I_AtExit(I_Shutdown, true);
-   I_AtExitPrio(I_ErrorMsg, true, "I_ErrorMsg", exit_priority_verylast);
    
    // killough 2/21/98: avoid sound initialization if no sound & no music
    { 
@@ -364,7 +362,7 @@ void I_Error(const char *error, ...) // killough 3/20/98: add const
     I_SafeExit(-1);
 }
 
-static void I_ErrorMsg()
+void I_ErrorMsg()
 {
     // Pop up a GUI dialog box to show the error message, if the
     // game was not run from the console (and the user will

--- a/Source/i_system.h
+++ b/Source/i_system.h
@@ -123,6 +123,7 @@ void I_AtExitPrio(atexit_func_t func, boolean run_if_error,
                   const char* name, exit_priority_t priority);
 #define I_AtExit(a,b) I_AtExitPrio(a,b,#a,exit_priority_normal)
 void I_SafeExit(int rc) NORETURN;
+void I_ErrorMsg(void);
 
 #endif
 


### PR DESCRIPTION
This change allows for earlier error reporting on Windows, notably if the IWAD is not found.