### PR TITLE
compatibility with PrBoom+ netgame reload

### DIFF
--- a/Source/d_event.h
+++ b/Source/d_event.h
@@ -92,7 +92,7 @@ typedef enum
 
   // Flag: game events, not really buttons.
   BT_SPECIAL      = 128,
-  //  BT_SPECIALMASK  = 3,   killough 9/29/98: unused now
+  BT_SPECIALMASK  = 3,
     
   // Flag, weapon change pending.
   // If true, the next 4 bits hold weapon num.
@@ -109,12 +109,12 @@ typedef enum
   // Save the game at each console.
   BTS_SAVEGAME    = 2,
 
+  // Reload level.
+  BTS_RELOAD      = 3,
+
   // Savegame slot numbers occupy the second byte of buttons.    
   BTS_SAVEMASK    = (4+8+16),
   BTS_SAVESHIFT   = 2,
-
-  // Reload level.
-  BTS_RELOAD      = 32,
   
 } buttoncode_t;
 

--- a/Source/g_game.c
+++ b/Source/g_game.c
@@ -514,20 +514,20 @@ void G_BuildTiccmd(ticcmd_t* cmd)
   if (sendpause)
     {
       sendpause = false;
-      cmd->buttons = BT_SPECIAL | BTS_PAUSE;
+      cmd->buttons = BT_SPECIAL | (BTS_PAUSE & BT_SPECIALMASK);
     }
 
   // killough 10/6/98: suppress savegames in demos
   if (sendsave && !demoplayback)
     {
       sendsave = false;
-      cmd->buttons = BT_SPECIAL | BTS_SAVEGAME | (savegameslot<<BTS_SAVESHIFT);
+      cmd->buttons = BT_SPECIAL | (BTS_SAVEGAME & BT_SPECIALMASK) | (savegameslot<<BTS_SAVESHIFT);
     }
 
   if (sendreload)
   {
     sendreload = false;
-    cmd->buttons = BT_SPECIAL | BTS_RELOAD;
+    cmd->buttons = BT_SPECIAL | (BTS_RELOAD & BT_SPECIALMASK);
   }
 
   // low-res turning
@@ -2032,29 +2032,32 @@ void G_Ticker(void)
       // check for special buttons
       for (i=0; i<MAXPLAYERS; i++)
 	if (playeringame[i] && players[i].cmd.buttons & BT_SPECIAL)
+	  switch (players[i].cmd.buttons & BT_SPECIALMASK)
 	  {
-	    // killough 9/29/98: allow multiple special buttons
-	    if (players[i].cmd.buttons & BTS_RELOAD)
-	    {
-	      gameaction = ga_reloadlevel;
-	    }
+	    case BTS_RELOAD:
+	      if (!demoplayback) // ignore in demos
+	      {
+	        gameaction = ga_reloadlevel;
+	      }
+	      break;
 
-	    if (players[i].cmd.buttons & BTS_PAUSE)
-	    {
+	    case BTS_PAUSE:
 	      if ((paused ^= 1))
 		S_PauseSound();
 	      else
 		S_ResumeSound();
-	    }
+	      break;
 	
-	    if (players[i].cmd.buttons & BTS_SAVEGAME)
-	      {
+	    case BTS_SAVEGAME:
 		if (!savedescription[0])
 		  strcpy(savedescription, "NET GAME");
 		savegameslot =
 		  (players[i].cmd.buttons & BTS_SAVEMASK)>>BTS_SAVESHIFT;
 		gameaction = ga_savegame;
-	      }
+	      break;
+
+	    default:
+	      break;
 	  }
     }
 


### PR DESCRIPTION
PrBoom+ has netgame reload: https://github.com/coelckers/prboom-plus/blob/784a17d73818cffa4ec3114cef99bcc990d157f4/prboom2/src/g_game.c#L1236-L1240
Also remove "killough 9/29/98: allow multiple special buttons", not sure if it's compatible and why we need it.