### PR TITLE
umapinfo: fix desync in finale skipping

### DIFF
--- a/src/f_finale.c
+++ b/src/f_finale.c
@@ -294,7 +294,7 @@ void F_Ticker(void)
   if (!demo_compatibility)
     WI_checkForAccelerate();  // killough 3/28/98: check for acceleration
   else
-    if (gamemode == commercial && finalecount > 50) // check for skipping
+    if (gamemode == commercial && (using_FMI || finalecount > 50)) // check for skipping
       for (i=0; i<MAXPLAYERS; i++)
         if (players[i].cmd.buttons)
           goto next_level;      // go on to the next level


### PR DESCRIPTION
Fixes desync in DBP37_AUGZEN.wad AUGZEND2ALL-00027.lmp [[dsda]](https://dsdarchive.com/files/demos/dbp37_augzen/61802/AugZenD2All.zip)