### PR TITLE
fix empty lump name in MUSINFO savegame load

### DIFF
--- a/Source/g_game.c
+++ b/Source/g_game.c
@@ -1856,7 +1856,9 @@ static void G_DoLoadGame(void)
 
     memcpy(lump, save_p, 8);
 
-    if ((i = W_CheckNumForName(lump)) > 0)
+    i = W_CheckNumForName(lump);
+
+    if (lump[0] && i > 0)
     {
       memset(&musinfo, 0, sizeof(musinfo));
       musinfo.current_item = i;


### PR DESCRIPTION
Fixes this issue: [[doomworld]](https://www.doomworld.com/forum/topic/112333-this-is-woof-900-feb-24-2022-updated-winmbf/?do=findComment&comment=2485787) Ozonia WAD: [[doomworld]](https://www.doomworld.com/forum/topic/103371-rc4-out-ozonia-boom-megawad/)
It seems that Ozonia has an "empty" lump? Not sure.