### PR TITLE
umapinfo: endpic affects secretexit

### DIFF
--- a/Source/f_finale.c
+++ b/Source/f_finale.c
@@ -260,7 +260,8 @@ static float Get_TextSpeed(void)
 
 static void FMI_Ticker()
 {
-  if (gamemapinfo->endpic[0] && (strcmp(gamemapinfo->endpic, "-") != 0))
+  if (gamemapinfo->endpic[0] && (strcmp(gamemapinfo->endpic, "-") != 0)
+      && !secretexit)
   {
     if (!stricmp(gamemapinfo->endpic, "$CAST"))
     {


### PR DESCRIPTION
Fixes #541
At this point I'm thinking maybe we should rewrite UMAPINFO's ending behavior anyway?