### PR TITLE
enable hires and uncapped by default

### DIFF
--- a/Source/m_misc.c
+++ b/Source/m_misc.c
@@ -135,7 +135,7 @@ default_t defaults[] = {
 
   { // killough 11/98: hires
     "hires", (config_t *) &hires, NULL,
-    {0}, {0,1}, number, ss_gen, wad_no,
+    {1}, {0,1}, number, ss_gen, wad_no,
     "1 to enable 640x400 resolution for rendering scenes"
   },
 
@@ -2131,7 +2131,7 @@ default_t defaults[] = {
   {
     "uncapped",
     (config_t *) &uncapped, NULL,
-    {0}, {0, 1}, number, ss_none, wad_no,
+    {1}, {0, 1}, number, ss_none, wad_no,
     "1 to enable uncapped rendering frame rate"
   },
 


### PR DESCRIPTION
I think we need to enable hires and uncapped otherwise Woof will look like Chocolate Doom to a new user. Also should we enable fullscreen mode by default?

Widescreen looks a bit awkward without wide assets. Since we are still distributing beta assets, I think we can add wide assets as well.