### PR TITLE
save shifted versions of '=', ',', '.' to config

### DIFF
--- a/Source/m_misc.c
+++ b/Source/m_misc.c
@@ -2379,7 +2379,20 @@ void M_SaveDefaults (void)
           {
             case input_type_key:
               if (v->value >= 33 && v->value <= 126)
-                fprintf(f, "%c", v->value);
+              {
+                // The '=', ',', and '.' keys originally meant the shifted
+                // versions of those keys, but w/o having to shift them in
+                // the game.
+                char c = v->value;
+                if (c == ',')
+                  c = '<';
+                if (c == '.')
+                  c = '>';
+                if (c == '=')
+                  c = '+';
+
+                fprintf(f, "%c", c);
+              }
               else
                 fprintf(f, "%s", M_GetNameForKey(v->value));
               break;
@@ -2512,7 +2525,18 @@ boolean M_ParseOption(const char *p, boolean wad)
         {
           if (strlen(buffer) == 1)
           {
-            if (!M_InputAddKey(dp->ident, buffer[0]))
+            // The '=', ',', and '.' keys originally meant the shifted
+            // versions of those keys, but w/o having to shift them in
+            // the game.
+            char c = buffer[0];
+            if (c == '<')
+              c = ',';
+            if (c == '>')
+              c = '.';
+            if (c == '+')
+              c = '=';
+
+            if (!M_InputAddKey(dp->ident, c))
               break;
           }
           else

--- a/Source/m_misc.c
+++ b/Source/m_misc.c
@@ -2386,9 +2386,9 @@ void M_SaveDefaults (void)
                 char c = v->value;
                 if (c == ',')
                   c = '<';
-                if (c == '.')
+                else if (c == '.')
                   c = '>';
-                if (c == '=')
+                else if (c == '=')
                   c = '+';
 
                 fprintf(f, "%c", c);
@@ -2531,9 +2531,9 @@ boolean M_ParseOption(const char *p, boolean wad)
             char c = buffer[0];
             if (c == '<')
               c = ',';
-            if (c == '>')
+            else if (c == '>')
               c = '.';
-            if (c == '+')
+            else if (c == '+')
               c = '=';
 
             if (!M_InputAddKey(dp->ident, c))

--- a/Source/m_misc.c
+++ b/Source/m_misc.c
@@ -1302,7 +1302,7 @@ default_t defaults[] = {
     NULL, NULL,
     {0}, {UL,UL}, input, ss_keys, wad_no,
     "key to take a screenshot (devparm independent)",
-    input_screenshot, { {input_type_key, '*'} }
+    input_screenshot, { {input_type_key, KEYD_PRTSCR} }
   },
 
   { // HOME key  // killough 10/98: shortcut to setup menu


### PR DESCRIPTION
Fixes this issue: [[doomworld]](https://www.doomworld.com/forum/topic/112333-this-is-woof-900-feb-24-2022-updated-winmbf/?do=findComment&comment=2478179)