### PR TITLE
coop stats

### DIFF
--- a/Source/g_game.c
+++ b/Source/g_game.c
@@ -1510,18 +1510,13 @@ static void G_DoPlayDemo(void)
 
   // [crispy] demo progress bar
   {
-    int i, numplayersingame = 0;
     byte *demo_ptr = demo_p;
-
-    for (i = 0; i < MAXPLAYERS; i++)
-      if (playeringame[i])
-        numplayersingame++;
 
     deftotaldemotics = defdemotics = 0;
 
     while (*demo_ptr != DEMOMARKER && (demo_ptr - demobuffer) < lumplength)
     {
-      demo_ptr += numplayersingame * (longtics ? 5 : 4);
+      demo_ptr += (longtics ? 5 : 4);
       deftotaldemotics++;
     }
   }

--- a/Source/hu_stuff.c
+++ b/Source/hu_stuff.c
@@ -807,7 +807,7 @@ static void HU_widget_build_monsec(void)
 {
   int i, playerscount;
   char *s;
-  char kills_str[80];
+  char kills_str[60];
   int offset = 0;
 
   int kills = 0, kills_color, kills_percent, kills_percent_color;

--- a/Source/hu_stuff.c
+++ b/Source/hu_stuff.c
@@ -805,25 +805,67 @@ static int HU_top(int i, int idx1, int top1)
 
 static void HU_widget_build_monsec(void)
 {
+  int i, playerscount;
   char *s;
+  char kills_str[80];
   int offset = 0;
 
-  int killcolor = (plr->killcount - extrakills >= totalkills ? '0'+CR_BLUE : '0'+CR_GOLD);
-  int kill_percent_color = (plr->killcount >= totalkills ? '0'+CR_BLUE : '0'+CR_GOLD);
-  int kill_percent = (totalkills == 0 ? 100 : plr->killcount * 100 / totalkills);
-  int itemcolor = (plr->itemcount >= totalitems ? '0'+CR_BLUE : '0'+CR_GOLD);
-  int secretcolor = (plr->secretcount >= totalsecret ? '0'+CR_BLUE : '0'+CR_GOLD);
+  int kills = 0, kills_color, kills_percent, kills_percent_color;
+  int items = 0, items_color;
+  int secrets = 0, secrets_color;
 
-  offset = sprintf(hud_monsecstr,
-    "STS \x1b%cK \x1b%c%d/%d",
-    '0'+CR_RED, killcolor, plr->killcount, totalkills);
+  for (i = 0, playerscount = 0; i < MAXPLAYERS; ++i)
+  {
+    int color = (i == displayplayer) ? '0'+CR_GRAY : '0'+CR_GOLD;
+    if (playeringame[i])
+    {
+      if (playerscount == 0)
+      {
+        offset = sprintf(kills_str,
+          "\x1b%c%d", color, players[i].killcount);
+      }
+      else
+      {
+        offset += sprintf(kills_str + offset,
+          "\x1b%c+\x1b%c%d", '0'+CR_GOLD, color, players[i].killcount);
+      }
+
+      kills += players[i].killcount;
+      items += players[i].itemcount;
+      secrets += players[i].secretcount;
+      ++playerscount;
+    }
+  }
+
+  kills_color = (kills - extrakills >= totalkills ? '0'+CR_BLUE : '0'+CR_GOLD);
+  kills_percent_color = (kills >= totalkills ? '0'+CR_BLUE : '0'+CR_GOLD);
+  kills_percent = (kills == 0 ? 100 : kills * 100 / totalkills);
+  items_color = (items >= totalitems ? '0'+CR_BLUE : '0'+CR_GOLD);
+  secrets_color = (secrets >= totalsecret ? '0'+CR_BLUE : '0'+CR_GOLD);
+
+  if (playerscount > 1)
+  {
+    offset = sprintf(hud_monsecstr,
+      "STS \x1b%cK %s \x1b%c%d/%d",
+      '0'+CR_RED, kills_str, kills_color, kills, totalkills);
+  }
+  else
+  {
+    offset = sprintf(hud_monsecstr,
+      "STS \x1b%cK \x1b%c%d/%d",
+      '0'+CR_RED, kills_color, plr->killcount, totalkills);
+  }
+
   if (extrakills)
+  {
     offset += sprintf(hud_monsecstr + offset, "+%d", extrakills);
+  }
+
   sprintf(hud_monsecstr + offset,
     " \x1b%c%d%% \x1b%cI \x1b%c%d/%d \x1b%cS \x1b%c%d/%d",
-    kill_percent_color, kill_percent,
-    '0'+CR_RED, itemcolor, plr->itemcount, totalitems,
-    '0'+CR_RED, secretcolor, plr->secretcount, totalsecret);
+    kills_percent_color, kills_percent,
+    '0'+CR_RED, items_color, items, totalitems,
+    '0'+CR_RED, secrets_color, secrets, totalsecret);
 
   HUlib_clearTextLine(&w_monsec);
   s = hud_monsecstr;

--- a/Source/p_inter.c
+++ b/Source/p_inter.c
@@ -709,19 +709,16 @@ static void P_KillMobj(mobj_t *source, mobj_t *target)
             for (i = 0, playerscount = 0; i < MAXPLAYERS; ++i)
             {
               if (playeringame[i])
-              {
-                if (demo_version < 203)
-                {
-                  players[i].killcount++;
-                  break;
-                }
                 ++playerscount;
-              }
             }
 
-            if (playerscount && demo_version >= 203)
+            if (playerscount)
             {
-              i = P_Random(pr_friends) % playerscount;
+              if (demo_version >= 203)
+                i = P_Random(pr_friends) % playerscount;
+              else
+                i = Woof_Random() % playerscount;
+
               players[i].killcount++;
             }
           }

--- a/Source/p_inter.c
+++ b/Source/p_inter.c
@@ -695,26 +695,37 @@ static void P_KillMobj(mobj_t *source, mobj_t *target)
 #ifndef MBF_STRICT
       // For compatibility with PrBoom+ complevel 11 netgame
       else
-        if (
-              (target->flags & MF_COUNTKILL) &&
-              (demo_version >= 203) && netgame && !deathmatch &&
-              !(
-                 target->lastenemy &&
-                 target->lastenemy->health > 0 &&
-                 target->lastenemy->player
-               )
-           )
+        if (netgame && !deathmatch && (target->flags & MF_COUNTKILL))
+        {
+          if (target->lastenemy && target->lastenemy->health > 0 &&
+              target->lastenemy->player)
           {
-            int i;
-            for (i = 0; i < MAXPLAYERS; ++i)
+              target->lastenemy->player->killcount++;
+          }
+          else
+          {
+            int i, playerscount;
+
+            for (i = 0, playerscount = 0; i < MAXPLAYERS; ++i)
             {
               if (playeringame[i])
               {
-                P_Random(pr_friends);
-                break;
+                if (demo_version < 203)
+                {
+                  players[i].killcount++;
+                  break;
+                }
+                ++playerscount;
               }
             }
+
+            if (playerscount && demo_version >= 203)
+            {
+              i = P_Random(pr_friends) % playerscount;
+              players[i].killcount++;
+            }
           }
+        }
 #endif
 
   if (target->player)


### PR DESCRIPTION
I implement PrBoom+'s killcount method because without it, the Time/STS widget looks broken in co-op. Also we have this code for demo compatibility anyway.