### PR TITLE
rearrange includes with include-what-you-use tool

### DIFF
--- a/opl/opl.c
+++ b/opl/opl.c
@@ -15,17 +15,13 @@
 //     OPL interface.
 //
 
-#include "config.h"
-
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
 #include "SDL.h"
-
+#include "m_io.h"
 #include "opl.h"
 #include "opl_internal.h"
-#include "m_io.h"
 
 //#define OPL_DEBUG_TRACE
 

--- a/opl/opl3.c
+++ b/opl/opl3.c
@@ -26,9 +26,8 @@
 // version: 1.8
 //
 
-#include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
+
 #include "opl3.h"
 
 #define RSM_FRAC    10

--- a/opl/opl3.h
+++ b/opl/opl3.h
@@ -31,6 +31,10 @@
 
 #include <inttypes.h>
 
+struct _opl3_channel;
+struct _opl3_chip;
+struct _opl3_slot;
+
 #define OPL_WRITEBUF_SIZE   1024
 #define OPL_WRITEBUF_DELAY  2
 

--- a/opl/opl_queue.h
+++ b/opl/opl_queue.h
@@ -18,6 +18,8 @@
 #ifndef OPL_QUEUE_H
 #define OPL_QUEUE_H
 
+#include <stdint.h>
+
 #include "opl.h"
 
 typedef struct opl_callback_queue_s opl_callback_queue_t;

--- a/opl/opl_sdl.c
+++ b/opl/opl_sdl.c
@@ -15,22 +15,16 @@
 //     OPL SDL interface.
 //
 
-#include "config.h"
-
+#include <assert.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-#include <errno.h>
-#include <assert.h>
 
 #include "SDL.h"
 #include "SDL_mixer.h"
-
-#include "opl3.h"
-
 #include "opl.h"
+#include "opl3.h"
 #include "opl_internal.h"
-
 #include "opl_queue.h"
 
 #define MAX_SOUND_SLICE_TIME 100 /* ms */

--- a/setup/execute.c
+++ b/setup/execute.c
@@ -14,19 +14,17 @@
 
 // Code for invoking Doom
 
+#include <ctype.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <ctype.h>
-
-#include <sys/types.h>
 
 #ifdef _WIN32
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#include <process.h>
 #include <shellapi.h>
 
 #else
@@ -36,13 +34,10 @@
 
 #endif
 
-#include "textscreen.h"
-
-#include "config.h"
 #include "execute.h"
 #include "m_argv.h"
-#include "m_misc2.h"
 #include "m_io.h"
+#include "m_misc2.h"
 
 struct execute_context_s
 {

--- a/setup/mainmenu.c
+++ b/setup/mainmenu.c
@@ -14,20 +14,14 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
+#include "SDL.h"
 #include "config.h"
-#include "textscreen.h"
-
-#include "execute.h"
-
-#include "m_argv.h"
+#include "doomkeys.h"
 #include "m_misc2.h"
-#include "z_zone.h"
-
-#include "setup_icon.c"
-
 #include "multiplayer.h"
+#include "setup_icon.c"
+#include "textscreen.h"
 
 static void DoQuit(void *widget, void *dosave)
 {

--- a/setup/multiplayer.c
+++ b/setup/multiplayer.c
@@ -12,25 +12,19 @@
 // GNU General Public License for more details.
 //
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
-#include "doomdef.h"
-
-#include "textscreen.h"
+#include <stdint.h>
 
 #include "d_iwad.h"
-#include "m_misc2.h"
-#include "d_englsh.h"
-
-#include "multiplayer.h"
+#include "doomdef.h"
+#include "doomkeys.h"
 #include "execute.h"
-
+#include "m_misc2.h"
+#include "multiplayer.h"
+#include "net_defs.h"
 #include "net_io.h"
 #include "net_query.h"
-
-#include "net_petname.h"
+#include "textscreen.h"
+#include "txt_scrollpane.h"
 
 #define MULTI_START_HELP_URL "https://www.chocolate-doom.org/setup-multi-start"
 #define MULTI_JOIN_HELP_URL "https://www.chocolate-doom.org/setup-multi-join"

--- a/src/am_map.c
+++ b/src/am_map.c
@@ -26,19 +26,29 @@
 //
 //-----------------------------------------------------------------------------
 
-#include "doomstat.h"
-#include "doomkeys.h"
-#include "st_stuff.h"
-#include "r_main.h"
-#include "p_setup.h"
-#include "p_maputl.h"
-#include "w_wad.h"
-#include "v_video.h"
-#include "p_spec.h"
 #include "am_map.h"
-#include "dstrings.h"
 #include "d_deh.h"    // Ty 03/27/98 - externalizations
+#include "d_player.h"
+#include "doomdata.h"
+#include "doomdef.h"
+#include "doomkeys.h"
+#include "doomstat.h"
+#include "i_video.h"
+#include "info.h"
+#include "m_fixed.h"
 #include "m_input.h"
+#include "p_maputl.h"
+#include "p_mobj.h"
+#include "p_setup.h"
+#include "p_spec.h"
+#include "r_defs.h"
+#include "r_main.h"
+#include "r_state.h"
+#include "st_stuff.h"
+#include "tables.h"
+#include "v_video.h"
+#include "w_wad.h"
+#include "z_zone.h"
 
 //jff 1/7/98 default automap colors added
 int mapcolor_back;    // map background

--- a/src/am_map.h
+++ b/src/am_map.h
@@ -29,7 +29,10 @@
 #ifndef __AMMAP_H__
 #define __AMMAP_H__
 
+#include <stdint.h>
+
 #include "d_event.h"
+#include "doomtype.h"
 #include "m_fixed.h"
 
 // Used by ST StatusBar stuff.

--- a/src/d_deh.c
+++ b/src/d_deh.c
@@ -28,22 +28,28 @@
 //
 //--------------------------------------------------------------------
 
-#include "m_io.h"
+#include <stdint.h>
 
+#include "d_englsh.h"
+#include "d_items.h"
+#include "d_think.h"
 // killough 5/2/98: fixed headers, removed rendunant external declarations:
 #include "doomdef.h"
-#include "doomstat.h"
-#include "sounds.h"
+#include "doomtype.h"
+#include "dsdhacked.h"
+#include "g_game.h"
+#include "i_system.h"
 #include "info.h"
 #include "m_argv.h" // [FG] M_CheckParm()
 #include "m_cheat.h"
+#include "m_fixed.h"
+#include "m_io.h"
 #include "m_misc2.h"
 #include "p_inter.h"
-#include "g_game.h"
-#include "d_think.h"
+#include "p_mobj.h"
+#include "sounds.h"
 #include "w_wad.h"
-
-#include "dsdhacked.h"
+#include "z_zone.h"
 
 static boolean bfgcells_modified = false;
 
@@ -121,9 +127,6 @@ char **dehfiles = NULL;  // filenames of .deh files for demo footer
 // which are set by D_ENGLSH.H or D_FRENCH.H(etc).  BEX files are a
 // better way of changing these strings globally by language.
 
-// ====================================================================
-// Any of these can be changed using the bex extensions
-#include "dstrings.h"  // to get the initial values
 char *s_D_DEVSTR    = D_DEVSTR;
 char *s_D_CDROM     = D_CDROM;
 char *s_PRESSKEY    = PRESSKEY;

--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -16,12 +16,10 @@
 //     to the IWAD type.
 //
 
-#include <stdlib.h>
-
-#include "i_system.h"
-#include "m_io.h"
 #include "d_iwad.h"
+#include "i_system.h"
 #include "m_argv.h"
+#include "m_io.h"
 #include "m_misc2.h"
 
 static const iwad_t iwads[] =

--- a/src/d_loop.c
+++ b/src/d_loop.c
@@ -16,27 +16,23 @@
 //     Main loop code.
 //
 
-#include <stdlib.h>
-#include <string.h>
-
-#include "doomstat.h"
 #include "d_event.h"
 #include "d_loop.h"
 #include "d_ticcmd.h"
-
+#include "doomdef.h"
+#include "doomstat.h"
 #include "i_system.h"
+#include "i_timer.h"
 #include "i_video.h"
-
 #include "m_argv.h"
 #include "m_fixed.h"
-
 #include "net_client.h"
 #include "net_gui.h"
 #include "net_io.h"
-#include "net_query.h"
-#include "net_server.h"
-#include "net_sdl.h"
 #include "net_loop.h"
+#include "net_query.h"
+#include "net_sdl.h"
+#include "net_server.h"
 
 // The complete set of data for a particular tic.
 

--- a/src/d_loop.h
+++ b/src/d_loop.h
@@ -19,6 +19,7 @@
 #ifndef __D_LOOP__
 #define __D_LOOP__
 
+#include "doomtype.h"
 #include "net_defs.h"
 
 // Callback function invoked while waiting for the netgame to start.

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -29,8 +29,6 @@
 //
 //-----------------------------------------------------------------------------
 
-#include <io.h>
-
 #include "../miniz/miniz.h"
 #include "SDL.h"
 #include "am_map.h"

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -29,55 +29,60 @@
 //
 //-----------------------------------------------------------------------------
 
-#include "m_io.h" // haleyjd
-#include "SDL_filesystem.h" // [FG] SDL_GetPrefPath()
-#include "SDL_stdinc.h" // [FG] SDL_qsort()
-
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#include <io.h>
 
 #include "../miniz/miniz.h"
-
+#include "SDL.h"
+#include "am_map.h"
+#include "config.h"
+#include "d_deh.h"  // Ty 04/08/98 - Externalizations
+#include "d_englsh.h"
+#include "d_iwad.h" // [FG] D_FindWADByName()
+#include "d_loop.h"
+#include "d_main.h"
+#include "d_player.h"
+#include "d_quit.h"
+#include "d_ticcmd.h"
 #include "doomdef.h"
 #include "doomstat.h"
-#include "dstrings.h"
-#include "sounds.h"
-#include "z_zone.h"
-#include "w_wad.h"
-#include "s_sound.h"
-#include "v_video.h"
+#include "dsdhacked.h"
 #include "f_finale.h"
 #include "f_wipe.h"
-#include "m_argv.h"
-#include "m_misc.h"
-#include "m_misc2.h" // [FG] M_StringDuplicate()
-#include "m_menu.h"
-#include "m_swap.h"
-#include "i_system.h"
-#include "i_sound.h"
-#include "i_video.h"
 #include "g_game.h"
 #include "hu_stuff.h"
-#include "wi_stuff.h"
-#include "st_stuff.h"
-#include "am_map.h"
+#include "i_endoom.h"
+#include "i_glob.h" // [FG] I_StartMultiGlob()
+#include "i_sound.h"
+#include "i_system.h"
+#include "i_timer.h"
+#include "i_video.h"
+#include "info.h"
+#include "m_argv.h"
+#include "m_fixed.h"
+#include "m_input.h"
+#include "m_io.h" // haleyjd
+#include "m_menu.h"
+#include "m_misc.h"
+#include "m_misc2.h" // [FG] M_StringDuplicate()
+#include "m_swap.h"
+#include "net_client.h"
+#include "p_map.h" // MELEERANGE
+#include "p_mobj.h"
 #include "p_setup.h"
+#include "r_defs.h"
 #include "r_draw.h"
 #include "r_main.h"
-#include "d_main.h"
-#include "d_iwad.h" // [FG] D_FindWADByName()
-#include "d_deh.h"  // Ty 04/08/98 - Externalizations
+#include "r_state.h"
+#include "s_sound.h"
+#include "sounds.h"
+#include "st_stuff.h"
 #include "statdump.h" // [FG] StatDump()
 #include "u_mapinfo.h" // U_ParseMapInfo()
-#include "i_glob.h" // [FG] I_StartMultiGlob()
-#include "p_map.h" // MELEERANGE
-#include "i_endoom.h"
-#include "d_quit.h"
-
-#include "dsdhacked.h"
-
-#include "net_client.h"
+#include "v_video.h"
+#include "version.h"
+#include "w_wad.h"
+#include "wi_stuff.h"
+#include "z_zone.h"
 
 // DEHacked support - Ty 03/09/97
 // killough 10/98:

--- a/src/d_main.h
+++ b/src/d_main.h
@@ -30,8 +30,9 @@
 #ifndef __D_MAIN__
 #define __D_MAIN__
 
-#include "doomdef.h"
 #include "d_event.h"
+#include "doomdef.h"
+#include "doomtype.h"
 
 extern char **wadfiles;       // killough 11/98
 

--- a/src/d_net.c
+++ b/src/d_net.c
@@ -17,17 +17,17 @@
 //	all OS independend parts.
 //
 
-#include <stdlib.h>
-
-#include "d_main.h"
-#include "m_argv.h"
-#include "m_menu.h"
-#include "m_misc2.h"
-#include "i_system.h"
-#include "i_video.h"
-#include "g_game.h"
+#include "d_player.h"
+#include "d_ticcmd.h"
 #include "doomdef.h"
 #include "doomstat.h"
+#include "doomtype.h"
+#include "g_game.h"
+#include "m_argv.h"
+#include "m_misc2.h"
+#include "net_defs.h"
+#include "p_mobj.h"
+#include "tables.h"
 //#include "w_checksum.h"
 //#include "w_wad.h"
 

--- a/src/d_quit.c
+++ b/src/d_quit.c
@@ -19,14 +19,13 @@
 #include <errno.h>
 
 #include "SDL.h"
-
+#include "doomdef.h"
 #include "doomstat.h"
-#include "i_system.h"
-#include "m_misc.h"
 #include "g_game.h"
-#include "m_io.h"
-#include "w_wad.h"
 #include "i_glob.h"
+#include "m_io.h"
+#include "m_misc.h"
+#include "w_wad.h"
 
 //
 // I_Quit

--- a/src/doomdef.h
+++ b/src/doomdef.h
@@ -30,18 +30,15 @@
 #ifndef __DOOMDEF__
 #define __DOOMDEF__
 
-// This must come first, since it redefines malloc(), free(), etc. -- killough:
-#include "z_zone.h"
-
+#include <ctype.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <ctype.h>
-#include <limits.h>
 
 #include "config.h"
-
 #include "version.h"
+#include "z_zone.h"
 
 // Game mode handling - identify IWAD version
 //  to handle IWAD dependend animations etc.

--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -34,14 +34,15 @@
 #ifndef __D_STATE__
 #define __D_STATE__
 
+#include "d_loop.h"
+// We need the playr data structure as well.
+#include "d_player.h"
+#include "d_ticcmd.h"
 // We need globally shared data structures,
 //  for defining the global state variables.
 #include "doomdata.h"
-#include "d_loop.h"
-
-// We need the playr data structure as well.
-#include "d_player.h"
-
+#include "doomdef.h"
+#include "doomtype.h"
 // and mapinfo information
 #include "u_mapinfo.h"
 

--- a/src/dsdhacked.c
+++ b/src/dsdhacked.c
@@ -19,13 +19,14 @@
 // DESCRIPTION:
 //      DSDHacked support
 
+#include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
-#include <ctype.h>
 
+#include "d_think.h"
 #include "doomtype.h"
-#include "info.h"
 #include "i_system.h" // I_Realloc
+#include "info.h"
 
 //
 //   States

--- a/src/dstrings.c
+++ b/src/dstrings.c
@@ -28,6 +28,8 @@
 
 #include "dstrings.h"
 
+#include "d_englsh.h"
+
 // killough 1/18/98: remove hardcoded limit, add const:
 const char *endmsg[]=
 {

--- a/src/f_finale.c
+++ b/src/f_finale.c
@@ -27,17 +27,27 @@
 //-----------------------------------------------------------------------------
 
 
-#include "doomstat.h"
-#include "d_event.h"
-#include "v_video.h"
-#include "w_wad.h"
-#include "s_sound.h"
-#include "sounds.h"
-#include "dstrings.h"
-#include "m_menu.h"
 #include "d_deh.h"  // Ty 03/22/98 - externalizations
+#include "d_event.h"
+#include "d_player.h"
+#include "d_ticcmd.h"
+#include "doomdef.h"
+#include "doomstat.h"
+#include "doomtype.h"
+#include "i_video.h"
+#include "info.h"
+#include "m_menu.h"
 #include "m_misc2.h" // [FG] M_StringDuplicate()
 #include "m_swap.h"
+#include "p_pspr.h"
+#include "r_defs.h"
+#include "r_state.h"
+#include "s_sound.h"
+#include "sounds.h"
+#include "u_mapinfo.h"
+#include "v_video.h"
+#include "w_wad.h"
+#include "z_zone.h"
 
 // Stage of animation:
 //  0 = text, 1 = art screen, 2 = character cast
@@ -353,6 +363,7 @@ void F_Ticker(void)
 // written.                                                         // phares
 
 #include "hu_stuff.h"
+
 extern  patch_t *hu_font[HU_FONTSIZE];
 
 // [FG] add line breaks for lines exceeding screenwidth

--- a/src/f_wipe.c
+++ b/src/f_wipe.c
@@ -27,10 +27,12 @@
 //-----------------------------------------------------------------------------
 
 #include "doomdef.h"
-#include "i_video.h"
-#include "v_video.h"
-#include "m_random.h"
+#include "doomtype.h"
 #include "f_wipe.h"
+#include "i_video.h"
+#include "m_random.h"
+#include "v_video.h"
+#include "z_zone.h"
 
 //
 // SCREEN WIPE PACKAGE

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -25,46 +25,62 @@
 //
 //-----------------------------------------------------------------------------
 
-#include <time.h>
-#include <stdarg.h>
 #include <errno.h>
+#include <io.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <time.h>
 
-#include "m_io.h" // haleyjd
-
-#include "doomstat.h"
-#include "doomkeys.h"
-#include "f_finale.h"
-#include "m_argv.h"
-#include "m_misc.h"
-#include "m_menu.h"
-#include "m_random.h"
-#include "p_setup.h"
-#include "p_saveg.h"
-#include "p_tick.h"
-#include "d_main.h"
-#include "wi_stuff.h"
-#include "hu_stuff.h"
-#include "st_stuff.h"
 #include "am_map.h"
-#include "w_wad.h"
-#include "r_main.h"
-#include "r_draw.h"
-#include "p_map.h"
-#include "s_sound.h"
-#include "s_musinfo.h"
-#include "dstrings.h"
-#include "sounds.h"
-#include "r_data.h"
-#include "r_sky.h"
+#include "config.h"
 #include "d_deh.h"              // Ty 3/27/98 deh declarations
-#include "p_inter.h"
+#include "d_main.h"
+#include "d_player.h"
+#include "d_ticcmd.h"
+#include "doomdata.h"
+#include "doomkeys.h"
+#include "doomstat.h"
+#include "f_finale.h"
 #include "g_game.h"
+#include "hu_stuff.h"
+#include "i_system.h"
+#include "i_timer.h"
 #include "i_video.h" // [FG] MAX_JSB, MAX_MB
-#include "statdump.h" // [FG] StatCopy()
-#include "m_misc2.h"
-#include "u_mapinfo.h"
+#include "info.h"
+#include "m_argv.h"
+#include "m_fixed.h"
 #include "m_input.h"
+#include "m_io.h" // haleyjd
+#include "m_menu.h"
+#include "m_misc.h"
+#include "m_misc2.h"
+#include "m_random.h"
 #include "memio.h"
+#include "net_defs.h"
+#include "p_inter.h"
+#include "p_map.h"
+#include "p_mobj.h"
+#include "p_pspr.h"
+#include "p_saveg.h"
+#include "p_setup.h"
+#include "p_tick.h"
+#include "r_data.h"
+#include "r_defs.h"
+#include "r_draw.h"
+#include "r_main.h"
+#include "r_sky.h"
+#include "s_musinfo.h"
+#include "s_sound.h"
+#include "sounds.h"
+#include "st_stuff.h"
+#include "statdump.h" // [FG] StatCopy()
+#include "tables.h"
+#include "u_mapinfo.h"
+#include "version.h"
+#include "w_wad.h"
+#include "wi_stuff.h"
+#include "z_zone.h"
 
 #define SAVEGAMESIZE  0x20000
 #define SAVESTRINGSIZE  24

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -26,7 +26,6 @@
 //-----------------------------------------------------------------------------
 
 #include <errno.h>
-#include <io.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -26,9 +26,10 @@
 #ifndef __G_GAME__
 #define __G_GAME__
 
-#include "doomdef.h"
 #include "d_event.h"
 #include "d_ticcmd.h"
+#include "doomdef.h"
+#include "doomtype.h"
 
 //
 // GAME

--- a/src/hu_lib.c
+++ b/src/hu_lib.c
@@ -26,14 +26,16 @@
 //-----------------------------------------------------------------------------
 
 #include "doomdef.h"
-#include "doomstat.h"
 #include "doomkeys.h"
-#include "v_video.h"
-#include "m_swap.h"
+#include "doomstat.h"
 #include "hu_lib.h"
 #include "hu_stuff.h"
-#include "r_main.h"
+#include "i_video.h"
+#include "m_swap.h"
 #include "r_draw.h"
+#include "r_main.h"
+#include "r_state.h"
+#include "v_video.h"
 
 // boolean : whether the screen is always erased
 #define noterased viewwindowx

--- a/src/hu_lib.h
+++ b/src/hu_lib.h
@@ -28,6 +28,7 @@
 #ifndef __HULIB__
 #define __HULIB__
 
+#include "doomtype.h"
 // We are referring to patches.
 #include "r_defs.h"
 #include "v_video.h"  //jff 2/16/52 include color range defs

--- a/src/hu_stuff.c
+++ b/src/hu_stuff.c
@@ -27,21 +27,34 @@
 
 // killough 5/3/98: remove unnecessary headers
 
-#include "doomstat.h"
-#include "doomkeys.h"
-#include "hu_stuff.h"
-#include "hu_lib.h"
-#include "st_stuff.h" /* jff 2/16/98 need loc of status bar */
-#include "w_wad.h"
-#include "s_sound.h"
-#include "dstrings.h"
-#include "sounds.h"
 #include "d_deh.h"   /* Ty 03/27/98 - externalization of mapnamesx arrays */
-#include "r_draw.h"
+#include "d_englsh.h"
+#include "d_items.h"
+#include "d_player.h"
+#include "d_ticcmd.h"
+#include "doomdef.h"
+#include "doomkeys.h"
+#include "doomstat.h"
+#include "hu_lib.h"
+#include "hu_stuff.h"
+#include "i_video.h"
+#include "m_fixed.h"
 #include "m_input.h"
-#include "p_map.h" // crosshair (linetarget)
 #include "m_misc2.h"
 #include "m_swap.h"
+#include "p_map.h" // crosshair (linetarget)
+#include "p_mobj.h"
+#include "r_data.h"
+#include "r_defs.h"
+#include "r_state.h"
+#include "s_sound.h"
+#include "sounds.h"
+#include "st_stuff.h" /* jff 2/16/98 need loc of status bar */
+#include "tables.h"
+#include "u_mapinfo.h"
+#include "v_video.h"
+#include "w_wad.h"
+#include "z_zone.h"
 
 // global heads up display controls
 

--- a/src/hu_stuff.h
+++ b/src/hu_stuff.h
@@ -27,6 +27,7 @@
 #define __HU_STUFF_H__
 
 #include "d_event.h"
+#include "doomtype.h"
 
 //
 // Globally visible constants.

--- a/src/i_endoom.c
+++ b/src/i_endoom.c
@@ -18,11 +18,10 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "config.h"
+#include "../textscreen/txt_main.h"
 #include "doomtype.h"
 #include "i_video.h"
-
-#include "../textscreen/txt_main.h"
+#include "txt_sdl.h"
 
 #define ENDOOM_W 80
 #define ENDOOM_H 25

--- a/src/i_flmusic.c
+++ b/src/i_flmusic.c
@@ -16,6 +16,10 @@
 
 #if defined(HAVE_FLUIDSYNTH)
 
+#include <fluidsynth/types.h>
+
+#include "config.h"
+#include "doomdef.h"
 #include "fluidsynth.h"
 
 #if (FLUIDSYNTH_VERSION_MAJOR < 2 || (FLUIDSYNTH_VERSION_MAJOR == 2 && FLUIDSYNTH_VERSION_MINOR < 2))
@@ -27,9 +31,7 @@
 
 #include "SDL.h"
 #include "SDL_mixer.h"
-
 #include "doomtype.h"
-#include "i_system.h"
 #include "i_sound.h"
 #include "m_misc2.h"
 #include "memio.h"

--- a/src/i_glob.c
+++ b/src/i_glob.c
@@ -16,14 +16,17 @@
 // to be interrogated.
 //
 
+#include <ctype.h>
+#include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
-#include <ctype.h>
+#include <sys/stat.h>
 
-#include "i_glob.h"
-#include "m_misc2.h"
-#include "m_io.h"
 #include "config.h"
+#include "doomtype.h"
+#include "i_glob.h"
+#include "m_io.h"
+#include "m_misc2.h"
 
 #if defined(_MSC_VER)
 // For Visual C++, we need to include the win_opendir module.

--- a/src/i_main.c
+++ b/src/i_main.c
@@ -26,14 +26,15 @@
 //
 //-----------------------------------------------------------------------------
 
-#include <stdio.h>
 #include <signal.h>
-#include "config.h"
+#include <stdio.h>
+#include <stdlib.h>
 
 #include "SDL.h" // haleyjd
-
-#include "m_argv.h"
+#include "config.h"
+#include "doomtype.h"
 #include "i_system.h"
+#include "m_argv.h"
 #include "m_misc2.h"
 
 // Descriptions taken from MSDN

--- a/src/i_oplmusic.c
+++ b/src/i_oplmusic.c
@@ -17,23 +17,23 @@
 //
 
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include "mus2mid.h"
-#include "memio.h"
+#include "../opl/opl.h"
 #include "doomtype.h"
-
 #include "i_sound.h"
-#include "m_swap.h"
-#include "m_misc2.h"
 #include "m_io.h"
+#include "m_swap.h"
+#include "memio.h"
+#include "midifile.h"
+#include "mus2mid.h"
 #include "w_wad.h"
 #include "z_zone.h"
 
-#include "../opl/opl.h"
-#include "midifile.h"
+struct opl_voice_s;
 
 // #define OPL_MIDI_DEBUG
 

--- a/src/i_sdlmusic.c
+++ b/src/i_sdlmusic.c
@@ -29,10 +29,11 @@
 // haleyjd
 #include "SDL.h"
 #include "SDL_mixer.h"
-
+#include "doomdef.h"
 #include "doomstat.h"
 #include "doomtype.h"
 #include "i_sound.h"
+#include "z_zone.h"
 
 ///
 // MUSIC API.
@@ -40,9 +41,8 @@
 
 // julian (10/25/2005): rewrote (nearly) entirely
 
-#include "mus2mid.h"
 #include "memio.h"
-#include "m_misc2.h"
+#include "mus2mid.h"
 
 // Only one track at a time
 static Mix_Music *music = NULL;

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -27,15 +27,19 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <math.h>
+#include <stdio.h>
+
 // haleyjd
 #include "SDL.h"
 #include "SDL_mixer.h"
-#include <math.h>
-
+#include "doomdef.h"
 #include "doomstat.h"
+#include "doomtype.h"
 #include "i_sound.h"
+#include "i_system.h"
 #include "w_wad.h"
-#include "d_main.h"
+#include "z_zone.h"
 
 // haleyjd
 #define MAX_CHANNELS 32

--- a/src/i_system.c
+++ b/src/i_system.c
@@ -25,6 +25,7 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <stdarg.h>
 #include <stdio.h>
 
 #ifdef _WIN32
@@ -36,10 +37,13 @@
 #endif
 
 #include "SDL.h"
-
+#include "config.h"
+#include "doomdef.h"
 #include "i_system.h"
-#include "m_misc2.h"
 #include "m_argv.h"
+#include "m_misc2.h"
+
+struct atexit_listentry_s;
 
 ticcmd_t *I_BaseTiccmd(void)
 {

--- a/src/i_system.h
+++ b/src/i_system.h
@@ -29,7 +29,10 @@
 #ifndef __I_SYSTEM__
 #define __I_SYSTEM__
 
+#include <stddef.h>
+
 #include "d_ticcmd.h"
+#include "doomtype.h"
 #include "i_timer.h"
 
 // Called by DoomMain.

--- a/src/i_timer.c
+++ b/src/i_timer.c
@@ -18,11 +18,9 @@
 //
 
 #include "SDL.h"
-
+#include "doomdef.h"
 #include "i_timer.h"
 #include "m_fixed.h"
-#include "doomstat.h"
-#include "m_argv.h"
 
 static int MSToTic(Uint32 time)
 {

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -27,26 +27,31 @@
 //
 //-----------------------------------------------------------------------------
 
-#include "SDL.h" // haleyjd
+#include <math.h>
+#include <stdint.h>
 
 #include "../miniz/miniz.h"
-
-#include "z_zone.h"  /* memory allocation wrappers -- killough */
-#include "doomstat.h"
-#include "doomkeys.h"
-#include "v_video.h"
-#include "d_main.h"
-#include "m_bbox.h"
-#include "st_stuff.h"
-#include "m_argv.h"
-#include "w_wad.h"
-#include "r_draw.h"
+#include "SDL.h" // haleyjd
 #include "am_map.h"
-#include "m_menu.h"
-#include "wi_stuff.h"
+#include "config.h"
+#include "d_event.h"
+#include "d_main.h"
+#include "doomdef.h"
+#include "doomkeys.h"
+#include "doomstat.h"
+#include "i_system.h"
+#include "i_timer.h"
 #include "i_video.h"
-#include "m_misc2.h"
+#include "m_argv.h"
+#include "m_fixed.h"
 #include "m_io.h"
+#include "m_menu.h"
+#include "m_misc2.h"
+#include "st_stuff.h"
+#include "v_video.h"
+#include "w_wad.h"
+#include "wi_stuff.h"
+#include "z_zone.h"
 
 // [FG] set the application icon
 

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -20,13 +20,14 @@
 #include <mmsystem.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <limits.h>
 
 #include "doomtype.h"
 #include "i_sound.h"
 #include "m_misc2.h"
 #include "memio.h"
-#include "mus2mid.h"
 #include "midifile.h"
+#include "mus2mid.h"
 
 static HMIDISTRM hMidiStream;
 static HANDLE hBufferReturnEvent;

--- a/src/info.h
+++ b/src/info.h
@@ -32,7 +32,6 @@
 #define __INFO__
 
 #include "config.h"
-
 // Needed for action function pointer handling.
 #include "d_think.h"
 

--- a/src/m_bbox.c
+++ b/src/m_bbox.c
@@ -31,6 +31,8 @@
 
 #include "m_bbox.h"
 
+#include "doomtype.h"
+
 void M_ClearBox (fixed_t *box)
 {
   box[BOXTOP] = box[BOXRIGHT] = D_MININT;

--- a/src/m_bbox.h
+++ b/src/m_bbox.h
@@ -30,8 +30,8 @@
 #ifndef __M_BBOX__
 #define __M_BBOX__
 
-#include "z_zone.h"         // killough 1/18/98
 #include "m_fixed.h"
+#include "z_zone.h"         // killough 1/18/98
 
 // Bounding box coordinate storage.
 enum

--- a/src/m_cheat.c
+++ b/src/m_cheat.c
@@ -26,22 +26,33 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <stdint.h>
+
+#include "d_deh.h"  // Ty 03/27/98 - externalized strings
+#include "d_player.h"
+#include "d_think.h"
+#include "doomdata.h"
+#include "doomdef.h"
 #include "doomstat.h"
-#include "p_tick.h"
 #include "g_game.h"
-#include "r_data.h"
+#include "info.h"
+#include "m_cheat.h"
+#include "m_fixed.h"
+#include "m_misc2.h"
 #include "p_inter.h"
 #include "p_map.h"
-#include "m_cheat.h"
-#include "m_argv.h"
+#include "p_mobj.h"
+#include "p_pspr.h"
+#include "p_spec.h" // SPECHITS
+#include "p_tick.h"
+#include "r_defs.h"
+#include "r_state.h"
 #include "s_sound.h"
 #include "sounds.h"
-#include "dstrings.h"
-#include "d_deh.h"  // Ty 03/27/98 - externalized strings
+#include "tables.h"
 #include "u_mapinfo.h"
 #include "w_wad.h"
-#include "m_misc2.h"
-#include "p_spec.h" // SPECHITS
+#include "z_zone.h"
 
 #define plyr (players+consoleplayer)     /* the console player */
 

--- a/src/m_input.c
+++ b/src/m_input.c
@@ -20,9 +20,9 @@
 //      Custom input
 
 #include <string.h>
-#include "m_input.h"
+
 #include "doomkeys.h"
-#include "i_video.h" // MAX_MB, MAX_JSB
+#include "m_input.h"
 
 static input_t composite_inputs[NUM_INPUT_ID];
 

--- a/src/m_io.c
+++ b/src/m_io.c
@@ -15,23 +15,24 @@
 //      Compatibility wrappers from Chocolate Doom
 //
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <errno.h>
+#include <string.h>
 
 #ifdef _WIN32
   #define WIN32_LEAN_AND_MEAN
   #include <windows.h>
-  #include <io.h>
   #include <direct.h>
+  #include <io.h>
 #else
   #include <fcntl.h>
   #include <unistd.h>
 #endif
 
-#include <sys/types.h>
 #include <sys/stat.h>
 
+#include "SDL.h"
 #include "i_system.h"
 
 #ifdef _WIN32
@@ -277,7 +278,6 @@ void M_MakeDirectory(const char *path)
 }
 
 #ifdef _WIN32
-#include "SDL_stdinc.h"
 
 typedef struct {
     char *var;

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -31,39 +31,46 @@
 //
 //-----------------------------------------------------------------------------
 
-#include <fcntl.h>
-#include "m_io.h" // haleyjd
-
-#include "doomdef.h"
-#include "doomstat.h"
-#include "doomtype.h" // [FG] inline
-#include "doomkeys.h"
-#include "dstrings.h"
-#include "d_main.h"
-#include "i_system.h"
-#include "i_video.h"
-#include "v_video.h"
-#include "w_wad.h"
-#include "r_main.h"
-#include "hu_stuff.h"
-#include "g_game.h"
-#include "s_sound.h"
-#include "sounds.h"
-#include "m_menu.h"
-#include "d_deh.h"
-#include "m_misc.h"
-#include "m_misc2.h" // [FG] M_StringDuplicate()
-#include "m_swap.h"
-#include "w_wad.h" // [FG] W_IsIWADLump() / W_WadNameForLump()
-#include "p_saveg.h" // saveg_compat
-#include "m_input.h"
-#include "r_draw.h" // [FG] R_SetFuzzColumnMode
-#include "r_sky.h" // [FG] R_InitSkyMap()
-#include "r_plane.h" // [FG] R_InitPlanes()
-#include "m_argv.h"
+#include <io.h>
 
 // [crispy] remove DOS reference from the game quit confirmation dialogs
 #include "SDL_platform.h"
+#include "config.h"
+#include "d_deh.h"
+#include "d_englsh.h"
+#include "d_main.h"
+#include "d_player.h"
+#include "doomdef.h"
+#include "doomkeys.h"
+#include "doomstat.h"
+#include "doomtype.h" // [FG] inline
+#include "dstrings.h"
+#include "g_game.h"
+#include "hu_stuff.h"
+#include "i_system.h"
+#include "i_timer.h"
+#include "i_video.h"
+#include "m_argv.h"
+#include "m_input.h"
+#include "m_io.h" // haleyjd
+#include "m_menu.h"
+#include "m_misc.h"
+#include "m_misc2.h" // [FG] M_StringDuplicate()
+#include "m_swap.h"
+#include "p_saveg.h" // saveg_compat
+#include "r_data.h"
+#include "r_defs.h"
+#include "r_draw.h" // [FG] R_SetFuzzColumnMode
+#include "r_main.h"
+#include "r_plane.h" // [FG] R_InitPlanes()
+#include "r_sky.h" // [FG] R_InitSkyMap()
+#include "r_state.h"
+#include "s_sound.h"
+#include "sounds.h"
+#include "u_mapinfo.h"
+#include "v_video.h"
+#include "w_wad.h"
+#include "z_zone.h"
 #ifndef _WIN32
 #include <unistd.h> // [FG] isatty()
 #endif

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -31,8 +31,6 @@
 //
 //-----------------------------------------------------------------------------
 
-#include <io.h>
-
 // [crispy] remove DOS reference from the game quit confirmation dialogs
 #include "SDL_platform.h"
 #include "config.h"

--- a/src/m_menu.h
+++ b/src/m_menu.h
@@ -31,6 +31,7 @@
 #define __M_MENU__
 
 #include "d_event.h"
+#include "doomtype.h"
 
 //
 // MENUS

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -30,32 +30,36 @@
 //
 //-----------------------------------------------------------------------------
 
-#include "doomstat.h"
-#include "doomkeys.h"
-#include "m_argv.h"
-#include "g_game.h"
-#include "m_menu.h"
+#include <io.h>
+
 #include "am_map.h"
-#include "w_wad.h"
-#include "i_system.h"
-#include "i_sound.h"
-#include "i_video.h"
-#include "v_video.h"
+#include "d_englsh.h"
+#include "d_main.h"
+#include "doomkeys.h"
+#include "doomstat.h"
+#include "g_game.h"
+#include "hu_lib.h" // HU_MAXMESSAGES
 #include "hu_stuff.h"
-#include "st_stuff.h"
-#include "dstrings.h"
+#include "i_sound.h"
+#include "i_system.h"
+#include "i_video.h"
+#include "m_argv.h"
+#include "m_io.h"
+#include "m_menu.h"
 #include "m_misc.h"
 #include "m_misc2.h"
 #include "m_swap.h"
-#include "s_sound.h"
-#include "sounds.h"
-#include "d_main.h"
+#include "p_mobj.h"
+#include "p_pspr.h"
+#include "r_defs.h"
 #include "r_draw.h" // [FG] fuzzcolumn_mode
 #include "r_sky.h" // [FG] stretchsky
-#include "hu_lib.h" // HU_MAXMESSAGES
-
-#include "m_io.h"
-#include <errno.h>
+#include "s_sound.h"
+#include "sounds.h"
+#include "st_stuff.h"
+#include "v_video.h"
+#include "w_wad.h"
+#include "z_zone.h"
 
 //
 // DEFAULTS

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -30,7 +30,7 @@
 //
 //-----------------------------------------------------------------------------
 
-#include <io.h>
+#include <errno.h>
 
 #include "am_map.h"
 #include "d_englsh.h"

--- a/src/m_misc2.h
+++ b/src/m_misc2.h
@@ -20,6 +20,7 @@
 #define __M_MISC2__
 
 #include <stdarg.h>
+#include <stddef.h>
 
 #include "doomtype.h"
 

--- a/src/m_random.c
+++ b/src/m_random.c
@@ -32,8 +32,12 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <stdint.h>
+
 #include "doomstat.h"
+#include "m_fixed.h"
 #include "m_random.h"
+#include "tables.h"
 
 //
 // M_Random

--- a/src/m_random.h
+++ b/src/m_random.h
@@ -31,6 +31,7 @@
 #define __M_RANDOM__
 
 #include "doomtype.h"
+#include "m_fixed.h"
 
 // killough 1/19/98: rewritten to use to use a better random number generator
 // in the new engine, although the old one is available for compatibility.

--- a/src/memio.c
+++ b/src/memio.c
@@ -17,11 +17,9 @@
 //
 
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
 #include "memio.h"
-
 #include "z_zone.h"
 
 typedef enum {

--- a/src/midifile.c
+++ b/src/midifile.c
@@ -15,14 +15,13 @@
 //    Reading of MIDI files.
 //
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
 
+#include "SDL.h"
 #include "doomtype.h"
-#include "m_swap.h"
-#include "i_system.h"
 #include "memio.h"
 #include "midifile.h"
 

--- a/src/mus2mid.c
+++ b/src/mus2mid.c
@@ -16,11 +16,8 @@
 // mus2mid.c - Ben Ryves 2006 - http://benryves.com - benryves@benryves.com
 // Use to convert a MUS file into a single track, type 0 MIDI file.
 
-#include <stdio.h>
-
 #include "doomtype.h"
 #include "m_swap.h"
-
 #include "memio.h"
 #include "mus2mid.h"
 

--- a/src/net_client.c
+++ b/src/net_client.c
@@ -14,28 +14,23 @@
 // Network client code
 //
 
-#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "config.h"
 #include "doomtype.h"
-#include "i_system.h"
 #include "i_timer.h" // I_Sleep
-#include "m_argv.h"
 #include "m_fixed.h"
-#include "m_misc2.h"
 #include "net_client.h"
 #include "net_common.h"
 #include "net_defs.h"
 #include "net_io.h"
 #include "net_packet.h"
+#include "net_petname.h"
 #include "net_query.h"
 #include "net_server.h"
 #include "net_structrw.h"
-#include "net_petname.h"
-#include "w_wad.h"
 
 extern void D_ReceiveTic(ticcmd_t *ticcmds, boolean *playeringame);
 

--- a/src/net_common.c
+++ b/src/net_common.c
@@ -14,20 +14,16 @@
 // Common code shared between the client and server
 //
 
-#include <stdio.h>
-#include <stdlib.h>
 #include <stdarg.h>
-#include <string.h>
 
 #include "doomtype.h"
 #include "i_system.h"
+#include "i_timer.h"
 #include "m_argv.h"
 #include "m_io.h"
-
 #include "net_common.h"
 #include "net_io.h"
 #include "net_packet.h"
-#include "net_structrw.h"
 
 // connections time out after 30 seconds
 

--- a/src/net_common.h
+++ b/src/net_common.h
@@ -18,6 +18,7 @@
 #define NET_COMMON_H
 
 #include "doomdef.h"
+#include "doomtype.h"
 #include "net_defs.h"
 #include "net_packet.h"
 

--- a/src/net_dedicated.c
+++ b/src/net_dedicated.c
@@ -16,15 +16,11 @@
 // 
 
 #include <stdio.h>
-#include <stdlib.h>
 
 #include "doomtype.h"
-
 #include "i_system.h"
 #include "i_timer.h" // I_Sleep
-
 #include "m_argv.h"
-
 #include "net_common.h"
 #include "net_sdl.h"
 #include "net_server.h"

--- a/src/net_gui.c
+++ b/src/net_gui.c
@@ -19,20 +19,19 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <ctype.h>
 
 #include "config.h"
-
+#include "doomkeys.h"
+#include "doomtype.h"
 #include "i_system.h"
 #include "i_video.h"
 #include "m_argv.h"
 #include "m_misc2.h"
-
 #include "net_client.h"
+#include "net_defs.h"
 #include "net_gui.h"
 #include "net_query.h"
 #include "net_server.h"
-
 #include "textscreen.h"
 
 static txt_window_t *window;

--- a/src/net_io.h
+++ b/src/net_io.h
@@ -18,6 +18,7 @@
 #ifndef NET_IO_H
 #define NET_IO_H
 
+#include "doomtype.h"
 #include "net_defs.h"
 
 extern net_addr_t net_broadcast_addr;

--- a/src/net_loop.c
+++ b/src/net_loop.c
@@ -16,7 +16,6 @@
 //
 
 #include <stdio.h>
-#include <stdlib.h>
 
 #include "doomtype.h"
 #include "i_system.h"

--- a/src/net_packet.h
+++ b/src/net_packet.h
@@ -18,6 +18,7 @@
 #ifndef NET_PACKET_H
 #define NET_PACKET_H
 
+#include "doomtype.h"
 #include "net_defs.h"
 
 net_packet_t *NET_NewPacket(int initial_size);

--- a/src/net_query.c
+++ b/src/net_query.c
@@ -15,22 +15,17 @@
 //     Querying servers to find their current status.
 //
 
-#include <stdio.h>
 #include <stdarg.h>
-#include <stdlib.h>
-#include <string.h>
 
+#include "doomdef.h"
 #include "i_system.h"
 #include "i_timer.h" // I_Sleep
-#include "m_misc2.h"
-
-#include "net_common.h"
 #include "net_defs.h"
 #include "net_io.h"
 #include "net_packet.h"
 #include "net_query.h"
-#include "net_structrw.h"
 #include "net_sdl.h"
+#include "net_structrw.h"
 
 // DNS address of the Internet master server.
 

--- a/src/net_query.h
+++ b/src/net_query.h
@@ -18,6 +18,7 @@
 #ifndef NET_QUERY_H
 #define NET_QUERY_H
 
+#include "doomtype.h"
 #include "net_defs.h"
 
 typedef void (*net_query_callback_t)(net_addr_t *addr,

--- a/src/net_sdl.c
+++ b/src/net_sdl.c
@@ -15,9 +15,10 @@
 //     Networking module which uses SDL_net
 //
 
+#include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdio.h>
 
 #include "doomtype.h"
 #include "i_system.h"

--- a/src/net_server.c
+++ b/src/net_server.c
@@ -14,29 +14,22 @@
 // Network server code
 //
 
-#include <stdio.h>
 #include <stdarg.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "config.h"
-
-#include "doomtype.h"
 #include "doomdef.h"
+#include "doomtype.h"
 #include "i_system.h"
-#include "i_video.h" // I_Sleep
+#include "i_timer.h"
 #include "m_argv.h"
 #include "m_misc2.h"
-
 #include "net_client.h"
 #include "net_common.h"
 #include "net_defs.h"
 #include "net_io.h"
-#include "net_loop.h"
 #include "net_packet.h"
 #include "net_query.h"
 #include "net_server.h"
-#include "net_sdl.h"
 #include "net_structrw.h"
 
 // How often to refresh our registration with the master server.

--- a/src/net_structrw.c
+++ b/src/net_structrw.c
@@ -14,8 +14,8 @@
 // Reading and writing various structures into packets
 //
 
+#include <stdint.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
 #include "doomtype.h"

--- a/src/net_structrw.h
+++ b/src/net_structrw.h
@@ -15,6 +15,8 @@
 #ifndef NET_STRUCTRW_H
 #define NET_STRUCTRW_H
 
+#include "d_ticcmd.h"
+#include "doomtype.h"
 //#include "aes_prng.h"
 #include "net_defs.h"
 #include "net_packet.h"

--- a/src/p_ceilng.c
+++ b/src/p_ceilng.c
@@ -26,12 +26,20 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <stddef.h>
+
+#include "d_think.h"
 #include "doomstat.h"
-#include "r_main.h"
+#include "doomtype.h"
+#include "m_fixed.h"
+#include "p_mobj.h"
 #include "p_spec.h"
 #include "p_tick.h"
+#include "r_defs.h"
+#include "r_state.h"
 #include "s_sound.h"
 #include "sounds.h"
+#include "z_zone.h"
 
 // the list of ceilings moving currently, including crushers
 ceilinglist_t *activeceilings;

--- a/src/p_doors.c
+++ b/src/p_doors.c
@@ -26,14 +26,22 @@
 //
 //-----------------------------------------------------------------------------
 
+#include "d_deh.h"  // Ty 03/27/98 - externalized
+#include "d_player.h"
+#include "d_think.h"
+#include "doomdata.h"
+#include "doomdef.h"
 #include "doomstat.h"
+#include "doomtype.h"
+#include "m_fixed.h"
+#include "p_mobj.h"
 #include "p_spec.h"
 #include "p_tick.h"
+#include "r_defs.h"
+#include "r_state.h"
 #include "s_sound.h"
 #include "sounds.h"
-#include "r_main.h"
-#include "dstrings.h"
-#include "d_deh.h"  // Ty 03/27/98 - externalized
+#include "z_zone.h"
 
 ///////////////////////////////////////////////////////////////
 //

--- a/src/p_enemy.c
+++ b/src/p_enemy.c
@@ -28,20 +28,37 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <stdint.h>
+
+#include "d_items.h"
+#include "d_player.h"
+#include "d_think.h"
+#include "doomdata.h"
+#include "doomdef.h"
 #include "doomstat.h"
+#include "doomtype.h"
+#include "g_game.h"
+#include "i_system.h"
+#include "info.h"
+#include "m_bbox.h"
+#include "m_fixed.h"
 #include "m_random.h"
-#include "r_main.h"
-#include "p_maputl.h"
+#include "p_enemy.h"
+#include "p_inter.h"
 #include "p_map.h"
+#include "p_maputl.h"
+#include "p_pspr.h"
 #include "p_setup.h"
 #include "p_spec.h"
+#include "p_tick.h"
+#include "r_defs.h"
+#include "r_main.h"
+#include "r_state.h"
 #include "s_sound.h"
 #include "sounds.h"
-#include "p_inter.h"
-#include "g_game.h"
-#include "p_enemy.h"
-#include "p_tick.h"
-#include "m_bbox.h"
+#include "tables.h"
+#include "u_mapinfo.h"
+#include "z_zone.h"
 
 static mobj_t *current_actor;
 

--- a/src/p_extnodes.c
+++ b/src/p_extnodes.c
@@ -27,15 +27,24 @@
 //
 //-----------------------------------------------------------------------------
 
-#include "r_main.h"
-#include "w_wad.h"
-#include "m_swap.h"
+#include <math.h>
+#include <wchar.h>
 
 // [FG] support maps with NODES in compressed ZDBSP format
 #include "../miniz/miniz.h"
-
+#include "doomdata.h"
+#include "doomdef.h"
+#include "doomtype.h"
+#include "i_system.h"
+#include "m_fixed.h"
+#include "m_swap.h"
 #include "p_extnodes.h"
 #include "p_setup.h"
+#include "r_defs.h"
+#include "r_main.h"
+#include "r_state.h"
+#include "w_wad.h"
+#include "z_zone.h"
 
 // [FG] support maps with NODES in DeePBSP format
 

--- a/src/p_extnodes.c
+++ b/src/p_extnodes.c
@@ -28,7 +28,6 @@
 //-----------------------------------------------------------------------------
 
 #include <math.h>
-#include <wchar.h>
 
 // [FG] support maps with NODES in compressed ZDBSP format
 #include "../miniz/miniz.h"

--- a/src/p_extnodes.h
+++ b/src/p_extnodes.h
@@ -31,6 +31,8 @@
 #ifndef __P_EXTNODES__
 #define __P_EXTNODES__
 
+#include "r_defs.h"
+
 typedef enum
 {
     MFMT_DOOMBSP = 0x000,

--- a/src/p_floor.c
+++ b/src/p_floor.c
@@ -27,13 +27,22 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <stddef.h>
+
+#include "d_think.h"
+#include "doomdata.h"
 #include "doomstat.h"
-#include "r_main.h"
+#include "doomtype.h"
+#include "m_fixed.h"
 #include "p_map.h"
+#include "p_mobj.h"
 #include "p_spec.h"
 #include "p_tick.h"
+#include "r_defs.h"
+#include "r_state.h"
 #include "s_sound.h"
 #include "sounds.h"
+#include "z_zone.h"
 
 ///////////////////////////////////////////////////////////////////////
 // 

--- a/src/p_genlin.c
+++ b/src/p_genlin.c
@@ -27,13 +27,19 @@
 //
 //-----------------------------------------------------------------------------
 
+#include "d_think.h"
 #include "doomstat.h"
-#include "r_main.h"
+#include "doomtype.h"
+#include "m_fixed.h"
+#include "m_random.h"
+#include "p_mobj.h"
 #include "p_spec.h"
 #include "p_tick.h"
-#include "m_random.h"
+#include "r_defs.h"
+#include "r_state.h"
 #include "s_sound.h"
 #include "sounds.h"
+#include "z_zone.h"
 
 //////////////////////////////////////////////////////////
 //

--- a/src/p_inter.c
+++ b/src/p_inter.c
@@ -26,17 +26,24 @@
 //
 //-----------------------------------------------------------------------------
 
-#include "doomstat.h"
-#include "dstrings.h"
-#include "m_random.h"
 #include "am_map.h"
+#include "d_deh.h"  // Ty 03/22/98 - externalized strings
+#include "d_items.h"
+#include "d_think.h"
+#include "doomdef.h"
+#include "doomstat.h"
+#include "i_system.h"
+#include "info.h"
+#include "m_fixed.h"
+#include "m_random.h"
+#include "p_inter.h"
+#include "p_pspr.h"
+#include "p_tick.h"
+#include "r_defs.h"
 #include "r_main.h"
 #include "s_sound.h"
 #include "sounds.h"
-#include "p_tick.h"
-#include "d_deh.h"  // Ty 03/22/98 - externalized strings
-
-#include "p_inter.h"
+#include "tables.h"
 
 #define BONUSADD        6
 

--- a/src/p_inter.h
+++ b/src/p_inter.h
@@ -30,6 +30,7 @@
 #define __P_INTER__
 
 #include "d_player.h"
+#include "doomtype.h"
 #include "p_mobj.h"
 
 // Ty 03/09/98 Moved to an int in p_inter.c for deh and externalization 

--- a/src/p_lights.c
+++ b/src/p_lights.c
@@ -28,12 +28,15 @@
 //
 //-----------------------------------------------------------------------------
 
+#include "d_think.h"
 #include "doomstat.h" //jff 5/18/98
-#include "doomdef.h"
+#include "m_fixed.h"
 #include "m_random.h"
-#include "r_main.h"
 #include "p_spec.h"
 #include "p_tick.h"
+#include "r_defs.h"
+#include "r_state.h"
+#include "z_zone.h"
 
 //////////////////////////////////////////////////////////
 //

--- a/src/p_map.c
+++ b/src/p_map.c
@@ -27,21 +27,27 @@
 //
 //-----------------------------------------------------------------------------
 
+#include "doomdata.h"
+#include "doomdef.h"
 #include "doomstat.h"
-#include "r_main.h"
-#include "p_mobj.h"
-#include "p_maputl.h"
+#include "i_system.h"
+#include "info.h"
+#include "m_argv.h"
+#include "m_bbox.h"
+#include "m_misc2.h"
+#include "m_random.h"
+#include "p_inter.h"
 #include "p_map.h"
+#include "p_maputl.h"
+#include "p_mobj.h"
 #include "p_setup.h"
 #include "p_spec.h"
+#include "r_main.h"
+#include "r_state.h"
 #include "s_sound.h"
 #include "sounds.h"
-#include "p_inter.h"
-#include "m_random.h"
-#include "m_bbox.h"
 #include "v_video.h"
-#include "m_argv.h"
-#include "m_misc2.h"
+#include "z_zone.h"
 
 static mobj_t    *tmthing;
 static int       tmflags;

--- a/src/p_map.h
+++ b/src/p_map.h
@@ -29,8 +29,12 @@
 #ifndef __P_MAP__
 #define __P_MAP__
 
-#include "r_defs.h"
 #include "d_player.h"
+#include "doomtype.h"
+#include "m_fixed.h"
+#include "p_mobj.h"
+#include "r_defs.h"
+#include "tables.h"
 
 #define USERANGE        (64*FRACUNIT)
 #define MELEERANGE      (64*FRACUNIT)

--- a/src/p_maputl.c
+++ b/src/p_maputl.c
@@ -29,12 +29,18 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <stdint.h>
+
+#include "doomdata.h"
+#include "doomdef.h"
 #include "doomstat.h"
 #include "m_bbox.h"
-#include "r_main.h"
-#include "p_maputl.h"
 #include "p_map.h"
+#include "p_maputl.h"
 #include "p_setup.h"
+#include "r_main.h"
+#include "r_state.h"
+#include "z_zone.h"
 
 //
 // P_AproxDistance

--- a/src/p_maputl.h
+++ b/src/p_maputl.h
@@ -29,7 +29,11 @@
 #ifndef __P_MAPUTL__
 #define __P_MAPUTL__
 
+#include "doomtype.h"
+#include "m_fixed.h"
+#include "p_mobj.h"
 #include "r_defs.h"
+#include "tables.h"
 
 // mapblocks are used to check movement against lines and things
 #define MAPBLOCKUNITS   128

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -26,23 +26,34 @@
 //
 //-----------------------------------------------------------------------------
 
+#include "d_player.h"
+#include "d_think.h"
+#include "d_ticcmd.h"
+#include "doomdata.h"
 #include "doomdef.h"
 #include "doomstat.h"
+#include "doomtype.h"
+#include "g_game.h"
+#include "hu_stuff.h"
+#include "info.h"
+#include "m_fixed.h"
 #include "m_random.h"
-#include "r_main.h"
-#include "p_maputl.h"
+#include "p_inter.h"
 #include "p_map.h"
-#include "p_tick.h"
+#include "p_maputl.h"
+#include "p_mobj.h"
+#include "p_pspr.h"
 #include "p_spec.h"
+#include "p_tick.h"
+#include "r_defs.h"
+#include "r_main.h"
+#include "s_musinfo.h" // [crispy] S_ParseMusInfo()
+#include "s_sound.h"
 #include "sounds.h"
 #include "st_stuff.h"
-#include "hu_stuff.h"
-#include "s_sound.h"
-#include "s_musinfo.h" // [crispy] S_ParseMusInfo()
-#include "info.h"
-#include "g_game.h"
-#include "p_inter.h"
+#include "tables.h"
 #include "v_video.h"
+#include "z_zone.h"
 
 // [FG] colored blood and gibs
 boolean colored_blood;

--- a/src/p_mobj.h
+++ b/src/p_mobj.h
@@ -29,21 +29,19 @@
 #ifndef __P_MOBJ__
 #define __P_MOBJ__
 
-// Basics.
-#include "tables.h"
-#include "m_fixed.h"
-
 // We need the thinker_t stuff.
 #include "d_think.h"
-
 // We need the WAD data structure for Map things,
 // from the THINGS lump.
 #include "doomdata.h"
-
+#include "doomtype.h"
 // States are tied to finite states are
 //  tied to animation frames.
 // Needs precompiled tables/data structures.
 #include "info.h"
+#include "m_fixed.h"
+// Basics.
+#include "tables.h"
 
 //
 // NOTES: mobj_t

--- a/src/p_plats.c
+++ b/src/p_plats.c
@@ -26,13 +26,21 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <stddef.h>
+
+#include "d_think.h"
 #include "doomstat.h"
+#include "doomtype.h"
+#include "m_fixed.h"
 #include "m_random.h"
-#include "r_main.h"
+#include "p_mobj.h"
 #include "p_spec.h"
 #include "p_tick.h"
+#include "r_defs.h"
+#include "r_state.h"
 #include "s_sound.h"
 #include "sounds.h"
+#include "z_zone.h"
 
 platlist_t *activeplats;       // killough 2/14/98: made global again
 

--- a/src/p_pspr.c
+++ b/src/p_pspr.c
@@ -27,17 +27,24 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <stdint.h>
+
+#include "d_event.h"
+#include "d_items.h"
+#include "d_player.h"
+#include "d_ticcmd.h"
 #include "doomstat.h"
-#include "r_main.h"
-#include "p_map.h"
-#include "p_inter.h"
-#include "p_pspr.h"
-#include "p_enemy.h"
 #include "m_random.h"
+#include "p_enemy.h"
+#include "p_inter.h"
+#include "p_map.h"
+#include "p_mobj.h"
+#include "p_pspr.h"
+#include "p_tick.h"
+#include "r_main.h"
 #include "s_sound.h"
 #include "sounds.h"
-#include "d_event.h"
-#include "p_tick.h"
+#include "tables.h"
 
 #define LOWERSPEED   (FRACUNIT*6)
 #define RAISESPEED   (FRACUNIT*6)

--- a/src/p_pspr.h
+++ b/src/p_pspr.h
@@ -30,6 +30,7 @@
 #define __P_PSPR__
 
 #include "doomdef.h"
+#include "doomtype.h"
 
 // Basic data types.
 // Needs fixed point, and BAM angles.
@@ -83,6 +84,7 @@ int P_WeaponPreferred(int w1, int w2);
 extern boolean weapon_recoilpitch;
 
 struct player_s;
+
 int P_SwitchWeapon(struct player_s *player);
 boolean P_CheckAmmo(struct player_s *player);
 void P_SetupPsprites(struct player_s *curplayer);

--- a/src/p_saveg.c
+++ b/src/p_saveg.c
@@ -26,16 +26,28 @@
 //
 //-----------------------------------------------------------------------------
 
+#include "am_map.h"
+#include "d_player.h"
+#include "d_think.h"
+#include "d_ticcmd.h"
+#include "doomdata.h"
+#include "doomdef.h"
 #include "doomstat.h"
-#include "r_main.h"
+#include "i_system.h"
+#include "info.h"
+#include "m_fixed.h"
+#include "m_random.h"
+#include "p_enemy.h"
 #include "p_maputl.h"
+#include "p_mobj.h"
+#include "p_pspr.h"
+#include "p_saveg.h"
 #include "p_spec.h"
 #include "p_tick.h"
-#include "p_saveg.h"
-#include "m_random.h"
-#include "am_map.h"
-#include "p_enemy.h"
+#include "r_defs.h"
+#include "r_state.h"
 #include "w_wad.h" // [FG] W_LumpLength()
+#include "z_zone.h"
 
 byte *save_p;
 

--- a/src/p_saveg.h
+++ b/src/p_saveg.h
@@ -29,6 +29,9 @@
 #ifndef __P_SAVEG__
 #define __P_SAVEG__
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include "doomtype.h"
 
 // Persistent storage/archiving.

--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -27,26 +27,35 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <math.h>
+#include <stdint.h>
+
+#include "d_player.h"
+#include "doomdata.h"
 #include "doomstat.h"
-#include "m_bbox.h"
-#include "m_argv.h"
 #include "g_game.h"
-#include "w_wad.h"
-#include "r_main.h"
-#include "r_things.h"
-#include "p_maputl.h"
+#include "i_system.h"
+#include "info.h"
+#include "m_argv.h"
+#include "m_bbox.h"
+#include "m_swap.h"
+#include "p_enemy.h"
+// [FG] support maps with NODES in compressed or uncompressed ZDBSP format or DeePBSP format
+#include "p_extnodes.h"
 #include "p_map.h"
+#include "p_maputl.h"
 #include "p_setup.h"
 #include "p_spec.h"
 #include "p_tick.h"
-#include "p_enemy.h"
-#include "s_sound.h"
+#include "r_data.h"
+#include "r_main.h"
+#include "r_state.h"
+#include "r_things.h"
 #include "s_musinfo.h" // [crispy] S_ParseMusInfo()
-#include "m_misc2.h" // [FG] M_StringJoin()
-#include "m_swap.h"
-
-// [FG] support maps with NODES in compressed or uncompressed ZDBSP format or DeePBSP format
-#include "p_extnodes.h"
+#include "s_sound.h"
+#include "tables.h"
+#include "w_wad.h"
+#include "z_zone.h"
 
 //
 // MAP related Lookup tables.

--- a/src/p_setup.h
+++ b/src/p_setup.h
@@ -30,6 +30,8 @@
 #define __P_SETUP__
 
 #include "doomdef.h"
+#include "doomtype.h"
+#include "m_fixed.h"
 #include "p_mobj.h"
 #include "r_defs.h"
 

--- a/src/p_sight.c
+++ b/src/p_sight.c
@@ -26,11 +26,19 @@
 //
 //-----------------------------------------------------------------------------
 
+#include "doomdata.h"
 #include "doomstat.h"
-#include "r_main.h"
-#include "p_maputl.h"
-#include "p_setup.h"
+#include "doomtype.h"
+#include "i_system.h"
 #include "m_bbox.h"
+#include "m_fixed.h"
+#include "p_maputl.h"
+#include "p_mobj.h"
+#include "p_setup.h"
+#include "r_defs.h"
+#include "r_main.h"
+#include "r_state.h"
+#include "tables.h"
 
 //
 // P_CheckSight

--- a/src/p_spec.c
+++ b/src/p_spec.c
@@ -34,28 +34,34 @@
 //
 //-----------------------------------------------------------------------------
 
+#include "d_deh.h"
+#include "doomdata.h"
 #include "doomstat.h"
+#include "g_game.h"
+#include "i_sound.h"
+#include "i_system.h"
+#include "info.h"
+#include "m_argv.h"
+#include "m_bbox.h"                                         // phares 3/20/98
+#include "m_random.h"
+#include "m_swap.h"
+#include "p_inter.h"
+#include "p_map.h"
+#include "p_maputl.h"
+#include "p_setup.h"
 #include "p_spec.h"
 #include "p_tick.h"
-#include "p_setup.h"
-#include "m_random.h"
-#include "d_englsh.h"
-#include "m_argv.h"
-#include "w_wad.h"
+#include "r_data.h"
+#include "r_draw.h"  // R_SetFuzzPosTic
 #include "r_main.h"
-#include "p_maputl.h"
-#include "p_map.h"
-#include "g_game.h"
-#include "p_inter.h"
+#include "r_plane.h"  // killough 10/98
+#include "r_sky.h"   // R_GetSkyColor
+#include "r_state.h"
 #include "s_sound.h"
 #include "sounds.h"
-#include "m_bbox.h"                                         // phares 3/20/98
-#include "d_deh.h"
-#include "r_plane.h"  // killough 10/98
-#include "i_sound.h"
-#include "r_draw.h"  // R_SetFuzzPosTic
-#include "r_sky.h"   // R_GetSkyColor
-#include "m_swap.h"
+#include "tables.h"
+#include "w_wad.h"
+#include "z_zone.h"
 
 //
 // Animating textures and planes

--- a/src/p_spec.h
+++ b/src/p_spec.h
@@ -28,8 +28,13 @@
 #ifndef __P_SPEC__
 #define __P_SPEC__
 
-#include "r_defs.h"
 #include "d_player.h"
+#include "d_think.h"
+#include "doomdef.h"
+#include "doomtype.h"
+#include "m_fixed.h"
+#include "p_mobj.h"
+#include "r_defs.h"
 
 //      Define values for map objects
 #define MO_TELEPORTMAN  14

--- a/src/p_switch.c
+++ b/src/p_switch.c
@@ -26,14 +26,23 @@
 //
 //-----------------------------------------------------------------------------
 
+#include "d_player.h"
+#include "doomdata.h"
+#include "doomdef.h"
 #include "doomstat.h"
-#include "w_wad.h"
-#include "r_main.h"
-#include "p_spec.h"
+#include "doomtype.h"
 #include "g_game.h"
+#include "i_system.h"
+#include "m_swap.h"
+#include "p_mobj.h"
+#include "p_spec.h"
+#include "r_data.h"
+#include "r_defs.h"
+#include "r_state.h"
 #include "s_sound.h"
 #include "sounds.h"
-#include "m_swap.h"
+#include "w_wad.h"
+#include "z_zone.h"
 
 // killough 2/8/98: Remove switch limit
 

--- a/src/p_telept.c
+++ b/src/p_telept.c
@@ -26,15 +26,25 @@
 //
 //-----------------------------------------------------------------------------
 
+#include "d_player.h"
+#include "d_think.h"
+#include "doomdef.h"
 #include "doomstat.h"
-#include "p_spec.h"
-#include "p_maputl.h"
+#include "doomtype.h"
+#include "info.h"
+#include "m_fixed.h"
 #include "p_map.h"
-#include "r_main.h"
+#include "p_maputl.h"
+#include "p_mobj.h"
+#include "p_spec.h"
 #include "p_tick.h"
+#include "p_user.h"
+#include "r_defs.h"
+#include "r_main.h"
+#include "r_state.h"
 #include "s_sound.h"
 #include "sounds.h"
-#include "p_user.h"
+#include "tables.h"
 
 //
 // TELEPORTATION

--- a/src/p_tick.c
+++ b/src/p_tick.c
@@ -26,12 +26,17 @@
 //
 //-----------------------------------------------------------------------------
 
+#include "d_player.h"
+#include "doomdef.h"
 #include "doomstat.h"
-#include "p_user.h"
+#include "doomtype.h"
+#include "info.h"
+#include "p_map.h"
 #include "p_spec.h"
 #include "p_tick.h"
-#include "p_map.h"
+#include "p_user.h"
 #include "s_musinfo.h" // [crispy] T_MAPMusic()
+#include "z_zone.h"
 
 int leveltime;
 int oldleveltime;

--- a/src/p_user.c
+++ b/src/p_user.c
@@ -28,13 +28,21 @@
 //
 //-----------------------------------------------------------------------------
 
-#include "doomstat.h"
 #include "d_event.h"
-#include "r_main.h"
+#include "d_ticcmd.h"
+#include "doomdef.h"
+#include "doomstat.h"
+#include "doomtype.h"
+#include "g_game.h"
+#include "info.h"
 #include "p_map.h"
+#include "p_mobj.h"
+#include "p_pspr.h"
 #include "p_spec.h"
 #include "p_user.h"
-#include "g_game.h"
+#include "r_data.h"
+#include "r_defs.h"
+#include "r_main.h"
 
 // Index of the special effects (INVUL inverse) map.
 

--- a/src/p_user.h
+++ b/src/p_user.h
@@ -32,6 +32,8 @@
 #define __P_USER__
 
 #include "d_player.h"
+#include "m_fixed.h"
+#include "tables.h"
 
 void P_PlayerThink(player_t *player);
 void P_CalcHeight(player_t *player);

--- a/src/r_bmaps.c
+++ b/src/r_bmaps.c
@@ -19,8 +19,10 @@
 //	Adapted from doomretro/src/r_data.c:97-209
 //
 
-#include "doomtype.h"
+#include "doomdef.h"
 #include "doomstat.h"
+#include "doomtype.h"
+#include "info.h"
 #include "r_data.h"
 #include "w_wad.h"
 

--- a/src/r_bsp.c
+++ b/src/r_bsp.c
@@ -26,14 +26,23 @@
 //
 //-----------------------------------------------------------------------------
 
+#include "d_player.h"
+#include "doomdata.h"
+#include "doomdef.h"
 #include "doomstat.h"
-#include "m_bbox.h"
+#include "doomtype.h"
 #include "i_system.h"
 #include "i_video.h" // [FG] uncapped
+#include "m_bbox.h"
+#include "m_fixed.h"
+#include "p_mobj.h"
+#include "r_defs.h"
 #include "r_main.h"
-#include "r_segs.h"
 #include "r_plane.h"
+#include "r_segs.h"
+#include "r_state.h"
 #include "r_things.h"
+#include "tables.h"
 
 seg_t     *curline;
 side_t    *sidedef;

--- a/src/r_data.c
+++ b/src/r_data.c
@@ -27,17 +27,28 @@
 //
 //-----------------------------------------------------------------------------
 
+#include "d_think.h"
+#include "doomdef.h"
 #include "doomstat.h"
-#include "p_tick.h"
-#include "w_wad.h"
-#include "r_main.h"
-#include "r_sky.h"
-#include "m_io.h"
+#include "doomtype.h"
+#include "i_system.h"
+#include "info.h"
 #include "m_argv.h" // M_CheckParm()
+#include "m_fixed.h"
+#include "m_io.h"
 #include "m_misc2.h"
 #include "m_swap.h"
-#include "v_video.h" // cr_dark
+#include "p_mobj.h"
+#include "p_tick.h"
 #include "r_bmaps.h" // [crispy] R_BrightmapForTexName()
+#include "r_data.h"
+#include "r_defs.h"
+#include "r_main.h"
+#include "r_sky.h"
+#include "r_state.h"
+#include "v_video.h" // cr_dark
+#include "w_wad.h"
+#include "z_zone.h"
 
 //
 // Graphics.

--- a/src/r_data.h
+++ b/src/r_data.h
@@ -30,6 +30,7 @@
 #ifndef __R_DATA__
 #define __R_DATA__
 
+#include "doomtype.h"
 #include "r_defs.h"
 #include "r_state.h"
 

--- a/src/r_draw.c
+++ b/src/r_draw.c
@@ -28,12 +28,17 @@
 //
 //-----------------------------------------------------------------------------
 
+#include "doomdef.h"
 #include "doomstat.h"
-#include "w_wad.h"
+#include "i_system.h"
+#include "i_video.h"
+#include "m_menu.h"
 #include "r_draw.h" // [FG]
 #include "r_main.h"
+#include "r_state.h"
 #include "v_video.h"
-#include "m_menu.h"
+#include "w_wad.h"
+#include "z_zone.h"
 
 #define MAXWIDTH  MAX_SCREENWIDTH          /* kilough 2/8/98 */
 #define MAXHEIGHT MAX_SCREENHEIGHT

--- a/src/r_draw.h
+++ b/src/r_draw.h
@@ -29,6 +29,8 @@
 #ifndef __R_DRAW__
 #define __R_DRAW__
 
+#include "doomtype.h"
+#include "m_fixed.h"
 #include "r_defs.h"
 
 extern lighttable_t *dc_colormap[2];

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -28,16 +28,25 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <stdint.h>
+
+#include "d_loop.h"
+#include "doomdata.h"
+#include "doomdef.h"
 #include "doomstat.h"
-#include "r_main.h"
-#include "r_things.h"
-#include "r_plane.h"
+#include "i_video.h"
+#include "p_mobj.h"
 #include "r_bsp.h"
+#include "r_data.h"
 #include "r_draw.h"
-#include "m_bbox.h"
+#include "r_main.h"
+#include "r_plane.h"
 #include "r_sky.h"
-#include "v_video.h"
+#include "r_state.h"
+#include "r_things.h"
 #include "st_stuff.h"
+#include "v_video.h"
+#include "z_zone.h"
 
 // Fineangles in the SCREENWIDTH wide window.
 #define FIELDOFVIEW 2048    

--- a/src/r_main.h
+++ b/src/r_main.h
@@ -30,7 +30,11 @@
 #define __R_MAIN__
 
 #include "d_player.h"
+#include "doomtype.h"
+#include "m_fixed.h"
 #include "r_data.h"
+#include "r_defs.h"
+#include "tables.h"
 
 //
 // POV related.

--- a/src/r_plane.c
+++ b/src/r_plane.c
@@ -40,17 +40,20 @@
 //
 //-----------------------------------------------------------------------------
 
-#include "z_zone.h"  /* memory allocation wrappers -- killough */
-
 #include "doomstat.h"
-#include "w_wad.h"
-#include "r_main.h"
-#include "r_draw.h"
-#include "r_things.h"
-#include "r_sky.h"
-#include "r_plane.h"
+#include "doomtype.h"
+#include "i_system.h"
 #include "r_bmaps.h" // [crispy] R_BrightmapForTexName()
+#include "r_draw.h"
+#include "r_main.h"
+#include "r_plane.h"
+#include "r_sky.h"
+#include "r_state.h"
 #include "r_swirl.h" // [crispy] R_DistortedFlat()
+#include "r_things.h"
+#include "tables.h"
+#include "w_wad.h"
+#include "z_zone.h"
 
 #define MAXVISPLANES 128    /* must be a power of 2 */
 

--- a/src/r_plane.h
+++ b/src/r_plane.h
@@ -29,7 +29,10 @@
 #ifndef __R_PLANE__
 #define __R_PLANE__
 
+#include "doomdef.h"
+#include "m_fixed.h"
 #include "r_data.h"
+#include "r_defs.h"
 
 // killough 10/98: special mask indicates sky flat comes from sidedef
 #define PL_SKYFLAT (0x80000000)

--- a/src/r_segs.c
+++ b/src/r_segs.c
@@ -28,16 +28,27 @@
 //
 // 4/25/98, 5/2/98 killough: reformatted, beautified
 
+#include <stdint.h>
+
+#include "doomdata.h"
+#include "doomdef.h"
 #include "doomstat.h"
+#include "doomtype.h"
+#include "i_system.h"
 #include "i_video.h"
-#include "p_tick.h"
-#include "r_main.h"
-#include "r_bsp.h"
-#include "r_plane.h"
-#include "r_things.h"
-#include "r_draw.h"
-#include "w_wad.h"
+#include "m_fixed.h"
 #include "r_bmaps.h" // [crispy] brightmaps
+#include "r_bsp.h"
+#include "r_data.h"
+#include "r_defs.h"
+#include "r_draw.h"
+#include "r_main.h"
+#include "r_plane.h"
+#include "r_state.h"
+#include "r_things.h"
+#include "tables.h"
+#include "w_wad.h"
+#include "z_zone.h"
 
 // OPTIMIZE: closed two sided lines as single sided
 

--- a/src/r_sky.c
+++ b/src/r_sky.c
@@ -30,11 +30,15 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <stddef.h>
+
 #include "i_video.h"
+#include "m_fixed.h"
+#include "r_data.h"
 #include "r_sky.h"
 #include "r_state.h" // [FG] textureheight[]
-#include "r_data.h"
 #include "w_wad.h"
+#include "z_zone.h"
 
 // [FG] stretch short skies
 boolean stretchsky;

--- a/src/r_sky.h
+++ b/src/r_sky.h
@@ -29,6 +29,7 @@
 #ifndef __R_SKY__
 #define __R_SKY__
 
+#include "doomtype.h"
 #include "m_fixed.h"
 
 // SKY, store the number for name.

--- a/src/r_swirl.c
+++ b/src/r_swirl.c
@@ -19,12 +19,15 @@
 
 // [crispy] adapted from smmu/r_ripple.c, by Simon Howard
 
+#include <stddef.h>
+
 #include "doomstat.h"
-
+#include "doomtype.h"
 #include "i_system.h"
-#include "w_wad.h"
-
+#include "m_fixed.h"
 #include "tables.h"
+#include "w_wad.h"
+#include "z_zone.h"
 
 
 // swirl factors determine the number of waves per flat width

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -27,17 +27,29 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <wchar.h>
+
+#include "d_player.h"
 #include "doomstat.h"
+#include "doomtype.h"
+#include "i_system.h"
 #include "i_video.h"
+#include "info.h"
+#include "m_swap.h"
+#include "p_mobj.h"
+#include "p_pspr.h"
+#include "r_bmaps.h" // [crispy] R_BrightmapForTexName()
+#include "r_bsp.h"
+#include "r_data.h"
+#include "r_draw.h"
+#include "r_main.h"
+#include "r_segs.h"
+#include "r_state.h"
+#include "r_things.h"
+#include "tables.h"
 #include "v_video.h"
 #include "w_wad.h"
-#include "r_main.h"
-#include "r_bsp.h"
-#include "r_segs.h"
-#include "r_draw.h"
-#include "r_things.h"
-#include "r_bmaps.h" // [crispy] R_BrightmapForTexName()
-#include "m_swap.h"
+#include "z_zone.h"
 
 #define MINZ        (FRACUNIT*4)
 #define BASEYCENTER 100

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -27,8 +27,6 @@
 //
 //-----------------------------------------------------------------------------
 
-#include <wchar.h>
-
 #include "d_player.h"
 #include "doomstat.h"
 #include "doomtype.h"

--- a/src/r_things.h
+++ b/src/r_things.h
@@ -29,6 +29,8 @@
 #ifndef __R_THINGS__
 #define __R_THINGS__
 
+#include <stdint.h>
+
 #include "doomdef.h"
 #include "m_fixed.h"
 #include "r_defs.h"

--- a/src/s_musinfo.c
+++ b/src/s_musinfo.c
@@ -23,19 +23,16 @@
 
 // HEADER FILES ------------------------------------------------------------
 
+#include <stdio.h>
 #include <string.h>
-#include <stdlib.h>
-#include "doomstat.h"
-#include "m_io.h"
+
 #include "i_system.h"
 #include "m_misc.h"
 #include "m_misc2.h"
-#include "r_defs.h"
+#include "s_musinfo.h"
 #include "s_sound.h"
 #include "w_wad.h"
 #include "z_zone.h"
-
-#include "s_musinfo.h"
 
 // MACROS ------------------------------------------------------------------
 

--- a/src/s_musinfo.h
+++ b/src/s_musinfo.h
@@ -22,6 +22,7 @@
 #ifndef __S_MUSINFO__
 #define __S_MUSINFO__
 
+#include "doomtype.h"
 #include "p_mobj.h"
 
 #define MAX_MUS_ENTRIES 65 // [crispy] 0 to 64 inclusive

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -29,14 +29,22 @@
 // killough 3/7/98: modified to allow arbitrary listeners in spy mode
 // killough 5/2/98: reindented, removed useless code, beautified
 
+#include "d_player.h"
+#include "doomdef.h"
 #include "doomstat.h"
-#include "s_sound.h"
-#include "s_musinfo.h" // [crispy] struct musinfo
 #include "i_sound.h"
-#include "r_main.h"
+#include "i_system.h"
+#include "m_fixed.h"
 #include "m_random.h"
-#include "m_misc2.h"
+#include "r_defs.h"
+#include "r_main.h"
+#include "s_musinfo.h" // [crispy] struct musinfo
+#include "s_sound.h"
+#include "sounds.h"
+#include "tables.h"
+#include "u_mapinfo.h"
 #include "w_wad.h"
+#include "z_zone.h"
 
 // when to clip out sounds
 // Does not fit the large outdoor areas.

--- a/src/s_sound.h
+++ b/src/s_sound.h
@@ -29,6 +29,7 @@
 #ifndef __S_SOUND__
 #define __S_SOUND__
 
+#include "doomtype.h"
 #include "p_mobj.h"
 
 //

--- a/src/sounds.c
+++ b/src/sounds.c
@@ -30,7 +30,8 @@
 
 // killough 5/3/98: reformatted
 
-#include "doomtype.h"
+#include <stddef.h>
+
 #include "sounds.h"
 
 //

--- a/src/st_lib.c
+++ b/src/st_lib.c
@@ -28,13 +28,14 @@
 //-----------------------------------------------------------------------------
 
 #include "doomdef.h"
-#include "doomstat.h"
+#include "i_system.h"
+#include "i_video.h"
+#include "m_swap.h"
+#include "st_lib.h"
+#include "st_stuff.h"
 #include "v_video.h"
 #include "w_wad.h"
-#include "st_stuff.h"
-#include "st_lib.h"
-#include "r_main.h"
-#include "m_swap.h"
+#include "z_zone.h"
 
 int sts_always_red;      //jff 2/18/98 control to disable status color changes
 int sts_pct_always_gray; // killough 2/21/98: always gray %'s? bug or feature?

--- a/src/st_lib.h
+++ b/src/st_lib.h
@@ -29,6 +29,7 @@
 #ifndef __STLIB__
 #define __STLIB__
 
+#include "doomtype.h"
 // We are referring to patches.
 #include "r_defs.h"
 #include "v_video.h"  // color ranges

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -29,22 +29,28 @@
 //
 //-----------------------------------------------------------------------------
 
+#include "am_map.h"
+#include "d_items.h"
+#include "d_player.h"
 #include "doomdef.h"
 #include "doomstat.h"
-#include "m_random.h"
-#include "i_video.h"
-#include "w_wad.h"
-#include "st_stuff.h"
 #include "hu_stuff.h" // [FG] hud_displayed, hud_distributed
-#include "st_lib.h"
-#include "r_main.h"
-#include "am_map.h"
+#include "i_video.h"
 #include "m_cheat.h"
-#include "s_sound.h"
-#include "sounds.h"
-#include "dstrings.h"
 #include "m_misc2.h"
+#include "m_random.h"
 #include "m_swap.h"
+#include "p_mobj.h"
+#include "r_data.h"
+#include "r_defs.h"
+#include "r_main.h"
+#include "r_state.h"
+#include "st_lib.h"
+#include "st_stuff.h"
+#include "tables.h"
+#include "v_video.h"
+#include "w_wad.h"
+#include "z_zone.h"
 
 // [crispy] immediately redraw status bar after help screens have been shown
 extern boolean inhelpscreens;

--- a/src/statdump.c
+++ b/src/statdump.c
@@ -19,15 +19,10 @@
 
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
-#include "doomdef.h"
 #include "d_player.h"
+#include "doomdef.h"
 #include "m_argv.h"
 #include "m_io.h"
-
 #include "statdump.h"
 
 /* Par times for E1M1-E1M9. */

--- a/src/tables.h
+++ b/src/tables.h
@@ -42,6 +42,8 @@
 #ifndef __TABLES__
 #define __TABLES__
 
+#include <stdint.h>
+
 #include "m_fixed.h"
 
 #define FINEANGLES              8192

--- a/src/u_mapinfo.c
+++ b/src/u_mapinfo.c
@@ -18,15 +18,13 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
-#include <ctype.h>
 
-#include "info.h"
 #include "m_misc2.h"
-#include "u_scanner.h"
-
 #include "u_mapinfo.h"
+#include "u_scanner.h"
 
 void M_AddEpisode(const char *map, const char *gfx, const char *txt, const char *alpha);
 void M_ClearEpisodes(void);

--- a/src/u_mapinfo.h
+++ b/src/u_mapinfo.h
@@ -21,6 +21,8 @@
 #ifndef __UMAPINFO_H
 #define __UMAPINFO_H
 
+#include <stddef.h>
+
 #include "doomtype.h"
 
 typedef struct

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -30,13 +30,14 @@
 //
 //-----------------------------------------------------------------------------
 
+#include "doomdef.h"
 #include "doomstat.h"
-#include "r_main.h"
-#include "m_bbox.h"
-#include "w_wad.h"   /* needed for color translation lump lookup */
-#include "v_video.h"
+#include "i_system.h"
 #include "i_video.h"
 #include "m_swap.h"
+#include "v_video.h"
+#include "w_wad.h"   /* needed for color translation lump lookup */
+#include "z_zone.h"
 
 // Each screen is [SCREENWIDTH*SCREENHEIGHT];
 byte *screens[5];

--- a/src/v_video.h
+++ b/src/v_video.h
@@ -32,11 +32,12 @@
 #ifndef __V_VIDEO__
 #define __V_VIDEO__
 
-#include "doomtype.h"
 #include "doomdef.h"
+#include "doomtype.h"
 #include "i_video.h"
 // Needed because we are refering to patches.
 #include "r_data.h"
+#include "r_defs.h"
 
 //
 // VIDEO

--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -27,9 +27,7 @@
 //-----------------------------------------------------------------------------
 
 #include <fcntl.h>
-#include <io.h>
 #include <sys/stat.h>
-#include <wchar.h>
 
 #include "d_main.h" // [FG] wadfiles
 #include "doomdef.h"

--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -27,14 +27,19 @@
 //-----------------------------------------------------------------------------
 
 #include <fcntl.h>
+#include <io.h>
+#include <sys/stat.h>
+#include <wchar.h>
 
-#include "doomstat.h"
+#include "d_main.h" // [FG] wadfiles
+#include "doomdef.h"
+#include "doomtype.h"
+#include "i_system.h"
 #include "m_io.h"
-
-#include "w_wad.h"
 #include "m_misc2.h" // [FG] M_BaseName()
 #include "m_swap.h"
-#include "d_main.h" // [FG] wadfiles
+#include "w_wad.h"
+#include "z_zone.h"
 
 //
 // GLOBALS

--- a/src/wi_stuff.c
+++ b/src/wi_stuff.c
@@ -27,18 +27,25 @@
 //
 //-----------------------------------------------------------------------------
 
+#include "d_event.h"
+#include "d_ticcmd.h"
+#include "doomdef.h"
 #include "doomstat.h"
-#include "m_random.h"
-#include "w_wad.h"
+#include "doomtype.h"
 #include "g_game.h"
-#include "r_main.h"
-#include "v_video.h"
-#include "wi_stuff.h"
+#include "hu_stuff.h"
+#include "i_video.h"
+#include "m_misc2.h"
+#include "m_random.h"
+#include "m_swap.h"
+#include "r_defs.h"
 #include "s_sound.h"
 #include "sounds.h"
-#include "hu_stuff.h"
-#include "m_misc2.h"
-#include "m_swap.h"
+#include "u_mapinfo.h"
+#include "v_video.h"
+#include "w_wad.h"
+#include "wi_stuff.h"
+#include "z_zone.h"
 
 // Ty 03/17/98: flag that new par times have been loaded in d_deh
 extern boolean deh_pars;  

--- a/src/wi_stuff.h
+++ b/src/wi_stuff.h
@@ -31,8 +31,8 @@
 
 //#include "v_video.h"
 
-#include "doomdef.h"
 #include "d_player.h"
+#include "doomdef.h"
 
 // States for the intermission
 

--- a/src/z_zone.c
+++ b/src/z_zone.c
@@ -35,6 +35,10 @@
 //-----------------------------------------------------------------------------
 
 #include "z_zone.h"
+
+#include <stdlib.h>
+#include <string.h>
+
 #include "i_system.h"
 
 // Minimum chunk size at which blocks are allocated

--- a/src/z_zone.h
+++ b/src/z_zone.h
@@ -37,11 +37,6 @@
 // Include system definitions so that prototypes become
 // active before macro replacements below are in effect.
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <assert.h>
-
 #include "doomtype.h"
 
 // ZONE MEMORY

--- a/textscreen/txt_button.c
+++ b/textscreen/txt_button.c
@@ -16,13 +16,10 @@
 #include <string.h>
 
 #include "doomkeys.h"
-
 #include "txt_button.h"
 #include "txt_gui.h"
-#include "txt_io.h"
 #include "txt_main.h"
 #include "txt_utf8.h"
-#include "txt_window.h"
 
 static void TXT_ButtonSizeCalc(TXT_UNCAST_ARG(button))
 {

--- a/textscreen/txt_button.h
+++ b/textscreen/txt_button.h
@@ -32,6 +32,8 @@ typedef struct txt_button_s txt_button_t;
 
 #include "txt_widget.h"
 
+struct txt_button_s;
+
 struct txt_button_s
 {
     txt_widget_t widget;

--- a/textscreen/txt_checkbox.c
+++ b/textscreen/txt_checkbox.c
@@ -16,13 +16,11 @@
 #include <string.h>
 
 #include "doomkeys.h"
-
 #include "txt_checkbox.h"
 #include "txt_gui.h"
 #include "txt_io.h"
 #include "txt_main.h"
 #include "txt_utf8.h"
-#include "txt_window.h"
 
 static void TXT_CheckBoxSizeCalc(TXT_UNCAST_ARG(checkbox))
 {

--- a/textscreen/txt_checkbox.h
+++ b/textscreen/txt_checkbox.h
@@ -38,6 +38,8 @@ typedef struct txt_checkbox_s txt_checkbox_t;
 
 #include "txt_widget.h"
 
+struct txt_checkbox_s;
+
 struct txt_checkbox_s
 {
     txt_widget_t widget;

--- a/textscreen/txt_desktop.c
+++ b/textscreen/txt_desktop.c
@@ -17,12 +17,10 @@
 #include <string.h>
 
 #include "doomkeys.h"
-
 #include "txt_desktop.h"
 #include "txt_gui.h"
 #include "txt_io.h"
 #include "txt_main.h"
-#include "txt_separator.h"
 #include "txt_window.h"
 
 #define HELP_KEY KEY_F1

--- a/textscreen/txt_dropdown.c
+++ b/textscreen/txt_dropdown.c
@@ -13,15 +13,13 @@
 //
 
 #include <stdlib.h>
-#include <string.h>
 
 #include "doomkeys.h"
-
 #include "txt_button.h"
 #include "txt_dropdown.h"
 #include "txt_gui.h"
-#include "txt_io.h"
 #include "txt_main.h"
+#include "txt_table.h"
 #include "txt_utf8.h"
 #include "txt_window.h"
 

--- a/textscreen/txt_dropdown.h
+++ b/textscreen/txt_dropdown.h
@@ -35,6 +35,8 @@ typedef struct txt_dropdown_list_s txt_dropdown_list_t;
 
 #include "txt_widget.h"
 
+struct txt_dropdown_list_s;
+
 //
 // Drop-down list box.
 // 

--- a/textscreen/txt_gui.c
+++ b/textscreen/txt_gui.c
@@ -20,6 +20,8 @@
 #include "txt_main.h"
 #include "txt_utf8.h"
 
+struct txt_cliparea_s;
+
 typedef struct txt_cliparea_s txt_cliparea_t;
 
 struct txt_cliparea_s

--- a/textscreen/txt_inputbox.c
+++ b/textscreen/txt_inputbox.c
@@ -18,13 +18,11 @@
 #include <string.h>
 
 #include "doomkeys.h"
-
-#include "txt_inputbox.h"
 #include "txt_gui.h"
+#include "txt_inputbox.h"
 #include "txt_io.h"
 #include "txt_main.h"
 #include "txt_utf8.h"
-#include "txt_window.h"
 
 extern txt_widget_class_t txt_inputbox_class;
 extern txt_widget_class_t txt_int_inputbox_class;

--- a/textscreen/txt_inputbox.h
+++ b/textscreen/txt_inputbox.h
@@ -34,6 +34,8 @@ typedef struct txt_inputbox_s txt_inputbox_t;
 
 #include "txt_widget.h"
 
+struct txt_inputbox_s;
+
 struct txt_inputbox_s
 {
     txt_widget_t widget;

--- a/textscreen/txt_io.c
+++ b/textscreen/txt_io.c
@@ -15,9 +15,6 @@
 // Text mode I/O functions, similar to C stdio
 //
 
-#include <stdlib.h>
-#include <string.h>
-
 #include "txt_io.h"
 #include "txt_main.h"
 

--- a/textscreen/txt_label.c
+++ b/textscreen/txt_label.c
@@ -15,12 +15,11 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "txt_label.h"
 #include "txt_gui.h"
 #include "txt_io.h"
+#include "txt_label.h"
 #include "txt_main.h"
 #include "txt_utf8.h"
-#include "txt_window.h"
 
 static void TXT_LabelSizeCalc(TXT_UNCAST_ARG(label))
 {

--- a/textscreen/txt_label.h
+++ b/textscreen/txt_label.h
@@ -32,6 +32,8 @@ typedef struct txt_label_s txt_label_t;
 #include "txt_main.h"
 #include "txt_widget.h"
 
+struct txt_label_s;
+
 struct txt_label_s
 {
     txt_widget_t widget;

--- a/textscreen/txt_scrollpane.c
+++ b/textscreen/txt_scrollpane.c
@@ -12,19 +12,14 @@
 // GNU General Public License for more details.
 //
 
-#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-#include <math.h>
-
-#include "txt_scrollpane.h"
-#include "txt_gui.h"
-#include "txt_io.h"
-#include "txt_main.h"
-#include "txt_table.h"
 
 #include "doomkeys.h"
+#include "txt_gui.h"
+#include "txt_main.h"
+#include "txt_scrollpane.h"
+#include "txt_table.h"
 
 #define SCROLLBAR_VERTICAL   (1 << 0)
 #define SCROLLBAR_HORIZONTAL (1 << 1)

--- a/textscreen/txt_scrollpane.h
+++ b/textscreen/txt_scrollpane.h
@@ -33,6 +33,8 @@ typedef struct txt_scrollpane_s txt_scrollpane_t;
 
 #include "txt_widget.h"
 
+struct txt_scrollpane_s;
+
 struct txt_scrollpane_s
 {
     txt_widget_t widget;

--- a/textscreen/txt_sdl.c
+++ b/textscreen/txt_sdl.c
@@ -15,16 +15,16 @@
 // Text mode emulation in SDL
 //
 
-#include "SDL.h"
-
 #include <ctype.h>
+#include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
+#include "SDL.h"
 #include "doomkeys.h"
 #include "m_io.h"
-
 #include "txt_main.h"
 #include "txt_sdl.h"
 #include "txt_utf8.h"
@@ -43,10 +43,10 @@ typedef struct
 
 // Fonts:
 
-#include "fonts/small.h"
-#include "fonts/normal.h"
-#include "fonts/large.h"
 #include "fonts/codepage.h"
+#include "fonts/large.h"
+#include "fonts/normal.h"
+#include "fonts/small.h"
 
 // Time between character blinks in ms
 

--- a/textscreen/txt_separator.c
+++ b/textscreen/txt_separator.c
@@ -15,12 +15,11 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "txt_separator.h"
 #include "txt_gui.h"
 #include "txt_io.h"
 #include "txt_main.h"
+#include "txt_separator.h"
 #include "txt_utf8.h"
-#include "txt_window.h"
 
 static void TXT_SeparatorSizeCalc(TXT_UNCAST_ARG(separator))
 {

--- a/textscreen/txt_separator.h
+++ b/textscreen/txt_separator.h
@@ -34,6 +34,8 @@ typedef struct txt_separator_s txt_separator_t;
 
 #include "txt_widget.h"
 
+struct txt_separator_s;
+
 struct txt_separator_s
 {
     txt_widget_t widget;

--- a/textscreen/txt_strut.c
+++ b/textscreen/txt_strut.c
@@ -13,14 +13,8 @@
 //
 
 #include <stdlib.h>
-#include <string.h>
-
-#include "doomkeys.h"
 
 #include "txt_strut.h"
-#include "txt_io.h"
-#include "txt_main.h"
-#include "txt_window.h"
 
 static void TXT_StrutSizeCalc(TXT_UNCAST_ARG(strut))
 {

--- a/textscreen/txt_strut.h
+++ b/textscreen/txt_strut.h
@@ -33,6 +33,8 @@ typedef struct txt_strut_s txt_strut_t;
 
 #include "txt_widget.h"
 
+struct txt_strut_s;
+
 struct txt_strut_s
 {
     txt_widget_t widget;

--- a/textscreen/txt_table.c
+++ b/textscreen/txt_table.c
@@ -17,9 +17,6 @@
 #include <string.h>
 
 #include "doomkeys.h"
-
-#include "txt_desktop.h"
-#include "txt_gui.h"
 #include "txt_io.h"
 #include "txt_main.h"
 #include "txt_separator.h"

--- a/textscreen/txt_table.h
+++ b/textscreen/txt_table.h
@@ -66,6 +66,8 @@ typedef struct txt_table_s txt_table_t;
 
 #include "txt_widget.h"
 
+struct txt_table_s;
+
 struct txt_table_s
 {
     txt_widget_t widget;

--- a/textscreen/txt_utf8.c
+++ b/textscreen/txt_utf8.c
@@ -12,10 +12,6 @@
 // GNU General Public License for more details.
 //
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
 #include "txt_utf8.h"
 
 // Encode a Unicode character as UTF-8, storing it in the buffer 'p'

--- a/textscreen/txt_widget.c
+++ b/textscreen/txt_widget.c
@@ -15,10 +15,12 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "txt_io.h"
-#include "txt_widget.h"
-#include "txt_gui.h"
 #include "txt_desktop.h"
+#include "txt_gui.h"
+#include "txt_io.h"
+#include "txt_main.h"
+#include "txt_widget.h"
+#include "txt_window.h"
 
 typedef struct
 {

--- a/textscreen/txt_widget.h
+++ b/textscreen/txt_widget.h
@@ -15,6 +15,8 @@
 #ifndef TXT_WIDGET_H
 #define TXT_WIDGET_H
 
+struct txt_widget_class_s;
+struct txt_widget_s;
 /**
  * @file txt_widget.h
  *

--- a/textscreen/txt_window.c
+++ b/textscreen/txt_window.c
@@ -12,20 +12,19 @@
 // GNU General Public License for more details.
 //
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
 #include <string.h>
 
-#include "doomkeys.h"
-
-#include "txt_label.h"
 #include "txt_desktop.h"
 #include "txt_gui.h"
 #include "txt_io.h"
+#include "txt_label.h"
 #include "txt_main.h"
 #include "txt_separator.h"
 #include "txt_window.h"
+#include "txt_window_action.h"
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN

--- a/textscreen/txt_window.h
+++ b/textscreen/txt_window.h
@@ -44,9 +44,11 @@
 
 typedef struct txt_window_s txt_window_t;
 
-#include "txt_widget.h"
 #include "txt_table.h"
+#include "txt_widget.h"
 #include "txt_window_action.h"
+
+struct txt_window_s;
 
 // Callback function for window key presses
 

--- a/textscreen/txt_window_action.h
+++ b/textscreen/txt_window_action.h
@@ -36,6 +36,8 @@ typedef struct txt_window_action_s txt_window_action_t;
 #include "txt_widget.h"
 #include "txt_window.h"
 
+struct txt_window_action_s;
+
 struct txt_window_action_s
 {
     txt_widget_t widget;

--- a/win32/win_version.c
+++ b/win32/win_version.c
@@ -18,9 +18,8 @@
 #include "win_version.h"
 
 #define WIN32_LEAN_AND_MEAN
-#include <_mingw.h>
-#include <string.h>
 #include <windows.h>
+#include <string.h>
 
 typedef long (__stdcall *PRTLGETVERSION)(PRTL_OSVERSIONINFOEXW);
 

--- a/win32/win_version.c
+++ b/win32/win_version.c
@@ -18,8 +18,9 @@
 #include "win_version.h"
 
 #define WIN32_LEAN_AND_MEAN
+#include <_mingw.h>
+#include <string.h>
 #include <windows.h>
-#include <stdlib.h>
 
 typedef long (__stdcall *PRTLGETVERSION)(PRTL_OSVERSIONINFOEXW);
 


### PR DESCRIPTION
I used this mapping file: [woof.imp.txt](https://github.com/fabiangreffrath/woof/files/9156141/woof.imp.txt)
 Command line:
```
CC="clang" cmake -B build_iwyu -DCMAKE_C_INCLUDE_WHAT_YOU_USE="include-what-you-use;-Xiwyu;--mapping_file=../woof.imp;"
cd build_iwyu
ninja > out
fix_includes.py --reorder < out
```

Still the tool adds includes from "facade" files, I think we need to use pragmas for perfect result. Not sure if it's worth it.

