### PR TITLE
fix all MSVC warnings

### DIFF
--- a/cmake/WoofSettings.cmake
+++ b/cmake/WoofSettings.cmake
@@ -40,13 +40,22 @@ if(MSVC)
     # Default warning setting for MSVC.
     _checked_add_compile_option(/W3)
 
+    # Treat all warnings as errors.
+    _checked_add_compile_option(/WX)
+
     # Extra warnings for cl.exe.
     _checked_add_compile_option(/we4013) # Implicit function declaration.
     _checked_add_compile_option(/we4133) # Incompatible types.
     _checked_add_compile_option(/we4477) # Format string mismatch.
 
-    # Disable "possible loss of data" warning.
+    # An integer type is converted to a smaller integer type. A possible loss of
+    # data.
     _checked_add_compile_option(/wd4244)
+    # Conversion from 'size_t' to 'type'
+    _checked_add_compile_option(/wd4267)
+    # Using the token operator to compare signed and unsigned numbers required
+    # the compiler to convert the signed value to unsigned.
+    _checked_add_compile_option(/wd4018)
 
     # Extra warnings for clang-cl.exe - prevents warning spam in SDL headers.
     _checked_add_compile_option(-Wno-pragma-pack)

--- a/cmake/WoofSettings.cmake
+++ b/cmake/WoofSettings.cmake
@@ -48,10 +48,10 @@ if(MSVC)
     _checked_add_compile_option(/we4133) # Incompatible types.
     _checked_add_compile_option(/we4477) # Format string mismatch.
 
-    # An integer type is converted to a smaller integer type. A possible loss of
-    # data.
+    # Disable several warnings for cl.exe.
+    # An integer type is converted to a smaller integer type.
     _checked_add_compile_option(/wd4244)
-    # Conversion from 'size_t' to 'type'
+    # Conversion from size_t to a smaller type.
     _checked_add_compile_option(/wd4267)
     # Using the token operator to compare signed and unsigned numbers required
     # the compiler to convert the signed value to unsigned.

--- a/opl/CMakeLists.txt
+++ b/opl/CMakeLists.txt
@@ -1,9 +1,14 @@
+include(WoofSettings)
+
 add_library(opl STATIC
             opl_internal.h
             opl.c           opl.h
             opl_queue.c     opl_queue.h
             opl_sdl.c
             opl3.c          opl3.h)
+
+target_woof_settings(opl)
+
 target_include_directories(opl
                            INTERFACE "."
                            PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../")

--- a/src/am_map.c
+++ b/src/am_map.c
@@ -495,7 +495,7 @@ void AM_changeWindowLoc(void)
   incy = m_paninc.y;
   if (automaprotate)
   {
-    AM_rotate(&incx, &incy, viewangle - ANG90);
+    AM_rotate(&incx, &incy, ANGLE_MAX - mapangle);
   }
   m_x += incx;
   m_y += incy;

--- a/src/am_map.c
+++ b/src/am_map.c
@@ -495,7 +495,7 @@ void AM_changeWindowLoc(void)
   incy = m_paninc.y;
   if (automaprotate)
   {
-    AM_rotate(&incx, &incy, -mapangle);
+    AM_rotate(&incx, &incy, mapangle);
   }
   m_x += incx;
   m_y += incy;

--- a/src/am_map.c
+++ b/src/am_map.c
@@ -495,7 +495,7 @@ void AM_changeWindowLoc(void)
   incy = m_paninc.y;
   if (automaprotate)
   {
-    AM_rotate(&incx, &incy, mapangle);
+    AM_rotate(&incx, &incy, viewangle - ANG90);
   }
   m_x += incx;
   m_y += incy;

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -4751,19 +4751,19 @@ void M_DrawStringCR(int cx, int cy, char *color, const char* ch)
 
 void M_DrawString(int cx, int cy, int color, const char* ch)
 {
-  return M_DrawStringCR(cx, cy, colrngs[color], ch);
+  M_DrawStringCR(cx, cy, colrngs[color], ch);
 }
 
 void M_DrawStringDisable(int cx, int cy, const char* ch)
 {
-  return M_DrawStringCR(cx, cy, cr_dark, ch);
+  M_DrawStringCR(cx, cy, cr_dark, ch);
 }
 
 // cph 2006/08/06 - M_DrawString() is the old M_DrawMenuString, except that it is not tied to menu_buffer
 
 void M_DrawMenuString(int cx, int cy, int color)
 {
-  return M_DrawString(cx, cy, color, menu_buffer);
+  M_DrawString(cx, cy, color, menu_buffer);
 }
 
 // M_GetPixelWidth() returns the number of pixels in the width of


### PR DESCRIPTION
C4244 An integer type is converted to a smaller integer type. A possible loss of data.
C4267 Conversion from 'size_t' to 'type'
Both of these warnings are related to converting the codebase to 64-bit and meaningless with a 32-bit build. Not sure if we should fix them.

C4018 Using the token operator to compare signed and unsigned numbers required the compiler to convert the signed value to unsigned.
There are many `unsigned int` types in the Choco code that can be easily replaced with signed types (such as loop indices).
