### PR TITLE
Ask for confirmation on window close event

### DIFF
--- a/src/d_event.h
+++ b/src/d_event.h
@@ -49,6 +49,10 @@ typedef enum
   ev_joyb_down,
   ev_joyb_up,
   ev_joystick,
+
+  // Quit event. Triggered when the user clicks the "close" button
+  // to terminate the application.
+  ev_quit,
 } evtype_t;
 
 // Event structure.

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -739,14 +739,11 @@ void I_GetEvent(void)
                 break;
 
             case SDL_QUIT:
-/*
                 {
                     event_t event;
                     event.type = ev_quit;
                     D_PostEvent(&event);
                 }
-*/
-                I_SafeExit(0);
                 break;
 
             case SDL_WINDOWEVENT:

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -4947,6 +4947,25 @@ boolean M_Responder (event_t* ev)
   int    s_input;
   static int joywait   = 0;
   static int repeat    = MENU_NULL;
+
+  // "close" button pressed on window?
+  if (ev->type == ev_quit)
+  {
+    // First click on close button = bring up quit confirm message.
+    // Second click on close button = confirm quit
+
+    if (menuactive && messageToPrint && messageRoutine == M_QuitResponse)
+    {
+      M_QuitResponse('y');
+    }
+    else
+    {
+      S_StartSound(NULL,sfx_swtchn);
+      M_QuitDOOM(0);
+    }
+
+    return true;
+  }
   
   ch = -1; // will be changed to a legit char if we're going to use it here
   action = MENU_NULL;


### PR DESCRIPTION
Ask for confirmation on `SDL_QUIT` (triggered when e.g. closing the game window), in order to avoid accidentally closing the game and losing progress

The code is a trivial port from Chocolate Doom (GPL2), see:
* https://github.com/chocolate-doom/chocolate-doom/commit/5014caee2a000ffd682f04bcbec76265b2163335
* https://github.com/chocolate-doom/chocolate-doom/commit/15f1bce94eec21fe9e11ee7e6745d01ccd4cfa70