### PR TITLE
fix rendering of the infinite ocean effect

### DIFF
--- a/Source/p_setup.c
+++ b/Source/p_setup.c
@@ -1365,7 +1365,7 @@ static angle_t anglediff(angle_t a, angle_t b)
 
     if (a - b < ANG180)
         return a - b;
-    else // [FG] wrap around
+    else // [crispy] wrap around
         return b - a;
 }
 
@@ -1390,7 +1390,7 @@ void P_SegLengths(boolean contrast_only)
             viewx = li->v1->r_x;
             viewy = li->v1->r_y;
             li->r_angle = R_PointToAngleCrispy(li->v2->r_x, li->v2->r_y);
-            // [FG] more than just a little adjustment?
+            // [crispy] more than just a little adjustment?
             // back to the original angle then
             if (anglediff(li->r_angle, li->angle) > ANG60/2)
             {

--- a/Source/p_setup.c
+++ b/Source/p_setup.c
@@ -1358,6 +1358,17 @@ void P_RemoveSlimeTrails(void)                // killough 10/98
 
 // [crispy] fix long wall wobble
 
+static angle_t anglediff(angle_t a, angle_t b)
+{
+    if (b > a)
+        return anglediff(b, a);
+
+    if (a - b < ANG180)
+        return a - b;
+    else // [FG] wrap around
+        return b - a;
+}
+
 void P_SegLengths(boolean contrast_only)
 {
     int i;
@@ -1379,6 +1390,12 @@ void P_SegLengths(boolean contrast_only)
             viewx = li->v1->r_x;
             viewy = li->v1->r_y;
             li->r_angle = R_PointToAngleCrispy(li->v2->r_x, li->v2->r_y);
+            // [FG] more than just a little adjustment?
+            // back to the original angle then
+            if (anglediff(li->r_angle, li->angle) > ANG60/2)
+            {
+                li->r_angle = li->angle;
+            }
         }
 
         // [crispy] smoother fake contrast

--- a/Source/r_segs.c
+++ b/Source/r_segs.c
@@ -490,8 +490,8 @@ static void R_RenderSegLoop (void)
 // above R_StoreWallRange
 static fixed_t R_ScaleFromGlobalAngle (angle_t visangle)
 {
-    int     anglea = ANG90 + (visangle - viewangle);
-    int     angleb = ANG90 + (visangle - rw_normalangle);
+    angle_t anglea = ANG90 + (visangle - viewangle);
+    angle_t angleb = ANG90 + (visangle - rw_normalangle);
     int     den = FixedMul(rw_distance, finesine[anglea >> ANGLETOFINESHIFT]);
     fixed_t num = FixedMul(projection,  finesine[angleb >> ANGLETOFINESHIFT]);
     fixed_t scale;


### PR DESCRIPTION
First, this requires changing the type for variables used to store
angle arithmetics in R_ScaleFromGlobalAngle to angle_t.

Second, this requires checking if generated seg angles and those
stored in the WAD differ "too much" and revert back to the stored
value then.