### PR TITLE
Optimization for drawing huge amount of drawsegs

### DIFF
--- a/src/r_things.c
+++ b/src/r_things.c
@@ -1086,7 +1086,6 @@ void R_DrawMasked(void)
 {
   int i;
   drawseg_t *ds;
-  const int cx = centerx;
 
   R_SortVisSprites();
 
@@ -1119,13 +1118,13 @@ void R_DrawMasked(void)
         drawsegs_xranges[0].items[drawsegs_xranges[0].count].user = ds;
         
         // e6y: ~13% of speed improvement on sunder.wad map10
-        if (ds->x1 < cx)
+        if (ds->x1 < centerx)
         {
           drawsegs_xranges[1].items[drawsegs_xranges[1].count] = 
             drawsegs_xranges[0].items[drawsegs_xranges[0].count];
           drawsegs_xranges[1].count++;
         }
-        if (ds->x2 >= cx)
+        if (ds->x2 >= centerx)
         {
           drawsegs_xranges[2].items[drawsegs_xranges[2].count] = 
             drawsegs_xranges[0].items[drawsegs_xranges[0].count];
@@ -1145,12 +1144,12 @@ void R_DrawMasked(void)
   {
     vissprite_t* spr = vissprite_ptrs[i];
 
-    if (spr->x2 < cx)
+    if (spr->x2 < centerx)
     {
       drawsegs_xrange = drawsegs_xranges[1].items;
       drawsegs_xrange_count = drawsegs_xranges[1].count;
     }
-    else if (spr->x1 >= cx)
+    else if (spr->x1 >= centerx)
     {
       drawsegs_xrange = drawsegs_xranges[2].items;
       drawsegs_xrange_count = drawsegs_xranges[2].count;

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -976,18 +976,18 @@ void R_DrawSprite (vissprite_t* spr)
       ds = curr->user;
 
       if (ds->scale1 > ds->scale2)
-      {
-        lowscale = ds->scale2;
-        scale = ds->scale1;
-      }
+        {
+          lowscale = ds->scale2;
+          scale = ds->scale1;
+        }
       else
-      {
-        lowscale = ds->scale1;
-        scale = ds->scale2;
-      }
+        {
+          lowscale = ds->scale1;
+          scale = ds->scale2;
+        }
 
-      if (scale < spr->scale || (lowscale < spr->scale
-      && !R_PointOnSegSide (spr->gx, spr->gy, ds->curline)))
+      if (scale < spr->scale || (lowscale < spr->scale &&
+                    !R_PointOnSegSide (spr->gx, spr->gy, ds->curline)))
       {
         if (ds->maskedtexturecol)       // masked mid texture?
         {

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -1086,7 +1086,7 @@ void R_DrawMasked(void)
 {
   int i;
   drawseg_t *ds;
-  const int cx = MAX_SCREENWIDTH / 2;
+  const int cx = centerx;
 
   R_SortVisSprites();
 
@@ -1104,9 +1104,9 @@ void R_DrawMasked(void)
       drawsegs_xrange_size = 2 * maxdrawsegs;
       for(i = 0; i < DS_RANGES_COUNT; i++)
       {
-        drawsegs_xranges[i].items = realloc(
+        drawsegs_xranges[i].items = Z_Realloc(
           drawsegs_xranges[i].items,
-          drawsegs_xrange_size * sizeof(drawsegs_xranges[i].items[0]));
+          drawsegs_xrange_size * sizeof(drawsegs_xranges[i].items[0]), PU_STATIC, 0);
       }
     }
     for (ds = ds_p; ds-- > drawsegs;)

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -1106,7 +1106,8 @@ void R_DrawMasked(void)
       {
         drawsegs_xranges[i].items = Z_Realloc(
           drawsegs_xranges[i].items,
-          drawsegs_xrange_size * sizeof(drawsegs_xranges[i].items[0]), PU_STATIC, 0);
+          drawsegs_xrange_size * sizeof(drawsegs_xranges[i].items[0]),
+          PU_STATIC, 0);
       }
     }
     for (ds = ds_p; ds-- > drawsegs;)


### PR DESCRIPTION
All credits goes to Andrey Budko (entryway). Important notes:

* This optimization significantly increasing performance for drawing huge amount of drawsegs. Optimal map for testing is [Planisphere ﻿2](https://www.doomworld.com/forum/topic/61701-planisphere-2/?page=2&tab=comments#comment-1884524).
* I have tried to preserve MBF coding style with two spaces. The diff in `R_DrawSprite` is slightly higher than it could be, but there is no choice really: without extra spaces code lines will look really messed up.
* Additionally checked BOOMEDIT.WAD with fake water flats - everything is fine.
* I remember there were some objections with applying optimizations, so I'll have to explain my POV:
_Optimizations themselves are not only about higher FPS (35 fps should be enough for everyone). Most important, that optimizations are stands for more effective code, which making things not only "faster", but uses less CPU power and makes less noise from CPU fans. Also, other optimizations were already ported from PrBoom+, so I believe we will be okay to apply this one._
* Woof? 🐶