### PR TITLE
fix suppress savegame in G_ReadDemoTiccmd

### DIFF
--- a/src/g_game.c
+++ b/src/g_game.c
@@ -975,9 +975,10 @@ static void G_ReadDemoTiccmd(ticcmd_t *cmd)
       // killough 3/26/98, 10/98: Ignore savegames in demos 
       if (demoplayback && 
 	  cmd->buttons & BT_SPECIAL &&
+	  cmd->buttons & BT_SPECIALMASK &&
 	  cmd->buttons & BTS_SAVEGAME)
 	{
-	  cmd->buttons &= ~BTS_SAVEGAME;
+	  cmd->buttons &= ~BT_SPECIALMASK;
 	  players[consoleplayer].message = "Game Saved (Suppressed)";
 	}
 


### PR DESCRIPTION
I forgot about "suppress savegame" in `G_ReadDemoTiccmd` when restoring `BT_SPECIALMASK`. Could this affect demo compatibility? Now [fw04des.zip](https://github.com/fabiangreffrath/woof/files/9164681/fw04des.zip) FW.wad desync in the same way as in PrBoom+ [[doomworld]](https://www.doomworld.com/forum/topic/112333-this-is-woof-1010-july-18-2022-updated-winmbf/?do=findComment&comment=2522415)