### PR TITLE
enable colored_blood in strictmode, but don't change vanilla monsters

### DIFF
--- a/autoload/chex.wad/extchex.deh
+++ b/autoload/chex.wad/extchex.deh
@@ -4,6 +4,12 @@ Dropped item = 0
 Thing 3 (Shotgun guy)
 Dropped item = 0
 
+Thing 15 (Cacodemon)
+Blood color = 0
+
+Thing 16 (Baron of Hell)
+Blood color = 0
+
 [STRINGS]
 HUSTR_E1M6 = E1M5: Caverns of Bazoik
 HUSTR_E1M7 = E1M5: Caverns of Bazoik

--- a/autoload/doom-all/bloodcolor.deh
+++ b/autoload/doom-all/bloodcolor.deh
@@ -1,8 +1,0 @@
-Thing 15 (Cacodemon)
-Blood color = 3
-
-Thing 16 (Baron of Hell)
-Blood color = 2
-
-Thing 18 (Hell Knight)
-Blood color = 2

--- a/autoload/hacx.wad/bloodcolor.deh
+++ b/autoload/hacx.wad/bloodcolor.deh
@@ -1,2 +1,8 @@
+Thing 16 (Baron of Hell)
+Blood color = 0
+
+Thing 18 (Hell knight)
+Blood color = 0
+
 Thing 21 (Arachnotron)
 Blood color = 2

--- a/autoload/rekkr.wad/bloodcolor.deh
+++ b/autoload/rekkr.wad/bloodcolor.deh
@@ -1,0 +1,5 @@
+Thing 15 (Cacodemon)
+Blood color = 0
+
+Thing 16 (Baron of Hell)
+Blood color = 0

--- a/autoload/rekkrsa.wad/bloodcolor.deh
+++ b/autoload/rekkrsa.wad/bloodcolor.deh
@@ -1,0 +1,5 @@
+Thing 15 (Cacodemon)
+Blood color = 0
+
+Thing 16 (Baron of Hell)
+Blood color = 0

--- a/src/d_deh.c
+++ b/src/d_deh.c
@@ -112,6 +112,8 @@ static int dehfseek(DEHFILE *fp, long offset)
 // variables used in other routines
 boolean deh_pars = FALSE; // in wi_stuff to allow pars in modified games
 
+boolean deh_set_blood_color = FALSE;
+
 char **dehfiles = NULL;  // filenames of .deh files for demo footer
 
 // #include "d_deh.h" -- we don't do that here but we declare the
@@ -1874,6 +1876,10 @@ void deh_procThing(DEHFILE *fpin, FILE* fpout, char *line)
         {
           if (!strcasecmp(key,deh_mobjinfo[ix]))  // killough 8/98
             {
+              if (!deh_set_blood_color && !strcasecmp(key, "Blood color"))
+                {
+                  deh_set_blood_color = true;
+                }
               // mbf21: process thing flags
               if (!strcasecmp(key, "MBF21 Bits"))
                 {

--- a/src/d_deh.c
+++ b/src/d_deh.c
@@ -1003,7 +1003,6 @@ typedef struct
 // killough 8/9/98: make DEH_BLOCKMAX self-adjusting
 #define DEH_BLOCKMAX (sizeof deh_blocks/sizeof*deh_blocks)  // size of array
 #define DEH_MAXKEYLEN 32 // as much of any key as we'll look at
-#define DEH_MOBJINFOMAX 32 // number of mobjinfo configuration keys
 
 // Put all the block header values, and the function to be called when that
 // one is encountered, in this array:
@@ -1038,6 +1037,49 @@ static boolean includenotext = false;
 // within the structure, so we can use index of the string in this
 // array to offset by sizeof(int) into the mobjinfo_t array at [nn]
 // * things are base zero but dehacked considers them to start at #1. ***
+
+enum {
+  DEH_MOBJINFO_DOOMEDNUM,
+  DEH_MOBJINFO_SPAWNSTATE,
+  DEH_MOBJINFO_SPAWNHEALTH,
+  DEH_MOBJINFO_SEESTATE,
+  DEH_MOBJINFO_SEESOUND,
+  DEH_MOBJINFO_REACTIONTIME,
+  DEH_MOBJINFO_ATTACKSOUND,
+  DEH_MOBJINFO_PAINSTATE,
+  DEH_MOBJINFO_PAINCHANCE,
+  DEH_MOBJINFO_PAINSOUND,
+  DEH_MOBJINFO_MELEESTATE,
+  DEH_MOBJINFO_MISSILESTATE,
+  DEH_MOBJINFO_DEATHSTATE,
+  DEH_MOBJINFO_XDEATHSTATE,
+  DEH_MOBJINFO_DEATHSOUND,
+  DEH_MOBJINFO_SPEED,
+  DEH_MOBJINFO_RADIUS,
+  DEH_MOBJINFO_HEIGHT,
+  DEH_MOBJINFO_MASS,
+  DEH_MOBJINFO_DAMAGE,
+  DEH_MOBJINFO_ACTIVESOUND,
+  DEH_MOBJINFO_FLAGS,
+  DEH_MOBJINFO_RAISESTATE,
+
+  // mbf21
+  DEH_MOBJINFO_INFIGHTING_GROUP,
+  DEH_MOBJINFO_PROJECTILE_GROUP,
+  DEH_MOBJINFO_SPLASH_GROUP,
+  DEH_MOBJINFO_FLAGS2,
+  DEH_MOBJINFO_RIPSOUND,
+  DEH_MOBJINFO_ALTSPEED,
+  DEH_MOBJINFO_MELEERANGE,
+
+  // [Woof!]
+  DEH_MOBJINFO_BLOODCOLOR,
+
+  // DEHEXTRA
+  DEH_MOBJINFO_DROPPEDITEM,
+
+  DEH_MOBJINFOMAX
+};
 
 char *deh_mobjinfo[DEH_MOBJINFOMAX] =
 {
@@ -1876,10 +1918,6 @@ void deh_procThing(DEHFILE *fpin, FILE* fpout, char *line)
         {
           if (!strcasecmp(key,deh_mobjinfo[ix]))  // killough 8/98
             {
-              if (!deh_set_blood_color && !strcasecmp(key, "Blood color"))
-                {
-                  deh_set_blood_color = true;
-                }
               // mbf21: process thing flags
               if (!strcasecmp(key, "MBF21 Bits"))
                 {
@@ -1939,7 +1977,7 @@ void deh_procThing(DEHFILE *fpin, FILE* fpout, char *line)
                                      value, value);
                 }
               // mbf21: dehacked thing groups
-              if (ix == 23)
+              if (ix == DEH_MOBJINFO_INFIGHTING_GROUP)
                 {
                   mobjinfo_t *mi = &mobjinfo[indexnum];
                   mi->infighting_group = (int)(value);
@@ -1950,7 +1988,7 @@ void deh_procThing(DEHFILE *fpin, FILE* fpout, char *line)
                   }
                   mi->infighting_group = mi->infighting_group + IG_END;
                 }
-              else if (ix == 24)
+              else if (ix == DEH_MOBJINFO_PROJECTILE_GROUP)
                 {
                   mobjinfo_t *mi = &mobjinfo[indexnum];
                   mi->projectile_group = (int)(value);
@@ -1959,7 +1997,7 @@ void deh_procThing(DEHFILE *fpin, FILE* fpout, char *line)
                   else
                     mi->projectile_group = mi->projectile_group + PG_END;
                 }
-              else if (ix == 25)
+              else if (ix == DEH_MOBJINFO_SPLASH_GROUP)
                 {
                   mobjinfo_t *mi = &mobjinfo[indexnum];
                   mi->splash_group = (int)(value);
@@ -1970,7 +2008,14 @@ void deh_procThing(DEHFILE *fpin, FILE* fpout, char *line)
                   }
                   mi->splash_group = mi->splash_group + SG_END;
                 }
-              else if (ix == 31)
+              else if (ix == DEH_MOBJINFO_BLOODCOLOR)
+                {
+                  mobjinfo_t *mi = &mobjinfo[indexnum];
+                  mi->bloodcolor = (int)(value);
+                  if (mi->bloodcolor)
+                    deh_set_blood_color = TRUE;
+                }
+              else if (ix == DEH_MOBJINFO_DROPPEDITEM)
                 {
                   mobjinfo_t *mi = &mobjinfo[indexnum];
                   mi->droppeditem = (int)(value - 1); // make it base zero (deh is 1-based)

--- a/src/d_deh.c
+++ b/src/d_deh.c
@@ -2011,7 +2011,12 @@ void deh_procThing(DEHFILE *fpin, FILE* fpout, char *line)
               else if (ix == DEH_MOBJINFO_BLOODCOLOR)
                 {
                   mobjinfo_t *mi = &mobjinfo[indexnum];
+
+                  if (value < 0 || value > 8)
+                    value = 0;
+
                   mi->bloodcolor = (int)(value);
+
                   if (mi->bloodcolor)
                     deh_set_blood_color = TRUE;
                 }

--- a/src/d_deh.c
+++ b/src/d_deh.c
@@ -2013,8 +2013,10 @@ void deh_procThing(DEHFILE *fpin, FILE* fpout, char *line)
                   mobjinfo_t *mi = &mobjinfo[indexnum];
 
                   if (value < 0 || value > 8)
-                    value = 0;
-
+                  {
+                    I_Error("Blood color must be >= 0 and <= 8 (check your dehacked)");
+                    return;
+                  }
                   mi->bloodcolor = (int)(value);
 
                   if (mi->bloodcolor)

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1686,11 +1686,6 @@ static void D_InitTables(void)
   mobjinfo[MT_HEADSHOT].altspeed = 20 * FRACUNIT;
   mobjinfo[MT_TROOPSHOT].altspeed = 20 * FRACUNIT;
 
-  // [Woof!]
-  mobjinfo[MT_HEAD].bloodcolor = 3; // Blue
-  mobjinfo[MT_BRUISER].bloodcolor = 2; // Green
-  mobjinfo[MT_KNIGHT].bloodcolor = 2; // Green
-
   // DEHEXTRA
   mobjinfo[MT_WOLFSS].droppeditem = MT_CLIP;
   mobjinfo[MT_POSSESSED].droppeditem = MT_CLIP;
@@ -1723,6 +1718,18 @@ static void D_InitTables(void)
 
   for (i = S_SARG_RUN1; i <= S_SARG_PAIN2; ++i)
     states[i].flags |= STATEF_SKILL5FAST;
+}
+
+void D_SetBloodColor(void)
+{
+  extern boolean deh_set_blood_color;
+
+  if (deh_set_blood_color)
+    return;
+
+  mobjinfo[MT_HEAD].bloodcolor = 3; // Blue
+  mobjinfo[MT_BRUISER].bloodcolor = 2; // Green
+  mobjinfo[MT_KNIGHT].bloodcolor = 2; // Green
 }
 
 // killough 2/22/98: Add support for ENDBOOM, which is PC-specific

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1727,9 +1727,18 @@ void D_SetBloodColor(void)
   if (deh_set_blood_color)
     return;
 
-  mobjinfo[MT_HEAD].bloodcolor = 3; // Blue
-  mobjinfo[MT_BRUISER].bloodcolor = 2; // Green
-  mobjinfo[MT_KNIGHT].bloodcolor = 2; // Green
+  if (colored_blood)
+  {
+    mobjinfo[MT_HEAD].bloodcolor = 3; // Blue
+    mobjinfo[MT_BRUISER].bloodcolor = 2; // Green
+    mobjinfo[MT_KNIGHT].bloodcolor = 2; // Green
+  }
+  else
+  {
+    mobjinfo[MT_HEAD].bloodcolor = 0;
+    mobjinfo[MT_BRUISER].bloodcolor = 0;
+    mobjinfo[MT_KNIGHT].bloodcolor = 0;
+  }
 }
 
 // killough 2/22/98: Add support for ENDBOOM, which is PC-specific

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1686,6 +1686,11 @@ static void D_InitTables(void)
   mobjinfo[MT_HEADSHOT].altspeed = 20 * FRACUNIT;
   mobjinfo[MT_TROOPSHOT].altspeed = 20 * FRACUNIT;
 
+  // [Woof!]
+  mobjinfo[MT_HEAD].bloodcolor = 3; // Blue
+  mobjinfo[MT_BRUISER].bloodcolor = 2; // Green
+  mobjinfo[MT_KNIGHT].bloodcolor = 2; // Green
+
   // DEHEXTRA
   mobjinfo[MT_WOLFSS].droppeditem = MT_CLIP;
   mobjinfo[MT_POSSESSED].droppeditem = MT_CLIP;

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1727,7 +1727,7 @@ void D_SetBloodColor(void)
   if (deh_set_blood_color)
     return;
 
-  if (colored_blood)
+  if (STRICTMODE(colored_blood))
   {
     mobjinfo[MT_HEAD].bloodcolor = 3; // Blue
     mobjinfo[MT_BRUISER].bloodcolor = 2; // Green

--- a/src/d_main.h
+++ b/src/d_main.h
@@ -51,6 +51,8 @@ extern boolean clfastparm; // checkparm of -fast
 
 extern boolean pistolstart;
 
+void D_SetBloodColor(void);
+
 // Called by IO functions when input is detected.
 void D_PostEvent(event_t* ev);
 

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -2722,8 +2722,6 @@ static void G_BoomComp()
 
 void G_ReloadDefaults(void)
 {
-  extern void D_SetBloodColor(void);
-
   // killough 3/1/98: Initialize options based on config file
   // (allows functions above to load different values for demos
   // and savegames without messing up defaults).

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -2722,6 +2722,8 @@ static void G_BoomComp()
 
 void G_ReloadDefaults(void)
 {
+  extern void D_SetBloodColor(void);
+
   // killough 3/1/98: Initialize options based on config file
   // (allows functions above to load different values for demos
   // and savegames without messing up defaults).
@@ -2827,6 +2829,9 @@ void G_ReloadDefaults(void)
     else if (mbf21)
       G_MBF21Defaults();
   }
+
+  if (!strictmode)
+    D_SetBloodColor();
 
   if (!mbf21)
   {

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -3572,7 +3572,7 @@ setup_menu_t enem_settings1[] =  // Enemy Settings screen
   {"Cosmetic",S_SKIP|S_TITLE,m_null,M_X,M_Y+ enem_title1*M_SPC},
 
   // [FG] colored blood and gibs
-  {"Colored Blood",S_YESNO,m_null,M_X,M_Y+ enem_colored_blood*M_SPC, {"colored_blood"}},
+  {"Colored Blood",S_YESNO,m_null,M_X,M_Y+ enem_colored_blood*M_SPC, {"colored_blood"}, 0, D_SetBloodColor},
 
   // [crispy] randomly flip corpse, blood and death animation sprites
   {"Randomly Mirrored Corpses",S_YESNO,m_null,M_X,M_Y+ enem_flipcorpses*M_SPC, {"flipcorpses"}},

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -147,7 +147,7 @@ boolean menuactive;    // The menus are up
 #define M_X_THRM     (M_X - M_THRM_WIDTH)
 
 #define DISABLE_ITEM(condition, item) \
-        (condition ? (item.m_flags |= S_DISABLE) : (item.m_flags &= ~S_DISABLE))
+        ((condition) ? (item.m_flags |= S_DISABLE) : (item.m_flags &= ~S_DISABLE))
 
 char savegamestrings[10][SAVESTRINGSIZE];
 
@@ -3836,9 +3836,10 @@ enum {
 
 static void M_UpdateStrictModeItems(void)
 {
+  extern boolean deh_set_blood_color;
   // map_player_coords
   DISABLE_STRICT(auto_settings1[5]);
-  DISABLE_STRICT(enem_settings1[enem_colored_blood]);
+  DISABLE_ITEM(strictmode || deh_set_blood_color, enem_settings1[enem_colored_blood]);
   DISABLE_STRICT(enem_settings1[enem_flipcorpses]);
   DISABLE_STRICT(gen_settings3[general_realtic]);
   DISABLE_STRICT(gen_settings2[general_brightmaps]);

--- a/src/p_map.c
+++ b/src/p_map.c
@@ -1883,7 +1883,7 @@ static boolean PIT_ChangeSector(mobj_t *thing)
       P_SetMobjState(thing, S_GIBS);
       thing->flags &= ~MF_SOLID;
       thing->height = thing->radius = 0;
-      if (NOTSTRICTMODE(colored_blood))
+      if (thing->info->bloodcolor)
       {
         thing->flags2 |= MF2_COLOREDBLOOD;
         thing->bloodcolor = V_BloodColor(thing->info->bloodcolor);
@@ -1923,7 +1923,7 @@ static boolean PIT_ChangeSector(mobj_t *thing)
 			thing->y,
 			thing->z + thing->height/2, MT_BLOOD);
 
-      if (NOTSTRICTMODE(colored_blood))
+      if (thing->info->bloodcolor)
       {
         mo->flags2 |= MF2_COLOREDBLOOD;
         mo->bloodcolor = V_BloodColor(thing->info->bloodcolor);

--- a/src/p_map.c
+++ b/src/p_map.c
@@ -1883,7 +1883,7 @@ static boolean PIT_ChangeSector(mobj_t *thing)
       P_SetMobjState(thing, S_GIBS);
       thing->flags &= ~MF_SOLID;
       thing->height = thing->radius = 0;
-      if (STRICTMODE(colored_blood))
+      if (NOTSTRICTMODE(colored_blood))
       {
         thing->flags2 |= MF2_COLOREDBLOOD;
         thing->bloodcolor = V_BloodColor(thing->info->bloodcolor);
@@ -1923,7 +1923,7 @@ static boolean PIT_ChangeSector(mobj_t *thing)
 			thing->y,
 			thing->z + thing->height/2, MT_BLOOD);
 
-      if (STRICTMODE(colored_blood))
+      if (NOTSTRICTMODE(colored_blood))
       {
         mo->flags2 |= MF2_COLOREDBLOOD;
         mo->bloodcolor = V_BloodColor(thing->info->bloodcolor);

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -1332,7 +1332,7 @@ void P_SpawnBlood(fixed_t x,fixed_t y,fixed_t z,int damage,mobj_t *bleeder)
   th = P_SpawnMobj(x,y,z, MT_BLOOD);
   th->momz = FRACUNIT*2;
   th->tics -= P_Random(pr_spawnblood)&3;
-  if (STRICTMODE(colored_blood))
+  if (NOTSTRICTMODE(colored_blood))
   {
     th->flags2 |= MF2_COLOREDBLOOD;
     th->bloodcolor = V_BloodColor(bleeder->info->bloodcolor);

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -1332,7 +1332,7 @@ void P_SpawnBlood(fixed_t x,fixed_t y,fixed_t z,int damage,mobj_t *bleeder)
   th = P_SpawnMobj(x,y,z, MT_BLOOD);
   th->momz = FRACUNIT*2;
   th->tics -= P_Random(pr_spawnblood)&3;
-  if (NOTSTRICTMODE(colored_blood))
+  if (bleeder->info->bloodcolor)
   {
     th->flags2 |= MF2_COLOREDBLOOD;
     th->bloodcolor = V_BloodColor(bleeder->info->bloodcolor);

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -206,9 +206,6 @@ static const int bloodcolor[] = {
 
 int V_BloodColor(int blood)
 {
-  if (blood < 0 || blood > 8)
-    blood = 0;
-
   return bloodcolor[blood];
 }
 


### PR DESCRIPTION
In the speedrunner discord, people are confused by the `bloodcolor.deh` file that appeared in the footer of the demo.
Also, in `strictmode` we should not allow blood color changing for PWADs that alter it in dehacked. Hopefully this makes sense 😄 