### PR TITLE
another attempt to fix frame interpolation for the newsync method

### DIFF
--- a/Source/d_loop.c
+++ b/Source/d_loop.c
@@ -718,7 +718,13 @@ void TryRunTics (void)
 
     if (new_sync)
     {
-	counts = availabletics;
+        // decide how many tics to run
+        if (realtics < availabletics-1)
+            counts = realtics+1;
+        else if (realtics < availabletics)
+            counts = realtics;
+        else
+            counts = availabletics;
 
         // [AM] If we've uncapped the framerate and there are no tics
         //      to run, return early instead of waiting around.

--- a/Source/d_loop.c
+++ b/Source/d_loop.c
@@ -718,13 +718,20 @@ void TryRunTics (void)
 
     if (new_sync)
     {
-        // decide how many tics to run
-        if (realtics < availabletics-1)
-            counts = realtics+1;
-        else if (realtics < availabletics)
-            counts = realtics;
+        if (uncapped)
+        {
+            // decide how many tics to run
+            if (realtics < availabletics-1)
+                counts = realtics+1;
+            else if (realtics < availabletics)
+                counts = realtics;
+            else
+                counts = availabletics;
+        }
         else
+        {
             counts = availabletics;
+        }
 
         // [AM] If we've uncapped the framerate and there are no tics
         //      to run, return early instead of waiting around.

--- a/Source/d_main.c
+++ b/Source/d_main.c
@@ -2251,6 +2251,8 @@ void D_DoomMain(void)
     I_AtExit(D_EndDoom, false);
   }
 
+  TryRunTics();
+
   main_loop_started = true;
 
   D_StartGameLoop();


### PR DESCRIPTION
This works more stable than the previous attempt, I think it's correct. This changes the new sync algorithm a bit, so in uncapped multiplayer mode we sometimes run 2 tics instead of always 1, but I think that's good enough for a casual play. I'll ask someone in the speedrunner community to test this.