### PR TITLE
Switch automap to FRACTOMAPBITS coordinate system

### DIFF
--- a/src/am_map.c
+++ b/src/am_map.c
@@ -76,6 +76,7 @@ int map_keyed_door_flash; // keyed doors are flashing
 // [Woof!] FRACTOMAPBITS: overflow-safe coordinate system.
 // Written by Andrey Budko (entryway), adapted from prboom-plus/src/am_map.*
 #define MAPBITS 12
+#define MAPUNIT (1<<MAPBITS)
 #define FRACTOMAPBITS (FRACBITS-MAPBITS)
 
 // [Woof!] New radius to use with FRACTOMAPBITS, since orginal 
@@ -657,7 +658,13 @@ void AM_LevelInit(void)
 
   AM_findMinMaxBoundaries();
 
-  scale_mtof = FixedDiv(min_scale_mtof, (int) (0.7*FRACUNIT));
+  // [crispy] initialize zoomlevel on all maps so that a 4096 units
+  // square map would just fit in (MAP01 is 3376x3648 units)
+  {
+    fixed_t a = FixedDiv(f_w, (max_w>>MAPBITS < 2048) ? 2*(max_w>>MAPBITS) : 4096);
+    fixed_t b = FixedDiv(f_h, (max_h>>MAPBITS < 2048) ? 2*(max_h>>MAPBITS) : 4096);
+    scale_mtof = FixedDiv(a < b ? a : b, (int) (0.7*MAPUNIT));
+  }
 
   if (scale_mtof > max_scale_mtof)
     scale_mtof = min_scale_mtof;

--- a/src/am_map.c
+++ b/src/am_map.c
@@ -1830,8 +1830,8 @@ void AM_drawPlayers(void)
     else
       color = mapcolor_plyr[their_color];   //jff 1/6/98 use default color
 
-    pt.x = p->mo->x;
-    pt.y = p->mo->y;
+    pt.x = p->mo->x >> FRACTOMAPBITS;
+    pt.y = p->mo->y >> FRACTOMAPBITS;
     if (automaprotate)
     {
       AM_rotatePoint(&pt);


### PR DESCRIPTION
📝 Notes:

* Andrey's comments are always `//e6y`, no sentences, that's why they are omited.
* I was forced to remove "initialize zoomlevel on all maps so that a 4096 units" as it was causing problems with finding map boundaries on some maps. 
* Visually, automap and it's default zoom levels are still same to previous implementation.

🐛 Extra bugs found (not related to this PR):
* ~Automap marks slightly spinning around of their rotating point, i.e. they are not placed statically.~ Problem of patch drawing / 320x200 coords, nothing can we do about it.
* Player's looking direction is not resetting to centered, when permanent mouse look is disabled. This can make looking direction stuck no not-centered, if mouse look was disabled with non-centered direction.