### PR TITLE
initial removal of z_zone.h macros

### DIFF
--- a/Source/am_map.c
+++ b/Source/am_map.c
@@ -410,9 +410,9 @@ void AM_addMark(void)
 
   if (markpointnum >= markpointnum_max)
     markpoints = Z_Realloc(markpoints,
-                        (markpointnum_max = markpointnum_max ? 
-                         markpointnum_max*2 : 16) * sizeof(*markpoints),
-                        PU_STATIC, 0);
+                           (markpointnum_max = markpointnum_max ?
+                            markpointnum_max*2 : 16) * sizeof(*markpoints),
+                           PU_STATIC, 0);
 
   // [crispy] keep the map static in overlay mode
   // if not following the player

--- a/Source/am_map.c
+++ b/Source/am_map.c
@@ -409,9 +409,10 @@ void AM_addMark(void)
   // remove limit on automap marks
 
   if (markpointnum >= markpointnum_max)
-    markpoints = realloc(markpoints,
+    markpoints = Z_Realloc(markpoints,
                         (markpointnum_max = markpointnum_max ? 
-                         markpointnum_max*2 : 16) * sizeof(*markpoints));
+                         markpointnum_max*2 : 16) * sizeof(*markpoints),
+                        PU_STATIC, 0);
 
   // [crispy] keep the map static in overlay mode
   // if not following the player

--- a/Source/d_deh.c
+++ b/Source/d_deh.c
@@ -2634,7 +2634,7 @@ void deh_procCheat(DEHFILE *fpin, FILE* fpout, char *line) // done
                                      strlen(cheat[i].cheat)) && i != iy)
                       cheat[i].deh_modified = true;
                 }
-                cheat[iy].cheat = strdup(p);
+                cheat[iy].cheat = (strdup)(p);
                 if (fpout) fprintf(fpout,
                                    "Assigned new cheat '%s' to cheat '%s'at index %d\n",
                                    p, cheat[ix].deh_cheat, iy); // killough 4/18/98
@@ -2795,7 +2795,7 @@ void deh_procText(DEHFILE *fpin, FILE* fpout, char *line)
 
           // killough 10/98: but it's an array of pointers, so we must
           // use strdup unless we redeclare sprnames and change all else
-          sprnames[i]=strdup(sprnames[i]);
+          sprnames[i]=(strdup)(sprnames[i]);
 
           strncpy(sprnames[i],&inbuffer[fromlen],tolen);
           found = TRUE;
@@ -2816,7 +2816,7 @@ void deh_procText(DEHFILE *fpin, FILE* fpout, char *line)
                                 "Changing name of sfx from %s to %*s\n",
                                 S_sfx[i].name,usedlen,&inbuffer[fromlen]);
 
-            S_sfx[i].name = strdup(&inbuffer[fromlen]);
+            S_sfx[i].name = (strdup)(&inbuffer[fromlen]);
             found = TRUE;
           }
         if (!found)  // not yet
@@ -2832,7 +2832,7 @@ void deh_procText(DEHFILE *fpin, FILE* fpout, char *line)
                                        "Changing name of music from %s to %*s\n",
                                        S_music[i].name,usedlen,&inbuffer[fromlen]);
 
-                    S_music[i].name = strdup(&inbuffer[fromlen]);
+                    S_music[i].name = (strdup)(&inbuffer[fromlen]);
                     found = TRUE;
                     break;  // only one matches, quit early
                   }
@@ -2845,13 +2845,13 @@ void deh_procText(DEHFILE *fpin, FILE* fpout, char *line)
       if (fpout) fprintf(fpout,"Checking text area through strings for '%.12s%s' from=%d to=%d\n",inbuffer, (strlen(inbuffer) > 12) ? "..." : "",fromlen,tolen);
       if (fromlen <= strlen(inbuffer))
         {
-          line2 = strdup(&inbuffer[fromlen]);
+          line2 = (strdup)(&inbuffer[fromlen]);
           inbuffer[fromlen] = '\0';
         }
 
       deh_procStringSub(NULL, inbuffer, line2, fpout);
     }
-  free(line2); // may be NULL, ignored by free()
+  (free)(line2); // may be NULL, ignored by free()
   return;
 }
 
@@ -2886,7 +2886,7 @@ void deh_procStrings(DEHFILE *fpin, FILE* fpout, char *line)
 
   if (fpout) fprintf(fpout,"Processing extended string substitution\n");
 
-  if (!holdstring) holdstring = malloc(maxstrlen*sizeof(*holdstring));
+  if (!holdstring) holdstring = (malloc)(maxstrlen*sizeof(*holdstring));
 
   *holdstring = '\0';  // empty string to start with
   strncpy(inbuffer,line,DEH_BUFFERMAX);
@@ -2913,7 +2913,7 @@ void deh_procStrings(DEHFILE *fpin, FILE* fpout, char *line)
           if (fpout) fprintf(fpout,
                              "* increased buffer from to %d for buffer size %d\n",
                              maxstrlen,(int)strlen(inbuffer));
-          holdstring = realloc(holdstring,maxstrlen*sizeof(*holdstring));
+          holdstring = (realloc)(holdstring,maxstrlen*sizeof(*holdstring));
         }
       // concatenate the whole buffer if continuation or the value iffirst
       strcat(holdstring,ptr_lstrip(((*holdstring) ? inbuffer : strval)));
@@ -2970,7 +2970,7 @@ boolean deh_procStringSub(char *key, char *lookfor, char *newstring, FILE *fpout
 
       if (found)
         {
-          *deh_strlookup[i].ppstr = strdup(newstring); // orphan originalstring
+          *deh_strlookup[i].ppstr = (strdup)(newstring); // orphan originalstring
           found = true;
           // Handle embedded \n's in the incoming string, convert to 0x0a's
           {
@@ -3058,7 +3058,7 @@ void deh_procBexSprites(DEHFILE *fpin, FILE* fpout, char *line)
     if (match >= 0)
     {
       if (fpout) fprintf(fpout, "Substituting '%s' for sprite '%s'\n", candidate, key);
-      sprnames[match] = strdup(candidate);
+      sprnames[match] = (strdup)(candidate);
     }
   }
 }
@@ -3106,7 +3106,7 @@ void deh_procBexSounds(DEHFILE *fpin, FILE* fpout, char *line)
     if (match >= 0)
     {
       if (fpout) fprintf(fpout, "Substituting '%s' for sound '%s'\n", candidate, key);
-      S_sfx[match].name = strdup(candidate);
+      S_sfx[match].name = (strdup)(candidate);
     }
   }
 }

--- a/Source/d_deh.c
+++ b/Source/d_deh.c
@@ -2913,7 +2913,7 @@ void deh_procStrings(DEHFILE *fpin, FILE* fpout, char *line)
           if (fpout) fprintf(fpout,
                              "* increased buffer from to %d for buffer size %d\n",
                              maxstrlen,(int)strlen(inbuffer));
-          holdstring = realloc(holdstring,maxstrlen*sizeof(*holdstring));
+          holdstring = I_Realloc(holdstring,maxstrlen*sizeof(*holdstring));
         }
       // concatenate the whole buffer if continuation or the value iffirst
       strcat(holdstring,ptr_lstrip(((*holdstring) ? inbuffer : strval)));

--- a/Source/d_deh.c
+++ b/Source/d_deh.c
@@ -1629,7 +1629,7 @@ void ProcessDehFile(const char *filename, char *outfilename, int lumpnum)
         }
       tmp = M_StringJoin(" \"", M_BaseName(filename), "\"", NULL);
       M_StringAdd(&dehfiles, tmp);
-      (free)(tmp);
+      free(tmp);
       infile.lump = NULL;
     }
   else  // DEH file comes from lump indicated by third argument
@@ -2634,7 +2634,7 @@ void deh_procCheat(DEHFILE *fpin, FILE* fpout, char *line) // done
                                      strlen(cheat[i].cheat)) && i != iy)
                       cheat[i].deh_modified = true;
                 }
-                cheat[iy].cheat = (strdup)(p);
+                cheat[iy].cheat = strdup(p);
                 if (fpout) fprintf(fpout,
                                    "Assigned new cheat '%s' to cheat '%s'at index %d\n",
                                    p, cheat[ix].deh_cheat, iy); // killough 4/18/98
@@ -2795,7 +2795,7 @@ void deh_procText(DEHFILE *fpin, FILE* fpout, char *line)
 
           // killough 10/98: but it's an array of pointers, so we must
           // use strdup unless we redeclare sprnames and change all else
-          sprnames[i]=(strdup)(sprnames[i]);
+          sprnames[i]=strdup(sprnames[i]);
 
           strncpy(sprnames[i],&inbuffer[fromlen],tolen);
           found = TRUE;
@@ -2816,7 +2816,7 @@ void deh_procText(DEHFILE *fpin, FILE* fpout, char *line)
                                 "Changing name of sfx from %s to %*s\n",
                                 S_sfx[i].name,usedlen,&inbuffer[fromlen]);
 
-            S_sfx[i].name = (strdup)(&inbuffer[fromlen]);
+            S_sfx[i].name = strdup(&inbuffer[fromlen]);
             found = TRUE;
           }
         if (!found)  // not yet
@@ -2832,7 +2832,7 @@ void deh_procText(DEHFILE *fpin, FILE* fpout, char *line)
                                        "Changing name of music from %s to %*s\n",
                                        S_music[i].name,usedlen,&inbuffer[fromlen]);
 
-                    S_music[i].name = (strdup)(&inbuffer[fromlen]);
+                    S_music[i].name = strdup(&inbuffer[fromlen]);
                     found = TRUE;
                     break;  // only one matches, quit early
                   }
@@ -2845,13 +2845,13 @@ void deh_procText(DEHFILE *fpin, FILE* fpout, char *line)
       if (fpout) fprintf(fpout,"Checking text area through strings for '%.12s%s' from=%d to=%d\n",inbuffer, (strlen(inbuffer) > 12) ? "..." : "",fromlen,tolen);
       if (fromlen <= strlen(inbuffer))
         {
-          line2 = (strdup)(&inbuffer[fromlen]);
+          line2 = strdup(&inbuffer[fromlen]);
           inbuffer[fromlen] = '\0';
         }
 
       deh_procStringSub(NULL, inbuffer, line2, fpout);
     }
-  (free)(line2); // may be NULL, ignored by free()
+  free(line2); // may be NULL, ignored by free()
   return;
 }
 
@@ -2886,7 +2886,7 @@ void deh_procStrings(DEHFILE *fpin, FILE* fpout, char *line)
 
   if (fpout) fprintf(fpout,"Processing extended string substitution\n");
 
-  if (!holdstring) holdstring = (malloc)(maxstrlen*sizeof(*holdstring));
+  if (!holdstring) holdstring = malloc(maxstrlen*sizeof(*holdstring));
 
   *holdstring = '\0';  // empty string to start with
   strncpy(inbuffer,line,DEH_BUFFERMAX);
@@ -2913,7 +2913,7 @@ void deh_procStrings(DEHFILE *fpin, FILE* fpout, char *line)
           if (fpout) fprintf(fpout,
                              "* increased buffer from to %d for buffer size %d\n",
                              maxstrlen,(int)strlen(inbuffer));
-          holdstring = (realloc)(holdstring,maxstrlen*sizeof(*holdstring));
+          holdstring = realloc(holdstring,maxstrlen*sizeof(*holdstring));
         }
       // concatenate the whole buffer if continuation or the value iffirst
       strcat(holdstring,ptr_lstrip(((*holdstring) ? inbuffer : strval)));
@@ -2970,7 +2970,7 @@ boolean deh_procStringSub(char *key, char *lookfor, char *newstring, FILE *fpout
 
       if (found)
         {
-          *deh_strlookup[i].ppstr = (strdup)(newstring); // orphan originalstring
+          *deh_strlookup[i].ppstr = strdup(newstring); // orphan originalstring
           found = true;
           // Handle embedded \n's in the incoming string, convert to 0x0a's
           {
@@ -3058,7 +3058,7 @@ void deh_procBexSprites(DEHFILE *fpin, FILE* fpout, char *line)
     if (match >= 0)
     {
       if (fpout) fprintf(fpout, "Substituting '%s' for sprite '%s'\n", candidate, key);
-      sprnames[match] = (strdup)(candidate);
+      sprnames[match] = strdup(candidate);
     }
   }
 }
@@ -3106,7 +3106,7 @@ void deh_procBexSounds(DEHFILE *fpin, FILE* fpout, char *line)
     if (match >= 0)
     {
       if (fpout) fprintf(fpout, "Substituting '%s' for sound '%s'\n", candidate, key);
-      S_sfx[match].name = (strdup)(candidate);
+      S_sfx[match].name = strdup(candidate);
     }
   }
 }

--- a/Source/d_main.c
+++ b/Source/d_main.c
@@ -615,7 +615,7 @@ char *D_DoomExeDir(void)
       size_t len = strlen(*myargv) + 1;
       char *p;
 
-      base = (malloc)(len);
+      base = malloc(len);
       memset(base, 0, len);
 
       p = base + len - 1;
@@ -652,7 +652,7 @@ char *D_DoomExeName(void)
         p--;
       while (p[i] && p[i] != '.')
         i++;
-      strncpy(name = (malloc)(i+1), p, i)[i] = 0;
+      strncpy(name = malloc(i+1), p, i)[i] = 0;
     }
   return name;
 }
@@ -719,7 +719,7 @@ static char *GetAutoloadDir(const char *base, const char *iwadname, boolean crea
     lower = M_StringDuplicate(iwadname);
     M_ForceLowercase(lower);
     result = M_StringJoin(base, DIR_SEPARATOR_S, lower, NULL);
-    (free)(lower);
+    free(lower);
 
     if (createdir)
     {
@@ -738,7 +738,7 @@ static void PrepareAutoloadPaths (void)
 
     for (i = 0; ; i++)
     {
-        autoload_paths = (realloc)(autoload_paths, (i + 1) * sizeof(*autoload_paths));
+        autoload_paths = realloc(autoload_paths, (i + 1) * sizeof(*autoload_paths));
 
         if (autoload_basedirs[i].dir)
         {
@@ -792,12 +792,12 @@ static void IdentifyVersionByContent(const char *iwadname)
     // read IWAD directory
     header.numlumps = LONG(header.numlumps);
     header.infotableofs = LONG(header.infotableofs);
-    fileinfo = (malloc)(header.numlumps * sizeof(filelump_t));
+    fileinfo = malloc(header.numlumps * sizeof(filelump_t));
 
     if (fseek(file, header.infotableofs, SEEK_SET) ||
         fread(fileinfo, sizeof(filelump_t), header.numlumps, file) != header.numlumps)
     {
-        (free)(fileinfo);
+        free(fileinfo);
         fclose(file);
         I_Error("CheckIWAD: failed to read directory %s", iwadname);
         return;
@@ -838,7 +838,7 @@ static void IdentifyVersionByContent(const char *iwadname)
         }
     }
 
-    (free)(fileinfo);
+    free(fileinfo);
     fclose(file);
 
     if (gamemode == indetermined)
@@ -883,7 +883,7 @@ char *FindIWADFile(void)
 
         char *iwadfile = myargv[iwadparm + 1];
 
-        char *file = (malloc)(strlen(iwadfile) + 5);
+        char *file = malloc(strlen(iwadfile) + 5);
         AddDefaultExtension(strcpy(file, iwadfile), ".wad");
 
         result = D_FindWADByName(file);
@@ -893,7 +893,7 @@ char *FindIWADFile(void)
             I_Error("IWAD file '%s' not found!", file);
         }
 
-        (free)(file);
+        free(file);
     }
     else
     {
@@ -941,7 +941,7 @@ void IdentifyVersion (void)
 
   // get config file from same directory as executable
   // killough 10/98
-  if (basedefault) (free)(basedefault);
+  if (basedefault) free(basedefault);
   basedefault = M_StringJoin(D_DoomPrefDir(), DIR_SEPARATOR_S, D_DoomExeName(), ".cfg", NULL);
 
   // set save path to -save parm or current dir
@@ -951,7 +951,7 @@ void IdentifyVersion (void)
     {
       if (!stat(myargv[i+1],&sbuf) && S_ISDIR(sbuf.st_mode)) // and is a dir
       {
-        if (basesavegame) (free)(basesavegame);
+        if (basesavegame) free(basesavegame);
         basesavegame = M_StringDuplicate(myargv[i+1]);
       }
       else
@@ -1144,7 +1144,7 @@ void FindResponseFile (void)
         // READ THE RESPONSE FILE INTO MEMORY
 
         // killough 10/98: add default .rsp extension
-        char *filename = (malloc)(strlen(myargv[i])+5);
+        char *filename = malloc(strlen(myargv[i])+5);
         AddDefaultExtension(strcpy(filename,&myargv[i][1]),".rsp");
 
         handle = fopen(filename,"rb");
@@ -1152,17 +1152,17 @@ void FindResponseFile (void)
           I_Error("No such response file!");          // killough 10/98
 
         printf("Found response file %s!\n",filename);
-        (free)(filename);
+        free(filename);
 
         fseek(handle,0,SEEK_END);
         size = ftell(handle);
         fseek(handle,0,SEEK_SET);
-        file = (malloc)(size);
+        file = malloc(size);
         // [FG] check return value
         if (!fread(file,size,1,handle))
         {
           fclose(handle);
-          (free)(file);
+          free(file);
           return;
         }
         fclose(handle);
@@ -1172,7 +1172,7 @@ void FindResponseFile (void)
           moreargs[index++] = myargv[k];
 
         firstargv = myargv[0];
-        myargv = (calloc)(sizeof(char *),MAXARGVS);
+        myargv = calloc(sizeof(char *),MAXARGVS);
         myargv[0] = firstargv;
 
         infile = file;
@@ -1259,7 +1259,7 @@ static int GuessFileType(const char *name)
         ret = FILETYPE_DEH;
     }
 
-    (free)(lower);
+    free(lower);
 
     return ret;
 }
@@ -1293,7 +1293,7 @@ static void M_AddLooseFiles(void)
 
     // allocate space for up to three additional regular parameters
 
-    arguments = (malloc)((myargc + 3) * sizeof(*arguments));
+    arguments = malloc((myargc + 3) * sizeof(*arguments));
     memset(arguments, 0, (myargc + 3) * sizeof(*arguments));
 
     // check the command line and make sure it does not already
@@ -1311,7 +1311,7 @@ static void M_AddLooseFiles(void)
             ((!isalpha(arg[0]) || arg[1] != ':' || arg[2] != '\\') &&
             (arg[0] != '\\' || arg[1] != '\\')))
         {
-            (free)(arguments);
+            free(arguments);
             return;
         }
 
@@ -1345,7 +1345,7 @@ static void M_AddLooseFiles(void)
         myargc++;
     }
 
-    newargv = (malloc)(myargc * sizeof(*newargv));
+    newargv = malloc(myargc * sizeof(*newargv));
 
     // sort the argument list by file type, except for the zeroth argument
     // which is the executable invocation itself
@@ -1359,7 +1359,7 @@ static void M_AddLooseFiles(void)
         newargv[i] = arguments[i].str;
     }
 
-    (free)(arguments);
+    free(arguments);
 
     myargv = newargv;
 }
@@ -1392,17 +1392,17 @@ static void D_ProcessDehCommandLine(void)
           if (deh)
             {
               char *probe;
-              char *file = (malloc)(strlen(myargv[p]) + 5);      // killough
+              char *file = malloc(strlen(myargv[p]) + 5);      // killough
               AddDefaultExtension(strcpy(file, myargv[p]), ".bex");
               probe = D_TryFindWADByName(file);
               if (access(probe, F_OK))  // nope
                 {
-                  (free)(probe);
+                  free(probe);
                   AddDefaultExtension(strcpy(file, myargv[p]), ".deh");
                   probe = D_TryFindWADByName(file);
                   if (access(probe, F_OK))  // still nope
                   {
-                    (free)(probe);
+                    free(probe);
                     I_Error("Cannot find .deh or .bex file named %s",
                             myargv[p]);
                   }
@@ -1410,8 +1410,8 @@ static void D_ProcessDehCommandLine(void)
               // during the beta we have debug output to dehout.txt
               // (apparently, this was never removed after Boom beta-killough)
               ProcessDehFile(probe, D_dehout(), 0);  // killough 10/98
-              (free)(probe);
-              (free)(file);
+              free(probe);
+              free(file);
             }
     }
   // ty 03/09/98 end of do dehacked stuff
@@ -1454,13 +1454,13 @@ static void D_AutoloadIWadDir()
     {
       autoload_dir = GetAutoloadDir(*base, "doom-all", true);
       AutoLoadWADs(autoload_dir);
-      (free)(autoload_dir);
+      free(autoload_dir);
     }
 
     // auto-loaded files per IWAD
     autoload_dir = GetAutoloadDir(*base, M_BaseName(wadfiles[0]), true);
     AutoLoadWADs(autoload_dir);
-    (free)(autoload_dir);
+    free(autoload_dir);
   }
 }
 
@@ -1478,7 +1478,7 @@ static void D_AutoloadPWadDir()
         char *autoload_dir;
         autoload_dir = GetAutoloadDir(*base, M_BaseName(myargv[p]), false);
         AutoLoadWADs(autoload_dir);
-        (free)(autoload_dir);
+        free(autoload_dir);
       }
     }
   }
@@ -1499,13 +1499,13 @@ static void D_ProcessWadPreincludes(void)
               s++;
             if (*s)
               {
-                char *file = (malloc)(strlen(s) + 5);
+                char *file = malloc(strlen(s) + 5);
                 AddDefaultExtension(strcpy(file, s), ".wad");
                 if (!access(file, R_OK))
                   D_AddFile(file);
                 else
                   printf("\nWarning: could not open %s\n", file);
-                (free)(file);
+                free(file);
               }
           }
     }
@@ -1548,13 +1548,13 @@ static void D_AutoloadDehDir()
     {
       autoload_dir = GetAutoloadDir(*base, "doom-all", true);
       AutoLoadPatches(autoload_dir);
-      (free)(autoload_dir);
+      free(autoload_dir);
     }
 
     // auto-loaded files per IWAD
     autoload_dir = GetAutoloadDir(*base, M_BaseName(wadfiles[0]), true);
     AutoLoadPatches(autoload_dir);
-    (free)(autoload_dir);
+    free(autoload_dir);
   }
 }
 
@@ -1572,7 +1572,7 @@ static void D_AutoloadPWadDehDir()
         char *autoload_dir;
         autoload_dir = GetAutoloadDir(*base, M_BaseName(myargv[p]), false);
         AutoLoadPatches(autoload_dir);
-        (free)(autoload_dir);
+        free(autoload_dir);
       }
     }
   }
@@ -1593,7 +1593,7 @@ static void D_ProcessDehPreincludes(void)
               s++;
             if (*s)
               {
-                char *file = (malloc)(strlen(s) + 5);
+                char *file = malloc(strlen(s) + 5);
                 AddDefaultExtension(strcpy(file, s), ".bex");
                 if (!access(file, R_OK))
                   ProcessDehFile(file, D_dehout(), 0);
@@ -1605,7 +1605,7 @@ static void D_ProcessDehPreincludes(void)
                     else
                       printf("\nWarning: could not open %s .deh or .bex\n", s);
                   }
-                (free)(file);
+                free(file);
               }
           }
     }
@@ -1778,7 +1778,7 @@ void D_DoomMain(void)
   FindResponseFile();         // Append response file arguments to command-line
 
   // killough 10/98: set default savename based on executable's name
-  sprintf(savegamename = (malloc)(16), "%.4ssav", D_DoomExeName());
+  sprintf(savegamename = malloc(16), "%.4ssav", D_DoomExeName());
 
   IdentifyVersion();
 
@@ -1903,7 +1903,7 @@ void D_DoomMain(void)
       mkdir("c:\\doomdata");
 
       // killough 10/98:
-      if (basedefault) (free)(basedefault);
+      if (basedefault) free(basedefault);
       basedefault = M_StringJoin("c:\\doomdata\\", D_DoomExeName(), ".cfg", NULL);
     }
 #endif
@@ -1972,12 +1972,12 @@ void D_DoomMain(void)
 
   if (p && p < myargc-1)
     {
-      char *file = (malloc)(strlen(myargv[p+1]) + 5);
+      char *file = malloc(strlen(myargv[p+1]) + 5);
       strcpy(file,myargv[p+1]);
       AddDefaultExtension(file,".lmp");     // killough
       D_AddFile(file);
       printf("Playing demo %s\n",file);
-      (free)(file);
+      free(file);
     }
 
   // get skill / episode / map from parms
@@ -2279,7 +2279,7 @@ void D_DoomMain(void)
     char *file;
     file = G_SaveGameName(startloadgame);
     G_LoadGame(file, startloadgame, true); // killough 5/15/98: add command flag
-    (free)(file);
+    free(file);
   }
   else
     if (!singledemo)                    // killough 12/98

--- a/Source/d_main.c
+++ b/Source/d_main.c
@@ -598,8 +598,9 @@ void D_AddFile(const char *file)
   static int numwadfiles, numwadfiles_alloc;
 
   if (numwadfiles >= numwadfiles_alloc)
-    wadfiles = realloc(wadfiles, (numwadfiles_alloc = numwadfiles_alloc ?
-                                  numwadfiles_alloc * 2 : 8)*sizeof*wadfiles);
+    wadfiles = Z_Realloc(wadfiles, (numwadfiles_alloc = numwadfiles_alloc ?
+                                  numwadfiles_alloc * 2 : 8)*sizeof*wadfiles,
+                        PU_STATIC, 0);
   // [FG] search for PWADs by their filename
   wadfiles[numwadfiles++] = !file ? NULL : D_TryFindWADByName(file);
 }
@@ -614,7 +615,7 @@ char *D_DoomExeDir(void)
       size_t len = strlen(*myargv) + 1;
       char *p;
 
-      base = malloc(len);
+      base = (malloc)(len);
       memset(base, 0, len);
 
       p = base + len - 1;
@@ -651,7 +652,7 @@ char *D_DoomExeName(void)
         p--;
       while (p[i] && p[i] != '.')
         i++;
-      strncpy(name = malloc(i+1), p, i)[i] = 0;
+      strncpy(name = (malloc)(i+1), p, i)[i] = 0;
     }
   return name;
 }
@@ -737,7 +738,7 @@ static void PrepareAutoloadPaths (void)
 
     for (i = 0; ; i++)
     {
-        autoload_paths = realloc(autoload_paths, (i + 1) * sizeof(*autoload_paths));
+        autoload_paths = (realloc)(autoload_paths, (i + 1) * sizeof(*autoload_paths));
 
         if (autoload_basedirs[i].dir)
         {
@@ -1143,7 +1144,7 @@ void FindResponseFile (void)
         // READ THE RESPONSE FILE INTO MEMORY
 
         // killough 10/98: add default .rsp extension
-        char *filename = malloc(strlen(myargv[i])+5);
+        char *filename = (malloc)(strlen(myargv[i])+5);
         AddDefaultExtension(strcpy(filename,&myargv[i][1]),".rsp");
 
         handle = fopen(filename,"rb");
@@ -1151,17 +1152,17 @@ void FindResponseFile (void)
           I_Error("No such response file!");          // killough 10/98
 
         printf("Found response file %s!\n",filename);
-        free(filename);
+        (free)(filename);
 
         fseek(handle,0,SEEK_END);
         size = ftell(handle);
         fseek(handle,0,SEEK_SET);
-        file = malloc (size);
+        file = (malloc)(size);
         // [FG] check return value
         if (!fread(file,size,1,handle))
         {
           fclose(handle);
-          free(file);
+          (free)(file);
           return;
         }
         fclose(handle);
@@ -1171,7 +1172,7 @@ void FindResponseFile (void)
           moreargs[index++] = myargv[k];
 
         firstargv = myargv[0];
-        myargv = calloc(sizeof(char *),MAXARGVS);
+        myargv = (calloc)(sizeof(char *),MAXARGVS);
         myargv[0] = firstargv;
 
         infile = file;
@@ -1292,7 +1293,7 @@ static void M_AddLooseFiles(void)
 
     // allocate space for up to three additional regular parameters
 
-    arguments = malloc((myargc + 3) * sizeof(*arguments));
+    arguments = (malloc)((myargc + 3) * sizeof(*arguments));
     memset(arguments, 0, (myargc + 3) * sizeof(*arguments));
 
     // check the command line and make sure it does not already
@@ -1310,7 +1311,7 @@ static void M_AddLooseFiles(void)
             ((!isalpha(arg[0]) || arg[1] != ':' || arg[2] != '\\') &&
             (arg[0] != '\\' || arg[1] != '\\')))
         {
-            free(arguments);
+            (free)(arguments);
             return;
         }
 
@@ -1344,7 +1345,7 @@ static void M_AddLooseFiles(void)
         myargc++;
     }
 
-    newargv = malloc(myargc * sizeof(*newargv));
+    newargv = (malloc)(myargc * sizeof(*newargv));
 
     // sort the argument list by file type, except for the zeroth argument
     // which is the executable invocation itself
@@ -1358,7 +1359,7 @@ static void M_AddLooseFiles(void)
         newargv[i] = arguments[i].str;
     }
 
-    free(arguments);
+    (free)(arguments);
 
     myargv = newargv;
 }
@@ -1777,7 +1778,7 @@ void D_DoomMain(void)
   FindResponseFile();         // Append response file arguments to command-line
 
   // killough 10/98: set default savename based on executable's name
-  sprintf(savegamename = malloc(16), "%.4ssav", D_DoomExeName());
+  sprintf(savegamename = (malloc)(16), "%.4ssav", D_DoomExeName());
 
   IdentifyVersion();
 

--- a/Source/d_main.c
+++ b/Source/d_main.c
@@ -598,9 +598,8 @@ void D_AddFile(const char *file)
   static int numwadfiles, numwadfiles_alloc;
 
   if (numwadfiles >= numwadfiles_alloc)
-    wadfiles = Z_Realloc(wadfiles, (numwadfiles_alloc = numwadfiles_alloc ?
-                                  numwadfiles_alloc * 2 : 8)*sizeof*wadfiles,
-                        PU_STATIC, 0);
+    wadfiles = I_Realloc(wadfiles, (numwadfiles_alloc = numwadfiles_alloc ?
+                                  numwadfiles_alloc * 2 : 8)*sizeof*wadfiles);
   // [FG] search for PWADs by their filename
   wadfiles[numwadfiles++] = !file ? NULL : D_TryFindWADByName(file);
 }

--- a/Source/d_main.c
+++ b/Source/d_main.c
@@ -738,7 +738,7 @@ static void PrepareAutoloadPaths (void)
 
     for (i = 0; ; i++)
     {
-        autoload_paths = realloc(autoload_paths, (i + 1) * sizeof(*autoload_paths));
+        autoload_paths = I_Realloc(autoload_paths, (i + 1) * sizeof(*autoload_paths));
 
         if (autoload_basedirs[i].dir)
         {

--- a/Source/dsdhacked.c
+++ b/Source/dsdhacked.c
@@ -324,9 +324,7 @@ int dsdh_GetOriginalSFXIndex(const char* key)
 //
 //  Things
 //
-//#include "p_map.h" // MELEERANGE
-#include "m_fixed.h"
-#define MELEERANGE      (64*FRACUNIT)
+#include "p_map.h" // MELEERANGE
 
 mobjinfo_t* mobjinfo;
 int num_mobj_types;

--- a/Source/dsdhacked.c
+++ b/Source/dsdhacked.c
@@ -25,8 +25,8 @@
 
 #include "doomtype.h"
 #include "d_io.h"
-//#include "z_zone.h"
 #include "info.h"
+#include "i_system.h" // I_Realloc
 
 //
 //   States
@@ -80,19 +80,19 @@ void dsdh_EnsureStatesCapacity(int limit)
     }
     else
     {
-      states = realloc(states, num_states * sizeof(*states));
+      states = I_Realloc(states, num_states * sizeof(*states));
     }
     memset(states + old_num_states, 0, (num_states - old_num_states) * sizeof(*states));
 
-    deh_codeptr = realloc(deh_codeptr, num_states * sizeof(*deh_codeptr));
+    deh_codeptr = I_Realloc(deh_codeptr, num_states * sizeof(*deh_codeptr));
     memset(deh_codeptr + old_num_states, 0, (num_states - old_num_states) * sizeof(*deh_codeptr));
 
     defined_codeptr_args =
-      realloc(defined_codeptr_args, num_states * sizeof(*defined_codeptr_args));
+      I_Realloc(defined_codeptr_args, num_states * sizeof(*defined_codeptr_args));
     memset(defined_codeptr_args + old_num_states, 0,
       (num_states - old_num_states) * sizeof(*defined_codeptr_args));
 
-    seenstate_tab = realloc(seenstate_tab, num_states * sizeof(*seenstate_tab));
+    seenstate_tab = I_Realloc(seenstate_tab, num_states * sizeof(*seenstate_tab));
     memset(seenstate_tab + old_num_states, 0,
       (num_states - old_num_states) * sizeof(*seenstate_tab));
 
@@ -148,11 +148,11 @@ static void EnsureSpritesCapacity(int limit)
     }
     else
     {
-      sprnames = realloc(sprnames, num_sprites * sizeof(*sprnames));
+      sprnames = I_Realloc(sprnames, num_sprites * sizeof(*sprnames));
     }
     memset(sprnames + old_num_sprites, 0, (num_sprites - old_num_sprites) * sizeof(*sprnames));
 
-    sprnames_state = realloc(sprnames_state, num_sprites * sizeof(*sprnames_state));
+    sprnames_state = I_Realloc(sprnames_state, num_sprites * sizeof(*sprnames_state));
     memset(sprnames_state + old_num_sprites, 0,
       (num_sprites - old_num_sprites) * sizeof(*sprnames_state));
   }
@@ -265,11 +265,11 @@ void dsdh_EnsureSFXCapacity(int limit)
     }
     else
     {
-      S_sfx = realloc(S_sfx, num_sfx * sizeof(*S_sfx));
+      S_sfx = I_Realloc(S_sfx, num_sfx * sizeof(*S_sfx));
     }
     memset(S_sfx + old_num_sfx, 0, (num_sfx - old_num_sfx) * sizeof(*S_sfx));
 
-    sfx_state = realloc(sfx_state, num_sfx * sizeof(*sfx_state));
+    sfx_state = I_Realloc(sfx_state, num_sfx * sizeof(*sfx_state));
     memset(sfx_state + old_num_sfx, 0,
       (num_sfx - old_num_sfx) * sizeof(*sfx_state));
 
@@ -357,7 +357,7 @@ void dsdh_EnsureMobjInfoCapacity(int limit)
     }
     else
     {
-      mobjinfo = realloc(mobjinfo, num_mobj_types * sizeof(*mobjinfo));
+      mobjinfo = I_Realloc(mobjinfo, num_mobj_types * sizeof(*mobjinfo));
     }
     memset(mobjinfo + old_num_mobj_types, 0,
       (num_mobj_types - old_num_mobj_types) * sizeof(*mobjinfo));

--- a/Source/dsdhacked.c
+++ b/Source/dsdhacked.c
@@ -25,7 +25,7 @@
 
 #include "doomtype.h"
 #include "d_io.h"
-#include "z_zone.h"
+//#include "z_zone.h"
 #include "info.h"
 
 //
@@ -324,7 +324,9 @@ int dsdh_GetOriginalSFXIndex(const char* key)
 //
 //  Things
 //
-#include "p_map.h" // MELEERANGE
+//#include "p_map.h" // MELEERANGE
+#include "m_fixed.h"
+#define MELEERANGE      (64*FRACUNIT)
 
 mobjinfo_t* mobjinfo;
 int num_mobj_types;

--- a/Source/f_finale.c
+++ b/Source/f_finale.c
@@ -219,7 +219,7 @@ void F_StartFinale (void)
   // [FG] do the "char* vs. const char*" dance
   if (finaletext_rw)
   {
-    (free)(finaletext_rw);
+    free(finaletext_rw);
     finaletext_rw = NULL;
   }
   finaletext_rw = M_StringDuplicate(finaletext);

--- a/Source/g_game.c
+++ b/Source/g_game.c
@@ -1558,7 +1558,7 @@ void G_ForcedLoadGame(void)
 
 void G_LoadGame(char *name, int slot, boolean command)
 {
-  if (savename) (free)(savename);
+  if (savename) free(savename);
   savename = M_StringDuplicate(name);
   savegameslot = slot;
   gameaction = ga_loadgame;
@@ -1773,7 +1773,7 @@ static void G_DoSaveGame(void)
   gameaction = ga_nothing;
   savedescription[0] = 0;
 
-  if (name) (free)(name);
+  if (name) free(name);
 }
 
 static void G_DoLoadGame(void)
@@ -1836,13 +1836,13 @@ static void G_DoLoadGame(void)
      uint64_t rchecksum = saveg_read64();
      if (checksum != rchecksum)
        {
-	 char *msg = Z_Malloc(strlen((char *) save_p) + 128, PU_STATIC, 0);
+	 char *msg = malloc(strlen((char *) save_p) + 128);
 	 strcpy(msg,"Incompatible Savegame!!!\n");
 	 if (save_p[sizeof checksum])
 	   strcat(strcat(msg,"Wads expected:\n\n"), (char *) save_p);
 	 strcat(msg, "\nAre you sure?");
 	 G_LoadGameErr(msg);
-	 Z_Free(msg);
+	 free(msg);
 	 return;
        }
    }
@@ -2938,9 +2938,8 @@ void G_RecordDemo(char *name)
   demo_insurance = 0;
       
   usergame = false;
-  if (demoname) (free)(demoname);
   demoname_size = strlen(name) + 5 + 6; // [crispy] + 6 for "-00000"
-  demoname = (malloc)(demoname_size);
+  demoname = I_Realloc(demoname, demoname_size);
   AddDefaultExtension(strcpy(demoname, name), ".lmp");  // 1/18/98 killough
 
   for(; j <= 99999 && !access(demoname, F_OK); ++j)
@@ -3391,7 +3390,7 @@ static void G_AddDemoFooter(void)
 
     tmp = M_StringJoin(" \"", M_BaseName(wadfiles[i]), "\"", NULL);
     M_StringAdd(&str, tmp);
-    (free)(tmp);
+    free(tmp);
   }
 
   if (dehfiles)
@@ -3405,7 +3404,7 @@ static void G_AddDemoFooter(void)
     M_StringAdd(&str, " -complevel vanilla");
     tmp = M_StringJoin(" -gameversion ", GetGameVersionCmdline(), NULL);
     M_StringAdd(&str, tmp);
-    (free)(tmp);
+    free(tmp);
   }
 
   if (coop_spawns)
@@ -3427,7 +3426,7 @@ static void G_AddDemoFooter(void)
   memcpy(demo_p, str, len);
   demo_p += len;
 
-  (free)(str);
+  free(str);
 }
 
 //===================

--- a/Source/g_game.c
+++ b/Source/g_game.c
@@ -968,7 +968,7 @@ static void G_WriteDemoTiccmd(ticcmd_t* cmd)
     {
       // no more space
       maxdemosize += 128*1024;   // add another 128K  -- killough
-      demobuffer = realloc(demobuffer,maxdemosize);
+      demobuffer = Z_Realloc(demobuffer,maxdemosize, PU_STATIC, 0);
       demo_p = position + demobuffer;  // back on track
       // end of main demo limit changes -- killough
     }
@@ -1148,7 +1148,7 @@ static void G_DoCompleted(void)
           players[i].didsecret = false;
       }
       wminfo.didsecret = players[consoleplayer].didsecret;
-      wminfo.partime = gamemapinfo->partime;
+      wminfo.partime = gamemapinfo->partime * TICRATE;
       goto frommapinfo;	// skip past the default setup.
     }
   }
@@ -1599,8 +1599,8 @@ void CheckSaveGame(size_t size)
   size_t pos = save_p - savebuffer;
   size += 1024;  // breathing room
   if (pos+size > savegamesize)
-    save_p = (savebuffer = realloc(savebuffer,
-           savegamesize += (size+1023) & ~1023)) + pos;
+    save_p = (savebuffer = Z_Realloc(savebuffer,
+           savegamesize += (size+1023) & ~1023, PU_STATIC, 0)) + pos;
 }
 
 // killough 3/22/98: form savegame name in one location
@@ -1670,7 +1670,7 @@ static void G_DoSaveGame(void)
 
   description = savedescription;
 
-  save_p = savebuffer = malloc(savegamesize);
+  save_p = savebuffer = Z_Malloc(savegamesize, PU_STATIC, 0);
 
   CheckSaveGame(SAVESTRINGSIZE+VERSIONSIZE+sizeof(uint64_t));
   memcpy (save_p, description, SAVESTRINGSIZE);
@@ -1767,7 +1767,7 @@ static void G_DoSaveGame(void)
   else
     players[consoleplayer].message = s_GGSAVED;  // Ty 03/27/98 - externalized
 
-  free(savebuffer);  // killough
+  Z_Free(savebuffer);  // killough
   savebuffer = save_p = NULL;
 
   gameaction = ga_nothing;
@@ -1836,13 +1836,13 @@ static void G_DoLoadGame(void)
      uint64_t rchecksum = saveg_read64();
      if (checksum != rchecksum)
        {
-	 char *msg = malloc(strlen((char *) save_p) + 128);
+	 char *msg = Z_Malloc(strlen((char *) save_p) + 128, PU_STATIC, 0);
 	 strcpy(msg,"Incompatible Savegame!!!\n");
 	 if (save_p[sizeof checksum])
 	   strcat(strcat(msg,"Wads expected:\n\n"), (char *) save_p);
 	 strcat(msg, "\nAre you sure?");
 	 G_LoadGameErr(msg);
-	 free(msg);
+	 Z_Free(msg);
 	 return;
        }
    }
@@ -2234,7 +2234,7 @@ static boolean G_CheckSpot(int playernum, mapthing_t *mthing)
       static size_t queuesize;
       if (queuesize < bodyquesize)
 	{
-	  bodyque = realloc(bodyque, bodyquesize*sizeof*bodyque);
+	  bodyque = Z_Realloc(bodyque, bodyquesize*sizeof*bodyque, PU_STATIC, 0);
 	  memset(bodyque+queuesize, 0, 
 		 (bodyquesize-queuesize)*sizeof*bodyque);
 	  queuesize = bodyquesize;
@@ -2953,7 +2953,7 @@ void G_RecordDemo(char *name)
     maxdemosize = atoi(myargv[i+1])*1024;
   if (maxdemosize < 0x20000)  // killough
     maxdemosize = 0x20000;
-  demobuffer = malloc(maxdemosize); // killough
+  demobuffer = Z_Malloc(maxdemosize, PU_STATIC, 0); // killough
   demorecording = true;
 }
 
@@ -3420,7 +3420,7 @@ static void G_AddDemoFooter(void)
   if (position + len > maxdemosize)
   {
     maxdemosize += len;
-    demobuffer = realloc(demobuffer, maxdemosize);
+    demobuffer = Z_Realloc(demobuffer, maxdemosize, PU_STATIC, 0);
     demo_p = position + demobuffer;
   }
 
@@ -3451,7 +3451,7 @@ boolean G_CheckDemoStatus(void)
 	I_Error("Error recording demo %s: %s", demoname,  // killough 11/98
 		errno ? strerror(errno) : "(Unknown Error)");
 
-      free(demobuffer);
+      Z_Free(demobuffer);
       demobuffer = NULL;  // killough
       fprintf(stderr, "Demo %s recorded\n", demoname);
       // [crispy] if a new game is started during demo recording, start a new demo

--- a/Source/i_flmusic.c
+++ b/Source/i_flmusic.c
@@ -158,7 +158,7 @@ static boolean I_FL_InitMusic(void)
                               lumpnum >= 0 ? "SNDFONT lump" : soundfont_path, NULL);
         SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_WARNING,
                                  PROJECT_STRING, errmsg, NULL);
-        (free)(errmsg);
+        free(errmsg);
         return false;
     }
 

--- a/Source/i_glob.c
+++ b/Source/i_glob.c
@@ -21,7 +21,6 @@
 #include <ctype.h>
 
 #include "i_glob.h"
-#include "m_misc.h"
 #include "m_misc2.h"
 #include "config.h"
 

--- a/Source/i_glob.c
+++ b/Source/i_glob.c
@@ -67,7 +67,7 @@ static boolean IsDirectory(char *dir, struct dirent *de)
 
         filename = M_StringJoin(dir, DIR_SEPARATOR_S, de->d_name, NULL);
         result = stat(filename, &sb);
-        (free)(filename);
+        free(filename);
 
         if (result != 0)
         {
@@ -97,7 +97,7 @@ static void FreeStringList(char **globs, int num_globs)
     int i;
     for (i = 0; i < num_globs; ++i)
     {
-        (free)(globs[i]);
+        free(globs[i]);
     }
     free(globs);
 }
@@ -181,7 +181,7 @@ void I_EndGlob(glob_t *glob)
     FreeStringList(glob->globs, glob->num_globs);
     FreeStringList(glob->filenames, glob->filenames_len);
 
-    (free)(glob->directory);
+    free(glob->directory);
     free(glob->last_filename);
     (void) closedir(glob->dir);
     free(glob);

--- a/Source/i_main.c
+++ b/Source/i_main.c
@@ -144,7 +144,7 @@ void I_AtExitPrio(atexit_func_t func, boolean run_on_error,
 {
     atexit_listentry_t *entry;
 
-    entry = (malloc)(sizeof(*entry));
+    entry = malloc(sizeof(*entry));
 
     entry->func = func;
     entry->run_on_error = run_on_error;

--- a/Source/i_oplmusic.c
+++ b/Source/i_oplmusic.c
@@ -1508,7 +1508,7 @@ static void I_OPL_PlaySong(void *handle, boolean looping)
 
     // Allocate track data.
 
-    tracks = (malloc)(MIDI_NumTracks(file) * sizeof(opl_track_data_t));
+    tracks = malloc(MIDI_NumTracks(file) * sizeof(opl_track_data_t));
 
     num_tracks = MIDI_NumTracks(file);
     running_tracks = num_tracks;
@@ -1605,7 +1605,7 @@ static void I_OPL_StopSong(void *handle)
         MIDI_FreeIterator(tracks[i].iter);
     }
 
-    (free)(tracks);
+    free(tracks);
 
     tracks = NULL;
     num_tracks = 0;

--- a/Source/i_oplmusic.c
+++ b/Source/i_oplmusic.c
@@ -27,7 +27,6 @@
 
 #include "i_sound.h"
 #include "m_swap.h"
-#include "m_misc.h"
 #include "m_misc2.h"
 #include "w_wad.h"
 #include "z_zone.h"
@@ -1509,7 +1508,7 @@ static void I_OPL_PlaySong(void *handle, boolean looping)
 
     // Allocate track data.
 
-    tracks = malloc(MIDI_NumTracks(file) * sizeof(opl_track_data_t));
+    tracks = (malloc)(MIDI_NumTracks(file) * sizeof(opl_track_data_t));
 
     num_tracks = MIDI_NumTracks(file);
     running_tracks = num_tracks;
@@ -1606,7 +1605,7 @@ static void I_OPL_StopSong(void *handle)
         MIDI_FreeIterator(tracks[i].iter);
     }
 
-    free(tracks);
+    (free)(tracks);
 
     tracks = NULL;
     num_tracks = 0;

--- a/Source/i_sdlmusic.c
+++ b/Source/i_sdlmusic.c
@@ -30,7 +30,7 @@
 #include "SDL.h"
 #include "SDL_mixer.h"
 
-//#include "doomstat.h"
+#include "doomstat.h"
 #include "doomtype.h"
 #include "i_sound.h"
 
@@ -91,12 +91,12 @@ static void I_SDL_PlaySong(void *handle, boolean looping)
 {
    if(CHECK_MUSIC(handle) && Mix_PlayMusic(music, looping ? -1 : 0) == -1)
    {
-      printf("I_PlaySong: Mix_PlayMusic failed\n");
+      dprintf("I_PlaySong: Mix_PlayMusic failed\n");
       return;
    }
    
    // haleyjd 10/28/05: make sure volume settings remain consistent
-   //I_SDL_SetMusicVolume(snd_MusicVolume);
+   I_SDL_SetMusicVolume(snd_MusicVolume);
 }
 
 //
@@ -232,7 +232,7 @@ static void *I_SDL_RegisterSong(void *data, int size)
 
       if (result)
       {
-         printf("Error loading music: %d", result);
+         dprintf("Error loading music: %d", result);
          return NULL;
       }
 

--- a/Source/i_sdlmusic.c
+++ b/Source/i_sdlmusic.c
@@ -30,7 +30,8 @@
 #include "SDL.h"
 #include "SDL_mixer.h"
 
-#include "doomstat.h"
+//#include "doomstat.h"
+#include "doomtype.h"
 #include "i_sound.h"
 
 ///
@@ -41,7 +42,6 @@
 
 #include "mus2mid.h"
 #include "memio.h"
-#include "m_misc.h"
 #include "m_misc2.h"
 
 // Only one track at a time
@@ -91,12 +91,12 @@ static void I_SDL_PlaySong(void *handle, boolean looping)
 {
    if(CHECK_MUSIC(handle) && Mix_PlayMusic(music, looping ? -1 : 0) == -1)
    {
-      dprintf("I_PlaySong: Mix_PlayMusic failed\n");
+      printf("I_PlaySong: Mix_PlayMusic failed\n");
       return;
    }
    
    // haleyjd 10/28/05: make sure volume settings remain consistent
-   I_SDL_SetMusicVolume(snd_MusicVolume);
+   //I_SDL_SetMusicVolume(snd_MusicVolume);
 }
 
 //
@@ -232,7 +232,7 @@ static void *I_SDL_RegisterSong(void *data, int size)
 
       if (result)
       {
-         dprintf("Error loading music: %d", result);
+         printf("Error loading music: %d", result);
          return NULL;
       }
 

--- a/Source/i_sound.c
+++ b/Source/i_sound.c
@@ -271,7 +271,7 @@ static boolean addsfx(sfxinfo_t *sfx, int channel, int pitch)
          sfx_alen = (Uint32)(((ULong64)samplecount * snd_samplerate) / samplerate);
          // [FG] double up twice: 8 -> 16 bit and mono -> stereo
          sfx->alen = 4 * sfx_alen;
-         sfx->data = precache_sounds ? (malloc)(sfx->alen) : Z_Malloc(sfx->alen, PU_STATIC, &sfx->data);
+         sfx->data = precache_sounds ? malloc(sfx->alen) : Z_Malloc(sfx->alen, PU_STATIC, &sfx->data);
          sfx_data = sfx->data;
       }
       else

--- a/Source/i_system.c
+++ b/Source/i_system.c
@@ -247,7 +247,7 @@ void *I_Realloc(void *ptr, size_t size)
 
     if (size != 0 && new_ptr == NULL)
     {
-        I_Error ("I_Realloc: failed on reallocation of %zu bytes", size);
+        I_Error("I_Realloc: failed on reallocation");
     }
 
     return new_ptr;

--- a/Source/i_system.c
+++ b/Source/i_system.c
@@ -235,6 +235,24 @@ void I_EndDoom(void)
     I_Endoom(endoom);
 }
 
+//
+// I_Realloc
+//
+
+void *I_Realloc(void *ptr, size_t size)
+{
+    void *new_ptr;
+
+    new_ptr = realloc(ptr, size);
+
+    if (size != 0 && new_ptr == NULL)
+    {
+        I_Error ("I_Realloc: failed on reallocation of %zu bytes", size);
+    }
+
+    return new_ptr;
+}
+
 //----------------------------------------------------------------------------
 //
 // $Log: i_system.c,v $

--- a/Source/i_system.h
+++ b/Source/i_system.h
@@ -103,6 +103,8 @@ void I_AtExitPrio(atexit_func_t func, boolean run_if_error,
 void I_SafeExit(int rc) NORETURN;
 void I_ErrorMsg(void);
 
+void *I_Realloc(void *ptr, size_t size);
+
 #endif
 
 //----------------------------------------------------------------------------

--- a/Source/i_video.c
+++ b/Source/i_video.c
@@ -1089,7 +1089,7 @@ void I_ShutdownGraphics(void)
       buflen = strlen(buf) + 1;
       if (strlen(window_position) < buflen)
       {
-          window_position = realloc(window_position, buflen);
+          window_position = I_Realloc(window_position, buflen);
       }
       M_StringCopy(window_position, buf, buflen);
 

--- a/Source/i_video.c
+++ b/Source/i_video.c
@@ -995,12 +995,12 @@ static void I_InitDiskFlash(void)
 
   if (diskflash)
     {
-      free(diskflash);
-      free(old_data);
+      Z_Free(diskflash);
+      Z_Free(old_data);
     }
 
-  diskflash = malloc((16<<hires) * (16<<hires) * sizeof(*diskflash));
-  old_data = malloc((16<<hires) * (16<<hires) * sizeof(*old_data));
+  diskflash = Z_Malloc((16<<hires) * (16<<hires) * sizeof(*diskflash), PU_STATIC, 0);
+  old_data = Z_Malloc((16<<hires) * (16<<hires) * sizeof(*old_data), PU_STATIC, 0);
 
   V_GetBlock(0, 0, 0, 16, 16, temp);
   V_DrawPatchDirect(0-WIDESCREENDELTA, 0, 0, W_CacheLumpName(M_CheckParm("-cdrom") ?
@@ -1089,7 +1089,7 @@ void I_ShutdownGraphics(void)
       buflen = strlen(buf) + 1;
       if (strlen(window_position) < buflen)
       {
-          window_position = realloc(window_position, buflen);
+          window_position = (realloc)(window_position, buflen);
       }
       M_StringCopy(window_position, buf, buflen);
 
@@ -1147,7 +1147,7 @@ boolean I_WritePNGfile(char *filename)
 
   // [FG] allocate memory for screenshot image
   pitch = rect.w * format->BytesPerPixel;
-  pixels = malloc(rect.h * pitch);
+  pixels = (malloc)(rect.h * pitch);
   SDL_RenderReadPixels(renderer, &rect, format->format, pixels, pitch);
 
   {
@@ -1175,7 +1175,7 @@ boolean I_WritePNGfile(char *filename)
   }
 
   SDL_FreeFormat(format);
-  free(pixels);
+  (free)(pixels);
 
   return ret;
 }

--- a/Source/i_video.c
+++ b/Source/i_video.c
@@ -1089,7 +1089,7 @@ void I_ShutdownGraphics(void)
       buflen = strlen(buf) + 1;
       if (strlen(window_position) < buflen)
       {
-          window_position = (realloc)(window_position, buflen);
+          window_position = realloc(window_position, buflen);
       }
       M_StringCopy(window_position, buf, buflen);
 
@@ -1147,7 +1147,7 @@ boolean I_WritePNGfile(char *filename)
 
   // [FG] allocate memory for screenshot image
   pitch = rect.w * format->BytesPerPixel;
-  pixels = (malloc)(rect.h * pitch);
+  pixels = malloc(rect.h * pitch);
   SDL_RenderReadPixels(renderer, &rect, format->format, pixels, pitch);
 
   {
@@ -1170,12 +1170,12 @@ boolean I_WritePNGfile(char *filename)
         }
         fclose(file);
       }
-      (free)(png);
+      free(png);
     }
   }
 
   SDL_FreeFormat(format);
-  (free)(pixels);
+  free(pixels);
 
   return ret;
 }

--- a/Source/m_cheat.c
+++ b/Source/m_cheat.c
@@ -502,7 +502,7 @@ static void cheat_clev0()
   else
     dprintf("Current: %s", cur);
 
-  (free)(cur);
+  free(cur);
 }
 
 static void cheat_clev(buf)

--- a/Source/m_menu.c
+++ b/Source/m_menu.c
@@ -609,7 +609,7 @@ void M_AddEpisode(const char *map, const char *gfx, const char *txt, const char 
     EpiMenuMap[EpiDef.numitems] = mapnum;
     strncpy(EpisodeMenu[EpiDef.numitems].name, gfx, 8);
     EpisodeMenu[EpiDef.numitems].name[9] = 0;
-    EpisodeMenu[EpiDef.numitems].alttext = txt ? strdup(txt) : NULL;
+    EpisodeMenu[EpiDef.numitems].alttext = txt ? (strdup)(txt) : NULL;
     EpisodeMenu[EpiDef.numitems].alphaKey = alpha ? *alpha : 0;
     EpiDef.numitems++;
   }
@@ -918,13 +918,13 @@ static void M_VerifyForcedLoadGame(int ch)
 {
   if (ch=='y')
     G_ForcedLoadGame();
-  free(messageString);       // free the message strdup()'ed below
+  (free)(messageString);       // free the message strdup()'ed below
   M_ClearMenus();
 }
 
 void M_ForcedLoadGame(const char *msg)
 {
-  M_StartMessage(strdup(msg), M_VerifyForcedLoadGame, true); // free()'d above
+  M_StartMessage((strdup)(msg), M_VerifyForcedLoadGame, true); // free()'d above
 }
 
 //
@@ -2107,7 +2107,7 @@ void M_DrawItem(setup_menu_t* s)
       // Enhance to support multiline text separated by newlines.
       // This supports multiline items on horizontally-crowded menus.
 
-      for (p = t = strdup(s->m_text); (p = strtok(p,"\n")); y += 8, p = NULL)
+      for (p = t = (strdup)(s->m_text); (p = strtok(p,"\n")); y += 8, p = NULL)
 	{      // killough 10/98: support left-justification:
 	  strcpy(menu_buffer,p);
 	  if (!(flags & S_LEFTJUST))
@@ -2125,7 +2125,7 @@ void M_DrawItem(setup_menu_t* s)
 	    M_DrawString(x - w - 8, y, color, ">");
 	  }
 	}
-      free(t);
+      (free)(t);
     }
 }
 
@@ -4268,8 +4268,8 @@ void M_ResetDefaults()
 		p->ident == dp->ident)
 	      {
 		if (dp->type == string)
-		  free(dp->location->s),
-		    dp->location->s = strdup(dp->defaultvalue.s);
+		  (free)(dp->location->s),
+		    dp->location->s = (strdup)(dp->defaultvalue.s);
 		else if (dp->type == number)
 		  dp->location->i = dp->defaultvalue.i;
 		else if (dp->type == input)
@@ -5746,7 +5746,7 @@ boolean M_Responder (event_t* ev)
 	      //
 	      // killough 10/98: fix bugs, simplify
 
-	      chat_string_buffer = malloc(CHAT_STRING_BFR_SIZE);
+	      chat_string_buffer = (malloc)(CHAT_STRING_BFR_SIZE);
 	      strncpy(chat_string_buffer,
 		      ptr1->var.def->location->s, CHAT_STRING_BFR_SIZE);
 
@@ -5756,7 +5756,7 @@ boolean M_Responder (event_t* ev)
 	      // set chat table pointer to working buffer
 	      // and free old string's memory.
 
-	      free(ptr1->var.def->location->s);
+	      (free)(ptr1->var.def->location->s);
 	      ptr1->var.def->location->s = chat_string_buffer;
 	      chat_index = 0; // current cursor position in chat_string_buffer
 	    }
@@ -6065,7 +6065,7 @@ void M_Drawer (void)
    {
       // haleyjd 11/11/04: must strdup message, cannot write into
       // string constants!
-      char *d = strdup(messageString);
+      char *d = (strdup)(messageString);
       char *p;
       int y = 100 - M_StringHeight(messageString)/2;
       
@@ -6084,7 +6084,7 @@ void M_Drawer (void)
       }
 
       // haleyjd 11/11/04: free duplicate string
-      free(d);
+      (free)(d);
    }
    else if(menuactive)
    {

--- a/Source/m_menu.c
+++ b/Source/m_menu.c
@@ -609,7 +609,7 @@ void M_AddEpisode(const char *map, const char *gfx, const char *txt, const char 
     EpiMenuMap[EpiDef.numitems] = mapnum;
     strncpy(EpisodeMenu[EpiDef.numitems].name, gfx, 8);
     EpisodeMenu[EpiDef.numitems].name[9] = 0;
-    EpisodeMenu[EpiDef.numitems].alttext = txt ? (strdup)(txt) : NULL;
+    EpisodeMenu[EpiDef.numitems].alttext = txt ? strdup(txt) : NULL;
     EpisodeMenu[EpiDef.numitems].alphaKey = alpha ? *alpha : 0;
     EpiDef.numitems++;
   }
@@ -814,7 +814,7 @@ static void M_DeleteGame(int i)
 
   M_ReadSaveStrings();
 
-  if (name) (free)(name);
+  if (name) free(name);
 }
 
 // [FG] support up to 8 pages of savegames
@@ -892,7 +892,7 @@ void M_LoadSelect(int choice)
 
   if (access(name, F_OK) != 0)
   {
-    if (name) (free)(name);
+    if (name) free(name);
     name = G_MBFSaveGameName(choice);
     saveg_compat = saveg_mbf;
   }
@@ -900,7 +900,7 @@ void M_LoadSelect(int choice)
   G_LoadGame(name, choice, false); // killough 3/16/98, 5/15/98: add slot, cmd
 
   M_ClearMenus ();
-  if (name) (free)(name);
+  if (name) free(name);
 
   // [crispy] allow quickload before quicksave
   if (quickSaveSlot == -2)
@@ -918,13 +918,13 @@ static void M_VerifyForcedLoadGame(int ch)
 {
   if (ch=='y')
     G_ForcedLoadGame();
-  (free)(messageString);       // free the message strdup()'ed below
+  free(messageString);       // free the message strdup()'ed below
   M_ClearMenus();
 }
 
 void M_ForcedLoadGame(const char *msg)
 {
-  M_StartMessage((strdup)(msg), M_VerifyForcedLoadGame, true); // free()'d above
+  M_StartMessage(strdup(msg), M_VerifyForcedLoadGame, true); // free()'d above
 }
 
 //
@@ -996,13 +996,13 @@ void M_ReadSaveStrings(void)
 
       char *name = G_SaveGameName(i);    // killough 3/22/98
       fp = fopen(name,"rb");
-      if (name) (free)(name);
+      if (name) free(name);
 
       if (!fp)
 	{   // Ty 03/27/98 - externalized:
 	  name = G_MBFSaveGameName(i);
 	  fp = fopen(name,"rb");
-	  if (name) (free)(name);
+	  if (name) free(name);
 	  if (!fp)
 	  {
 	  strcpy(&savegamestrings[i][0],s_EMPTYSTRING);
@@ -1077,7 +1077,7 @@ static void SetDefaultSaveName (int slot)
 
     M_snprintf(savegamestrings[slot], SAVESTRINGSIZE,
                "%s (%s)", maplump, wadname);
-    (free)(wadname);
+    free(wadname);
 
     M_ForceUppercase(savegamestrings[slot]);
 }
@@ -2107,7 +2107,7 @@ void M_DrawItem(setup_menu_t* s)
       // Enhance to support multiline text separated by newlines.
       // This supports multiline items on horizontally-crowded menus.
 
-      for (p = t = (strdup)(s->m_text); (p = strtok(p,"\n")); y += 8, p = NULL)
+      for (p = t = strdup(s->m_text); (p = strtok(p,"\n")); y += 8, p = NULL)
 	{      // killough 10/98: support left-justification:
 	  strcpy(menu_buffer,p);
 	  if (!(flags & S_LEFTJUST))
@@ -2125,7 +2125,7 @@ void M_DrawItem(setup_menu_t* s)
 	    M_DrawString(x - w - 8, y, color, ">");
 	  }
 	}
-      (free)(t);
+      free(t);
     }
 }
 
@@ -4268,8 +4268,8 @@ void M_ResetDefaults()
 		p->ident == dp->ident)
 	      {
 		if (dp->type == string)
-		  (free)(dp->location->s),
-		    dp->location->s = (strdup)(dp->defaultvalue.s);
+		  free(dp->location->s),
+		    dp->location->s = strdup(dp->defaultvalue.s);
 		else if (dp->type == number)
 		  dp->location->i = dp->defaultvalue.i;
 		else if (dp->type == input)
@@ -5746,7 +5746,7 @@ boolean M_Responder (event_t* ev)
 	      //
 	      // killough 10/98: fix bugs, simplify
 
-	      chat_string_buffer = (malloc)(CHAT_STRING_BFR_SIZE);
+	      chat_string_buffer = malloc(CHAT_STRING_BFR_SIZE);
 	      strncpy(chat_string_buffer,
 		      ptr1->var.def->location->s, CHAT_STRING_BFR_SIZE);
 
@@ -5756,7 +5756,7 @@ boolean M_Responder (event_t* ev)
 	      // set chat table pointer to working buffer
 	      // and free old string's memory.
 
-	      (free)(ptr1->var.def->location->s);
+	      free(ptr1->var.def->location->s);
 	      ptr1->var.def->location->s = chat_string_buffer;
 	      chat_index = 0; // current cursor position in chat_string_buffer
 	    }
@@ -6065,7 +6065,7 @@ void M_Drawer (void)
    {
       // haleyjd 11/11/04: must strdup message, cannot write into
       // string constants!
-      char *d = (strdup)(messageString);
+      char *d = strdup(messageString);
       char *p;
       int y = 100 - M_StringHeight(messageString)/2;
       
@@ -6084,7 +6084,7 @@ void M_Drawer (void)
       }
 
       // haleyjd 11/11/04: free duplicate string
-      (free)(d);
+      free(d);
    }
    else if(menuactive)
    {
@@ -6472,7 +6472,7 @@ void M_Init(void)
     else
 #endif
     string = M_StringReplace(replace, "prompt", "desktop");
-    (free)(replace);
+    free(replace);
     endmsg[9] = string;
   }
 }

--- a/Source/m_misc.c
+++ b/Source/m_misc.c
@@ -2536,14 +2536,14 @@ boolean M_ParseOption(const char *p, boolean wad)
 	  dp->orig_default.s = dp->location->s;         // Save original default
 	}
       else
-	free(dp->location->s);                // Free old value
+	(free)(dp->location->s);                // Free old value
 
-      dp->location->s = strdup(strparm+1);    // Change default value
+      dp->location->s = (strdup)(strparm+1);    // Change default value
 
       if (dp->current)                                // Current value
 	{
-	  free(dp->current->s);               // Free old value
-	  dp->current->s = strdup(strparm+1); // Change current value
+	  (free)(dp->current->s);               // Free old value
+	  dp->current->s = (strdup)(strparm+1); // Change current value
 	}
     }
   else if (dp->type == number)
@@ -2663,13 +2663,13 @@ void M_LoadOptions(void)
 	  int len = 0;
 	  while (len < size && p[len++] && p[len-1] != '\n');
 	  if (len >= buflen)
-	    buf = realloc(buf, buflen = len+1);
+	    buf = (realloc)(buf, buflen = len+1);
 	  strncpy(buf, p, len)[len] = 0;
 	  p += len;
 	  size -= len;
 	  M_ParseOption(buf, true);
 	}
-      free(buf);
+      (free)(buf);
       Z_ChangeTag(options, PU_CACHE);
     }
   }
@@ -2699,7 +2699,7 @@ void M_LoadDefaults (void)
 
   for (dp = defaults; dp->name; dp++)
     if (dp->type == string)
-      dp->location->s = strdup(dp->defaultvalue.s);
+      dp->location->s = (strdup)(dp->defaultvalue.s);
     else if (dp->type == number)
       dp->location->i = dp->defaultvalue.i;
     else if (dp->type == input)
@@ -2721,9 +2721,9 @@ void M_LoadDefaults (void)
   if (!defaultfile)
   {
     if ((i = M_CheckParm("-config")) && i < myargc-1)
-      defaultfile = strdup(myargv[i+1]);
+      defaultfile = (strdup)(myargv[i+1]);
     else
-      defaultfile = strdup(basedefault);
+      defaultfile = (strdup)(basedefault);
   }
 
   NormalizeSlashes(defaultfile);
@@ -2763,11 +2763,11 @@ void M_LoadDefaults (void)
                 skipblanks = 1, p = "\n";
 
             if (comment >= comment_alloc)
-              comments = realloc(comments, sizeof *comments *
+              comments = (realloc)(comments, sizeof *comments *
                                  (comment_alloc = comment_alloc ?
                                   comment_alloc * 2 : 10));
             comments[comment].line = line;
-            comments[comment++].text = strdup(p);
+            comments[comment++].text = (strdup)(p);
           }
       fclose (f);
     }

--- a/Source/m_misc.c
+++ b/Source/m_misc.c
@@ -2489,7 +2489,7 @@ void M_SaveDefaults (void)
     I_Error("Could not write defaults to %s: %s\n", defaultfile,
 	    errno ? strerror(errno): "(Unknown Error)");
 
-  (free)(tmpfile);
+  free(tmpfile);
 }
 
 //
@@ -2536,14 +2536,14 @@ boolean M_ParseOption(const char *p, boolean wad)
 	  dp->orig_default.s = dp->location->s;         // Save original default
 	}
       else
-	(free)(dp->location->s);                // Free old value
+	free(dp->location->s);                // Free old value
 
-      dp->location->s = (strdup)(strparm+1);    // Change default value
+      dp->location->s = strdup(strparm+1);    // Change default value
 
       if (dp->current)                                // Current value
 	{
-	  (free)(dp->current->s);               // Free old value
-	  dp->current->s = (strdup)(strparm+1); // Change current value
+	  free(dp->current->s);               // Free old value
+	  dp->current->s = strdup(strparm+1); // Change current value
 	}
     }
   else if (dp->type == number)
@@ -2663,13 +2663,13 @@ void M_LoadOptions(void)
 	  int len = 0;
 	  while (len < size && p[len++] && p[len-1] != '\n');
 	  if (len >= buflen)
-	    buf = (realloc)(buf, buflen = len+1);
+	    buf = realloc(buf, buflen = len+1);
 	  strncpy(buf, p, len)[len] = 0;
 	  p += len;
 	  size -= len;
 	  M_ParseOption(buf, true);
 	}
-      (free)(buf);
+      free(buf);
       Z_ChangeTag(options, PU_CACHE);
     }
   }
@@ -2699,7 +2699,7 @@ void M_LoadDefaults (void)
 
   for (dp = defaults; dp->name; dp++)
     if (dp->type == string)
-      dp->location->s = (strdup)(dp->defaultvalue.s);
+      dp->location->s = strdup(dp->defaultvalue.s);
     else if (dp->type == number)
       dp->location->i = dp->defaultvalue.i;
     else if (dp->type == input)
@@ -2721,9 +2721,9 @@ void M_LoadDefaults (void)
   if (!defaultfile)
   {
     if ((i = M_CheckParm("-config")) && i < myargc-1)
-      defaultfile = (strdup)(myargv[i+1]);
+      defaultfile = strdup(myargv[i+1]);
     else
-      defaultfile = (strdup)(basedefault);
+      defaultfile = strdup(basedefault);
   }
 
   NormalizeSlashes(defaultfile);
@@ -2763,11 +2763,11 @@ void M_LoadDefaults (void)
                 skipblanks = 1, p = "\n";
 
             if (comment >= comment_alloc)
-              comments = (realloc)(comments, sizeof *comments *
+              comments = realloc(comments, sizeof *comments *
                                  (comment_alloc = comment_alloc ?
                                   comment_alloc * 2 : 10));
             comments[comment].line = line;
-            comments[comment++].text = (strdup)(p);
+            comments[comment++].text = strdup(p);
           }
       fclose (f);
     }

--- a/Source/m_misc.c
+++ b/Source/m_misc.c
@@ -2763,7 +2763,7 @@ void M_LoadDefaults (void)
                 skipblanks = 1, p = "\n";
 
             if (comment >= comment_alloc)
-              comments = realloc(comments, sizeof *comments *
+              comments = I_Realloc(comments, sizeof *comments *
                                  (comment_alloc = comment_alloc ?
                                   comment_alloc * 2 : 10));
             comments[comment].line = line;

--- a/Source/net_client.c
+++ b/Source/net_client.c
@@ -465,10 +465,10 @@ static void NET_CL_ParseSYN(net_packet_t *packet)
 
 static void SetRejectReason(const char *s)
 {
-    (free)(net_client_reject_reason);
+    free(net_client_reject_reason);
     if (s != NULL)
     {
-        net_client_reject_reason = (strdup)(s);
+        net_client_reject_reason = strdup(s);
     }
     else
     {

--- a/Source/net_common.c
+++ b/Source/net_common.c
@@ -151,7 +151,7 @@ static void NET_Conn_ParseReliableACK(net_connection_t *conn, net_packet_t *pack
         conn->reliable_packets = rp->next;
         
         NET_FreePacket(rp->packet);
-        (free)(rp);
+        free(rp);
     }
 }
 
@@ -383,7 +383,7 @@ net_packet_t *NET_Conn_NewReliable(net_connection_t *conn, int packet_type)
 
     // Add to the list of reliable packets
 
-    rp = (malloc)(sizeof(net_reliable_packet_t));
+    rp = malloc(sizeof(net_reliable_packet_t));
     rp->packet = packet;
     rp->next = NULL;
     rp->seq = conn->reliable_send_seq;

--- a/Source/net_query.c
+++ b/Source/net_query.c
@@ -226,7 +226,7 @@ static query_target_t *GetTargetForAddr(net_addr_t *addr, boolean create)
         return NULL;
     }
 
-    targets = realloc(targets, sizeof(query_target_t) * (num_targets + 1));
+    targets = I_Realloc(targets, sizeof(query_target_t) * (num_targets + 1));
 
     target = &targets[num_targets];
     target->type = QUERY_TARGET_SERVER;

--- a/Source/net_query.c
+++ b/Source/net_query.c
@@ -226,7 +226,7 @@ static query_target_t *GetTargetForAddr(net_addr_t *addr, boolean create)
         return NULL;
     }
 
-    targets = (realloc)(targets, sizeof(query_target_t) * (num_targets + 1));
+    targets = realloc(targets, sizeof(query_target_t) * (num_targets + 1));
 
     target = &targets[num_targets];
     target->type = QUERY_TARGET_SERVER;
@@ -248,7 +248,7 @@ static void FreeTargets(void)
     {
         NET_ReleaseAddress(targets[i].addr);
     }
-    (free)(targets);
+    free(targets);
     targets = NULL;
     num_targets = 0;
 }
@@ -588,7 +588,7 @@ void NET_Query_Init(void)
         net_sdl_module.InitClient();
     }
 
-    (free)(targets);
+    free(targets);
     targets = NULL;
     num_targets = 0;
 

--- a/Source/net_sdl.c
+++ b/Source/net_sdl.c
@@ -349,7 +349,7 @@ net_addr_t *NET_SDL_ResolveAddress(const char *address)
     
     result = SDLNet_ResolveHost(&ip, addr_hostname, addr_port);
 
-    (free)(addr_hostname);
+    free(addr_hostname);
 
     if (result)
     {

--- a/Source/net_server.c
+++ b/Source/net_server.c
@@ -1803,7 +1803,7 @@ static void NET_SV_RunClient(net_client_t *client)
             NET_SV_GameEnded();
         }
 
-        (free)(client->name);
+        free(client->name);
         NET_ReleaseAddress(client->addr);
 
         // Are there any clients left connected?  If not, return the

--- a/Source/p_ceilng.c
+++ b/Source/p_ceilng.c
@@ -416,7 +416,7 @@ int EV_CeilingCrushStop(line_t* line)
 //
 void P_AddActiveCeiling(ceiling_t* ceiling)
 {
-  ceilinglist_t *list = malloc(sizeof *list);
+  ceilinglist_t *list = Z_Malloc(sizeof *list, PU_STATIC, 0);
   list->ceiling = ceiling;
   ceiling->list = list;
   if ((list->next = activeceilings))
@@ -440,7 +440,7 @@ void P_RemoveActiveCeiling(ceiling_t* ceiling)
   P_RemoveThinker(&ceiling->thinker);
   if ((*list->prev = list->next))
     list->next->prev = list->prev;
-  free(list);
+  Z_Free(list);
 }
 
 //
@@ -455,7 +455,7 @@ void P_RemoveAllActiveCeilings(void)
   while (activeceilings)
   {  
     ceilinglist_t *next = activeceilings->next;
-    free(activeceilings);
+    Z_Free(activeceilings);
     activeceilings = next;
   }
 }

--- a/Source/p_enemy.c
+++ b/Source/p_enemy.c
@@ -2461,9 +2461,10 @@ void P_SpawnBrainTargets(void)  // killough 3/26/98: renamed old function
         if (m->type == MT_BOSSTARGET )
           {   // killough 2/7/98: remove limit on icon landings:
             if (numbraintargets >= numbraintargets_alloc)
-              braintargets = realloc(braintargets,
+              braintargets = Z_Realloc(braintargets,
                       (numbraintargets_alloc = numbraintargets_alloc ?
-                       numbraintargets_alloc*2 : 32) *sizeof *braintargets);
+                       numbraintargets_alloc*2 : 32) *sizeof *braintargets,
+                      PU_STATIC, 0);
             braintargets[numbraintargets++] = m;
           }
       }

--- a/Source/p_extnodes.c
+++ b/Source/p_extnodes.c
@@ -288,7 +288,7 @@ void P_LoadNodes_ZDBSP (int lump, boolean compressed)
 	output = Z_Malloc(outlen, PU_STATIC, 0);
 
 	// initialize stream state for decompression
-	zstream = malloc(sizeof(*zstream));
+	zstream = Z_Malloc(sizeof(*zstream), PU_STATIC, 0);
 	memset(zstream, 0, sizeof(*zstream));
 	zstream->next_in = data + 4;
 	zstream->avail_in = len - 4;
@@ -321,7 +321,7 @@ void P_LoadNodes_ZDBSP (int lump, boolean compressed)
 
 	// release the original data lump
 	W_CacheLumpNum(lump, PU_CACHE);
-	free(zstream);
+	Z_Free(zstream);
     }
     else
     {

--- a/Source/p_map.c
+++ b/Source/p_map.c
@@ -451,7 +451,7 @@ static boolean PIT_CheckLine(line_t *ld) // killough 3/26/98: make static
       if (numspechit >= spechit_max)
 	{
 	  spechit_max = spechit_max ? spechit_max*2 : 8;
-	  spechit = realloc(spechit,sizeof *spechit*spechit_max); // killough
+	  spechit = Z_Realloc(spechit,sizeof *spechit*spechit_max,PU_STATIC,0); // killough
 	}
       spechit[numspechit++] = ld;
 

--- a/Source/p_maputl.c
+++ b/Source/p_maputl.c
@@ -446,7 +446,7 @@ static void check_intercept(void)
   if (offset >= num_intercepts)
     {
       num_intercepts = num_intercepts ? num_intercepts*2 : MAXINTERCEPTS_ORIGINAL;
-      intercepts = realloc(intercepts, sizeof(*intercepts)*num_intercepts);
+      intercepts = Z_Realloc(intercepts, sizeof(*intercepts)*num_intercepts, PU_STATIC, 0);
       intercept_p = intercepts + offset;
     }
 }

--- a/Source/p_mobj.c
+++ b/Source/p_mobj.c
@@ -1137,7 +1137,8 @@ void P_SpawnMapThing (mapthing_t* mthing)
 	    num_deathmatchstarts*2 : 16;
 	  deathmatchstarts = Z_Realloc(deathmatchstarts,
 				     num_deathmatchstarts *
-				     sizeof(*deathmatchstarts), PU_STATIC, 0);
+				     sizeof(*deathmatchstarts),
+				     PU_STATIC, 0);
 	  deathmatch_p = deathmatchstarts + offset;
 	}
       memcpy(deathmatch_p++, mthing, sizeof*mthing);

--- a/Source/p_mobj.c
+++ b/Source/p_mobj.c
@@ -66,7 +66,7 @@ boolean P_SetMobjState(mobj_t* mobj,statenum_t state)
   statenum_t* tempstate = NULL;               // for use with recursion
 
   if (recursion++)                            // if recursion detected,
-    seenstate = tempstate = calloc(num_states, sizeof(statenum_t)); // allocate state table
+    seenstate = tempstate = Z_Calloc(num_states, sizeof(statenum_t), PU_STATIC, 0); // allocate state table
 
   do
     {
@@ -104,7 +104,7 @@ boolean P_SetMobjState(mobj_t* mobj,statenum_t state)
       seenstate[i] = 0;  // killough 4/9/98: erase memory of states
 
   if (tempstate)
-    free(tempstate);
+    Z_Free(tempstate);
 
   return ret;
 }
@@ -1135,9 +1135,9 @@ void P_SpawnMapThing (mapthing_t* mthing)
 	{
 	  num_deathmatchstarts = num_deathmatchstarts ?
 	    num_deathmatchstarts*2 : 16;
-	  deathmatchstarts = realloc(deathmatchstarts,
+	  deathmatchstarts = Z_Realloc(deathmatchstarts,
 				     num_deathmatchstarts *
-				     sizeof(*deathmatchstarts));
+				     sizeof(*deathmatchstarts), PU_STATIC, 0);
 	  deathmatch_p = deathmatchstarts + offset;
 	}
       memcpy(deathmatch_p++, mthing, sizeof*mthing);

--- a/Source/p_plats.c
+++ b/Source/p_plats.c
@@ -386,7 +386,7 @@ int EV_StopPlat(line_t* line)
 //
 void P_AddActivePlat(plat_t* plat)
 {
-  platlist_t *list = malloc(sizeof *list);
+  platlist_t *list = Z_Malloc(sizeof *list, PU_STATIC, 0);
   list->plat = plat;
   plat->list = list;
   if ((list->next = activeplats))
@@ -410,7 +410,7 @@ void P_RemoveActivePlat(plat_t* plat)
   P_RemoveThinker(&plat->thinker);
   if ((*list->prev = list->next))
     list->next->prev = list->prev;
-  free(list);
+  Z_Free(list);
 }
 
 //
@@ -425,7 +425,7 @@ void P_RemoveAllActivePlats(void)
   while (activeplats)
   {  
     platlist_t *next = activeplats->next;
-    free(activeplats);
+    Z_Free(activeplats);
     activeplats = next;
   }
 }

--- a/Source/p_saveg.c
+++ b/Source/p_saveg.c
@@ -2129,7 +2129,7 @@ void P_ArchiveThinkers (void)
   CheckSaveGame(size*(sizeof(mobj_t)+4));       // killough 2/14/98
 
   // save off the current thinkers
-  mobj = malloc(sizeof(*mobj));
+  mobj = Z_Malloc(sizeof(*mobj), PU_STATIC, 0);
 
   for (th = thinkercap.next ; th != &thinkercap ; th=th->next)
     if (th->function == P_MobjThinker)
@@ -2181,7 +2181,7 @@ void P_ArchiveThinkers (void)
         saveg_write_pad();
         saveg_write_mobj_t(mobj);
       }
-  free(mobj);
+  Z_Free(mobj);
 
   // add a terminating marker
   saveg_write8(tc_end);
@@ -2263,19 +2263,19 @@ void P_UnArchiveThinkers (void)
   // killough 2/14/98: count number of thinkers by skipping through them
   {
     byte *sp = save_p;     // save pointer and skip header
-    mobj_t *mobj = malloc(sizeof(mobj_t));
+    mobj_t *mobj = Z_Malloc(sizeof(mobj_t), PU_STATIC, 0);
     for (size = 1; *save_p++ == tc_mobj; size++)  // killough 2/14/98
       {                     // skip all entries, adding up count
         saveg_read_pad();
         saveg_read_mobj_t(mobj);
       }
-    free(mobj);
+    Z_Free(mobj);
 
     if (*--save_p != tc_end)
       I_Error ("Unknown tclass %i in savegame", *save_p);
 
     // first table entry special: 0 maps to NULL
-    *(mobj_p = malloc(size * sizeof *mobj_p)) = 0;   // table of pointers
+    *(mobj_p = Z_Malloc(size * sizeof *mobj_p, PU_STATIC, 0)) = 0;   // table of pointers
     save_p = sp;           // restore save pointer
   }
 
@@ -2347,7 +2347,7 @@ void P_UnArchiveThinkers (void)
     }
   }
 
-  free(mobj_p);    // free translation table
+  Z_Free(mobj_p);    // free translation table
 
   // killough 3/26/98: Spawn icon landings:
   if (gamemode == commercial)
@@ -2783,8 +2783,9 @@ void P_UnArchiveMap(void)
     {
       int i;
       while (markpointnum >= markpointnum_max)
-        markpoints = realloc(markpoints, sizeof *markpoints *
-         (markpointnum_max = markpointnum_max ? markpointnum_max*2 : 16));
+        markpoints = Z_Realloc(markpoints, sizeof *markpoints *
+         (markpointnum_max = markpointnum_max ? markpointnum_max*2 : 16),
+         PU_STATIC, 0);
 
       for (i = 0; i < markpointnum; ++i)
       {

--- a/Source/p_setup.c
+++ b/Source/p_setup.c
@@ -613,7 +613,7 @@ static void AddBlockLine
   if (done[blockno])
     return;
 
-  l = malloc(sizeof(linelist_t));
+  l = Z_Malloc(sizeof(linelist_t), PU_STATIC, 0);
   l->num = lineno;
   l->next = lists[blockno];
   lists[blockno] = l;
@@ -669,16 +669,16 @@ static void P_CreateBlockMap(void)
   // finally make an array in which we can mark blocks done per line
 
   // CPhipps - calloc's
-  blocklists = calloc(NBlocks,sizeof(linelist_t *));
-  blockcount = calloc(NBlocks,sizeof(int));
-  blockdone = malloc(NBlocks*sizeof(int));
+  blocklists = Z_Calloc(NBlocks,sizeof(linelist_t *), PU_STATIC, 0);
+  blockcount = Z_Calloc(NBlocks,sizeof(int), PU_STATIC, 0);
+  blockdone = Z_Malloc(NBlocks*sizeof(int), PU_STATIC, 0);
 
   // initialize each blocklist, and enter the trailing -1 in all blocklists
   // note the linked list of lines grows backwards
 
   for (i=0;i<NBlocks;i++)
   {
-    blocklists[i] = malloc(sizeof(linelist_t));
+    blocklists[i] = Z_Malloc(sizeof(linelist_t), PU_STATIC, 0);
     blocklists[i]->num = -1;
     blocklists[i]->next = NULL;
     blockcount[i]++;
@@ -869,16 +869,16 @@ static void P_CreateBlockMap(void)
     {
       linelist_t *tmp = bl->next;
       blockmaplump[offs++] = bl->num;
-      free(bl);
+      Z_Free(bl);
       bl = tmp;
     }
   }
 
   // free all temporary storage
 
-  free (blocklists);
-  free (blockcount);
-  free (blockdone);
+  Z_Free(blocklists);
+  Z_Free(blockcount);
+  Z_Free(blockdone);
 }
 
 #else // MBF_STRICT
@@ -944,7 +944,7 @@ static void P_CreateBlockMap(void)
   {
     typedef struct { int n, nalloc, *list; } bmap_t;  // blocklist structure
     unsigned tot = bmapwidth * bmapheight;            // size of blockmap
-    bmap_t *bmap = calloc(sizeof *bmap, tot);         // array of blocklists
+    bmap_t *bmap = Z_Calloc(sizeof *bmap, tot, PU_STATIC, 0); // array of blocklists
 
     for (i=0; i < numlines; i++)
       {
@@ -1035,12 +1035,12 @@ static void P_CreateBlockMap(void)
 	      blockmaplump[ndx++] = bp->list[--bp->n];  // Copy linedef list
 	    while (bp->n);
 	    blockmaplump[ndx++] = -1;                   // Store trailer
-	    free(bp->list);                             // Free linedef list
+	    Z_Free(bp->list);                           // Free linedef list
 	  }
 	else            // Empty blocklist: point to reserved empty blocklist
 	  blockmaplump[i] = tot;
 
-      free(bmap);    // Free uncompressed blockmap
+      Z_Free(bmap);    // Free uncompressed blockmap
     }
   }
 }
@@ -1272,7 +1272,7 @@ int P_GroupLines (void)
 
 void P_RemoveSlimeTrails(void)                // killough 10/98
 {
-  byte *hit = calloc(1, numvertexes);         // Hitlist for vertices
+  byte *hit = Z_Calloc(1, numvertexes, PU_STATIC, 0);         // Hitlist for vertices
   int i;
   for (i=0; i<numsegs; i++)                   // Go through each seg
     {
@@ -1314,7 +1314,7 @@ void P_RemoveSlimeTrails(void)                // killough 10/98
 	  while ((v != segs[i].v2) && (v = segs[i].v2));
 	}
     }
-  free(hit);
+  Z_Free(hit);
 }
 
 // [FG] re-calculated seg lengths and angles used for rendering

--- a/Source/p_setup.c
+++ b/Source/p_setup.c
@@ -1569,7 +1569,7 @@ void P_SetupLevel(int episode, int map, int playermask, skill_t skill)
       ttime/3600, (ttime%3600)/60, ttime%60,
       demo_version);
 
-    (free)(rfn_str);
+    free(rfn_str);
   }
 }
 

--- a/Source/p_spec.c
+++ b/Source/p_spec.c
@@ -136,7 +136,7 @@ void P_InitPicAnims (void)
       if (lastanim >= anims + maxanims)
         {
           size_t newmax = maxanims ? maxanims*2 : MAXANIMS;
-          anims = realloc(anims, newmax*sizeof(*anims));   // killough
+          anims = Z_Realloc(anims, newmax*sizeof(*anims), PU_STATIC, 0);   // killough
           lastanim = anims + maxanims;
           maxanims = newmax;
         }

--- a/Source/p_switch.c
+++ b/Source/p_switch.c
@@ -74,8 +74,9 @@ void P_InitSwitchList(void)
   for (i=0;;i++)
   {
     if (index+1 >= max_numswitches)
-      switchlist = realloc(switchlist, sizeof *switchlist *
-          (max_numswitches = max_numswitches ? max_numswitches*2 : 8));
+      switchlist = Z_Realloc(switchlist, sizeof *switchlist *
+          (max_numswitches = max_numswitches ? max_numswitches*2 : 8),
+          PU_STATIC, 0);
     if (SHORT(alphSwitchList[i].episode) <= episode) //jff 5/11/98 endianess
     {
       int texture1, texture2;

--- a/Source/r_data.c
+++ b/Source/r_data.c
@@ -977,7 +977,7 @@ void R_InitTranMap(int progress)
 	fclose(cachefp);
 
       Z_ChangeTag(playpal, PU_CACHE);
-      (free)(fname);
+      free(fname);
     }
 }
 

--- a/Source/r_data.c
+++ b/Source/r_data.c
@@ -211,7 +211,7 @@ static void R_GenerateComposite(int texnum)
   unsigned *colofs2 = texturecolumnofs2[texnum];
   int i = texture->patchcount;
   // killough 4/9/98: marks to identify transparent regions in merged textures
-  byte *marks = calloc(texture->width, texture->height), *source;
+  byte *marks = Z_Calloc(texture->width, texture->height, PU_STATIC, 0), *source;
 
   // [FG] memory block for opaque textures
   byte *block2 = Z_Malloc(texture->width * texture->height, PU_STATIC,
@@ -243,7 +243,7 @@ static void R_GenerateComposite(int texnum)
   // killough 4/9/98: Next, convert multipatched columns into true columns,
   // to fix Medusa bug while still allowing for transparent regions.
 
-  source = malloc(texture->height);       // temporary column
+  source = Z_Malloc(texture->height, PU_STATIC, 0);       // temporary column
   for (i=0; i < texture->width; i++)
     // [FG] generate composites for all columns
 //  if (collump[i] == -1)                 // process only multipatched columns
@@ -296,8 +296,8 @@ static void R_GenerateComposite(int texnum)
             col = (column_t *)((byte *) col + len + 4); // next post
           }
       }
-  free(source);         // free temporary column
-  free(marks);          // free transparency marks
+  Z_Free(source);         // free temporary column
+  Z_Free(marks);          // free transparency marks
 
   // Now that the texture has been built in column cache,
   // it is purgable from zone memory.
@@ -327,7 +327,7 @@ static void R_GenerateLookup(int texnum, int *const errors)
 
   struct {
     unsigned patches, posts;
-  } *count = calloc(sizeof *count, texture->width);
+  } *count = Z_Calloc(sizeof *count, texture->width, PU_STATIC, 0);
 
   // killough 12/98: First count the number of patches per column.
 
@@ -484,7 +484,7 @@ static void R_GenerateLookup(int texnum, int *const errors)
 	++*errors;
       }
   }
-  free(count);                    // killough 4/9/98
+  Z_Free(count);                    // killough 4/9/98
 }
 
 //
@@ -553,7 +553,7 @@ void R_InitTextures (void)
   names = W_CacheLumpName("PNAMES", PU_STATIC);
   nummappatches = LONG(*((int *)names));
   name_p = names+4;
-  patchlookup = malloc(nummappatches*sizeof(*patchlookup));  // killough
+  patchlookup = Z_Malloc(nummappatches*sizeof(*patchlookup), PU_STATIC, 0);  // killough
 
   for (i=0 ; i<nummappatches ; i++)
     {
@@ -717,7 +717,7 @@ void R_InitTextures (void)
       totalwidth += texture->width;
     }
  
-  free(patchlookup);         // killough
+  Z_Free(patchlookup);         // killough
 
   Z_Free(maptex1);
   if (maptex2)
@@ -1075,7 +1075,7 @@ void R_PrecacheLevel(void)
 
   {
     size_t size = numflats > num_sprites  ? numflats : num_sprites;
-    hitlist = malloc(numtextures > size ? numtextures : size);
+    hitlist = Z_Malloc(numtextures > size ? numtextures : size, PU_STATIC, 0);
   }
 
   // Precache flats.
@@ -1139,7 +1139,7 @@ void R_PrecacheLevel(void)
             while (--k >= 0);
           }
       }
-  free(hitlist);
+  Z_Free(hitlist);
 }
 
 // [FG] check if the lump can be a Doom patch

--- a/Source/r_main.c
+++ b/Source/r_main.c
@@ -325,16 +325,16 @@ void R_InitLightTables (void)
     for (cm = 0; cm < numcolormaps; ++cm)
     {
       for (i = 0; i < LIGHTLEVELS; ++i)
-        free(c_scalelight[cm][i]);
+        Z_Free(c_scalelight[cm][i]);
 
-      free(c_scalelight[cm]);
+      Z_Free(c_scalelight[cm]);
     }
-    free(c_scalelight);
+    Z_Free(c_scalelight);
   }
 
   if (scalelightfixed)
   {
-    free(scalelightfixed);
+    Z_Free(scalelightfixed);
   }
 
   if (c_zlight)
@@ -342,11 +342,11 @@ void R_InitLightTables (void)
     for (cm = 0; cm < numcolormaps; ++cm)
     {
       for (i = 0; i < LIGHTLEVELS; ++i)
-        free(c_zlight[cm][i]);
+        Z_Free(c_zlight[cm][i]);
 
-      free(c_zlight[cm]);
+      Z_Free(c_zlight[cm]);
     }
-    free(c_zlight);
+    Z_Free(c_zlight);
   }
 
   if (smoothlight)
@@ -370,7 +370,7 @@ void R_InitLightTables (void)
       LIGHTZSHIFT = 20;
   }
 
-  scalelightfixed = malloc(MAXLIGHTSCALE * sizeof(*scalelightfixed));
+  scalelightfixed = Z_Malloc(MAXLIGHTSCALE * sizeof(*scalelightfixed), PU_STATIC, 0);
 
   // killough 4/4/98: dynamic colormaps
   c_zlight = Z_Malloc(sizeof(*c_zlight) * numcolormaps, PU_STATIC, 0);
@@ -378,8 +378,8 @@ void R_InitLightTables (void)
 
   for (cm = 0; cm < numcolormaps; ++cm)
   {
-    c_zlight[cm] = malloc(LIGHTLEVELS * sizeof(**c_zlight));
-    c_scalelight[cm] = malloc(LIGHTLEVELS * sizeof(**c_scalelight));
+    c_zlight[cm] = Z_Malloc(LIGHTLEVELS * sizeof(**c_zlight), PU_STATIC, 0);
+    c_scalelight[cm] = Z_Malloc(LIGHTLEVELS * sizeof(**c_scalelight), PU_STATIC, 0);
   }
 
   // Calculate the light levels to use
@@ -389,7 +389,7 @@ void R_InitLightTables (void)
       int j, startmap = ((LIGHTLEVELS-LIGHTBRIGHT-i)*2)*NUMCOLORMAPS/LIGHTLEVELS;
 
       for (cm = 0; cm < numcolormaps; ++cm)
-        c_zlight[cm][i] = malloc(MAXLIGHTZ * sizeof(***c_zlight));
+        c_zlight[cm][i] = Z_Malloc(MAXLIGHTZ * sizeof(***c_zlight), PU_STATIC, 0);
 
       for (j=0; j<MAXLIGHTZ; j++)
         {
@@ -522,7 +522,7 @@ void R_ExecuteSetViewSize (void)
       int cm;
 
       for (cm = 0; cm < numcolormaps; ++cm)
-        c_scalelight[cm][i] = malloc(MAXLIGHTSCALE * sizeof(***c_scalelight));
+        c_scalelight[cm][i] = Z_Malloc(MAXLIGHTSCALE * sizeof(***c_scalelight), PU_STATIC, 0);
 
       for (j=0 ; j<MAXLIGHTSCALE ; j++)
         {                                       // killough 11/98:

--- a/Source/r_main.c
+++ b/Source/r_main.c
@@ -310,8 +310,8 @@ void R_InitLightTables (void)
   int i;
     
   // killough 4/4/98: dynamic colormaps
-  c_zlight = malloc(sizeof(*c_zlight) * numcolormaps);
-  c_scalelight = malloc(sizeof(*c_scalelight) * numcolormaps);
+  c_zlight = Z_Malloc(sizeof(*c_zlight) * numcolormaps, PU_STATIC, 0);
+  c_scalelight = Z_Malloc(sizeof(*c_scalelight) * numcolormaps, PU_STATIC, 0);
 
   // Calculate the light levels to use
   //  for each level / distance combination.

--- a/Source/r_plane.c
+++ b/Source/r_plane.c
@@ -211,7 +211,7 @@ static visplane_t *new_visplane(unsigned hash)
 {
   visplane_t *check = freetail;
   if (!check)
-    check = calloc(1, sizeof *check);
+    check = Z_Calloc(1, sizeof *check, PU_STATIC, 0);
   else
     if (!(freetail = freetail->next))
       freehead = &freetail;

--- a/Source/r_segs.c
+++ b/Source/r_segs.c
@@ -518,7 +518,7 @@ void R_StoreWallRange(const int start, const int stop)
   if (ds_p == drawsegs+maxdrawsegs)   // killough 1/98 -- fix 2s line HOM
     {
       unsigned newmax = maxdrawsegs ? maxdrawsegs*2 : 128; // killough
-      drawsegs = realloc(drawsegs,newmax*sizeof(*drawsegs));
+      drawsegs = Z_Realloc(drawsegs,newmax*sizeof(*drawsegs),PU_STATIC,0);
       ds_p = drawsegs+maxdrawsegs;
       maxdrawsegs = newmax;
     }

--- a/Source/r_things.c
+++ b/Source/r_things.c
@@ -158,7 +158,7 @@ void R_InitSpriteDefs(char **namelist)
   // Create hash table based on just the first four letters of each sprite
   // killough 1/31/98
 
-  hash = malloc(sizeof(*hash)*numentries); // allocate hash table
+  hash = Z_Malloc(sizeof(*hash)*numentries,PU_STATIC,0); // allocate hash table
 
   for (i=0; i<numentries; i++)             // initialize hash table as empty
     hash[i].index = -1;
@@ -245,7 +245,7 @@ void R_InitSpriteDefs(char **namelist)
             }
         }
     }
-  free(hash);             // free hash table
+  Z_Free(hash);             // free hash table
 }
 
 //
@@ -287,7 +287,7 @@ vissprite_t *R_NewVisSprite(void)
   if (num_vissprite >= num_vissprite_alloc)             // killough
     {
       num_vissprite_alloc = num_vissprite_alloc ? num_vissprite_alloc*2 : 128;
-      vissprites = realloc(vissprites,num_vissprite_alloc*sizeof(*vissprites));
+      vissprites = Z_Realloc(vissprites,num_vissprite_alloc*sizeof(*vissprites),PU_STATIC,0);
     }
  return vissprites + num_vissprite++;
 }
@@ -849,9 +849,9 @@ void R_SortVisSprites (void)
 
       if (num_vissprite_ptrs < num_vissprite*2)
         {
-          free(vissprite_ptrs);  // better than realloc -- no preserving needed
-          vissprite_ptrs = malloc((num_vissprite_ptrs = num_vissprite_alloc*2)
-                                  * sizeof *vissprite_ptrs);
+          Z_Free(vissprite_ptrs);  // better than realloc -- no preserving needed
+          vissprite_ptrs = Z_Malloc((num_vissprite_ptrs = num_vissprite_alloc*2)
+                                  * sizeof *vissprite_ptrs, PU_STATIC, 0);
         }
 
       while (--i>=0)

--- a/Source/s_sound.c
+++ b/Source/s_sound.c
@@ -811,9 +811,9 @@ void S_Init(int sfxVolume, int musicVolume)
       // simultaneously) within zone memory.
       
       // killough 10/98:
-      channels = (calloc)(numChannels = default_numChannels, sizeof(channel_t));
+      channels = calloc(numChannels = default_numChannels, sizeof(channel_t));
       // [FG] removed map objects may finish their sounds
-      sobjs = (calloc)(numChannels, sizeof(degenmobj_t));
+      sobjs = calloc(numChannels, sizeof(degenmobj_t));
    }
 
    S_SetMusicVolume(musicVolume);

--- a/Source/s_sound.c
+++ b/Source/s_sound.c
@@ -811,9 +811,9 @@ void S_Init(int sfxVolume, int musicVolume)
       // simultaneously) within zone memory.
       
       // killough 10/98:
-      channels = calloc(numChannels = default_numChannels, sizeof(channel_t));
+      channels = (calloc)(numChannels = default_numChannels, sizeof(channel_t));
       // [FG] removed map objects may finish their sounds
-      sobjs = calloc(numChannels, sizeof(degenmobj_t));
+      sobjs = (calloc)(numChannels, sizeof(degenmobj_t));
    }
 
    S_SetMusicVolume(musicVolume);

--- a/Source/u_mapinfo.c
+++ b/Source/u_mapinfo.c
@@ -18,20 +18,18 @@
 //
 //-----------------------------------------------------------------------------
 
-#include "config.h"
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
 
-#include "doomdef.h"
 #include "info.h"
 #include "d_io.h"
-#include "m_misc.h"
 #include "m_misc2.h"
-#include "g_game.h"
 #include "u_scanner.h"
 
 #include "u_mapinfo.h"
+
+int G_ValidateMapName(const char *mapname, int *pEpi, int *pMap);
 
 void M_AddEpisode(const char *map, const char *gfx, const char *txt, const char *alpha);
 void M_ClearEpisodes(void);
@@ -596,7 +594,7 @@ static int ParseStandardProperty(u_scanner_t* s, mapentry_t *mape)
   else if (!strcasecmp(pname, "partime"))
   {
     if (U_MustGetInteger(s))
-      mape->partime = TICRATE * s->number;
+      mape->partime = s->number;
   }
   else if (!strcasecmp(pname, "intertext"))
   {

--- a/Source/u_mapinfo.c
+++ b/Source/u_mapinfo.c
@@ -29,8 +29,6 @@
 
 #include "u_mapinfo.h"
 
-int G_ValidateMapName(const char *mapname, int *pEpi, int *pMap);
-
 void M_AddEpisode(const char *map, const char *gfx, const char *txt, const char *alpha);
 void M_ClearEpisodes(void);
 

--- a/Source/u_scanner.c
+++ b/Source/u_scanner.c
@@ -24,8 +24,6 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 // THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "config.h"
-
 #include <stdio.h>
 #include <string.h>
 #include <stdarg.h>

--- a/Source/v_video.c
+++ b/Source/v_video.c
@@ -225,7 +225,7 @@ void V_InitColorTranslation(void)
         gamemission == pack_hacx ||
         gamemission == pack_rekkr)
     {
-      char *temp = (malloc)(256);
+      char *temp = malloc(256);
       memcpy (temp, *p->map2, 256);
       if (gamemission == pack_chex)
         memcpy (temp+112, *p->map2+176, 16); // green range

--- a/Source/v_video.c
+++ b/Source/v_video.c
@@ -904,10 +904,10 @@ void V_Init(void)
    
    if(s)
    {
-      free(s);
+      Z_Free(s);
    }
    
-   screens[3] = (screens[2] = (screens[1] = s = calloc(size,3)) + size) + size;
+   screens[3] = (screens[2] = (screens[1] = s = Z_Calloc(size,3,PU_STATIC,0)) + size) + size;
 }
 
 //----------------------------------------------------------------------------

--- a/Source/v_video.c
+++ b/Source/v_video.c
@@ -225,7 +225,7 @@ void V_InitColorTranslation(void)
         gamemission == pack_hacx ||
         gamemission == pack_rekkr)
     {
-      char *temp = malloc(256);
+      char *temp = Z_Malloc(256, PU_STATIC, 0);
       memcpy (temp, *p->map2, 256);
       if (gamemission == pack_chex)
         memcpy (temp+112, *p->map2+176, 16); // green range

--- a/Source/w_wad.c
+++ b/Source/w_wad.c
@@ -157,7 +157,7 @@ static void W_AddFile(const char *name) // killough 1/31/98: static, const
   int         startlump;
   filelump_t  *fileinfo, *fileinfo2free=NULL; //killough
   filelump_t  singleinfo;
-  char        *filename = strcpy((malloc)(strlen(name)+5), name);
+  char        *filename = strcpy(malloc(strlen(name)+5), name);
 
   NormalizeSlashes(AddDefaultExtension(filename, ".wad"));  // killough 11/98
 
@@ -167,7 +167,7 @@ static void W_AddFile(const char *name) // killough 1/31/98: static, const
     {
       if (strlen(name) > 4 && !strcasecmp(name+strlen(name)-4 , ".lmp" ))
 	{
-	  (free)(filename);
+	  free(filename);
 	  return;
 	}
       // killough 11/98: allow .lmp extension if none existed before
@@ -201,7 +201,7 @@ static void W_AddFile(const char *name) // killough 1/31/98: static, const
       header.numlumps = LONG(header.numlumps);
       header.infotableofs = LONG(header.infotableofs);
       length = header.numlumps*sizeof(filelump_t);
-      fileinfo2free = fileinfo = (malloc)(length);    // killough
+      fileinfo2free = fileinfo = malloc(length);    // killough
       lseek(handle, header.infotableofs, SEEK_SET);
       // [FG] check return value
       if (!read(handle, fileinfo, length))
@@ -209,7 +209,7 @@ static void W_AddFile(const char *name) // killough 1/31/98: static, const
       numlumps += header.numlumps;
     }
 
-    (free)(filename);           // killough 11/98
+    free(filename);           // killough 11/98
 
     // Fill in lumpinfo
     lumpinfo = Z_Realloc(lumpinfo, numlumps*sizeof(lumpinfo_t), PU_STATIC, 0);
@@ -228,7 +228,7 @@ static void W_AddFile(const char *name) // killough 1/31/98: static, const
         lump_p->wad_file = name;
       }
 
-    (free)(fileinfo2free);      // killough
+    free(fileinfo2free);      // killough
 }
 
 // jff 1/23/98 Create routines to reorder the master directory
@@ -249,7 +249,7 @@ static int IsMarker(const char *marker, const char *name)
 static void W_CoalesceMarkedResource(const char *start_marker,
                                      const char *end_marker, int namespace)
 {
-  lumpinfo_t *marked = (malloc)(sizeof(*marked) * numlumps);
+  lumpinfo_t *marked = malloc(sizeof(*marked) * numlumps);
   size_t i, num_marked = 0, num_unmarked = 0;
   int is_marked = 0, mark_end = 0;
   lumpinfo_t *lump = lumpinfo;
@@ -291,7 +291,7 @@ static void W_CoalesceMarkedResource(const char *start_marker,
   // Append marked list to end of unmarked list
   memcpy(lumpinfo + num_unmarked, marked, num_marked * sizeof(*marked));
 
-  (free)(marked);                                   // free marked list
+  free(marked);                                   // free marked list
 
   numlumps = num_unmarked + num_marked;           // new total number of lumps
 
@@ -538,7 +538,7 @@ void *W_CacheLumpNum(int lump, int tag)
 void WritePredefinedLumpWad(const char *filename)
 {
    FILE *file;
-   char *fn = (malloc)(strlen(filename) + 5);  // we may have to add ".wad" to the name they pass
+   char *fn = malloc(strlen(filename) + 5);  // we may have to add ".wad" to the name they pass
    
    if(!filename || !*filename)  // check for null pointer or empty name
       return;  // early return
@@ -581,7 +581,7 @@ void WritePredefinedLumpWad(const char *filename)
       I_Error("Predefined lumps wad, %s written, exiting\n", filename);
    }
    I_Error("Cannot open predefined lumps wad %s for output\n", filename);
-   (free)(fn);
+   free(fn);
 }
 
 // [FG] name of the WAD file that contains the lump

--- a/Source/w_wad.c
+++ b/Source/w_wad.c
@@ -538,10 +538,12 @@ void *W_CacheLumpNum(int lump, int tag)
 void WritePredefinedLumpWad(const char *filename)
 {
    FILE *file;
-   char *fn = malloc(strlen(filename) + 5);  // we may have to add ".wad" to the name they pass
+   char *fn;
    
    if(!filename || !*filename)  // check for null pointer or empty name
       return;  // early return
+
+   fn = malloc(strlen(filename) + 5);  // we may have to add ".wad" to the name they pass
 
    AddDefaultExtension(strcpy(fn, filename), ".wad");
 

--- a/Source/w_wad.c
+++ b/Source/w_wad.c
@@ -157,7 +157,7 @@ static void W_AddFile(const char *name) // killough 1/31/98: static, const
   int         startlump;
   filelump_t  *fileinfo, *fileinfo2free=NULL; //killough
   filelump_t  singleinfo;
-  char        *filename = strcpy(malloc(strlen(name)+5), name);
+  char        *filename = strcpy((malloc)(strlen(name)+5), name);
 
   NormalizeSlashes(AddDefaultExtension(filename, ".wad"));  // killough 11/98
 
@@ -167,7 +167,7 @@ static void W_AddFile(const char *name) // killough 1/31/98: static, const
     {
       if (strlen(name) > 4 && !strcasecmp(name+strlen(name)-4 , ".lmp" ))
 	{
-	  free(filename);
+	  (free)(filename);
 	  return;
 	}
       // killough 11/98: allow .lmp extension if none existed before
@@ -201,7 +201,7 @@ static void W_AddFile(const char *name) // killough 1/31/98: static, const
       header.numlumps = LONG(header.numlumps);
       header.infotableofs = LONG(header.infotableofs);
       length = header.numlumps*sizeof(filelump_t);
-      fileinfo2free = fileinfo = malloc(length);    // killough
+      fileinfo2free = fileinfo = (malloc)(length);    // killough
       lseek(handle, header.infotableofs, SEEK_SET);
       // [FG] check return value
       if (!read(handle, fileinfo, length))
@@ -209,10 +209,10 @@ static void W_AddFile(const char *name) // killough 1/31/98: static, const
       numlumps += header.numlumps;
     }
 
-    free(filename);           // killough 11/98
+    (free)(filename);           // killough 11/98
 
     // Fill in lumpinfo
-    lumpinfo = realloc(lumpinfo, numlumps*sizeof(lumpinfo_t));
+    lumpinfo = Z_Realloc(lumpinfo, numlumps*sizeof(lumpinfo_t), PU_STATIC, 0);
 
     lump_p = &lumpinfo[startlump];
 
@@ -228,7 +228,7 @@ static void W_AddFile(const char *name) // killough 1/31/98: static, const
         lump_p->wad_file = name;
       }
 
-    free(fileinfo2free);      // killough
+    (free)(fileinfo2free);      // killough
 }
 
 // jff 1/23/98 Create routines to reorder the master directory
@@ -249,7 +249,7 @@ static int IsMarker(const char *marker, const char *name)
 static void W_CoalesceMarkedResource(const char *start_marker,
                                      const char *end_marker, int namespace)
 {
-  lumpinfo_t *marked = malloc(sizeof(*marked) * numlumps);
+  lumpinfo_t *marked = (malloc)(sizeof(*marked) * numlumps);
   size_t i, num_marked = 0, num_unmarked = 0;
   int is_marked = 0, mark_end = 0;
   lumpinfo_t *lump = lumpinfo;
@@ -291,7 +291,7 @@ static void W_CoalesceMarkedResource(const char *start_marker,
   // Append marked list to end of unmarked list
   memcpy(lumpinfo + num_unmarked, marked, num_marked * sizeof(*marked));
 
-  free(marked);                                   // free marked list
+  (free)(marked);                                   // free marked list
 
   numlumps = num_unmarked + num_marked;           // new total number of lumps
 
@@ -423,7 +423,7 @@ void W_InitMultipleFiles(char *const *filenames)
   numlumps = num_predefined_lumps;
 
   // lumpinfo will be realloced as lumps are added
-  lumpinfo = malloc(numlumps*sizeof(*lumpinfo));
+  lumpinfo = Z_Malloc(numlumps*sizeof(*lumpinfo), PU_STATIC, 0);
 
   memcpy(lumpinfo, predefined_lumps, numlumps*sizeof(*lumpinfo));
 
@@ -449,7 +449,7 @@ void W_InitMultipleFiles(char *const *filenames)
   W_CoalesceMarkedResource("HI_START", "HI_END", ns_hires);
 
   // set up caching
-  lumpcache = calloc(sizeof *lumpcache, numlumps); // killough
+  lumpcache = Z_Calloc(sizeof *lumpcache, numlumps, PU_STATIC, 0); // killough
 
   if (!lumpcache)
     I_Error ("Couldn't allocate lumpcache");

--- a/Source/z_zone.c
+++ b/Source/z_zone.c
@@ -199,7 +199,7 @@ void Z_DumpHistory(char *buf)
 
 static void Z_Close(void)
 {
-  (free)(zonebase);
+  free(zonebase);
   zone = rover = zonebase = NULL;
 }
 
@@ -236,7 +236,7 @@ void Z_Init(void)
 
    // Allocate the memory
 
-  while (!(zonebase=(malloc)(zonebase_size=size + HEADER_SIZE + CACHE_ALIGN)))
+  while (!(zonebase=malloc(zonebase_size=size + HEADER_SIZE + CACHE_ALIGN)))
     if (size < (MIN_RAM-LEAVE_ASIDE < RETRY_AMOUNT ? RETRY_AMOUNT :
                                                      MIN_RAM-LEAVE_ASIDE))
       I_Error("Z_Init: failed on allocation of %lu bytes",(unsigned long)
@@ -387,7 +387,7 @@ allocated:
    // This will squeeze the remaining juice out of this machine
    // and start cutting into virtual memory if it has it.
    
-   while(!(block = (malloc)(size + HEADER_SIZE)))
+   while(!(block = malloc(size + HEADER_SIZE)))
    {
       if(!blockbytag[PU_CACHE])
          I_Error("Z_Malloc: Failure trying to allocate %lu bytes"
@@ -463,7 +463,7 @@ void (Z_Free)(void *p, const char *file, int line)
 #ifdef INSTRUMENTED
          virtual_memory -= block->size;
 #endif
-         (free)(block);
+         free(block);
       }
       else
       {
@@ -579,7 +579,7 @@ void (Z_FreeTags)(int lowtag, int hightag, const char *file, int line)
          if(block->user)            // Nullify user if one exists
             *block->user = NULL;
          
-         (free)(block);              // Free the block
+         free(block);              // Free the block
          
          block = next;               // Advance to next block
       }

--- a/Source/z_zone.h
+++ b/Source/z_zone.h
@@ -81,7 +81,7 @@ void Z_DumpHistory(char *);
 #define Z_CheckHeap()      (Z_CheckHeap)(__FILE__,__LINE__)
 
 // Remove all definitions before including system definitions
-
+#if 0
 #undef malloc
 #undef free
 #undef realloc
@@ -93,6 +93,7 @@ void Z_DumpHistory(char *);
 #define realloc(p,n)       X_Realloc(p,n,PU_STATIC,0)
 #define calloc(n1,n2)      X_Calloc(n1,n2,PU_STATIC,0)
 #define strdup(s)          X_Strdup(s,PU_STATIC,0)
+#endif
 
 // dprintf() is already declared in <stdio.h>, define it out of the way
 #define dprintf doomprintf

--- a/Source/z_zone.h
+++ b/Source/z_zone.h
@@ -80,21 +80,6 @@ void Z_DumpHistory(char *);
 #define Z_Realloc(a,b,c,d) (Z_Realloc)  (a,b,c,d,__FILE__,__LINE__)
 #define Z_CheckHeap()      (Z_CheckHeap)(__FILE__,__LINE__)
 
-// Remove all definitions before including system definitions
-#if 0
-#undef malloc
-#undef free
-#undef realloc
-#undef calloc
-#undef strdup
-
-#define malloc(n)          X_Malloc(n,PU_STATIC,0)
-#define free(p)            X_Free(p)
-#define realloc(p,n)       X_Realloc(p,n,PU_STATIC,0)
-#define calloc(n1,n2)      X_Calloc(n1,n2,PU_STATIC,0)
-#define strdup(s)          X_Strdup(s,PU_STATIC,0)
-#endif
-
 // dprintf() is already declared in <stdio.h>, define it out of the way
 #define dprintf doomprintf
 // Doom-style printf

--- a/Source/z_zone.h
+++ b/Source/z_zone.h
@@ -88,11 +88,11 @@ void Z_DumpHistory(char *);
 #undef calloc
 #undef strdup
 
-#define malloc(n)          Z_Malloc(n,PU_STATIC,0)
-#define free(p)            Z_Free(p)
-#define realloc(p,n)       Z_Realloc(p,n,PU_STATIC,0)
-#define calloc(n1,n2)      Z_Calloc(n1,n2,PU_STATIC,0)
-#define strdup(s)          Z_Strdup(s,PU_STATIC,0)
+#define malloc(n)          X_Malloc(n,PU_STATIC,0)
+#define free(p)            X_Free(p)
+#define realloc(p,n)       X_Realloc(p,n,PU_STATIC,0)
+#define calloc(n1,n2)      X_Calloc(n1,n2,PU_STATIC,0)
+#define strdup(s)          X_Strdup(s,PU_STATIC,0)
 
 // dprintf() is already declared in <stdio.h>, define it out of the way
 #define dprintf doomprintf

--- a/Source/z_zone.h
+++ b/Source/z_zone.h
@@ -34,14 +34,6 @@
 #ifndef __Z_ZONE__
 #define __Z_ZONE__
 
-// Remove all definitions before including system definitions
-
-#undef malloc
-#undef free
-#undef realloc
-#undef calloc
-#undef strdup
-
 // Include system definitions so that prototypes become
 // active before macro replacements below are in effect.
 


### PR DESCRIPTION
Done using the method suggested by @fabiangreffrath. The question is where to use zone memory and where stdlib. I suggest:
- `p_*`, `r_*` files only zone memory
- `i_*`, `m_*`, `deh.c`, `u_*` only stdlib
- `d_*`, `w_*` stdlib for all strings manipulation