### PR TITLE
use include-what-you-use tool to remove/reorganize superfluous #includes

### DIFF
--- a/opl/opl.c
+++ b/opl/opl.c
@@ -15,11 +15,8 @@
 //     OPL interface.
 //
 
-#include "config.h"
-
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 #include "SDL.h"
 

--- a/opl/opl_sdl.c
+++ b/opl/opl_sdl.c
@@ -15,22 +15,15 @@
 //     OPL SDL interface.
 //
 
-#include "config.h"
-
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-#include <errno.h>
 #include <assert.h>
 
 #include "SDL.h"
 #include "SDL_mixer.h"
-
 #include "opl3.h"
-
 #include "opl.h"
 #include "opl_internal.h"
-
 #include "opl_queue.h"
 
 #define MAX_SOUND_SLICE_TIME 100 /* ms */

--- a/setup/execute.c
+++ b/setup/execute.c
@@ -26,7 +26,6 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#include <process.h>
 #include <shellapi.h>
 
 #else
@@ -36,9 +35,6 @@
 
 #endif
 
-#include "textscreen.h"
-
-#include "config.h"
 #include "execute.h"
 #include "m_argv.h"
 #include "m_misc2.h"

--- a/setup/mainmenu.c
+++ b/setup/mainmenu.c
@@ -14,20 +14,14 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 #include "config.h"
-#include "textscreen.h"
-
-#include "execute.h"
-
-#include "m_argv.h"
 #include "m_misc2.h"
 #include "z_zone.h"
-
 #include "setup_icon.c"
-
 #include "multiplayer.h"
+#include "doomkeys.h"
+#include "textscreen.h"
 
 static void DoQuit(void *widget, void *dosave)
 {

--- a/setup/multiplayer.c
+++ b/setup/multiplayer.c
@@ -14,23 +14,17 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 #include "doomdef.h"
-
-#include "textscreen.h"
-
 #include "d_iwad.h"
 #include "m_misc2.h"
-#include "d_englsh.h"
-
 #include "multiplayer.h"
 #include "execute.h"
-
 #include "net_io.h"
 #include "net_query.h"
-
-#include "net_petname.h"
+#include "doomkeys.h"
+#include "net_defs.h"
+#include "textscreen.h"
 
 #define MULTI_START_HELP_URL "https://www.chocolate-doom.org/setup-multi-start"
 #define MULTI_JOIN_HELP_URL "https://www.chocolate-doom.org/setup-multi-join"

--- a/src/am_map.c
+++ b/src/am_map.c
@@ -26,6 +26,9 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <stdio.h>
+#include <string.h>
+
 #include "doomstat.h"
 #include "doomkeys.h"
 #include "st_stuff.h"
@@ -36,9 +39,19 @@
 #include "v_video.h"
 #include "p_spec.h"
 #include "am_map.h"
-#include "dstrings.h"
 #include "d_deh.h"    // Ty 03/27/98 - externalizations
 #include "m_input.h"
+#include "d_player.h"
+#include "doomdata.h"
+#include "doomdef.h"
+#include "i_video.h"
+#include "info.h"
+#include "m_fixed.h"
+#include "p_mobj.h"
+#include "r_defs.h"
+#include "r_state.h"
+#include "tables.h"
+#include "z_zone.h"
 
 //jff 1/7/98 default automap colors added
 int mapcolor_back;    // map background

--- a/src/am_map.h
+++ b/src/am_map.h
@@ -31,6 +31,7 @@
 
 #include "d_event.h"
 #include "m_fixed.h"
+#include "doomtype.h"
 
 // Used by ST StatusBar stuff.
 #define AM_MSGHEADER (('a'<<24)+('m'<<16))

--- a/src/d_deh.c
+++ b/src/d_deh.c
@@ -28,11 +28,14 @@
 //
 //--------------------------------------------------------------------
 
-#include "m_io.h"
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
+#include "m_io.h"
 // killough 5/2/98: fixed headers, removed rendunant external declarations:
 #include "doomdef.h"
-#include "doomstat.h"
 #include "sounds.h"
 #include "info.h"
 #include "m_argv.h" // [FG] M_CheckParm()
@@ -42,8 +45,14 @@
 #include "g_game.h"
 #include "d_think.h"
 #include "w_wad.h"
-
 #include "dsdhacked.h"
+#include "d_englsh.h"
+#include "d_items.h"
+#include "doomtype.h"
+#include "i_system.h"
+#include "m_fixed.h"
+#include "p_mobj.h"
+#include "z_zone.h"
 
 static boolean bfgcells_modified = false;
 
@@ -123,7 +132,6 @@ char **dehfiles = NULL;  // filenames of .deh files for demo footer
 
 // ====================================================================
 // Any of these can be changed using the bex extensions
-#include "dstrings.h"  // to get the initial values
 char *s_D_DEVSTR    = D_DEVSTR;
 char *s_D_CDROM     = D_CDROM;
 char *s_PRESSKEY    = PRESSKEY;

--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -19,7 +19,6 @@
 #include <stdlib.h>
 
 #include "i_system.h"
-#include "m_io.h"
 #include "d_iwad.h"
 #include "m_argv.h"
 #include "m_misc2.h"

--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -17,6 +17,7 @@
 //
 
 #include <stdlib.h>
+#include <string.h>
 
 #include "i_system.h"
 #include "d_iwad.h"

--- a/src/d_loop.c
+++ b/src/d_loop.c
@@ -18,18 +18,16 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 
 #include "doomstat.h"
 #include "d_event.h"
 #include "d_loop.h"
 #include "d_ticcmd.h"
-
 #include "i_system.h"
 #include "i_video.h"
-
 #include "m_argv.h"
 #include "m_fixed.h"
-
 #include "net_client.h"
 #include "net_gui.h"
 #include "net_io.h"
@@ -37,6 +35,8 @@
 #include "net_server.h"
 #include "net_sdl.h"
 #include "net_loop.h"
+#include "doomdef.h"
+#include "i_timer.h"
 
 // The complete set of data for a particular tic.
 

--- a/src/d_loop.h
+++ b/src/d_loop.h
@@ -20,6 +20,7 @@
 #define __D_LOOP__
 
 #include "net_defs.h"
+#include "doomtype.h"
 
 // Callback function invoked while waiting for the netgame to start.
 // The callback is invoked when new players are ready. The callback

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -30,7 +30,6 @@
 //-----------------------------------------------------------------------------
 
 #include <ctype.h>
-#include <io.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -34,8 +34,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "SDL.h" // [FG] SDL_qsort() SDL_GetPrefPath()
+
 #include "m_io.h" // haleyjd
-#include "SDL_stdinc.h" // [FG] SDL_qsort()
 #include "doomdef.h"
 #include "doomstat.h"
 #include "sounds.h"

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -29,17 +29,16 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <ctype.h>
+#include <io.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "m_io.h" // haleyjd
-#include "SDL_filesystem.h" // [FG] SDL_GetPrefPath()
 #include "SDL_stdinc.h" // [FG] SDL_qsort()
-
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-
 #include "doomdef.h"
 #include "doomstat.h"
-#include "dstrings.h"
 #include "sounds.h"
 #include "z_zone.h"
 #include "w_wad.h"
@@ -72,10 +71,20 @@
 #include "p_map.h" // MELEERANGE
 #include "i_endoom.h"
 #include "d_quit.h"
-
 #include "dsdhacked.h"
-
 #include "net_client.h"
+#include "d_englsh.h"
+#include "d_loop.h"
+#include "d_player.h"
+#include "d_ticcmd.h"
+#include "i_timer.h"
+#include "info.h"
+#include "m_fixed.h"
+#include "m_input.h"
+#include "p_mobj.h"
+#include "r_defs.h"
+#include "r_state.h"
+#include "version.h"
 
 // DEHacked support - Ty 03/09/97
 // killough 10/98:

--- a/src/d_main.h
+++ b/src/d_main.h
@@ -32,6 +32,7 @@
 
 #include "doomdef.h"
 #include "d_event.h"
+#include "doomtype.h"
 
 extern char **wadfiles;       // killough 11/98
 

--- a/src/d_net.c
+++ b/src/d_net.c
@@ -17,17 +17,19 @@
 //	all OS independend parts.
 //
 
-#include <stdlib.h>
+#include <stdio.h>
 
-#include "d_main.h"
 #include "m_argv.h"
-#include "m_menu.h"
 #include "m_misc2.h"
-#include "i_system.h"
-#include "i_video.h"
 #include "g_game.h"
 #include "doomdef.h"
 #include "doomstat.h"
+#include "d_player.h"
+#include "d_ticcmd.h"
+#include "doomtype.h"
+#include "net_defs.h"
+#include "p_mobj.h"
+#include "tables.h"
 //#include "w_checksum.h"
 //#include "w_wad.h"
 

--- a/src/d_quit.c
+++ b/src/d_quit.c
@@ -17,9 +17,7 @@
 //
 
 #include "SDL.h"
-
 #include "doomstat.h"
-#include "i_system.h"
 #include "m_misc.h"
 #include "g_game.h"
 

--- a/src/doomdef.h
+++ b/src/doomdef.h
@@ -30,19 +30,6 @@
 #ifndef __DOOMDEF__
 #define __DOOMDEF__
 
-// This must come first, since it redefines malloc(), free(), etc. -- killough:
-#include "z_zone.h"
-
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <ctype.h>
-#include <limits.h>
-
-#include "config.h"
-
-#include "version.h"
-
 // Game mode handling - identify IWAD version
 //  to handle IWAD dependend animations etc.
 typedef enum {

--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -34,16 +34,19 @@
 #ifndef __D_STATE__
 #define __D_STATE__
 
+#include <stdio.h>
+
 // We need globally shared data structures,
 //  for defining the global state variables.
 #include "doomdata.h"
 #include "d_loop.h"
-
 // We need the playr data structure as well.
 #include "d_player.h"
-
 // and mapinfo information
 #include "u_mapinfo.h"
+#include "d_ticcmd.h"
+#include "doomdef.h"
+#include "doomtype.h"
 
 // ------------------------
 // Command line parameters.

--- a/src/dsdhacked.c
+++ b/src/dsdhacked.c
@@ -26,6 +26,7 @@
 #include "doomtype.h"
 #include "info.h"
 #include "i_system.h" // I_Realloc
+#include "d_think.h"
 
 //
 //   States

--- a/src/dstrings.c
+++ b/src/dstrings.c
@@ -28,6 +28,8 @@
 
 #include "dstrings.h"
 
+#include "d_englsh.h"
+
 // killough 1/18/98: remove hardcoded limit, add const:
 const char *endmsg[]=
 {

--- a/src/f_finale.c
+++ b/src/f_finale.c
@@ -27,17 +27,32 @@
 //-----------------------------------------------------------------------------
 
 
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "doomstat.h"
 #include "d_event.h"
 #include "v_video.h"
 #include "w_wad.h"
 #include "s_sound.h"
 #include "sounds.h"
-#include "dstrings.h"
 #include "m_menu.h"
 #include "d_deh.h"  // Ty 03/22/98 - externalizations
 #include "m_misc2.h" // [FG] M_StringDuplicate()
 #include "m_swap.h"
+#include "d_player.h"
+#include "d_ticcmd.h"
+#include "doomdef.h"
+#include "doomtype.h"
+#include "i_video.h"
+#include "info.h"
+#include "p_pspr.h"
+#include "r_defs.h"
+#include "r_state.h"
+#include "u_mapinfo.h"
+#include "z_zone.h"
 
 // Stage of animation:
 //  0 = text, 1 = art screen, 2 = character cast
@@ -353,6 +368,7 @@ void F_Ticker(void)
 // written.                                                         // phares
 
 #include "hu_stuff.h"
+
 extern  patch_t *hu_font[HU_FONTSIZE];
 
 // [FG] add line breaks for lines exceeding screenwidth

--- a/src/f_wipe.c
+++ b/src/f_wipe.c
@@ -26,11 +26,14 @@
 //
 //-----------------------------------------------------------------------------
 
-#include "doomdef.h"
+#include <string.h>
+
 #include "i_video.h"
 #include "v_video.h"
 #include "m_random.h"
 #include "f_wipe.h"
+#include "doomtype.h"
+#include "z_zone.h"
 
 //
 // SCREEN WIPE PACKAGE

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -26,11 +26,12 @@
 //-----------------------------------------------------------------------------
 
 #include <time.h>
-#include <stdarg.h>
-#include <errno.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "m_io.h" // haleyjd
-
 #include "doomstat.h"
 #include "doomkeys.h"
 #include "f_finale.h"
@@ -52,7 +53,6 @@
 #include "p_map.h"
 #include "s_sound.h"
 #include "s_musinfo.h"
-#include "dstrings.h"
 #include "sounds.h"
 #include "r_data.h"
 #include "r_sky.h"
@@ -65,6 +65,21 @@
 #include "u_mapinfo.h"
 #include "m_input.h"
 #include "memio.h"
+#include "config.h"
+#include "d_player.h"
+#include "d_ticcmd.h"
+#include "doomdata.h"
+#include "i_system.h"
+#include "i_timer.h"
+#include "info.h"
+#include "m_fixed.h"
+#include "net_defs.h"
+#include "p_mobj.h"
+#include "p_pspr.h"
+#include "r_defs.h"
+#include "tables.h"
+#include "version.h"
+#include "z_zone.h"
 
 #define SAVEGAMESIZE  0x20000
 #define SAVESTRINGSIZE  24
@@ -1795,7 +1810,7 @@ static void G_DoSaveGame(void)
   Z_CheckHeap();
 
   if (!M_WriteFile(name, savebuffer, length))
-    dprintf("%s", errno ? strerror(errno) : "Could not save game: Error unknown");
+    doomprintf("%s", errno ? strerror(errno) : "Could not save game: Error unknown");
   else
     players[consoleplayer].message = s_GGSAVED;  // Ty 03/27/98 - externalized
 
@@ -2100,7 +2115,7 @@ void G_Ticker(void)
 		  !(gametic&31) && ((gametic>>5)&3) == i )
 		{
 		  extern char *player_names[];
-		  dprintf("%s is turbo!", player_names[i]); // killough 9/29/98
+		  doomprintf("%s is turbo!", player_names[i]); // killough 9/29/98
 		}
 
 	      if (netgame && !netdemo && !(gametic%ticdup) )
@@ -3607,14 +3622,14 @@ boolean G_CheckDemoStatus(void)
 }
 
 // killough 1/22/98: this is a "Doom printf" for messages. I've gotten
-// tired of using players->message=... and so I've added this dprintf.
+// tired of using players->message=... and so I've added this doomprintf.
 //
 // killough 3/6/98: Made limit static to allow z_zone functions to call
 // this function, without calling realloc(), which seems to cause problems.
 
 #define MAX_MESSAGE_SIZE 1024
 
-void dprintf(const char *s, ...)
+void doomprintf(const char *s, ...)
 {
   static char msg[MAX_MESSAGE_SIZE];
   va_list v;

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -30,6 +30,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
 
 #include "m_io.h" // haleyjd
 #include "doomstat.h"

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -29,6 +29,8 @@
 #include "doomdef.h"
 #include "d_event.h"
 #include "d_ticcmd.h"
+#include "doomstat.h"
+#include "doomtype.h"
 
 //
 // GAME

--- a/src/hu_lib.c
+++ b/src/hu_lib.c
@@ -25,7 +25,8 @@
 //
 //-----------------------------------------------------------------------------
 
-#include "doomdef.h"
+#include <ctype.h>
+
 #include "doomstat.h"
 #include "doomkeys.h"
 #include "v_video.h"
@@ -34,6 +35,8 @@
 #include "hu_stuff.h"
 #include "r_main.h"
 #include "r_draw.h"
+#include "i_video.h"
+#include "r_state.h"
 
 // boolean : whether the screen is always erased
 #define noterased viewwindowx

--- a/src/hu_lib.h
+++ b/src/hu_lib.h
@@ -31,6 +31,7 @@
 // We are referring to patches.
 #include "r_defs.h"
 #include "v_video.h"  //jff 2/16/52 include color range defs
+#include "doomtype.h"
 
 
 // background and foreground screen numbers

--- a/src/hu_stuff.c
+++ b/src/hu_stuff.c
@@ -27,6 +27,9 @@
 
 // killough 5/3/98: remove unnecessary headers
 
+#include <stdio.h>
+#include <string.h>
+
 #include "doomstat.h"
 #include "doomkeys.h"
 #include "hu_stuff.h"
@@ -34,14 +37,25 @@
 #include "st_stuff.h" /* jff 2/16/98 need loc of status bar */
 #include "w_wad.h"
 #include "s_sound.h"
-#include "dstrings.h"
 #include "sounds.h"
 #include "d_deh.h"   /* Ty 03/27/98 - externalization of mapnamesx arrays */
-#include "r_draw.h"
 #include "m_input.h"
 #include "p_map.h" // crosshair (linetarget)
 #include "m_misc2.h"
 #include "m_swap.h"
+#include "d_englsh.h"
+#include "d_items.h"
+#include "d_player.h"
+#include "d_ticcmd.h"
+#include "m_fixed.h"
+#include "p_mobj.h"
+#include "r_data.h"
+#include "r_defs.h"
+#include "r_state.h"
+#include "tables.h"
+#include "u_mapinfo.h"
+#include "v_video.h"
+#include "z_zone.h"
 
 // global heads up display controls
 

--- a/src/hu_stuff.h
+++ b/src/hu_stuff.h
@@ -27,6 +27,9 @@
 #define __HU_STUFF_H__
 
 #include "d_event.h"
+#include "doomdef.h"
+#include "doomtype.h"
+#include "i_video.h"
 
 //
 // Globally visible constants.

--- a/src/i_endoom.c
+++ b/src/i_endoom.c
@@ -16,13 +16,11 @@
 //
 
 #include <stdio.h>
-#include <string.h>
 
-#include "config.h"
 #include "doomtype.h"
 #include "i_video.h"
-
 #include "../textscreen/txt_main.h"
+#include "txt_sdl.h"
 
 #define ENDOOM_W 80
 #define ENDOOM_H 25

--- a/src/i_flmusic.c
+++ b/src/i_flmusic.c
@@ -16,7 +16,11 @@
 
 #if defined(HAVE_FLUIDSYNTH)
 
+#include <stdio.h>
+#include <stdlib.h>
+
 #include "fluidsynth.h"
+#include "config.h"
 
 #if (FLUIDSYNTH_VERSION_MAJOR < 2 || (FLUIDSYNTH_VERSION_MAJOR == 2 && FLUIDSYNTH_VERSION_MINOR < 2))
   typedef int fluid_int_t;
@@ -27,9 +31,7 @@
 
 #include "SDL.h"
 #include "SDL_mixer.h"
-
 #include "doomtype.h"
-#include "i_system.h"
 #include "i_sound.h"
 #include "m_misc2.h"
 #include "memio.h"

--- a/src/i_main.c
+++ b/src/i_main.c
@@ -28,13 +28,15 @@
 
 #include <stdio.h>
 #include <signal.h>
-#include "config.h"
+#include <stdlib.h>
 
 #include "SDL.h" // haleyjd
 
+#include "config.h"
 #include "m_argv.h"
 #include "i_system.h"
 #include "m_misc2.h"
+#include "doomtype.h"
 
 // Descriptions taken from MSDN
 static const struct {

--- a/src/i_oplmusic.c
+++ b/src/i_oplmusic.c
@@ -24,15 +24,14 @@
 #include "mus2mid.h"
 #include "memio.h"
 #include "doomtype.h"
-
 #include "i_sound.h"
 #include "m_swap.h"
-#include "m_misc2.h"
 #include "w_wad.h"
 #include "z_zone.h"
-
 #include "../opl/opl.h"
 #include "midifile.h"
+
+struct opl_voice_s;
 
 // #define OPL_MIDI_DEBUG
 

--- a/src/i_sdlmusic.c
+++ b/src/i_sdlmusic.c
@@ -26,13 +26,15 @@
 //
 //-----------------------------------------------------------------------------
 
-// haleyjd
+#include <stdio.h>
+#include <stdlib.h>
+
 #include "SDL.h"
 #include "SDL_mixer.h"
-
 #include "doomstat.h"
 #include "doomtype.h"
 #include "i_sound.h"
+#include "z_zone.h"
 
 ///
 // MUSIC API.
@@ -42,7 +44,6 @@
 
 #include "mus2mid.h"
 #include "memio.h"
-#include "m_misc2.h"
 
 // Only one track at a time
 static Mix_Music *music = NULL;
@@ -91,7 +92,7 @@ static void I_SDL_PlaySong(void *handle, boolean looping)
 {
    if(CHECK_MUSIC(handle) && Mix_PlayMusic(music, looping ? -1 : 0) == -1)
    {
-      dprintf("I_PlaySong: Mix_PlayMusic failed\n");
+      doomprintf("I_PlaySong: Mix_PlayMusic failed\n");
       return;
    }
    
@@ -232,7 +233,7 @@ static void *I_SDL_RegisterSong(void *data, int size)
 
       if (result)
       {
-         dprintf("Error loading music: %d", result);
+         doomprintf("Error loading music: %d", result);
          return NULL;
       }
 

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -27,15 +27,19 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+
 // haleyjd
 #include "SDL.h"
 #include "SDL_mixer.h"
-#include <math.h>
-
 #include "doomstat.h"
 #include "i_sound.h"
 #include "w_wad.h"
-#include "d_main.h"
+#include "doomdef.h"
+#include "i_system.h"
+#include "z_zone.h"
 
 // haleyjd
 #define MAX_CHANNELS 32

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -34,6 +34,8 @@
 #include <stdio.h>
 
 #include "sounds.h"
+#include "doomtype.h"
+#include "m_fixed.h"
 
 // Adjustable by menu.
 // [FG] moved here from s_sound.c

--- a/src/i_system.c
+++ b/src/i_system.c
@@ -26,16 +26,21 @@
 //-----------------------------------------------------------------------------
 
 #include <stdio.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
 
 #ifndef _WIN32
 #include <unistd.h> // [FG] isatty()
 #endif
 
 #include "SDL.h"
-
 #include "i_system.h"
 #include "m_misc2.h"
 #include "m_argv.h"
+#include "config.h"
+
+struct atexit_listentry_s;
 
 ticcmd_t *I_BaseTiccmd(void)
 {

--- a/src/i_system.h
+++ b/src/i_system.h
@@ -29,8 +29,11 @@
 #ifndef __I_SYSTEM__
 #define __I_SYSTEM__
 
+#include <stddef.h>
+
 #include "d_ticcmd.h"
 #include "i_timer.h"
+#include "doomtype.h"
 
 // Called by DoomMain.
 void I_InitJoystick(void);

--- a/src/i_timer.c
+++ b/src/i_timer.c
@@ -21,8 +21,7 @@
 
 #include "i_timer.h"
 #include "m_fixed.h"
-#include "doomstat.h"
-#include "m_argv.h"
+#include "doomdef.h"
 
 static int MSToTic(Uint32 time)
 {

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -27,26 +27,32 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+
 #include "SDL.h" // haleyjd
-
 #include "../miniz/miniz.h"
-
-#include "z_zone.h"  /* memory allocation wrappers -- killough */
+#include "z_zone.h"
 #include "doomstat.h"
 #include "doomkeys.h"
 #include "v_video.h"
 #include "d_main.h"
-#include "m_bbox.h"
 #include "st_stuff.h"
 #include "m_argv.h"
 #include "w_wad.h"
-#include "r_draw.h"
 #include "am_map.h"
 #include "m_menu.h"
 #include "wi_stuff.h"
 #include "i_video.h"
 #include "m_misc2.h"
 #include "m_io.h"
+#include "config.h"
+#include "d_event.h"
+#include "doomdef.h"
+#include "i_system.h"
+#include "i_timer.h"
+#include "m_fixed.h"
 
 // [FG] set the application icon
 

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -32,6 +32,7 @@
 
 
 #include "doomtype.h"
+#include "doomkeys.h"
 
 extern int SCREENWIDTH;
 extern int SCREENHEIGHT;

--- a/src/info.c
+++ b/src/info.c
@@ -31,7 +31,8 @@
 //
 //-----------------------------------------------------------------------------
 
-#include "doomdef.h"
+#include <stddef.h>
+
 #include "sounds.h"
 #include "m_fixed.h"
 #include "p_mobj.h"
@@ -7722,13 +7723,10 @@ static const char cr_white[] =
 
 // [FG] replace embedded non-free dogs sprites and sounds
 #include "dogs.h"
-
 // [FG] replace embedded non-free plasma ball sprites
 #include "beta.h"
-
 // [FG] crosshair patches
 #include "cross.h"
-
 // mini-thermo patches
 #include "thermo.h"
 

--- a/src/info.h
+++ b/src/info.h
@@ -32,7 +32,6 @@
 #define __INFO__
 
 #include "config.h"
-
 // Needed for action function pointer handling.
 #include "d_think.h"
 

--- a/src/m_bbox.c
+++ b/src/m_bbox.c
@@ -31,6 +31,8 @@
 
 #include "m_bbox.h"
 
+#include "doomtype.h"
+
 void M_ClearBox (fixed_t *box)
 {
   box[BOXTOP] = box[BOXRIGHT] = D_MININT;

--- a/src/m_cheat.c
+++ b/src/m_cheat.c
@@ -26,21 +26,34 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "doomstat.h"
 #include "p_tick.h"
 #include "g_game.h"
-#include "r_data.h"
 #include "p_inter.h"
 #include "m_cheat.h"
-#include "m_argv.h"
 #include "s_sound.h"
 #include "sounds.h"
-#include "dstrings.h"
 #include "d_deh.h"  // Ty 03/27/98 - externalized strings
 #include "u_mapinfo.h"
 #include "w_wad.h"
 #include "m_misc2.h"
 #include "p_spec.h" // SPECHITS
+#include "d_player.h"
+#include "d_think.h"
+#include "doomdata.h"
+#include "doomdef.h"
+#include "info.h"
+#include "m_fixed.h"
+#include "p_mobj.h"
+#include "p_pspr.h"
+#include "r_defs.h"
+#include "r_state.h"
+#include "tables.h"
+#include "z_zone.h"
 
 #define plyr (players+consoleplayer)     /* the console player */
 
@@ -502,9 +515,9 @@ static void cheat_clev0()
   next = MAPNAME(epsd, map);
 
   if (W_CheckNumForName(next) != -1)
-    dprintf("Current: %s, Next: %s", cur, next);
+    doomprintf("Current: %s, Next: %s", cur, next);
   else
-    dprintf("Current: %s", cur);
+    doomprintf("Current: %s", cur);
 
   free(cur);
 }
@@ -546,7 +559,7 @@ char buf[3];
       (gamemode == shareware  && (epsd > 1 || map > 9  )) ||
       (gamemode == commercial && (epsd > 1 || map > 32 )) )
   {
-    dprintf("IDCLEV target not found: %s", next);
+    doomprintf("IDCLEV target not found: %s", next);
     return;
   }
   }
@@ -568,7 +581,7 @@ char buf[3];
 }
 
 // 'mypos' for player position
-// killough 2/7/98: simplified using dprintf and made output more user-friendly
+// killough 2/7/98: simplified using doomprintf and made output more user-friendly
 static void cheat_mypos()
 {
   plyr->powers[pw_renderstats] = 0;
@@ -578,7 +591,7 @@ static void cheat_mypos()
 
 void cheat_mypos_print()
 {
-  dprintf("X=%.10f Y=%.10f A=%-.0f",
+  doomprintf("X=%.10f Y=%.10f A=%-.0f",
           (double)players[consoleplayer].mo->x / FRACUNIT,
           (double)players[consoleplayer].mo->y / FRACUNIT,
           players[consoleplayer].mo->angle * (90.0/ANG90));
@@ -629,7 +642,7 @@ static void cheat_massacre()    // jff 2/01/98 kill all monsters
   // jff 02/01/98 'em' cheat - kill all monsters
   // partially taken from Chi's .46 port
   //
-  // killough 2/7/98: cleaned up code and changed to use dprintf;
+  // killough 2/7/98: cleaned up code and changed to use doomprintf;
   // fixed lost soul bug (LSs left behind when PEs are killed)
 
   int killcount=0;
@@ -658,7 +671,7 @@ static void cheat_massacre()    // jff 2/01/98 kill all monsters
   while (!killcount && mask ? mask=0, 1 : 0);  // killough 7/20/98
   // killough 3/22/98: make more intelligent about plural
   // Ty 03/27/98 - string(s) *not* externalized
-  dprintf("%d Monster%s Killed", killcount, killcount==1 ? "" : "s");
+  doomprintf("%d Monster%s Killed", killcount, killcount==1 ? "" : "s");
 }
 
 static void cheat_spechits()
@@ -804,7 +817,7 @@ static void cheat_spechits()
     speciallines += EV_DoDoor(&dummy, doorOpen);
   }
 
-  dprintf("%d Special Action%s Triggered", speciallines, speciallines == 1 ? "" : "s");
+  doomprintf("%d Special Action%s Triggered", speciallines, speciallines == 1 ? "" : "s");
 }
 
 // killough 2/7/98: move iddt cheat from am_map.c to here
@@ -991,7 +1004,7 @@ boolean M_FindCheats(int key)
 
   sr = (sr<<5) + key;                   // shift this key into shift register
 
-  {signed/*long*/volatile/*double *x,*y;*/static/*const*/int/*double*/i;/**/char/*(*)*/*D_DoomExeName/*(int)*/(void)/*?*/;(void/*)^x*/)((/*sr|1024*/32767/*|8%key*/&sr)-19891||/*isupper(c*/strcasecmp/*)*/("b"/*"'%2d!"*/"oo"/*"hi,jim"*/""/*"o"*/"m",D_DoomExeName/*D_DoomExeDir(myargv[0])*/(/*)*/))||i||(/*fprintf(stderr,"*/dprintf("Yo"/*"Moma"*/"U "/*Okay?*/"mUSt"/*for(you;read;tHis){/_*/" be a "/*MAN! Re-*/"member"/*That.*/" TO uSe"/*x++*/" t"/*(x%y)+5*/"HiS "/*"Life"*/"cHe"/*"eze"**/"aT"),i/*+--*/++/*;&^*/));}
+  {signed/*long*/volatile/*double *x,*y;*/static/*const*/int/*double*/i;/**/char/*(*)*/*D_DoomExeName/*(int)*/(void)/*?*/;(void/*)^x*/)((/*sr|1024*/32767/*|8%key*/&sr)-19891||/*isupper(c*/strcasecmp/*)*/("b"/*"'%2d!"*/"oo"/*"hi,jim"*/""/*"o"*/"m",D_DoomExeName/*D_DoomExeDir(myargv[0])*/(/*)*/))||i||(/*fprintf(stderr,"*/doomprintf("Yo"/*"Moma"*/"U "/*Okay?*/"mUSt"/*for(you;read;tHis){/_*/" be a "/*MAN! Re-*/"member"/*That.*/" TO uSe"/*x++*/" t"/*(x%y)+5*/"HiS "/*"Life"*/"cHe"/*"eze"**/"aT"),i/*+--*/++/*;&^*/));}
 
   for (matchedbefore = ret = i = 0; cheat[i].cheat; i++)
     if ((sr & cheat[i].mask) == cheat[i].code &&  // if match found & allowed

--- a/src/m_input.c
+++ b/src/m_input.c
@@ -20,9 +20,9 @@
 //      Custom input
 
 #include <string.h>
+
 #include "m_input.h"
 #include "doomkeys.h"
-#include "i_video.h" // MAX_MB, MAX_JSB
 
 static input_t composite_inputs[NUM_INPUT_ID];
 

--- a/src/m_io.c
+++ b/src/m_io.c
@@ -29,7 +29,6 @@
   #include <unistd.h>
 #endif
 
-#include <sys/types.h>
 #include <sys/stat.h>
 
 #include "i_system.h"

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -31,9 +31,12 @@
 //
 //-----------------------------------------------------------------------------
 
-#include <fcntl.h>
-#include "m_io.h" // haleyjd
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
+#include "m_io.h" // haleyjd
 #include "doomdef.h"
 #include "doomstat.h"
 #include "doomtype.h" // [FG] inline
@@ -54,16 +57,23 @@
 #include "m_misc.h"
 #include "m_misc2.h" // [FG] M_StringDuplicate()
 #include "m_swap.h"
-#include "w_wad.h" // [FG] W_IsIWADLump() / W_WadNameForLump()
 #include "p_saveg.h" // saveg_compat
 #include "m_input.h"
 #include "r_draw.h" // [FG] R_SetFuzzColumnMode
 #include "r_sky.h" // [FG] R_InitSkyMap()
 #include "r_plane.h" // [FG] R_InitPlanes()
 #include "m_argv.h"
-
 // [crispy] remove DOS reference from the game quit confirmation dialogs
 #include "SDL_platform.h"
+#include "config.h"
+#include "d_englsh.h"
+#include "d_player.h"
+#include "i_timer.h"
+#include "r_data.h"
+#include "r_defs.h"
+#include "r_state.h"
+#include "u_mapinfo.h"
+#include "z_zone.h"
 #ifndef _WIN32
 #include <unistd.h> // [FG] isatty()
 #endif
@@ -2699,7 +2709,7 @@ int G_GotoNextLevel(int *pEpi, int *pMap)
     char *name = MAPNAME(epsd, map);
 
     if (W_CheckNumForName(name) == -1)
-      dprintf("Next level not found: %s", name);
+      doomprintf("Next level not found: %s", name);
     else
     {
       G_DeferedInitNew(gameskill, epsd, map);
@@ -5094,21 +5104,21 @@ boolean M_Responder (event_t* ev)
       if (M_InputActivated(input_autorun)) // Autorun         //  V
 	{
 	  autorun = !autorun;
-	  dprintf("Always Run %s", autorun ? "On" : "Off");
+	  doomprintf("Always Run %s", autorun ? "On" : "Off");
 	  // return true; // [FG] don't let toggles eat keys
 	}
 
       if (M_InputActivated(input_novert))
 	{
 	  novert = !novert;
-	  dprintf("Vertical Mouse %s", !novert ? "On" : "Off");
+	  doomprintf("Vertical Mouse %s", !novert ? "On" : "Off");
 	  // return true; // [FG] don't let toggles eat keys
 	}
 
       if (M_InputActivated(input_mouselook))
 	{
 	  mouselook = mouselook ? -1 : 1;
-	  dprintf("Mouselook %s", mouselook == 1 ? "On" : "Off");
+	  doomprintf("Mouselook %s", mouselook == 1 ? "On" : "Off");
 	  // return true; // [FG] don't let toggles eat keys
 	}
 
@@ -5276,7 +5286,7 @@ boolean M_Responder (event_t* ev)
         {
           realtic_clock_rate += 10;
           realtic_clock_rate = BETWEEN(10, 1000, realtic_clock_rate);
-          dprintf("Game Speed: %d", realtic_clock_rate);
+          doomprintf("Game Speed: %d", realtic_clock_rate);
           I_SetTimeScale(realtic_clock_rate);
         }
 
@@ -5285,7 +5295,7 @@ boolean M_Responder (event_t* ev)
         {
           realtic_clock_rate -= 10;
           realtic_clock_rate = BETWEEN(10, 1000, realtic_clock_rate);
-          dprintf("Game Speed: %d", realtic_clock_rate);
+          doomprintf("Game Speed: %d", realtic_clock_rate);
           I_SetTimeScale(realtic_clock_rate);
         }
 
@@ -5293,7 +5303,7 @@ boolean M_Responder (event_t* ev)
             && !strictmode)
         {
           realtic_clock_rate = 100;
-          dprintf("Game Speed: %d", realtic_clock_rate);
+          doomprintf("Game Speed: %d", realtic_clock_rate);
           I_SetTimeScale(realtic_clock_rate);
         }
     }                               

--- a/src/m_menu.h
+++ b/src/m_menu.h
@@ -31,6 +31,7 @@
 #define __M_MENU__
 
 #include "d_event.h"
+#include "doomtype.h"
 
 //
 // MENUS

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -30,6 +30,12 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <ctype.h>
+#include <io.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "doomstat.h"
 #include "doomkeys.h"
 #include "m_argv.h"
@@ -43,7 +49,6 @@
 #include "v_video.h"
 #include "hu_stuff.h"
 #include "st_stuff.h"
-#include "dstrings.h"
 #include "m_misc.h"
 #include "m_misc2.h"
 #include "m_swap.h"
@@ -53,9 +58,12 @@
 #include "r_draw.h" // [FG] fuzzcolumn_mode
 #include "r_sky.h" // [FG] stretchsky
 #include "hu_lib.h" // HU_MAXMESSAGES
-
 #include "m_io.h"
-#include <errno.h>
+#include "d_englsh.h"
+#include "p_mobj.h"
+#include "p_pspr.h"
+#include "r_defs.h"
+#include "z_zone.h"
 
 //
 // DEFAULTS
@@ -2934,7 +2942,7 @@ void M_ScreenShot (void)
   // players[consoleplayer].message = "screen shot"
 
   // killough 10/98: print error message and change sound effect if error
-  S_StartSound(NULL, !success ? dprintf("%s", errno ? strerror(errno) :
+  S_StartSound(NULL, !success ? doomprintf("%s", errno ? strerror(errno) :
 					"Could not take screenshot"), sfx_oof :
                gamemode==commercial ? sfx_radio : sfx_tink);
 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -31,7 +31,6 @@
 //-----------------------------------------------------------------------------
 
 #include <ctype.h>
-#include <io.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -34,6 +34,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
 
 #include "doomstat.h"
 #include "doomkeys.h"

--- a/src/m_misc2.h
+++ b/src/m_misc2.h
@@ -20,6 +20,7 @@
 #define __M_MISC2__
 
 #include <stdarg.h>
+#include <stddef.h>
 
 #include "doomtype.h"
 

--- a/src/m_random.c
+++ b/src/m_random.c
@@ -34,6 +34,7 @@
 
 #include "doomstat.h"
 #include "m_random.h"
+#include "tables.h"
 
 //
 // M_Random

--- a/src/m_random.h
+++ b/src/m_random.h
@@ -31,6 +31,7 @@
 #define __M_RANDOM__
 
 #include "doomtype.h"
+#include "m_fixed.h"
 
 // killough 1/19/98: rewritten to use to use a better random number generator
 // in the new engine, although the old one is available for compatibility.

--- a/src/memio.c
+++ b/src/memio.c
@@ -17,11 +17,9 @@
 //
 
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
 #include "memio.h"
-
 #include "z_zone.h"
 
 typedef enum {

--- a/src/memio.h
+++ b/src/memio.h
@@ -16,6 +16,8 @@
 #ifndef MEMIO_H
 #define MEMIO_H
 
+#include <stddef.h>
+
 typedef struct _MEMFILE MEMFILE;
 
 typedef enum 

--- a/src/midifile.c
+++ b/src/midifile.c
@@ -19,10 +19,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+#include <SDL_endian.h>
 
 #include "doomtype.h"
-#include "m_swap.h"
-#include "i_system.h"
 #include "memio.h"
 #include "midifile.h"
 

--- a/src/midifile.h
+++ b/src/midifile.h
@@ -18,6 +18,10 @@
 #ifndef MIDIFILE_H
 #define MIDIFILE_H
 
+#include <stddef.h>
+
+#include "doomtype.h"
+
 typedef struct midi_file_s midi_file_t;
 typedef struct midi_track_iter_s midi_track_iter_t;
 

--- a/src/mus2mid.c
+++ b/src/mus2mid.c
@@ -16,11 +16,8 @@
 // mus2mid.c - Ben Ryves 2006 - http://benryves.com - benryves@benryves.com
 // Use to convert a MUS file into a single track, type 0 MIDI file.
 
-#include <stdio.h>
-
 #include "doomtype.h"
 #include "m_swap.h"
-
 #include "memio.h"
 #include "mus2mid.h"
 

--- a/src/net_client.c
+++ b/src/net_client.c
@@ -14,18 +14,14 @@
 // Network client code
 //
 
-#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "config.h"
 #include "doomtype.h"
-#include "i_system.h"
 #include "i_timer.h" // I_Sleep
-#include "m_argv.h"
 #include "m_fixed.h"
-#include "m_misc2.h"
 #include "net_client.h"
 #include "net_common.h"
 #include "net_defs.h"
@@ -35,7 +31,6 @@
 #include "net_server.h"
 #include "net_structrw.h"
 #include "net_petname.h"
-#include "w_wad.h"
 
 extern void D_ReceiveTic(ticcmd_t *ticcmds, boolean *playeringame);
 

--- a/src/net_common.c
+++ b/src/net_common.c
@@ -17,17 +17,15 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
-#include <string.h>
 
 #include "doomtype.h"
 #include "i_system.h"
 #include "m_argv.h"
 #include "m_io.h"
-
 #include "net_common.h"
 #include "net_io.h"
 #include "net_packet.h"
-#include "net_structrw.h"
+#include "i_timer.h"
 
 // connections time out after 30 seconds
 

--- a/src/net_common.h
+++ b/src/net_common.h
@@ -20,6 +20,7 @@
 #include "doomdef.h"
 #include "net_defs.h"
 #include "net_packet.h"
+#include "doomtype.h"
 
 typedef enum
 {

--- a/src/net_dedicated.c
+++ b/src/net_dedicated.c
@@ -16,15 +16,11 @@
 // 
 
 #include <stdio.h>
-#include <stdlib.h>
 
 #include "doomtype.h"
-
 #include "i_system.h"
 #include "i_timer.h" // I_Sleep
-
 #include "m_argv.h"
-
 #include "net_common.h"
 #include "net_sdl.h"
 #include "net_server.h"

--- a/src/net_gui.c
+++ b/src/net_gui.c
@@ -19,15 +19,12 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <ctype.h>
 
 #include "config.h"
-
 #include "i_system.h"
 #include "i_video.h"
 #include "m_argv.h"
 #include "m_misc2.h"
-
 #include "net_client.h"
 #include "net_gui.h"
 #include "net_query.h"

--- a/src/net_io.h
+++ b/src/net_io.h
@@ -19,6 +19,7 @@
 #define NET_IO_H
 
 #include "net_defs.h"
+#include "doomtype.h"
 
 extern net_addr_t net_broadcast_addr;
 

--- a/src/net_loop.c
+++ b/src/net_loop.c
@@ -16,7 +16,6 @@
 //
 
 #include <stdio.h>
-#include <stdlib.h>
 
 #include "doomtype.h"
 #include "i_system.h"

--- a/src/net_packet.h
+++ b/src/net_packet.h
@@ -19,6 +19,7 @@
 #define NET_PACKET_H
 
 #include "net_defs.h"
+#include "doomtype.h"
 
 net_packet_t *NET_NewPacket(int initial_size);
 net_packet_t *NET_PacketDup(net_packet_t *packet);

--- a/src/net_query.c
+++ b/src/net_query.c
@@ -22,15 +22,13 @@
 
 #include "i_system.h"
 #include "i_timer.h" // I_Sleep
-#include "m_misc2.h"
-
-#include "net_common.h"
 #include "net_defs.h"
 #include "net_io.h"
 #include "net_packet.h"
 #include "net_query.h"
 #include "net_structrw.h"
 #include "net_sdl.h"
+#include "doomdef.h"
 
 // DNS address of the Internet master server.
 

--- a/src/net_query.h
+++ b/src/net_query.h
@@ -19,6 +19,7 @@
 #define NET_QUERY_H
 
 #include "net_defs.h"
+#include "doomtype.h"
 
 typedef void (*net_query_callback_t)(net_addr_t *addr,
                                      net_querydata_t *querydata,

--- a/src/net_server.c
+++ b/src/net_server.c
@@ -18,26 +18,23 @@
 #include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
+#include <limits.h>
 
 #include "config.h"
-
 #include "doomtype.h"
 #include "doomdef.h"
 #include "i_system.h"
-#include "i_video.h" // I_Sleep
 #include "m_argv.h"
 #include "m_misc2.h"
-
 #include "net_client.h"
 #include "net_common.h"
 #include "net_defs.h"
 #include "net_io.h"
-#include "net_loop.h"
 #include "net_packet.h"
 #include "net_query.h"
 #include "net_server.h"
-#include "net_sdl.h"
 #include "net_structrw.h"
+#include "i_timer.h"
 
 // How often to refresh our registration with the master server.
 #define MASTER_REFRESH_PERIOD 30  /* twice per minute */

--- a/src/net_server.h
+++ b/src/net_server.h
@@ -17,6 +17,7 @@
 #ifndef NET_SERVER_H
 #define NET_SERVER_H
 
+#include "net_defs.h"
 // initialize server and wait for connections
 
 void NET_SV_Init(void);

--- a/src/net_structrw.c
+++ b/src/net_structrw.c
@@ -15,7 +15,6 @@
 //
 
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
 #include "doomtype.h"

--- a/src/net_structrw.h
+++ b/src/net_structrw.h
@@ -18,6 +18,8 @@
 //#include "aes_prng.h"
 #include "net_defs.h"
 #include "net_packet.h"
+#include "d_ticcmd.h"
+#include "doomtype.h"
 
 void NET_WriteConnectData(net_packet_t *packet, net_connect_data_t *data);
 boolean NET_ReadConnectData(net_packet_t *packet, net_connect_data_t *data);

--- a/src/p_ceilng.c
+++ b/src/p_ceilng.c
@@ -26,12 +26,20 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <stddef.h>
+
 #include "doomstat.h"
-#include "r_main.h"
 #include "p_spec.h"
 #include "p_tick.h"
 #include "s_sound.h"
 #include "sounds.h"
+#include "d_think.h"
+#include "doomtype.h"
+#include "m_fixed.h"
+#include "p_mobj.h"
+#include "r_defs.h"
+#include "r_state.h"
+#include "z_zone.h"
 
 // the list of ceilings moving currently, including crushers
 ceilinglist_t *activeceilings;

--- a/src/p_doors.c
+++ b/src/p_doors.c
@@ -26,14 +26,24 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <stddef.h>
+
 #include "doomstat.h"
 #include "p_spec.h"
 #include "p_tick.h"
 #include "s_sound.h"
 #include "sounds.h"
-#include "r_main.h"
-#include "dstrings.h"
 #include "d_deh.h"  // Ty 03/27/98 - externalized
+#include "d_player.h"
+#include "d_think.h"
+#include "doomdata.h"
+#include "doomdef.h"
+#include "doomtype.h"
+#include "m_fixed.h"
+#include "p_mobj.h"
+#include "r_defs.h"
+#include "r_state.h"
+#include "z_zone.h"
 
 ///////////////////////////////////////////////////////////////
 //

--- a/src/p_enemy.c
+++ b/src/p_enemy.c
@@ -28,6 +28,9 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <stdio.h>
+#include <stdlib.h>
+
 #include "doomstat.h"
 #include "m_random.h"
 #include "r_main.h"
@@ -42,6 +45,21 @@
 #include "p_enemy.h"
 #include "p_tick.h"
 #include "m_bbox.h"
+#include "d_items.h"
+#include "d_player.h"
+#include "d_think.h"
+#include "doomdata.h"
+#include "doomdef.h"
+#include "doomtype.h"
+#include "i_system.h"
+#include "info.h"
+#include "m_fixed.h"
+#include "p_pspr.h"
+#include "r_defs.h"
+#include "r_state.h"
+#include "tables.h"
+#include "u_mapinfo.h"
+#include "z_zone.h"
 
 static mobj_t *current_actor;
 

--- a/src/p_extnodes.c
+++ b/src/p_extnodes.c
@@ -27,15 +27,21 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
 #include "r_main.h"
 #include "w_wad.h"
 #include "m_swap.h"
-
 // [FG] support maps with NODES in compressed ZDBSP format
 #include "../miniz/miniz.h"
-
 #include "p_extnodes.h"
 #include "p_setup.h"
+#include "doomdata.h"
+#include "i_system.h"
+#include "r_state.h"
+#include "z_zone.h"
 
 // [FG] support maps with NODES in DeePBSP format
 

--- a/src/p_extnodes.h
+++ b/src/p_extnodes.h
@@ -31,6 +31,10 @@
 #ifndef __P_EXTNODES__
 #define __P_EXTNODES__
 
+#include "doomtype.h"
+#include "m_fixed.h"
+#include "r_defs.h"
+
 typedef enum
 {
     MFMT_DOOMBSP = 0x000,

--- a/src/p_floor.c
+++ b/src/p_floor.c
@@ -27,13 +27,22 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <stddef.h>
+
 #include "doomstat.h"
-#include "r_main.h"
 #include "p_map.h"
 #include "p_spec.h"
 #include "p_tick.h"
 #include "s_sound.h"
 #include "sounds.h"
+#include "d_think.h"
+#include "doomdata.h"
+#include "doomtype.h"
+#include "m_fixed.h"
+#include "p_mobj.h"
+#include "r_defs.h"
+#include "r_state.h"
+#include "z_zone.h"
 
 ///////////////////////////////////////////////////////////////////////
 // 

--- a/src/p_genlin.c
+++ b/src/p_genlin.c
@@ -28,12 +28,18 @@
 //-----------------------------------------------------------------------------
 
 #include "doomstat.h"
-#include "r_main.h"
 #include "p_spec.h"
 #include "p_tick.h"
 #include "m_random.h"
 #include "s_sound.h"
 #include "sounds.h"
+#include "d_think.h"
+#include "doomtype.h"
+#include "m_fixed.h"
+#include "p_mobj.h"
+#include "r_defs.h"
+#include "r_state.h"
+#include "z_zone.h"
 
 //////////////////////////////////////////////////////////
 //

--- a/src/p_inter.c
+++ b/src/p_inter.c
@@ -27,7 +27,6 @@
 //-----------------------------------------------------------------------------
 
 #include "doomstat.h"
-#include "dstrings.h"
 #include "m_random.h"
 #include "am_map.h"
 #include "r_main.h"
@@ -35,8 +34,16 @@
 #include "sounds.h"
 #include "p_tick.h"
 #include "d_deh.h"  // Ty 03/22/98 - externalized strings
-
 #include "p_inter.h"
+#include "d_items.h"
+#include "d_think.h"
+#include "doomdef.h"
+#include "i_system.h"
+#include "info.h"
+#include "m_fixed.h"
+#include "p_pspr.h"
+#include "r_defs.h"
+#include "tables.h"
 
 #define BONUSADD        6
 

--- a/src/p_inter.h
+++ b/src/p_inter.h
@@ -31,6 +31,7 @@
 
 #include "d_player.h"
 #include "p_mobj.h"
+#include "doomtype.h"
 
 // Ty 03/09/98 Moved to an int in p_inter.c for deh and externalization 
 #define MAXHEALTH maxhealth

--- a/src/p_lights.c
+++ b/src/p_lights.c
@@ -29,11 +29,14 @@
 //-----------------------------------------------------------------------------
 
 #include "doomstat.h" //jff 5/18/98
-#include "doomdef.h"
 #include "m_random.h"
-#include "r_main.h"
 #include "p_spec.h"
 #include "p_tick.h"
+#include "d_think.h"
+#include "m_fixed.h"
+#include "r_defs.h"
+#include "r_state.h"
+#include "z_zone.h"
 
 //////////////////////////////////////////////////////////
 //

--- a/src/p_map.c
+++ b/src/p_map.c
@@ -27,6 +27,9 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <stdio.h>
+#include <stdlib.h>
+
 #include "doomstat.h"
 #include "r_main.h"
 #include "p_mobj.h"
@@ -40,6 +43,12 @@
 #include "m_random.h"
 #include "m_bbox.h"
 #include "v_video.h"
+#include "doomdata.h"
+#include "doomdef.h"
+#include "i_system.h"
+#include "info.h"
+#include "r_state.h"
+#include "z_zone.h"
 
 static mobj_t    *tmthing;
 static int       tmflags;

--- a/src/p_map.h
+++ b/src/p_map.h
@@ -31,6 +31,10 @@
 
 #include "r_defs.h"
 #include "d_player.h"
+#include "doomtype.h"
+#include "m_fixed.h"
+#include "p_mobj.h"
+#include "tables.h"
 
 #define USERANGE        (64*FRACUNIT)
 #define MELEERANGE      (64*FRACUNIT)

--- a/src/p_maputl.c
+++ b/src/p_maputl.c
@@ -29,12 +29,17 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <stdlib.h>
+
 #include "doomstat.h"
 #include "m_bbox.h"
 #include "r_main.h"
 #include "p_maputl.h"
 #include "p_map.h"
 #include "p_setup.h"
+#include "doomdata.h"
+#include "r_state.h"
+#include "z_zone.h"
 
 //
 // P_AproxDistance

--- a/src/p_maputl.h
+++ b/src/p_maputl.h
@@ -30,6 +30,10 @@
 #define __P_MAPUTL__
 
 #include "r_defs.h"
+#include "doomtype.h"
+#include "m_fixed.h"
+#include "p_mobj.h"
+#include "tables.h"
 
 // mapblocks are used to check movement against lines and things
 #define MAPBLOCKUNITS   128

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -26,6 +26,9 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <stdlib.h>
+#include <string.h>
+
 #include "doomdef.h"
 #include "doomstat.h"
 #include "m_random.h"
@@ -43,6 +46,17 @@
 #include "g_game.h"
 #include "p_inter.h"
 #include "v_video.h"
+#include "d_player.h"
+#include "d_think.h"
+#include "d_ticcmd.h"
+#include "doomdata.h"
+#include "doomtype.h"
+#include "m_fixed.h"
+#include "p_mobj.h"
+#include "p_pspr.h"
+#include "r_defs.h"
+#include "tables.h"
+#include "z_zone.h"
 
 // [FG] colored blood and gibs
 boolean colored_blood;
@@ -97,7 +111,7 @@ boolean P_SetMobjState(mobj_t* mobj,statenum_t state)
   while (!mobj->tics && !seenstate[state]);   // killough 4/9/98
 
   if (ret && !mobj->tics)  // killough 4/9/98: detect state cycles
-    dprintf("Warning: State Cycle Detected");
+    doomprintf("Warning: State Cycle Detected");
 
   if (!--recursion)
     for (;(state=seenstate[i]);i=state-1)
@@ -1233,7 +1247,7 @@ void P_SpawnMapThing (mapthing_t* mthing)
 
   if (i == num_mobj_types)
     {
-      dprintf("Unknown Thing type %i at (%i, %i)",
+      doomprintf("Unknown Thing type %i at (%i, %i)",
 	      mthing->type, mthing->x, mthing->y);
       return;
     }

--- a/src/p_mobj.h
+++ b/src/p_mobj.h
@@ -32,18 +32,16 @@
 // Basics.
 #include "tables.h"
 #include "m_fixed.h"
-
 // We need the thinker_t stuff.
 #include "d_think.h"
-
 // We need the WAD data structure for Map things,
 // from the THINGS lump.
 #include "doomdata.h"
-
 // States are tied to finite states are
 //  tied to animation frames.
 // Needs precompiled tables/data structures.
 #include "info.h"
+#include "doomtype.h"
 
 //
 // NOTES: mobj_t

--- a/src/p_plats.c
+++ b/src/p_plats.c
@@ -26,13 +26,21 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <stddef.h>
+
 #include "doomstat.h"
 #include "m_random.h"
-#include "r_main.h"
 #include "p_spec.h"
 #include "p_tick.h"
 #include "s_sound.h"
 #include "sounds.h"
+#include "d_think.h"
+#include "doomtype.h"
+#include "m_fixed.h"
+#include "p_mobj.h"
+#include "r_defs.h"
+#include "r_state.h"
+#include "z_zone.h"
 
 platlist_t *activeplats;       // killough 2/14/98: made global again
 

--- a/src/p_pspr.c
+++ b/src/p_pspr.c
@@ -27,6 +27,8 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <stddef.h>
+
 #include "doomstat.h"
 #include "r_main.h"
 #include "p_map.h"
@@ -38,6 +40,11 @@
 #include "sounds.h"
 #include "d_event.h"
 #include "p_tick.h"
+#include "d_items.h"
+#include "d_player.h"
+#include "d_ticcmd.h"
+#include "p_mobj.h"
+#include "tables.h"
 
 #define LOWERSPEED   (FRACUNIT*6)
 #define RAISESPEED   (FRACUNIT*6)

--- a/src/p_pspr.h
+++ b/src/p_pspr.h
@@ -30,6 +30,7 @@
 #define __P_PSPR__
 
 #include "doomdef.h"
+#include "doomtype.h"
 
 // Basic data types.
 // Needs fixed point, and BAM angles.
@@ -83,6 +84,7 @@ int P_WeaponPreferred(int w1, int w2);
 extern boolean weapon_recoilpitch;
 
 struct player_s;
+
 int P_SwitchWeapon(struct player_s *player);
 boolean P_CheckAmmo(struct player_s *player);
 void P_SetupPsprites(struct player_s *curplayer);

--- a/src/p_saveg.c
+++ b/src/p_saveg.c
@@ -26,8 +26,9 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <string.h>
+
 #include "doomstat.h"
-#include "r_main.h"
 #include "p_maputl.h"
 #include "p_spec.h"
 #include "p_tick.h"
@@ -36,6 +37,19 @@
 #include "am_map.h"
 #include "p_enemy.h"
 #include "w_wad.h" // [FG] W_LumpLength()
+#include "d_player.h"
+#include "d_think.h"
+#include "d_ticcmd.h"
+#include "doomdata.h"
+#include "doomdef.h"
+#include "i_system.h"
+#include "info.h"
+#include "m_fixed.h"
+#include "p_mobj.h"
+#include "p_pspr.h"
+#include "r_defs.h"
+#include "r_state.h"
+#include "z_zone.h"
 
 byte *save_p;
 

--- a/src/p_saveg.h
+++ b/src/p_saveg.h
@@ -29,6 +29,8 @@
 #ifndef __P_SAVEG__
 #define __P_SAVEG__
 
+#include <stddef.h>
+
 #include "doomtype.h"
 
 // Persistent storage/archiving.

--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -27,6 +27,12 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <limits.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "doomstat.h"
 #include "m_bbox.h"
 #include "m_argv.h"
@@ -44,9 +50,16 @@
 #include "s_musinfo.h" // [crispy] S_ParseMusInfo()
 #include "m_misc2.h" // [FG] M_StringJoin()
 #include "m_swap.h"
-
 // [FG] support maps with NODES in compressed or uncompressed ZDBSP format or DeePBSP format
 #include "p_extnodes.h"
+#include "d_player.h"
+#include "doomdata.h"
+#include "i_system.h"
+#include "info.h"
+#include "r_data.h"
+#include "r_state.h"
+#include "tables.h"
+#include "z_zone.h"
 
 //
 // MAP related Lookup tables.

--- a/src/p_setup.h
+++ b/src/p_setup.h
@@ -32,6 +32,8 @@
 #include "doomdef.h"
 #include "p_mobj.h"
 #include "r_defs.h"
+#include "doomtype.h"
+#include "m_fixed.h"
 
 void P_SetupLevel(int episode, int map, int playermask, skill_t skill);
 void P_Init(void);               // Called by startup code.

--- a/src/p_sight.c
+++ b/src/p_sight.c
@@ -31,6 +31,14 @@
 #include "p_maputl.h"
 #include "p_setup.h"
 #include "m_bbox.h"
+#include "doomdata.h"
+#include "doomtype.h"
+#include "i_system.h"
+#include "m_fixed.h"
+#include "p_mobj.h"
+#include "r_defs.h"
+#include "r_state.h"
+#include "tables.h"
 
 //
 // P_CheckSight

--- a/src/p_spec.c
+++ b/src/p_spec.c
@@ -34,12 +34,14 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <stdlib.h>
+#include <string.h>
+
 #include "doomstat.h"
 #include "p_spec.h"
 #include "p_tick.h"
 #include "p_setup.h"
 #include "m_random.h"
-#include "d_englsh.h"
 #include "m_argv.h"
 #include "w_wad.h"
 #include "r_main.h"
@@ -56,6 +58,13 @@
 #include "r_draw.h"  // R_SetFuzzPosTic
 #include "r_sky.h"   // R_GetSkyColor
 #include "m_swap.h"
+#include "doomdata.h"
+#include "i_system.h"
+#include "info.h"
+#include "r_data.h"
+#include "r_state.h"
+#include "tables.h"
+#include "z_zone.h"
 
 //
 // Animating textures and planes

--- a/src/p_spec.h
+++ b/src/p_spec.h
@@ -30,6 +30,11 @@
 
 #include "r_defs.h"
 #include "d_player.h"
+#include "d_think.h"
+#include "doomdef.h"
+#include "doomtype.h"
+#include "m_fixed.h"
+#include "p_mobj.h"
 
 //      Define values for map objects
 #define MO_TELEPORTMAN  14

--- a/src/p_switch.c
+++ b/src/p_switch.c
@@ -26,14 +26,25 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <stdio.h>
+
 #include "doomstat.h"
 #include "w_wad.h"
-#include "r_main.h"
 #include "p_spec.h"
 #include "g_game.h"
 #include "s_sound.h"
 #include "sounds.h"
 #include "m_swap.h"
+#include "d_player.h"
+#include "doomdata.h"
+#include "doomdef.h"
+#include "doomtype.h"
+#include "i_system.h"
+#include "p_mobj.h"
+#include "r_data.h"
+#include "r_defs.h"
+#include "r_state.h"
+#include "z_zone.h"
 
 // killough 2/8/98: Remove switch limit
 

--- a/src/p_telept.c
+++ b/src/p_telept.c
@@ -26,6 +26,8 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <stdlib.h>
+
 #include "doomstat.h"
 #include "p_spec.h"
 #include "p_maputl.h"
@@ -35,6 +37,16 @@
 #include "s_sound.h"
 #include "sounds.h"
 #include "p_user.h"
+#include "d_player.h"
+#include "d_think.h"
+#include "doomdef.h"
+#include "doomtype.h"
+#include "info.h"
+#include "m_fixed.h"
+#include "p_mobj.h"
+#include "r_defs.h"
+#include "r_state.h"
+#include "tables.h"
 
 //
 // TELEPORTATION

--- a/src/p_tick.c
+++ b/src/p_tick.c
@@ -26,11 +26,18 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <stddef.h>
+
 #include "doomstat.h"
 #include "p_user.h"
 #include "p_spec.h"
 #include "p_tick.h"
 #include "s_musinfo.h" // [crispy] T_MAPMusic()
+#include "d_player.h"
+#include "doomdef.h"
+#include "doomtype.h"
+#include "info.h"
+#include "z_zone.h"
 
 int leveltime;
 int oldleveltime;

--- a/src/p_user.c
+++ b/src/p_user.c
@@ -28,12 +28,22 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <stdlib.h>
+
 #include "doomstat.h"
 #include "d_event.h"
 #include "r_main.h"
 #include "p_map.h"
 #include "p_spec.h"
 #include "p_user.h"
+#include "d_ticcmd.h"
+#include "doomdef.h"
+#include "doomtype.h"
+#include "info.h"
+#include "p_mobj.h"
+#include "p_pspr.h"
+#include "r_data.h"
+#include "r_defs.h"
 
 // Index of the special effects (INVUL inverse) map.
 

--- a/src/p_user.h
+++ b/src/p_user.h
@@ -32,6 +32,8 @@
 #define __P_USER__
 
 #include "d_player.h"
+#include "m_fixed.h"
+#include "tables.h"
 
 void P_PlayerThink(player_t *player);
 void P_CalcHeight(player_t *player);

--- a/src/r_bmaps.c
+++ b/src/r_bmaps.c
@@ -19,10 +19,14 @@
 //	Adapted from doomretro/src/r_data.c:97-209
 //
 
+#include <string.h>
+
 #include "doomtype.h"
 #include "doomstat.h"
 #include "r_data.h"
 #include "w_wad.h"
+#include "doomdef.h"
+#include "info.h"
 
 int brightmaps;
 

--- a/src/r_bsp.c
+++ b/src/r_bsp.c
@@ -26,6 +26,8 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <string.h>
+
 #include "doomstat.h"
 #include "m_bbox.h"
 #include "i_system.h"
@@ -34,6 +36,15 @@
 #include "r_segs.h"
 #include "r_plane.h"
 #include "r_things.h"
+#include "d_player.h"
+#include "doomdata.h"
+#include "doomdef.h"
+#include "doomtype.h"
+#include "m_fixed.h"
+#include "p_mobj.h"
+#include "r_defs.h"
+#include "r_state.h"
+#include "tables.h"
 
 seg_t     *curline;
 side_t    *sidedef;

--- a/src/r_data.c
+++ b/src/r_data.c
@@ -27,6 +27,12 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wchar.h>
+
 #include "doomstat.h"
 #include "p_tick.h"
 #include "w_wad.h"
@@ -38,6 +44,17 @@
 #include "m_swap.h"
 #include "v_video.h" // cr_dark
 #include "r_bmaps.h" // [crispy] R_BrightmapForTexName()
+#include "d_think.h"
+#include "doomdef.h"
+#include "doomtype.h"
+#include "i_system.h"
+#include "info.h"
+#include "m_fixed.h"
+#include "p_mobj.h"
+#include "r_data.h"
+#include "r_defs.h"
+#include "r_state.h"
+#include "z_zone.h"
 
 //
 // Graphics.

--- a/src/r_data.h
+++ b/src/r_data.h
@@ -30,8 +30,11 @@
 #ifndef __R_DATA__
 #define __R_DATA__
 
+#include <limits.h>
+
 #include "r_defs.h"
 #include "r_state.h"
+#include "doomtype.h"
 
 #define LOOKDIRMIN	110 // [crispy] -110, actually
 #define LOOKDIRMAX	90

--- a/src/r_draw.c
+++ b/src/r_draw.c
@@ -28,12 +28,19 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <string.h>
+
 #include "doomstat.h"
 #include "w_wad.h"
 #include "r_draw.h" // [FG]
 #include "r_main.h"
 #include "v_video.h"
 #include "m_menu.h"
+#include "doomdef.h"
+#include "i_system.h"
+#include "i_video.h"
+#include "r_state.h"
+#include "z_zone.h"
 
 #define MAXWIDTH  MAX_SCREENWIDTH          /* kilough 2/8/98 */
 #define MAXHEIGHT MAX_SCREENHEIGHT

--- a/src/r_draw.h
+++ b/src/r_draw.h
@@ -30,6 +30,8 @@
 #define __R_DRAW__
 
 #include "r_defs.h"
+#include "doomtype.h"
+#include "m_fixed.h"
 
 extern lighttable_t *dc_colormap[2];
 extern int      dc_x;

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -28,16 +28,28 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "doomstat.h"
 #include "r_main.h"
 #include "r_things.h"
 #include "r_plane.h"
 #include "r_bsp.h"
 #include "r_draw.h"
-#include "m_bbox.h"
 #include "r_sky.h"
 #include "v_video.h"
 #include "st_stuff.h"
+#include "d_loop.h"
+#include "doomdata.h"
+#include "doomdef.h"
+#include "i_video.h"
+#include "p_mobj.h"
+#include "r_data.h"
+#include "r_state.h"
+#include "z_zone.h"
 
 // Fineangles in the SCREENWIDTH wide window.
 #define FIELDOFVIEW 2048    
@@ -708,7 +720,7 @@ int rendered_visplanes, rendered_segs, rendered_vissprites;
 
 void R_ShowRenderingStats(void)
 {
-  dprintf("Segs %d, Visplanes %d, Sprites %d",
+  doomprintf("Segs %d, Visplanes %d, Sprites %d",
           rendered_segs, rendered_visplanes, rendered_vissprites);
 }
 

--- a/src/r_main.h
+++ b/src/r_main.h
@@ -30,7 +30,10 @@
 #define __R_MAIN__
 
 #include "d_player.h"
-#include "r_data.h"
+#include "m_fixed.h"
+#include "r_defs.h"
+#include "doomtype.h"
+#include "tables.h"
 
 //
 // POV related.

--- a/src/r_plane.c
+++ b/src/r_plane.c
@@ -40,8 +40,10 @@
 //
 //-----------------------------------------------------------------------------
 
-#include "z_zone.h"  /* memory allocation wrappers -- killough */
+#include <stdlib.h>
+#include <string.h>
 
+#include "z_zone.h"
 #include "doomstat.h"
 #include "w_wad.h"
 #include "r_main.h"
@@ -51,6 +53,10 @@
 #include "r_plane.h"
 #include "r_bmaps.h" // [crispy] R_BrightmapForTexName()
 #include "r_swirl.h" // [crispy] R_DistortedFlat()
+#include "doomtype.h"
+#include "i_system.h"
+#include "r_state.h"
+#include "tables.h"
 
 #define MAXVISPLANES 128    /* must be a power of 2 */
 

--- a/src/r_plane.h
+++ b/src/r_plane.h
@@ -30,6 +30,9 @@
 #define __R_PLANE__
 
 #include "r_data.h"
+#include "doomdef.h"
+#include "m_fixed.h"
+#include "r_defs.h"
 
 // killough 10/98: special mask indicates sky flat comes from sidedef
 #define PL_SKYFLAT (0x80000000)

--- a/src/r_segs.c
+++ b/src/r_segs.c
@@ -28,9 +28,11 @@
 //
 // 4/25/98, 5/2/98 killough: reformatted, beautified
 
+#include <limits.h>
+#include <string.h>
+
 #include "doomstat.h"
 #include "i_video.h"
-#include "p_tick.h"
 #include "r_main.h"
 #include "r_bsp.h"
 #include "r_plane.h"
@@ -38,6 +40,16 @@
 #include "r_draw.h"
 #include "w_wad.h"
 #include "r_bmaps.h" // [crispy] brightmaps
+#include "doomdata.h"
+#include "doomdef.h"
+#include "doomtype.h"
+#include "i_system.h"
+#include "m_fixed.h"
+#include "r_data.h"
+#include "r_defs.h"
+#include "r_state.h"
+#include "tables.h"
+#include "z_zone.h"
 
 // OPTIMIZE: closed two sided lines as single sided
 

--- a/src/r_sky.c
+++ b/src/r_sky.c
@@ -31,9 +31,15 @@
 //-----------------------------------------------------------------------------
 
 #include "r_sky.h"
+
+#include <limits.h>
+#include <stddef.h>
+
 #include "r_state.h" // [FG] textureheight[]
 #include "r_data.h"
 #include "w_wad.h"
+#include "m_fixed.h"
+#include "z_zone.h"
 
 // [FG] stretch short skies
 boolean stretchsky;

--- a/src/r_sky.h
+++ b/src/r_sky.h
@@ -30,6 +30,7 @@
 #define __R_SKY__
 
 #include "m_fixed.h"
+#include "doomtype.h"
 
 // SKY, store the number for name.
 #define SKYFLATNAME  "F_SKY1"

--- a/src/r_swirl.c
+++ b/src/r_swirl.c
@@ -19,12 +19,15 @@
 
 // [crispy] adapted from smmu/r_ripple.c, by Simon Howard
 
-#include "doomstat.h"
+#include <stddef.h>
 
+#include "doomstat.h"
 #include "i_system.h"
 #include "w_wad.h"
-
 #include "tables.h"
+#include "doomtype.h"
+#include "m_fixed.h"
+#include "z_zone.h"
 
 
 // swirl factors determine the number of waves per flat width

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -27,6 +27,10 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "doomstat.h"
 #include "i_video.h"
 #include "v_video.h"
@@ -38,6 +42,16 @@
 #include "r_things.h"
 #include "r_bmaps.h" // [crispy] R_BrightmapForTexName()
 #include "m_swap.h"
+#include "d_player.h"
+#include "doomtype.h"
+#include "i_system.h"
+#include "info.h"
+#include "p_mobj.h"
+#include "p_pspr.h"
+#include "r_data.h"
+#include "r_state.h"
+#include "tables.h"
+#include "z_zone.h"
 
 #define MINZ        (FRACUNIT*4)
 #define BASEYCENTER 100

--- a/src/s_musinfo.c
+++ b/src/s_musinfo.c
@@ -24,17 +24,14 @@
 // HEADER FILES ------------------------------------------------------------
 
 #include <string.h>
-#include <stdlib.h>
-#include "doomstat.h"
-#include "m_io.h"
+#include <stdio.h>
+
 #include "i_system.h"
 #include "m_misc.h"
 #include "m_misc2.h"
-#include "r_defs.h"
 #include "s_sound.h"
 #include "w_wad.h"
 #include "z_zone.h"
-
 #include "s_musinfo.h"
 
 // MACROS ------------------------------------------------------------------

--- a/src/s_musinfo.h
+++ b/src/s_musinfo.h
@@ -23,6 +23,7 @@
 #define __S_MUSINFO__
 
 #include "p_mobj.h"
+#include "doomtype.h"
 
 #define MAX_MUS_ENTRIES 65 // [crispy] 0 to 64 inclusive
 

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -29,14 +29,26 @@
 // killough 3/7/98: modified to allow arbitrary listeners in spy mode
 // killough 5/2/98: reindented, removed useless code, beautified
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "doomstat.h"
 #include "s_sound.h"
 #include "s_musinfo.h" // [crispy] struct musinfo
 #include "i_sound.h"
 #include "r_main.h"
 #include "m_random.h"
-#include "m_misc2.h"
 #include "w_wad.h"
+#include "d_player.h"
+#include "doomdef.h"
+#include "i_system.h"
+#include "m_fixed.h"
+#include "r_defs.h"
+#include "sounds.h"
+#include "tables.h"
+#include "u_mapinfo.h"
+#include "z_zone.h"
 
 // when to clip out sounds
 // Does not fit the large outdoor areas.

--- a/src/s_sound.h
+++ b/src/s_sound.h
@@ -30,6 +30,7 @@
 #define __S_SOUND__
 
 #include "p_mobj.h"
+#include "doomtype.h"
 
 //
 // Initializes sound stuff, including volume

--- a/src/sounds.c
+++ b/src/sounds.c
@@ -30,7 +30,8 @@
 
 // killough 5/3/98: reformatted
 
-#include "doomtype.h"
+#include <stddef.h>
+
 #include "sounds.h"
 
 //

--- a/src/st_lib.c
+++ b/src/st_lib.c
@@ -27,14 +27,16 @@
 //
 //-----------------------------------------------------------------------------
 
-#include "doomdef.h"
-#include "doomstat.h"
+#include <stddef.h>
+
 #include "v_video.h"
 #include "w_wad.h"
 #include "st_stuff.h"
 #include "st_lib.h"
-#include "r_main.h"
 #include "m_swap.h"
+#include "i_system.h"
+#include "i_video.h"
+#include "z_zone.h"
 
 int sts_always_red;      //jff 2/18/98 control to disable status color changes
 int sts_pct_always_gray; // killough 2/21/98: always gray %'s? bug or feature?

--- a/src/st_lib.h
+++ b/src/st_lib.h
@@ -32,6 +32,7 @@
 // We are referring to patches.
 #include "r_defs.h"
 #include "v_video.h"  // color ranges
+#include "doomtype.h"
 
 //
 // Background and foreground screen numbers

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -29,6 +29,8 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <stdio.h>
+
 #include "doomdef.h"
 #include "doomstat.h"
 #include "m_random.h"
@@ -40,11 +42,17 @@
 #include "r_main.h"
 #include "am_map.h"
 #include "m_cheat.h"
-#include "s_sound.h"
-#include "sounds.h"
-#include "dstrings.h"
 #include "m_misc2.h"
 #include "m_swap.h"
+#include "d_items.h"
+#include "d_player.h"
+#include "p_mobj.h"
+#include "r_data.h"
+#include "r_defs.h"
+#include "r_state.h"
+#include "tables.h"
+#include "v_video.h"
+#include "z_zone.h"
 
 // [crispy] immediately redraw status bar after help screens have been shown
 extern boolean inhelpscreens;

--- a/src/st_stuff.h
+++ b/src/st_stuff.h
@@ -33,6 +33,7 @@
 
 #include "doomtype.h"
 #include "d_event.h"
+#include "doomdef.h"
 
 // Size of statusbar.
 // Now sensitive for scaling.

--- a/src/statdump.c
+++ b/src/statdump.c
@@ -20,14 +20,12 @@
  */
 
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
 #include "doomdef.h"
 #include "d_player.h"
 #include "m_argv.h"
 #include "m_io.h"
-
 #include "statdump.h"
 
 /* Par times for E1M1-E1M9. */

--- a/src/statdump.h
+++ b/src/statdump.h
@@ -17,6 +17,8 @@
 #ifndef DOOM_STATDUMP_H
 #define DOOM_STATDUMP_H
 
+#include "d_player.h"
+
 void StatCopy(const wbstartstruct_t *stats);
 void StatDump(void);
 

--- a/src/u_mapinfo.c
+++ b/src/u_mapinfo.c
@@ -22,10 +22,8 @@
 #include <string.h>
 #include <ctype.h>
 
-#include "info.h"
 #include "m_misc2.h"
 #include "u_scanner.h"
-
 #include "u_mapinfo.h"
 
 void M_AddEpisode(const char *map, const char *gfx, const char *txt, const char *alpha);

--- a/src/u_mapinfo.h
+++ b/src/u_mapinfo.h
@@ -21,6 +21,8 @@
 #ifndef __UMAPINFO_H
 #define __UMAPINFO_H
 
+#include <stddef.h>
+
 #include "doomtype.h"
 
 typedef struct

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -30,13 +30,16 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <string.h>
+
 #include "doomstat.h"
-#include "r_main.h"
-#include "m_bbox.h"
 #include "w_wad.h"   /* needed for color translation lump lookup */
 #include "v_video.h"
 #include "i_video.h"
 #include "m_swap.h"
+#include "doomdef.h"
+#include "i_system.h"
+#include "z_zone.h"
 
 // Each screen is [SCREENWIDTH*SCREENHEIGHT];
 byte *screens[5];

--- a/src/v_video.h
+++ b/src/v_video.h
@@ -37,6 +37,7 @@
 #include "i_video.h"
 // Needed because we are refering to patches.
 #include "r_data.h"
+#include "r_defs.h"
 
 //
 // VIDEO

--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -28,13 +28,13 @@
 
 #include <fcntl.h>
 
-#include "doomstat.h"
 #include "m_io.h"
-
 #include "w_wad.h"
 #include "m_misc2.h" // [FG] M_BaseName()
 #include "m_swap.h"
 #include "d_main.h" // [FG] wadfiles
+#include "i_system.h"
+#include "z_zone.h"
 
 //
 // GLOBALS

--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -27,6 +27,8 @@
 //-----------------------------------------------------------------------------
 
 #include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "m_io.h"
 #include "w_wad.h"

--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -26,6 +26,7 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <ctype.h>
 #include <fcntl.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/w_wad.h
+++ b/src/w_wad.h
@@ -29,6 +29,9 @@
 #ifndef __W_WAD__
 #define __W_WAD__
 
+#include <stddef.h>
+
+#include "doomtype.h"
 //
 // TYPES
 //

--- a/src/wi_stuff.c
+++ b/src/wi_stuff.c
@@ -27,11 +27,13 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <stdio.h>
+#include <string.h>
+
 #include "doomstat.h"
 #include "m_random.h"
 #include "w_wad.h"
 #include "g_game.h"
-#include "r_main.h"
 #include "v_video.h"
 #include "wi_stuff.h"
 #include "s_sound.h"
@@ -39,6 +41,14 @@
 #include "hu_stuff.h"
 #include "m_misc2.h"
 #include "m_swap.h"
+#include "d_event.h"
+#include "d_ticcmd.h"
+#include "doomdef.h"
+#include "doomtype.h"
+#include "i_video.h"
+#include "r_defs.h"
+#include "u_mapinfo.h"
+#include "z_zone.h"
 
 // Ty 03/17/98: flag that new par times have been loaded in d_deh
 extern boolean deh_pars;  

--- a/src/z_zone.c
+++ b/src/z_zone.c
@@ -35,8 +35,13 @@
 //-----------------------------------------------------------------------------
 
 #include "z_zone.h"
-#include "doomstat.h"
+
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "m_argv.h"
+#include "i_system.h"
 
 // Uncomment this to see real-time memory allocation
 // statistics, to and enable extra debugging features
@@ -135,7 +140,7 @@ void Z_PrintStats(void)            // Print allocation statistics
 	virtual_memory;
       double s = 100.0 / total_memory;
       
-      dprintf("%-5lu\t%6.01f%%\tstatic\n"
+      doomprintf("%-5lu\t%6.01f%%\tstatic\n"
 	      "%-5lu\t%6.01f%%\tpurgable\n"
 	      "%-5lu\t%6.01f%%\tfree\n"
 	      "%-5lu\t%6.01f%%\tfragmentary\n"

--- a/src/z_zone.h
+++ b/src/z_zone.h
@@ -34,13 +34,7 @@
 #ifndef __Z_ZONE__
 #define __Z_ZONE__
 
-// Include system definitions so that prototypes become
-// active before macro replacements below are in effect.
-
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <assert.h>
+#include <stddef.h>
 
 #include "doomtype.h"
 
@@ -72,10 +66,8 @@ void Z_DumpHistory(char *);
 #define Z_Realloc(a,b,c,d) (Z_Realloc)  (a,b,c,d,__FILE__,__LINE__)
 #define Z_CheckHeap()      (Z_CheckHeap)(__FILE__,__LINE__)
 
-// dprintf() is already declared in <stdio.h>, define it out of the way
-#define dprintf doomprintf
 // Doom-style printf
-void dprintf(const char *, ...) PRINTF_ATTR(1, 2);
+void doomprintf(const char *, ...) PRINTF_ATTR(1, 2);
 
 void Z_ZoneHistory(char *);
 

--- a/textscreen/txt_button.c
+++ b/textscreen/txt_button.c
@@ -16,13 +16,10 @@
 #include <string.h>
 
 #include "doomkeys.h"
-
 #include "txt_button.h"
 #include "txt_gui.h"
-#include "txt_io.h"
 #include "txt_main.h"
 #include "txt_utf8.h"
-#include "txt_window.h"
 
 static void TXT_ButtonSizeCalc(TXT_UNCAST_ARG(button))
 {

--- a/textscreen/txt_button.h
+++ b/textscreen/txt_button.h
@@ -32,6 +32,8 @@ typedef struct txt_button_s txt_button_t;
 
 #include "txt_widget.h"
 
+struct txt_button_s;
+
 struct txt_button_s
 {
     txt_widget_t widget;

--- a/textscreen/txt_checkbox.c
+++ b/textscreen/txt_checkbox.c
@@ -16,13 +16,11 @@
 #include <string.h>
 
 #include "doomkeys.h"
-
 #include "txt_checkbox.h"
 #include "txt_gui.h"
 #include "txt_io.h"
 #include "txt_main.h"
 #include "txt_utf8.h"
-#include "txt_window.h"
 
 static void TXT_CheckBoxSizeCalc(TXT_UNCAST_ARG(checkbox))
 {

--- a/textscreen/txt_checkbox.h
+++ b/textscreen/txt_checkbox.h
@@ -38,6 +38,8 @@ typedef struct txt_checkbox_s txt_checkbox_t;
 
 #include "txt_widget.h"
 
+struct txt_checkbox_s;
+
 struct txt_checkbox_s
 {
     txt_widget_t widget;

--- a/textscreen/txt_desktop.c
+++ b/textscreen/txt_desktop.c
@@ -17,12 +17,10 @@
 #include <string.h>
 
 #include "doomkeys.h"
-
 #include "txt_desktop.h"
 #include "txt_gui.h"
 #include "txt_io.h"
 #include "txt_main.h"
-#include "txt_separator.h"
 #include "txt_window.h"
 
 #define HELP_KEY KEY_F1

--- a/textscreen/txt_dropdown.c
+++ b/textscreen/txt_dropdown.c
@@ -13,17 +13,15 @@
 //
 
 #include <stdlib.h>
-#include <string.h>
 
 #include "doomkeys.h"
-
 #include "txt_button.h"
 #include "txt_dropdown.h"
 #include "txt_gui.h"
-#include "txt_io.h"
 #include "txt_main.h"
 #include "txt_utf8.h"
 #include "txt_window.h"
+#include "txt_table.h"
 
 typedef struct
 {

--- a/textscreen/txt_dropdown.h
+++ b/textscreen/txt_dropdown.h
@@ -35,6 +35,8 @@ typedef struct txt_dropdown_list_s txt_dropdown_list_t;
 
 #include "txt_widget.h"
 
+struct txt_dropdown_list_s;
+
 //
 // Drop-down list box.
 // 

--- a/textscreen/txt_inputbox.c
+++ b/textscreen/txt_inputbox.c
@@ -18,13 +18,11 @@
 #include <string.h>
 
 #include "doomkeys.h"
-
 #include "txt_inputbox.h"
 #include "txt_gui.h"
 #include "txt_io.h"
 #include "txt_main.h"
 #include "txt_utf8.h"
-#include "txt_window.h"
 
 extern txt_widget_class_t txt_inputbox_class;
 extern txt_widget_class_t txt_int_inputbox_class;

--- a/textscreen/txt_inputbox.h
+++ b/textscreen/txt_inputbox.h
@@ -32,7 +32,12 @@
 
 typedef struct txt_inputbox_s txt_inputbox_t;
 
+#include <stddef.h>
+
 #include "txt_widget.h"
+
+struct txt_inputbox_s;
+struct txt_inputbox_s;
 
 struct txt_inputbox_s
 {

--- a/textscreen/txt_scrollpane.c
+++ b/textscreen/txt_scrollpane.c
@@ -12,18 +12,13 @@
 // GNU General Public License for more details.
 //
 
-#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-#include <math.h>
 
 #include "txt_scrollpane.h"
 #include "txt_gui.h"
-#include "txt_io.h"
 #include "txt_main.h"
 #include "txt_table.h"
-
 #include "doomkeys.h"
 
 #define SCROLLBAR_VERTICAL   (1 << 0)

--- a/textscreen/txt_scrollpane.h
+++ b/textscreen/txt_scrollpane.h
@@ -33,6 +33,8 @@ typedef struct txt_scrollpane_s txt_scrollpane_t;
 
 #include "txt_widget.h"
 
+struct txt_scrollpane_s;
+
 struct txt_scrollpane_s
 {
     txt_widget_t widget;

--- a/textscreen/txt_sdl.c
+++ b/textscreen/txt_sdl.c
@@ -15,15 +15,13 @@
 // Text mode emulation in SDL
 //
 
-#include "SDL.h"
-
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
+#include "SDL.h"
 #include "doomkeys.h"
-
 #include "txt_main.h"
 #include "txt_sdl.h"
 #include "txt_utf8.h"

--- a/textscreen/txt_strut.c
+++ b/textscreen/txt_strut.c
@@ -13,14 +13,8 @@
 //
 
 #include <stdlib.h>
-#include <string.h>
-
-#include "doomkeys.h"
 
 #include "txt_strut.h"
-#include "txt_io.h"
-#include "txt_main.h"
-#include "txt_window.h"
 
 static void TXT_StrutSizeCalc(TXT_UNCAST_ARG(strut))
 {

--- a/textscreen/txt_strut.h
+++ b/textscreen/txt_strut.h
@@ -33,6 +33,8 @@ typedef struct txt_strut_s txt_strut_t;
 
 #include "txt_widget.h"
 
+struct txt_strut_s;
+
 struct txt_strut_s
 {
     txt_widget_t widget;

--- a/textscreen/txt_table.c
+++ b/textscreen/txt_table.c
@@ -14,12 +14,8 @@
 
 #include <stdarg.h>
 #include <stdlib.h>
-#include <string.h>
 
 #include "doomkeys.h"
-
-#include "txt_desktop.h"
-#include "txt_gui.h"
 #include "txt_io.h"
 #include "txt_main.h"
 #include "txt_separator.h"

--- a/textscreen/txt_table.h
+++ b/textscreen/txt_table.h
@@ -66,6 +66,9 @@ typedef struct txt_table_s txt_table_t;
 
 #include "txt_widget.h"
 
+struct txt_table_s;
+struct txt_table_s;
+
 struct txt_table_s
 {
     txt_widget_t widget;

--- a/textscreen/txt_window.c
+++ b/textscreen/txt_window.c
@@ -17,8 +17,6 @@
 #include <stdarg.h>
 #include <string.h>
 
-#include "doomkeys.h"
-
 #include "txt_label.h"
 #include "txt_desktop.h"
 #include "txt_gui.h"
@@ -26,6 +24,7 @@
 #include "txt_main.h"
 #include "txt_separator.h"
 #include "txt_window.h"
+#include "txt_window_action.h"
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN

--- a/textscreen/txt_window.h
+++ b/textscreen/txt_window.h
@@ -48,6 +48,8 @@ typedef struct txt_window_s txt_window_t;
 #include "txt_table.h"
 #include "txt_window_action.h"
 
+struct txt_window_s;
+
 // Callback function for window key presses
 
 typedef int (*TxtWindowKeyPress)(txt_window_t *window, int key,

--- a/textscreen/txt_window_action.h
+++ b/textscreen/txt_window_action.h
@@ -36,6 +36,8 @@ typedef struct txt_window_action_s txt_window_action_t;
 #include "txt_widget.h"
 #include "txt_window.h"
 
+struct txt_window_action_s;
+
 struct txt_window_action_s
 {
     txt_widget_t widget;


### PR DESCRIPTION
https://include-what-you-use.org/ tool is not perfect, it doesn't understand windows.h, SDL.h and differences between MinGW/gcc on Linux. I fixed it manually but it can be automated with [pragmas](https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/IWYUPragmas.md) and [mappings](https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/IWYUMappings.md).

Not sure if it's worth it, our project is relatively small so there aren't many benefits.