### PR TITLE
Keep arrow stable in non-rotate mode

### DIFF
--- a/src/am_map.c
+++ b/src/am_map.c
@@ -1667,16 +1667,18 @@ void AM_rotate
 static void AM_rotatePoint(mpoint_t *pt)
 {
   int64_t tmpx;
+  // [crispy] smooth automap rotation
+  const angle_t smoothangle = (!(!followplayer && automapoverlay)) ? ANG90 - viewangle : mapangle;
 
   pt->x -= mapcenter.x;
   pt->y -= mapcenter.y;
 
-  tmpx = (int64_t)FixedMul(pt->x, finecosine[mapangle>>ANGLETOFINESHIFT])
-       - (int64_t)FixedMul(pt->y, finesine[mapangle>>ANGLETOFINESHIFT])
+  tmpx = (int64_t)FixedMul(pt->x, finecosine[smoothangle>>ANGLETOFINESHIFT])
+       - (int64_t)FixedMul(pt->y, finesine[smoothangle>>ANGLETOFINESHIFT])
        + mapcenter.x;
 
-  pt->y = (int64_t)FixedMul(pt->x, finesine[mapangle>>ANGLETOFINESHIFT])
-        + (int64_t)FixedMul(pt->y, finecosine[mapangle>>ANGLETOFINESHIFT])
+  pt->y = (int64_t)FixedMul(pt->x, finesine[smoothangle>>ANGLETOFINESHIFT])
+        + (int64_t)FixedMul(pt->y, finecosine[smoothangle>>ANGLETOFINESHIFT])
         + mapcenter.y;
 
   pt->x = tmpx;
@@ -2073,7 +2075,7 @@ void AM_Drawer (void)
     // if not following the player
     if (followplayer || !automapoverlay)
     {
-      mapangle = ANG90 - viewangle;
+      mapangle = ANG90 - plr->mo->angle;
     }
   }
 

--- a/src/am_map.c
+++ b/src/am_map.c
@@ -1668,7 +1668,7 @@ static void AM_rotatePoint(mpoint_t *pt)
 {
   int64_t tmpx;
   // [crispy] smooth automap rotation
-  const angle_t smoothangle = (!(!followplayer && automapoverlay)) ? ANG90 - viewangle : mapangle;
+  const angle_t smoothangle = (followplayer || !automapoverlay) ? ANG90 - viewangle : mapangle;
 
   pt->x -= mapcenter.x;
   pt->y -= mapcenter.y;


### PR DESCRIPTION
This keeps arrow stable in non-rotate mode with preserving smooth rotation.

Extra suggestion: do not draw little dot in follow mode? 