### PR TITLE
Pan/zoom automap faster by holding run button

### DIFF
--- a/src/am_map.c
+++ b/src/am_map.c
@@ -89,10 +89,6 @@ int map_keyed_door_flash; // keyed doors are flashing
 // pulls out to 0.5x in 1 second
 #define M_ZOOMOUT       ((int) (FRACUNIT/1.02))
 
-// [crispy] zoom faster by holding run button
-#define M1_ZOOMIN       ((int) (1.07*FRACUNIT))
-#define M1_ZOOMOUT      ((int) (FRACUNIT/1.07))
-
 // [crispy] zoom faster with the mouse wheel
 #define M2_ZOOMIN       ((int) (1.08*FRACUNIT))
 #define M2_ZOOMOUT      ((int) (FRACUNIT/1.08))
@@ -105,6 +101,7 @@ static int m_zoomin_kbd;
 static int m_zoomout_kbd;
 static int m_zoomin_mouse;
 static int m_zoomout_mouse;
+static boolean mousewheelzoom;
 
 // translates between frame-buffer and map distances
 // [FG] fix int overflow that causes map and grid lines to disappear
@@ -554,6 +551,7 @@ void AM_initVariables(void)
   m_paninc.x = m_paninc.y = 0;
   ftom_zoommul = FRACUNIT;
   mtof_zoommul = FRACUNIT;
+  mousewheelzoom = false; // [crispy]
 
   m_w = FTOM(f_w);
   m_h = FTOM(f_h);
@@ -755,8 +753,8 @@ boolean AM_Responder
   if (M_InputGameActive(input_speed))
   {
     f_paninc = F2_PANINC;
-    m_zoomin_kbd = M1_ZOOMIN;
-    m_zoomout_kbd = M1_ZOOMOUT;
+    m_zoomin_kbd = M2_ZOOMIN;
+    m_zoomout_kbd = M2_ZOOMOUT;
     m_zoomin_mouse = M2_ZOOMINFAST;
     m_zoomout_mouse = M2_ZOOMOUTFAST;
   }
@@ -811,6 +809,7 @@ boolean AM_Responder
       if (ev->type == ev_mouseb_down &&
       	(ev->data1 == MOUSE_BUTTON_WHEELUP || ev->data1 == MOUSE_BUTTON_WHEELDOWN))
       {
+        mousewheelzoom = true;
         mtof_zoommul = m_zoomout_mouse;
         ftom_zoommul = m_zoomin_mouse;
       }
@@ -825,6 +824,7 @@ boolean AM_Responder
       if (ev->type == ev_mouseb_down &&
       	(ev->data1 == MOUSE_BUTTON_WHEELUP || ev->data1 == MOUSE_BUTTON_WHEELDOWN))
       {
+        mousewheelzoom = true;
         mtof_zoommul = m_zoomin_mouse;
         ftom_zoommul = m_zoomout_mouse;
       }
@@ -927,8 +927,7 @@ boolean AM_Responder
     else if (M_InputDeactivated(input_map_zoomout) ||
              M_InputDeactivated(input_map_zoomin))
     {
-      if (ftom_zoommul != M2_ZOOMOUT && ftom_zoommul != M2_ZOOMIN
-      &&  ftom_zoommul != M2_ZOOMOUTFAST && ftom_zoommul != M2_ZOOMINFAST)
+      if (!mousewheelzoom)
       {
         mtof_zoommul = FRACUNIT;
         ftom_zoommul = FRACUNIT;
@@ -952,11 +951,11 @@ void AM_changeWindowScale(void)
   scale_ftom = FixedDiv(FRACUNIT, scale_mtof);
 
   // [crispy] reset after zooming with the mouse wheel
-  if (ftom_zoommul == M2_ZOOMIN || ftom_zoommul == M2_ZOOMOUT
-  ||  ftom_zoommul == M2_ZOOMINFAST || ftom_zoommul == M2_ZOOMOUTFAST)
+  if (mousewheelzoom)
   {
     mtof_zoommul = FRACUNIT;
     ftom_zoommul = FRACUNIT;
+    mousewheelzoom = false;
   }
 
   if (scale_mtof < min_scale_mtof)

--- a/src/am_map.c
+++ b/src/am_map.c
@@ -81,7 +81,7 @@ int map_keyed_door_flash; // keyed doors are flashing
 // moves 140 pixels in 1 second
 #define F_PANINC  4
 // [crispy] pan faster by holding run button
-#define F2_PANINC 8
+#define F2_PANINC 12
 // how much zoom-in per tic
 // goes to 2x in 1 second
 #define M_ZOOMIN        ((int) (1.02*FRACUNIT))

--- a/src/am_map.c
+++ b/src/am_map.c
@@ -89,6 +89,10 @@ int map_keyed_door_flash; // keyed doors are flashing
 // pulls out to 0.5x in 1 second
 #define M_ZOOMOUT       ((int) (FRACUNIT/1.02))
 
+// [crispy] zoom faster by holding run button
+#define M1_ZOOMIN       ((int) (1.07*FRACUNIT))
+#define M1_ZOOMOUT      ((int) (FRACUNIT/1.07))
+
 // [crispy] zoom faster with the mouse wheel
 #define M2_ZOOMIN       ((int) (1.08*FRACUNIT))
 #define M2_ZOOMOUT      ((int) (FRACUNIT/1.08))
@@ -99,8 +103,8 @@ int map_keyed_door_flash; // keyed doors are flashing
 static int f_paninc;
 static int m_zoomin_kbd;
 static int m_zoomout_kbd;
-// static int m_zoomin_mouse;
-// static int m_zoomout_mouse;
+static int m_zoomin_mouse;
+static int m_zoomout_mouse;
 
 // translates between frame-buffer and map distances
 // [FG] fix int overflow that causes map and grid lines to disappear
@@ -751,18 +755,18 @@ boolean AM_Responder
   if (M_InputGameActive(input_speed))
   {
     f_paninc = F2_PANINC;
-    m_zoomin_kbd = M2_ZOOMIN;
-    m_zoomout_kbd = M2_ZOOMOUT;
-    // m_zoomin_mouse = M2_ZOOMINFAST;
-    // m_zoomout_mouse = M2_ZOOMOUTFAST;
+    m_zoomin_kbd = M1_ZOOMIN;
+    m_zoomout_kbd = M1_ZOOMOUT;
+    m_zoomin_mouse = M2_ZOOMINFAST;
+    m_zoomout_mouse = M2_ZOOMOUTFAST;
   }
   else
   {
     f_paninc = F_PANINC;
     m_zoomin_kbd = M_ZOOMIN;
     m_zoomout_kbd = M_ZOOMOUT;
-    // m_zoomin_mouse = M2_ZOOMIN;
-    // m_zoomout_mouse = M2_ZOOMOUT;
+    m_zoomin_mouse = M2_ZOOMIN;
+    m_zoomout_mouse = M2_ZOOMOUT;
   }
 
   rc = false;
@@ -807,8 +811,8 @@ boolean AM_Responder
       if (ev->type == ev_mouseb_down &&
       	(ev->data1 == MOUSE_BUTTON_WHEELUP || ev->data1 == MOUSE_BUTTON_WHEELDOWN))
       {
-        mtof_zoommul = M2_ZOOMOUT;
-        ftom_zoommul = M2_ZOOMIN;
+        mtof_zoommul = m_zoomout_mouse;
+        ftom_zoommul = m_zoomin_mouse;
       }
       else
       {
@@ -821,8 +825,8 @@ boolean AM_Responder
       if (ev->type == ev_mouseb_down &&
       	(ev->data1 == MOUSE_BUTTON_WHEELUP || ev->data1 == MOUSE_BUTTON_WHEELDOWN))
       {
-        mtof_zoommul = M2_ZOOMIN;
-        ftom_zoommul = M2_ZOOMOUT;
+        mtof_zoommul = m_zoomin_mouse;
+        ftom_zoommul = m_zoomout_mouse;
       }
       else
       {
@@ -923,7 +927,8 @@ boolean AM_Responder
     else if (M_InputDeactivated(input_map_zoomout) ||
              M_InputDeactivated(input_map_zoomin))
     {
-      if (ftom_zoommul != M2_ZOOMOUT && ftom_zoommul != M2_ZOOMIN)
+      if (ftom_zoommul != M2_ZOOMOUT && ftom_zoommul != M2_ZOOMIN
+      &&  ftom_zoommul != M2_ZOOMOUTFAST && ftom_zoommul != M2_ZOOMINFAST)
       {
         mtof_zoommul = FRACUNIT;
         ftom_zoommul = FRACUNIT;
@@ -947,7 +952,8 @@ void AM_changeWindowScale(void)
   scale_ftom = FixedDiv(FRACUNIT, scale_mtof);
 
   // [crispy] reset after zooming with the mouse wheel
-  if (ftom_zoommul == M2_ZOOMIN || ftom_zoommul == M2_ZOOMOUT)
+  if (ftom_zoommul == M2_ZOOMIN || ftom_zoommul == M2_ZOOMOUT
+  ||  ftom_zoommul == M2_ZOOMINFAST || ftom_zoommul == M2_ZOOMOUTFAST)
   {
     mtof_zoommul = FRACUNIT;
     ftom_zoommul = FRACUNIT;

--- a/src/am_map.c
+++ b/src/am_map.c
@@ -80,6 +80,8 @@ int map_keyed_door_flash; // keyed doors are flashing
 // how much the automap moves window per tic in frame-buffer coordinates
 // moves 140 pixels in 1 second
 #define F_PANINC  4
+// [crispy] pan faster by holding run button
+#define F2_PANINC 8
 // how much zoom-in per tic
 // goes to 2x in 1 second
 #define M_ZOOMIN        ((int) (1.02*FRACUNIT))
@@ -90,6 +92,15 @@ int map_keyed_door_flash; // keyed doors are flashing
 // [crispy] zoom faster with the mouse wheel
 #define M2_ZOOMIN       ((int) (1.08*FRACUNIT))
 #define M2_ZOOMOUT      ((int) (FRACUNIT/1.08))
+#define M2_ZOOMINFAST   ((int) (1.5*FRACUNIT))
+#define M2_ZOOMOUTFAST  ((int) (FRACUNIT/1.5))
+
+// [crispy] toggleable pan/zoom speed
+static int f_paninc;
+static int m_zoomin_kbd;
+static int m_zoomout_kbd;
+// static int m_zoomin_mouse;
+// static int m_zoomout_mouse;
 
 // translates between frame-buffer and map distances
 // [FG] fix int overflow that causes map and grid lines to disappear
@@ -737,6 +748,23 @@ boolean AM_Responder
   static int bigstate=0;
   static char buffer[20];
 
+  if (M_InputGameActive(input_speed))
+  {
+    f_paninc = F2_PANINC;
+    m_zoomin_kbd = M2_ZOOMIN;
+    m_zoomout_kbd = M2_ZOOMOUT;
+    // m_zoomin_mouse = M2_ZOOMINFAST;
+    // m_zoomout_mouse = M2_ZOOMOUTFAST;
+  }
+  else
+  {
+    f_paninc = F_PANINC;
+    m_zoomin_kbd = M_ZOOMIN;
+    m_zoomout_kbd = M_ZOOMOUT;
+    // m_zoomin_mouse = M2_ZOOMIN;
+    // m_zoomout_mouse = M2_ZOOMOUT;
+  }
+
   rc = false;
 
   if (!automapactive)
@@ -756,22 +784,22 @@ boolean AM_Responder
                                                                 // phares
     if (M_InputActivated(input_map_right))                      //    |
       if (!followplayer && !automapoverlay)                     //    V
-        m_paninc.x = FTOM(F_PANINC);
+        m_paninc.x = FTOM(f_paninc);
       else
         rc = false;
     else if (M_InputActivated(input_map_left))
       if (!followplayer && !automapoverlay)
-          m_paninc.x = -FTOM(F_PANINC);
+          m_paninc.x = -FTOM(f_paninc);
       else
           rc = false;
     else if (M_InputActivated(input_map_up))
       if (!followplayer && !automapoverlay)
-          m_paninc.y = FTOM(F_PANINC);
+          m_paninc.y = FTOM(f_paninc);
       else
           rc = false;
     else if (M_InputActivated(input_map_down))
       if (!followplayer && !automapoverlay)
-          m_paninc.y = -FTOM(F_PANINC);
+          m_paninc.y = -FTOM(f_paninc);
       else
           rc = false;
     else if (M_InputActivated(input_map_zoomout))
@@ -784,8 +812,8 @@ boolean AM_Responder
       }
       else
       {
-        mtof_zoommul = M_ZOOMOUT;
-        ftom_zoommul = M_ZOOMIN;
+        mtof_zoommul = m_zoomout_kbd;
+        ftom_zoommul = m_zoomin_kbd;
       }
     }
     else if (M_InputActivated(input_map_zoomin))
@@ -798,8 +826,8 @@ boolean AM_Responder
       }
       else
       {
-        mtof_zoommul = M_ZOOMIN;
-        ftom_zoommul = M_ZOOMOUT;
+        mtof_zoommul = m_zoomin_kbd;
+        ftom_zoommul = m_zoomout_kbd;
       }
     }
     else if (M_InputActivated(input_map))


### PR DESCRIPTION
I'm afraid I need some help here. What I have got at this moment:

* Fast panning working just fine.
* Fast keyboard zoom have notable delay before start zooming. Standard zooming still fine though.
* Fast mouse wheel zoom isn't working at all. Really no idea why, I've left it commented out for now.

This PR was used as reference: https://github.com/fabiangreffrath/crispy-doom/pull/906/commits/e4233bc82e753c7b0d4cadb8dca8878832ee07d3