### PR TITLE
add missed parts of emulation of missed back side on two-sided lines

### DIFF
--- a/Source/p_map.c
+++ b/Source/p_map.c
@@ -1427,14 +1427,18 @@ static boolean PTR_AimTraverse (intercept_t *in)
 
       dist = FixedMul (attackrange, in->frac);
 
-      if (li->frontsector->floorheight != li->backsector->floorheight)
+      // Andrey Budko: emulation of missed back side on two-sided lines.
+      // backsector can be NULL when emulating missing back side.
+      if (li->backsector == NULL ||
+          li->frontsector->floorheight != li->backsector->floorheight)
 	{
 	  slope = FixedDiv (openbottom - shootz , dist);
 	  if (slope > bottomslope)
 	    bottomslope = slope;
 	}
 
-      if (li->frontsector->ceilingheight != li->backsector->ceilingheight)
+      if (li->backsector == NULL ||
+          li->frontsector->ceilingheight != li->backsector->ceilingheight)
 	{
 	  slope = FixedDiv (opentop - shootz , dist);
 	  if (slope < topslope)
@@ -1510,6 +1514,15 @@ static boolean PTR_ShootTraverse(intercept_t *in)
 
 	  // killough 11/98: simplify
 
+	  // Andrey Budko: emulation of missed back side on two-sided lines.
+	  // backsector can be NULL when emulating missing back side.
+	  if (li->backsector == NULL)
+	  {
+	    if ((slope = FixedDiv(openbottom - shootz , dist)) <= aimslope &&
+	        (slope = FixedDiv(opentop - shootz , dist)) >= aimslope)
+	      return true;      // shot continues
+	  }
+	  else
 	  if ((li->frontsector->floorheight==li->backsector->floorheight ||
 	       (slope = FixedDiv(openbottom - shootz , dist)) <= aimslope) &&
 	      (li->frontsector->ceilingheight==li->backsector->ceilingheight ||


### PR DESCRIPTION
See: https://github.com/coelckers/prboom-plus/commit/358cdd96ee5b745ca260361e84aaac1d99088a5b
This fixes a crash in FEZ1.WAD: [fez1-924.zip](https://github.com/fabiangreffrath/woof/files/8771407/fez1-924.zip)
The demo plays without desync if the `-setmem dosbox` parameter is added. See [PrBoom+ bugtracker](https://sourceforge.net/p/prboom-plus/bugs/176/)
BTW there is visual glitch on this map in Choco/Crispy
Woof/vanilla exe in dosbox: ![doom10](https://user-images.githubusercontent.com/5077629/170271312-3fd4e5bc-0fc0-4f22-ace9-2f83e3e16718.png)
Choco/Crispy: ![DOOM0029](https://user-images.githubusercontent.com/5077629/170271605-5f0006ef-173d-4ee4-885a-5925d490b03c.png)

 