### PR TITLE
fix overlapping uses of global variables in p_map.c for mbf21 complevel

### DIFF
--- a/Source/p_map.c
+++ b/Source/p_map.c
@@ -2226,10 +2226,13 @@ void P_CreateSecNodeList(mobj_t *thing,fixed_t x,fixed_t y)
 
   // [FG] Overlapping uses of global variables in p_map.c
   // http://prboom.sourceforge.net/mbf-bugs.html
-   if (demo_compatibility)
+   if (demo_compatibility || mbf21)
    {
      tmthing = saved_tmthing;
      tmflags = saved_tmflags;
+   }
+   if (demo_compatibility)
+   {
      tmx = saved_tmx;
      tmy = saved_tmy;
      if (tmthing)


### PR DESCRIPTION
This fixes Judgment.wad MAP03 demos (demo1 and this: [judg03f627.zip](https://github.com/fabiangreffrath/woof/files/8596720/judg03f627.zip)).

@kraflab, could you look at this condition: https://github.com/kraflab/dsda-doom/blob/13312ceb2d67cf4cdf18981e26996a0b954ba9ad/prboom2/src/p_map.c#L3206-L3220 I think it's not right.