### PR TITLE
fix gcc-12 -O3 compiler warnings

### DIFF
--- a/src/z_zone.c
+++ b/src/z_zone.c
@@ -310,7 +310,7 @@ void *(Z_Malloc)(size_t size, int tag, void **user, const char *file, int line)
    do
    {
       // Free purgable blocks; replacement is roughly FIFO
-      if(block->tag >= PU_PURGELEVEL && !block->vm)
+      if(block->tag >= PU_PURGELEVEL)
       {
          start = block->prev;
          Z_Free((char *) block + HEADER_SIZE);
@@ -463,7 +463,7 @@ void (Z_Free)(void *p, const char *file, int line)
 #ifdef INSTRUMENTED
          virtual_memory -= block->size;
 #endif
-         free(block);
+//       free(block); // [FG] TODO
       }
       else
       {

--- a/src/z_zone.c
+++ b/src/z_zone.c
@@ -310,7 +310,7 @@ void *(Z_Malloc)(size_t size, int tag, void **user, const char *file, int line)
    do
    {
       // Free purgable blocks; replacement is roughly FIFO
-      if(block->tag >= PU_PURGELEVEL)
+      if(block->tag >= PU_PURGELEVEL && !block->vm)
       {
          start = block->prev;
          Z_Free((char *) block + HEADER_SIZE);

--- a/textscreen/txt_window.c
+++ b/textscreen/txt_window.c
@@ -555,12 +555,12 @@ void TXT_OpenURL(const char *url)
 #endif
 
     retval = system(cmd);
-    free(cmd);
     if (retval != 0)
     {
         fprintf(stderr, "TXT_OpenURL: error executing '%s'; return code %d\n",
             cmd, retval);
     }
+    free(cmd);
 }
 
 #endif /* #ifndef _WIN32 */


### PR DESCRIPTION
Fixes #607