### PR TITLE
add FluidSynth gain setting to config

### DIFF
--- a/src/i_flmusic.c
+++ b/src/i_flmusic.c
@@ -40,7 +40,7 @@
 char *soundfont_path = "";
 boolean mus_chorus;
 boolean mus_reverb;
-int     mus_gain = 1;
+int     mus_gain = 100;
 
 static fluid_synth_t *synth = NULL;
 static fluid_settings_t *settings = NULL;
@@ -170,7 +170,7 @@ static void I_FL_SetMusicVolume(int volume)
 {
     // FluidSynth's default is 0.2. Make 1.0 the maximum.
     // 0 -- 0.2 -- 10.0
-    fluid_synth_set_gain(synth, ((float)volume / 15) * (float)mus_gain);
+    fluid_synth_set_gain(synth, ((float)volume / 15) * ((float)mus_gain / 100));
 }
 
 static void I_FL_PauseSong(void *handle)

--- a/src/i_flmusic.c
+++ b/src/i_flmusic.c
@@ -40,6 +40,7 @@
 char *soundfont_path = "";
 boolean mus_chorus;
 boolean mus_reverb;
+int     mus_gain = 1;
 
 static fluid_synth_t *synth = NULL;
 static fluid_settings_t *settings = NULL;
@@ -168,7 +169,8 @@ static boolean I_FL_InitMusic(void)
 static void I_FL_SetMusicVolume(int volume)
 {
     // FluidSynth's default is 0.2. Make 1.0 the maximum.
-    fluid_synth_set_gain(synth, (float)volume / 15);
+    // 0 -- 0.2 -- 10.0
+    fluid_synth_set_gain(synth, ((float)volume / 15) * (float)mus_gain);
 }
 
 static void I_FL_PauseSong(void *handle)

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -92,6 +92,7 @@ extern int show_endoom;
 extern char *soundfont_path;
 extern boolean mus_chorus;
 extern boolean mus_reverb;
+extern int     mus_gain;
 #endif
 extern boolean demobar;
 extern boolean smoothlight;
@@ -2198,6 +2199,13 @@ default_t defaults[] = {
     (config_t *) &mus_reverb, NULL,
     {0}, {0, 1}, number, ss_none, wad_no,
     "1 to enable FluidSynth reverb"
+  },
+
+  {
+    "mus_gain",
+    (config_t *) &mus_gain, NULL,
+    {1}, {1, 10}, number, ss_none, wad_no,
+    "amplify FluidSynth output level"
   },
 #endif
 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -2204,8 +2204,8 @@ default_t defaults[] = {
   {
     "mus_gain",
     (config_t *) &mus_gain, NULL,
-    {100}, {0, 1000}, number, ss_none, wad_no,
-    "fine tune FluidSynth output level"
+    {100}, {10, 1000}, number, ss_none, wad_no,
+    "fine tune FluidSynth output level (default 100%)"
   },
 #endif
 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -2204,8 +2204,8 @@ default_t defaults[] = {
   {
     "mus_gain",
     (config_t *) &mus_gain, NULL,
-    {1}, {1, 10}, number, ss_none, wad_no,
-    "amplify FluidSynth output level"
+    {100}, {0, 1000}, number, ss_none, wad_no,
+    "fine tune FluidSynth output level"
   },
 #endif
 


### PR DESCRIPTION
Increase volume for "silent" soundfonts [[doomworld]](https://www.doomworld.com/forum/topic/129928-new-sc55-soundfont-266mb-all-new-441k-samples/?do=findComment&comment=2522430) Although Trevor0402's SC-55 SoundFont.v1.2b volume levels are fine for me.