### PR TITLE
initial implementation of beta patches conversion

### DIFF
--- a/src/am_map.c
+++ b/src/am_map.c
@@ -621,7 +621,7 @@ void AM_loadPics(void)
   for (i=0;i<10;i++)
   {
     sprintf(namebuf, "AMMNUM%d", i);
-    marknums[i] = W_CacheLumpName(namebuf, PU_STATIC);
+    marknums[i] = R_PatchByName(namebuf, PU_STATIC);
   }
 }
 

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -329,7 +329,7 @@ void D_Display (void)
     {
       int y = 4;
       int x = (viewwindowx>>hires);
-      patch_t *patch = W_CacheLumpName("M_PAUSE", PU_CACHE);
+      patch_t *patch = R_PatchByName("M_PAUSE", PU_CACHE);
 
       if (!automapactive)
         y += (viewwindowy>>hires);
@@ -405,19 +405,7 @@ void D_PageDrawer(void)
 {
   if (pagename)
     {
-      int l = W_CheckNumForName(pagename);
-      byte *t = W_CacheLumpNum(l, PU_CACHE);
-      size_t s = W_LumpLength(l);
-      unsigned c = 0;
-      while (s--)
-	c = c*3 + t[s];
-      V_DrawPatchFullScreen(0, (patch_t *) t);
-      if (c==2119826587u || c==2391756584u)
-        // [FG] removed the embedded DOGOVRLY title pic overlay graphic lump
-        if (W_CheckNumForName("DOGOVRLY") > 0)
-        {
-	V_DrawPatch(0, 0, 0, W_CacheLumpName("DOGOVRLY", PU_CACHE));
-        }
+      V_DrawPatchFullScreen(0, R_PatchByName(pagename, PU_CACHE));
     }
   else
     M_DrawCredits();
@@ -553,6 +541,9 @@ void D_DoAdvanceDemo(void)
   {
     int i = W_CheckNumForName("TITLEPIC");
     int j = W_CheckNumForName("DMENUPIC");
+
+    if (!strncasecmp("DOOMPRES", W_WadNameForLump(i), 8))
+      name = "INTERPIC";
 
     if (i < 0 || (j >= 0 && W_IsIWADLump(i)))
       name = (j >= 0) ? "DMENUPIC" : "INTERPIC";

--- a/src/f_finale.c
+++ b/src/f_finale.c
@@ -388,7 +388,7 @@ void F_TextWrite (void)
   if (gamemapinfo && W_CheckNumForName(finaleflat) != -1 &&
       (W_CheckNumForName)(finaleflat, ns_flats) == -1)
   {
-    V_DrawPatchFullScreen(0, W_CacheLumpName(finaleflat, PU_LEVEL));
+    V_DrawPatchFullScreen(0, R_PatchByName(finaleflat, PU_LEVEL));
   }
   else
   {
@@ -699,7 +699,7 @@ void F_CastDrawer (void)
     
   // erase the entire screen to a background
   //V_DrawPatch (0,0,0, W_CacheLumpName (bgcastcall, PU_CACHE)); // Ty 03/30/98 bg texture extern
-  V_DrawPatchFullScreen(0, W_CacheLumpName (bgcastcall, PU_CACHE));
+  V_DrawPatchFullScreen(0, R_PatchByName (bgcastcall, PU_CACHE));
 
   F_CastPrint (castorder[castnum].name);
     
@@ -709,7 +709,7 @@ void F_CastDrawer (void)
   lump = sprframe->lump[0];
   flip = (boolean)sprframe->flip[0];
                         
-  patch = W_CacheLumpNum (lump+firstspritelump, PU_CACHE);
+  patch = R_PatchByNum (lump+firstspritelump, PU_CACHE);
   if (flip)
     V_DrawPatchFlipped (160,170,0,patch);
   else
@@ -768,8 +768,8 @@ void F_BunnyScroll (void)
   static int  laststage;
   int         p2offset, p1offset, pillar_width;
               
-  p1 = W_CacheLumpName ("PFUB2", PU_LEVEL);
-  p2 = W_CacheLumpName ("PFUB1", PU_LEVEL);
+  p1 = R_PatchByName ("PFUB2", PU_LEVEL);
+  p2 = R_PatchByName ("PFUB1", PU_LEVEL);
 
   V_MarkRect (0, 0, SCREENWIDTH, SCREENHEIGHT);
       
@@ -823,7 +823,7 @@ void F_BunnyScroll (void)
   {
     V_DrawPatch ((ORIGWIDTH-13*8)/2,
                  (ORIGHEIGHT-8*8)/2,0,
-                 W_CacheLumpName ("END0",PU_CACHE));
+                 R_PatchByName ("END0",PU_CACHE));
     laststage = 0;
     return;
   }
@@ -840,7 +840,7 @@ void F_BunnyScroll (void)
   sprintf (name,"END%i",stage);
   V_DrawPatch ((ORIGWIDTH-13*8)/2,
                (ORIGHEIGHT-8*8)/2,0,
-               W_CacheLumpName (name,PU_CACHE));
+               R_PatchByName (name,PU_CACHE));
 }
 
 
@@ -865,7 +865,7 @@ void F_Drawer (void)
     }
     else
     {
-      V_DrawPatchFullScreen(0, W_CacheLumpName(gamemapinfo->endpic, PU_CACHE));
+      V_DrawPatchFullScreen(0, R_PatchByName(gamemapinfo->endpic, PU_CACHE));
     }
     return;
   }
@@ -885,21 +885,21 @@ void F_Drawer (void)
       case 1:
            if ( gamemode == retail || gamemode == commercial )
              V_DrawPatchFullScreen (0,
-               W_CacheLumpName("CREDIT",PU_CACHE));
+               R_PatchByName("CREDIT",PU_CACHE));
            else
              V_DrawPatchFullScreen (0,
-               W_CacheLumpName("HELP2",PU_CACHE));
+               R_PatchByName("HELP2",PU_CACHE));
            break;
       case 2:
            V_DrawPatchFullScreen (0,
-             W_CacheLumpName("VICTORY2",PU_CACHE));
+             R_PatchByName("VICTORY2",PU_CACHE));
            break;
       case 3:
            F_BunnyScroll ();
            break;
       case 4:
            V_DrawPatchFullScreen (0,
-             W_CacheLumpName("ENDPIC",PU_CACHE));
+             R_PatchByName("ENDPIC",PU_CACHE));
            break;
     }
   }

--- a/src/hu_stuff.c
+++ b/src/hu_stuff.c
@@ -407,65 +407,65 @@ void HU_Init(void)
       if ('0'<=j && j<='9')
         {
           sprintf(buffer, "DIG%.1d",j-48);
-          hu_font2[i] = (patch_t *) W_CacheLumpName(buffer, PU_STATIC);
+          hu_font2[i] = (patch_t *) R_PatchByName(buffer, PU_STATIC);
           sprintf(buffer, "STCFN%.3d",j);
-          hu_font[i] = (patch_t *) W_CacheLumpName(buffer, PU_STATIC);
+          hu_font[i] = (patch_t *) R_PatchByName(buffer, PU_STATIC);
         }
       else
         if ('A'<=j && j<='Z')
           {
             sprintf(buffer, "DIG%c",j);
-            hu_font2[i] = (patch_t *) W_CacheLumpName(buffer, PU_STATIC);
+            hu_font2[i] = (patch_t *) R_PatchByName(buffer, PU_STATIC);
             sprintf(buffer, "STCFN%.3d",j);
-            hu_font[i] = (patch_t *) W_CacheLumpName(buffer, PU_STATIC);
+            hu_font[i] = (patch_t *) R_PatchByName(buffer, PU_STATIC);
           }
         else
           if (j == '%')
             {
-              hu_font2[i] = (patch_t *) W_CacheLumpName("DIG37", PU_STATIC);
-              hu_font[i] = (patch_t *) W_CacheLumpName("STCFN037", PU_STATIC);
+              hu_font2[i] = (patch_t *) R_PatchByName("DIG37", PU_STATIC);
+              hu_font[i] = (patch_t *) R_PatchByName("STCFN037", PU_STATIC);
             }
         else
           if (j == '+')
             {
-              hu_font2[i] = (patch_t *) W_CacheLumpName("DIG43", PU_STATIC);
-              hu_font[i] = (patch_t *) W_CacheLumpName("STCFN043", PU_STATIC);
+              hu_font2[i] = (patch_t *) R_PatchByName("DIG43", PU_STATIC);
+              hu_font[i] = (patch_t *) R_PatchByName("STCFN043", PU_STATIC);
             }
         else
           if (j == '.')
             {
-              hu_font2[i] = (patch_t *) W_CacheLumpName("DIG46", PU_STATIC);
-              hu_font[i] = (patch_t *) W_CacheLumpName("STCFN046", PU_STATIC);
+              hu_font2[i] = (patch_t *) R_PatchByName("DIG46", PU_STATIC);
+              hu_font[i] = (patch_t *) R_PatchByName("STCFN046", PU_STATIC);
             }
         else
           if (j=='-')
             {
-              hu_font2[i] = (patch_t *) W_CacheLumpName("DIG45", PU_STATIC);
-              hu_font[i] = (patch_t *) W_CacheLumpName("STCFN045", PU_STATIC);
+              hu_font2[i] = (patch_t *) R_PatchByName("DIG45", PU_STATIC);
+              hu_font[i] = (patch_t *) R_PatchByName("STCFN045", PU_STATIC);
             }
           else
             if (j=='/')
               {
-                hu_font2[i] = (patch_t *) W_CacheLumpName("DIG47", PU_STATIC);
-                hu_font[i] = (patch_t *) W_CacheLumpName("STCFN047", PU_STATIC);
+                hu_font2[i] = (patch_t *) R_PatchByName("DIG47", PU_STATIC);
+                hu_font[i] = (patch_t *) R_PatchByName("STCFN047", PU_STATIC);
               }
             else
               if (j==':')
                 {
-                  hu_font2[i] = (patch_t *) W_CacheLumpName("DIG58", PU_STATIC);
-                  hu_font[i] = (patch_t *) W_CacheLumpName("STCFN058", PU_STATIC);
+                  hu_font2[i] = (patch_t *) R_PatchByName("DIG58", PU_STATIC);
+                  hu_font[i] = (patch_t *) R_PatchByName("STCFN058", PU_STATIC);
                 }
               else
                 if (j=='[')
                   {
-                    hu_font2[i] = (patch_t *) W_CacheLumpName("DIG91", PU_STATIC);
-                    hu_font[i] = (patch_t *) W_CacheLumpName("STCFN091", PU_STATIC);
+                    hu_font2[i] = (patch_t *) R_PatchByName("DIG91", PU_STATIC);
+                    hu_font[i] = (patch_t *) R_PatchByName("STCFN091", PU_STATIC);
                   }
                 else
                   if (j==']')
                     {
-                      hu_font2[i] = (patch_t *) W_CacheLumpName("DIG93", PU_STATIC);
-                      hu_font[i] = (patch_t *) W_CacheLumpName("STCFN093", PU_STATIC);
+                      hu_font2[i] = (patch_t *) R_PatchByName("DIG93", PU_STATIC);
+                      hu_font[i] = (patch_t *) R_PatchByName("STCFN093", PU_STATIC);
                     }
                   else
                     if (j<97)
@@ -474,7 +474,7 @@ void HU_Init(void)
                         // [FG] removed the embedded STCFN096 lump
                         if (W_CheckNumForName(buffer) != -1)
                         {
-                        hu_font2[i] = hu_font[i] = (patch_t *) W_CacheLumpName(buffer, PU_STATIC);
+                        hu_font2[i] = hu_font[i] = (patch_t *) R_PatchByName(buffer, PU_STATIC);
                         }
                         else
                           hu_font2[i] = hu_font[i] = hu_font[0];
@@ -485,19 +485,19 @@ void HU_Init(void)
                         {
                           sprintf(buffer, "STBR%.3d",j);
                           hu_font2[i] = hu_font[i] =
-                            (patch_t *) W_CacheLumpName(buffer, PU_STATIC);
+                            (patch_t *) R_PatchByName(buffer, PU_STATIC);
                         }
                       else
                         hu_font[i] = hu_font[0]; //jff 2/16/98 account for gap
     }
 
   //jff 2/26/98 load patches for keys and double keys
-  hu_fontk[0] = (patch_t *) W_CacheLumpName("STKEYS0", PU_STATIC);
-  hu_fontk[1] = (patch_t *) W_CacheLumpName("STKEYS1", PU_STATIC);
-  hu_fontk[2] = (patch_t *) W_CacheLumpName("STKEYS2", PU_STATIC);
-  hu_fontk[3] = (patch_t *) W_CacheLumpName("STKEYS3", PU_STATIC);
-  hu_fontk[4] = (patch_t *) W_CacheLumpName("STKEYS4", PU_STATIC);
-  hu_fontk[5] = (patch_t *) W_CacheLumpName("STKEYS5", PU_STATIC);
+  hu_fontk[0] = (patch_t *) R_PatchByName("STKEYS0", PU_STATIC);
+  hu_fontk[1] = (patch_t *) R_PatchByName("STKEYS1", PU_STATIC);
+  hu_fontk[2] = (patch_t *) R_PatchByName("STKEYS2", PU_STATIC);
+  hu_fontk[3] = (patch_t *) R_PatchByName("STKEYS3", PU_STATIC);
+  hu_fontk[4] = (patch_t *) R_PatchByName("STKEYS4", PU_STATIC);
+  hu_fontk[5] = (patch_t *) R_PatchByName("STKEYS5", PU_STATIC);
 
   // [FG] support crosshair patches from extras.wad
   for (i = 1; i < HU_CROSSHAIRS; i++)
@@ -1007,7 +1007,7 @@ static void HU_InitCrosshair(void)
 
   if (crosshair_nam[hud_crosshair])
   {
-    crosshair.patch = W_CacheLumpName(crosshair_nam[hud_crosshair], PU_STATIC);
+    crosshair.patch = R_PatchByName(crosshair_nam[hud_crosshair], PU_STATIC);
 
     crosshair.w = SHORT(crosshair.patch->width)/2;
     crosshair.h = SHORT(crosshair.patch->height)/2;

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -992,7 +992,7 @@ static void I_InitDiskFlash(void)
   old_data = Z_Malloc((16<<hires) * (16<<hires) * sizeof(*old_data), PU_STATIC, 0);
 
   V_GetBlock(0, 0, 0, 16, 16, temp);
-  V_DrawPatchDirect(0-WIDESCREENDELTA, 0, 0, W_CacheLumpName(M_CheckParm("-cdrom") ?
+  V_DrawPatchDirect(0-WIDESCREENDELTA, 0, 0, R_PatchByName(M_CheckParm("-cdrom") ?
                                              "STCDROM" : "STDISK", PU_CACHE));
   V_GetBlock(0, 0, 0, 16, 16, diskflash);
   V_DrawBlock(0, 0, 0, 16, 16, temp);

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -404,7 +404,7 @@ void M_DrawMainMenu(void)
   // [crispy] force status bar refresh
   inhelpscreens = true;
 
-  V_DrawPatchDirect (94,2,0,W_CacheLumpName("M_DOOM",PU_CACHE));
+  V_DrawPatchDirect (94,2,0,R_PatchByName("M_DOOM",PU_CACHE));
 }
 
 /////////////////////////////
@@ -516,7 +516,7 @@ void M_DrawReadThis1(void)
 {
   inhelpscreens = true;
   if (gamemode == shareware)
-    V_DrawPatchFullScreen (0,W_CacheLumpName("HELP2",PU_CACHE));
+    V_DrawPatchFullScreen(0, R_PatchByName("HELP2",PU_CACHE));
   else
     M_DrawCredits();
 }
@@ -532,7 +532,7 @@ void M_DrawReadThis2(void)
   if (gamemode == shareware)
     M_DrawCredits();
   else
-    V_DrawPatchFullScreen (0,W_CacheLumpName("CREDIT",PU_CACHE));
+    V_DrawPatchFullScreen (0,R_PatchByName("CREDIT",PU_CACHE));
 }
 
 /////////////////////////////
@@ -704,8 +704,8 @@ void M_DrawNewGame(void)
   // [crispy] force status bar refresh
   inhelpscreens = true;
 
-  V_DrawPatchDirect (96,14,0,W_CacheLumpName("M_NEWG",PU_CACHE));
-  V_DrawPatchDirect (54,38,0,W_CacheLumpName("M_SKILL",PU_CACHE));
+  V_DrawPatchDirect (96,14,0,R_PatchByName("M_NEWG",PU_CACHE));
+  V_DrawPatchDirect (54,38,0,R_PatchByName("M_SKILL",PU_CACHE));
 }
 
 void M_NewGame(int choice)
@@ -851,7 +851,7 @@ void M_DrawLoad(void)
   int i;
 
   //jff 3/15/98 use symbolic load position
-  V_DrawPatchDirect (72,LOADGRAPHIC_Y,0,W_CacheLumpName("M_LOADG",PU_CACHE));
+  V_DrawPatchDirect (72,LOADGRAPHIC_Y,0,R_PatchByName("M_LOADG",PU_CACHE));
   for (i = 0 ; i < load_end ; i++)
     {
       M_DrawSaveLoadBorder(LoadDef.x,LoadDef.y+LINEHEIGHT*i);
@@ -872,15 +872,15 @@ void M_DrawSaveLoadBorder(int x,int y)
 {
   int i;
   
-  V_DrawPatchDirect (x-8,y+7,0,W_CacheLumpName("M_LSLEFT",PU_CACHE));
+  V_DrawPatchDirect (x-8,y+7,0,R_PatchByName("M_LSLEFT",PU_CACHE));
   
   for (i = 0 ; i < 24 ; i++)
     {
-      V_DrawPatchDirect (x,y+7,0,W_CacheLumpName("M_LSCNTR",PU_CACHE));
+      V_DrawPatchDirect (x,y+7,0,R_PatchByName("M_LSCNTR",PU_CACHE));
       x += 8;
     }
 
-  V_DrawPatchDirect (x,y+7,0,W_CacheLumpName("M_LSRGHT",PU_CACHE));
+  V_DrawPatchDirect (x,y+7,0,R_PatchByName("M_LSRGHT",PU_CACHE));
 }
 
 //
@@ -1035,7 +1035,7 @@ void M_DrawSave(void)
   int i;
 
   //jff 3/15/98 use symbolic load position
-  V_DrawPatchDirect (72,LOADGRAPHIC_Y,0,W_CacheLumpName("M_SAVEG",PU_CACHE));
+  V_DrawPatchDirect (72,LOADGRAPHIC_Y,0,R_PatchByName("M_SAVEG",PU_CACHE));
   for (i = 0 ; i < load_end ; i++)
     {
       M_DrawSaveLoadBorder(LoadDef.x,LoadDef.y+LINEHEIGHT*i);
@@ -1213,7 +1213,7 @@ char msgNames[2][9]  = {"M_MSGOFF","M_MSGON"};
 
 void M_DrawOptions(void)
 {
-  V_DrawPatchDirect (108,15,0,W_CacheLumpName("M_OPTTTL",PU_CACHE));
+  V_DrawPatchDirect(108,15,0,R_PatchByName("M_OPTTTL",PU_CACHE));
 
   /*  obsolete -- killough
       V_DrawPatchDirect (OptionsDef.x + 175,OptionsDef.y+LINEHEIGHT*detail,0,
@@ -1228,7 +1228,7 @@ void M_DrawOptions(void)
   else
   if (OptionsDef.lumps_missing == -1)
   V_DrawPatchDirect (OptionsDef.x + 120,OptionsDef.y+LINEHEIGHT*messages,0,
-		     W_CacheLumpName(msgNames[showMessages],PU_CACHE));
+		     R_PatchByName(msgNames[showMessages],PU_CACHE));
 
   /* M_DrawThermo(OptionsDef.x,OptionsDef.y+LINEHEIGHT*(mousesens+1),
      10,mouseSensitivity);   killough */
@@ -1344,7 +1344,7 @@ menu_t SoundDef =
 
 void M_DrawSound(void)
 {
-  V_DrawPatchDirect (60,38,0,W_CacheLumpName("M_SVOL",PU_CACHE));
+  V_DrawPatchDirect (60,38,0,R_PatchByName("M_SVOL",PU_CACHE));
 
   M_DrawThermo(SoundDef.x,SoundDef.y+LINEHEIGHT*(sfx_vol+1),16,snd_SfxVolume);
 
@@ -1443,7 +1443,7 @@ void M_DrawMouse(void)
 {
   int mhmx,mvmx; //jff 4/3/98 clamp drawn position to 23 max
 
-  V_DrawPatchDirect (60,38,0,W_CacheLumpName("M_MSENS",PU_CACHE));
+  V_DrawPatchDirect (60,38,0,R_PatchByName("M_MSENS",PU_CACHE));
 
   //jff 4/3/98 clamp horizontal sensitivity display
   mhmx = mouseSensitivity_horiz; // >23? 23 : mouseSensitivity_horiz;
@@ -2085,7 +2085,7 @@ void M_DrawItem(setup_menu_t* s)
     // Draw the 'off' version if this isn't the current menu item
     // Draw the blinking version in tune with the blinking skull otherwise
 
-    V_DrawPatchDirect(x,y,0,W_CacheLumpName(ResetButtonName
+    V_DrawPatchDirect(x,y,0,R_PatchByName(ResetButtonName
 					    [flags & (S_HILITE|S_SELECT) ?
 					    whichSkull : 0], PU_CACHE));
   else  // Draw the item string
@@ -2148,21 +2148,21 @@ static void M_DrawMiniThermo(int x, int y, int size, int dot, int color)
   int  i;
 
   xx = x;
-  V_DrawPatch(xx, y, 0, W_CacheLumpName("M_MTHRML", PU_CACHE));
+  V_DrawPatch(xx, y, 0, R_PatchByName("M_MTHRML", PU_CACHE));
   xx += M_THRM_STEP;
   for (i = 0; i < size; i++)
   {
-    V_DrawPatch(xx, y, 0, W_CacheLumpName("M_MTHRMM", PU_CACHE));
+    V_DrawPatch(xx, y, 0, R_PatchByName("M_MTHRMM", PU_CACHE));
     xx += M_THRM_STEP;
   }
-  V_DrawPatch(xx, y, 0, W_CacheLumpName("M_MTHRMR", PU_CACHE));
+  V_DrawPatch(xx, y, 0, R_PatchByName("M_MTHRMR", PU_CACHE));
 
   // [FG] do not crash anymore if value exceeds thermometer range
   if (dot >= size)
       dot = size - 1;
 
   V_DrawPatchTranslated((x + M_THRM_STEP) + dot * M_THRM_STEP, y, 0,
-                        W_CacheLumpName("M_MTHRMO", PU_CACHE), colrngs[color], 0);
+                        R_PatchByName("M_MTHRMO", PU_CACHE), colrngs[color], 0);
 }
 
 void M_DrawSetting(setup_menu_t* s)
@@ -2305,7 +2305,7 @@ void M_DrawSetting(setup_menu_t* s)
        
       ch = s->var.def->location->i;
       if (!ch) // don't show this item in automap mode
-	V_DrawPatchDirect (x+1,y,0,W_CacheLumpName("M_PALNO",PU_CACHE));
+	V_DrawPatchDirect (x+1,y,0,R_PatchByName("M_PALNO",PU_CACHE));
       else
 	{
 	  ptr = colorblock;
@@ -3465,7 +3465,7 @@ void M_DrawColPal()
 
   // Draw a background, border, and paint chips
 
-  V_DrawPatchDirect (COLORPALXORIG-5,COLORPALYORIG-5,0,W_CacheLumpName("M_COLORS",PU_CACHE));
+  V_DrawPatchDirect (COLORPALXORIG-5,COLORPALYORIG-5,0,R_PatchByName("M_COLORS",PU_CACHE));
 
   // Draw the cursor around the paint chip
   // (cpx,cpy) is the upper left-hand corner of the paint chip
@@ -4673,7 +4673,7 @@ void M_DrawExtHelp(void)
   inhelpscreens = true;              // killough 5/1/98
   namebfr[4] = extended_help_index/10 + 0x30;
   namebfr[5] = extended_help_index%10 + 0x30;
-  V_DrawPatchFullScreen(0,W_CacheLumpName(namebfr,PU_CACHE));
+  V_DrawPatchFullScreen(0,R_PatchByName(namebfr,PU_CACHE));
 }
 
 //
@@ -4886,7 +4886,7 @@ void M_DrawHelp (void)
   }
   else
   {
-    V_DrawPatchFullScreen(0, W_CacheLumpNum(helplump, PU_CACHE));
+    V_DrawPatchFullScreen(0, R_PatchByNum(helplump, PU_CACHE));
   }
 }
   
@@ -6405,7 +6405,7 @@ void M_Drawer (void)
       {
          if (currentMenu->menuitems[i].name[0])
             V_DrawPatchTranslated(x,y,0,
-            W_CacheLumpName(currentMenu->menuitems[i].name,PU_CACHE),
+            R_PatchByName(currentMenu->menuitems[i].name,PU_CACHE),
             currentMenu->menuitems[i].status == 0 ? cr_dark : cr_red,0);
          y += LINEHEIGHT;
       }
@@ -6414,7 +6414,7 @@ void M_Drawer (void)
       
       V_DrawPatchDirect(x + SKULLXOFF,
          currentMenu->y - 5 + itemOn*LINEHEIGHT,0,
-         W_CacheLumpName(skullName[whichSkull],PU_CACHE));
+         R_PatchByName(skullName[whichSkull],PU_CACHE));
    }
 }
 
@@ -6493,14 +6493,14 @@ void M_DrawThermo(int x,int y,int thermWidth,int thermDot )
   char num[4];
 
   xx = x;
-  V_DrawPatchDirect (xx,y,0,W_CacheLumpName("M_THERML",PU_CACHE));
+  V_DrawPatchDirect (xx,y,0,R_PatchByName("M_THERML",PU_CACHE));
   xx += 8;
   for (i=0;i<thermWidth;i++)
     {
-      V_DrawPatchDirect (xx,y,0,W_CacheLumpName("M_THERMM",PU_CACHE));
+      V_DrawPatchDirect (xx,y,0,R_PatchByName("M_THERMM",PU_CACHE));
       xx += 8;
     }
-  V_DrawPatchDirect (xx,y,0,W_CacheLumpName("M_THERMR",PU_CACHE));
+  V_DrawPatchDirect (xx,y,0,R_PatchByName("M_THERMR",PU_CACHE));
 
   // [FG] write numerical values next to thermometer
   M_snprintf(num, 4, "%3d", thermDot);
@@ -6511,7 +6511,7 @@ void M_DrawThermo(int x,int y,int thermWidth,int thermDot )
       thermDot = thermWidth - 1;
 
   V_DrawPatchDirect ((x+8) + thermDot*8,y,
-		     0,W_CacheLumpName("M_THERMO",PU_CACHE));
+		     0,R_PatchByName("M_THERMO",PU_CACHE));
 }
 
 //
@@ -6521,7 +6521,7 @@ void M_DrawThermo(int x,int y,int thermWidth,int thermDot )
 void M_DrawEmptyCell (menu_t* menu,int item)
 {
   V_DrawPatchDirect (menu->x - 10,menu->y+item*LINEHEIGHT - 1, 0,
-		     W_CacheLumpName("M_CELL1",PU_CACHE));
+		     R_PatchByName("M_CELL1",PU_CACHE));
 }
 
 //
@@ -6531,7 +6531,7 @@ void M_DrawEmptyCell (menu_t* menu,int item)
 void M_DrawSelCell (menu_t* menu,int item)
 {
   V_DrawPatchDirect (menu->x - 10,menu->y+item*LINEHEIGHT - 1, 0,
-		     W_CacheLumpName("M_CELL2",PU_CACHE));
+		     R_PatchByName("M_CELL2",PU_CACHE));
 }
 
 /////////////////////////////
@@ -6714,7 +6714,7 @@ void M_Init(void)
 
   if (W_CheckNumForName("M_GDHIGH") != -1)
   {
-    patch_t *patch = W_CacheLumpName("M_GDHIGH", PU_CACHE);
+    patch_t *patch = R_PatchByName("M_GDHIGH", PU_CACHE);
     if (OptionsDef.x + 175 + SHORT(patch->width) >= ORIGWIDTH)
     {
       if (W_CheckNumForName("M_DISP") != -1)

--- a/src/r_data.c
+++ b/src/r_data.c
@@ -1155,16 +1155,6 @@ void R_PrecacheLevel(void)
   Z_Free(hitlist);
 }
 
-static int patch_beta_size = 0;
-
-static int R_PatchSize(int num)
-{
-  if (strcasecmp("DOOMPRES.WAD", W_WadNameForLump(num)))
-    return W_LumpLength(num);
-
-  return patch_beta_size;
-}
-
 // [FG] check if the lump can be a Doom patch
 // taken from PrBoom+ prboom2/src/r_patch.c:L350-L390
 

--- a/src/r_data.h
+++ b/src/r_data.h
@@ -63,6 +63,9 @@ void R_InitColormaps(void);   // killough 8/9/98
 
 boolean R_IsPatchLump (const int lump);
 
+patch_t *R_PatchByNum(int num, int tag);
+#define R_PatchByName(name, tag) R_PatchByNum(W_GetNumForName(name), tag)
+
 extern byte *main_tranmap, *tranmap;
 
 #endif

--- a/src/r_draw.c
+++ b/src/r_draw.c
@@ -855,21 +855,21 @@ void R_FillBackScreen (void)
   // killough 11/98: use the function in m_menu.c
   M_DrawBackground(gamemode==commercial ? "GRNROCK" : "FLOOR7_2", screens[1]);
         
-  patch = W_CacheLumpName("brdr_t", PU_CACHE);
+  patch = R_PatchByName("brdr_t", PU_CACHE);
 
   for (x=0; x<scaledviewwidth; x+=8)
     V_DrawPatch(viewwindowx+x-WIDESCREENDELTA,viewwindowy-8,1,patch);
 
-  patch = W_CacheLumpName("brdr_b",PU_CACHE);
+  patch = R_PatchByName("brdr_b",PU_CACHE);
 
   for (x=0; x<scaledviewwidth; x+=8)   // killough 11/98:
     V_DrawPatch (viewwindowx+x-WIDESCREENDELTA,viewwindowy+scaledviewheight,1,patch);
 
-  patch = W_CacheLumpName("brdr_l",PU_CACHE);
+  patch = R_PatchByName("brdr_l",PU_CACHE);
 
   for (y=0; y<scaledviewheight; y+=8)             // killough 11/98
     V_DrawPatch (viewwindowx-8-WIDESCREENDELTA,viewwindowy+y,1,patch);
-  patch = W_CacheLumpName("brdr_r",PU_CACHE);
+  patch = R_PatchByName("brdr_r",PU_CACHE);
 
   for (y=0; y<scaledviewheight; y+=8)             // killough 11/98
     V_DrawPatch(viewwindowx+scaledviewwidth-WIDESCREENDELTA,viewwindowy+y,1,patch);
@@ -878,22 +878,22 @@ void R_FillBackScreen (void)
   V_DrawPatch(viewwindowx-8-WIDESCREENDELTA,
               viewwindowy-8,
               1,
-              W_CacheLumpName("brdr_tl",PU_CACHE));
+              R_PatchByName("brdr_tl",PU_CACHE));
     
   V_DrawPatch(viewwindowx+scaledviewwidth-WIDESCREENDELTA,
               viewwindowy-8,
               1,
-              W_CacheLumpName("brdr_tr",PU_CACHE));
+              R_PatchByName("brdr_tr",PU_CACHE));
     
   V_DrawPatch(viewwindowx-8-WIDESCREENDELTA,
               viewwindowy+scaledviewheight,             // killough 11/98
               1,
-              W_CacheLumpName("brdr_bl",PU_CACHE));
+              R_PatchByName("brdr_bl",PU_CACHE));
     
   V_DrawPatch(viewwindowx+scaledviewwidth-WIDESCREENDELTA,
               viewwindowy+scaledviewheight,             // killough 11/98
               1,
-              W_CacheLumpName("brdr_br",PU_CACHE));
+              R_PatchByName("brdr_br",PU_CACHE));
 } 
 
 //

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -385,7 +385,7 @@ void R_DrawVisSprite(vissprite_t *vis, int x1, int x2)
   column_t *column;
   int      texturecolumn;
   fixed_t  frac;
-  patch_t  *patch = W_CacheLumpNum (vis->patch+firstspritelump, PU_CACHE);
+  patch_t  *patch = R_PatchByNum (vis->patch+firstspritelump, PU_CACHE);
 
   dc_colormap[0] = vis->colormap[0];
   dc_colormap[1] = vis->colormap[1];

--- a/src/st_lib.c
+++ b/src/st_lib.c
@@ -54,7 +54,7 @@ void STlib_init(void)
 {
   // [FG] allow playing with the Doom v1.2 IWAD which is missing the STTMINUS lump
   if (W_CheckNumForName("STTMINUS") >= 0)
-  sttminus = (patch_t *) W_CacheLumpName("STTMINUS", PU_STATIC);
+  sttminus = (patch_t *) R_PatchByName("STTMINUS", PU_STATIC);
   else
     sttminus = NULL;
 }

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -429,7 +429,7 @@ void ST_refreshBackground(boolean force)
           // [crispy] preserve bezel bottom edge
           if (scaledviewwidth == SCREENWIDTH)
           {
-            patch_t *const patch = W_CacheLumpName("brdr_b", PU_CACHE);
+            patch_t *const patch = R_PatchByName("brdr_b", PU_CACHE);
 
             for (x = 0; x < WIDESCREENDELTA; x += 8)
             {
@@ -974,24 +974,24 @@ void ST_loadGraphics(void)
   for (i=0;i<10;i++)
     {
       sprintf(namebuf, "STTNUM%d", i);
-      tallnum[i] = (patch_t *) W_CacheLumpName(namebuf, PU_STATIC);
+      tallnum[i] = (patch_t *) R_PatchByName(namebuf, PU_STATIC);
       M_snprintf(namebuf, sizeof(namebuf), "STYSNUM%d", i);
-      shortnum[i] = (patch_t *) W_CacheLumpName(namebuf, PU_STATIC);
+      shortnum[i] = (patch_t *) R_PatchByName(namebuf, PU_STATIC);
     }
 
   // Load percent key.
   //Note: why not load STMINUS here, too?
-  tallpercent = (patch_t *) W_CacheLumpName("STTPRCNT", PU_STATIC);
+  tallpercent = (patch_t *) R_PatchByName("STTPRCNT", PU_STATIC);
 
   // key cards
   for (i=0;i<NUMCARDS+3;i++)  //jff 2/23/98 show both keys too
     {
       sprintf(namebuf, "STKEYS%d", i);
-      keys[i] = (patch_t *) W_CacheLumpName(namebuf, PU_STATIC);
+      keys[i] = (patch_t *) R_PatchByName(namebuf, PU_STATIC);
     }
 
   // arms background
-  armsbg = (patch_t *) W_CacheLumpName("STARMS", PU_STATIC);
+  armsbg = (patch_t *) R_PatchByName("STARMS", PU_STATIC);
 
   // arms ownership widgets
   for (i=0;i<6;i++)
@@ -999,7 +999,7 @@ void ST_loadGraphics(void)
       sprintf(namebuf, "STGNUM%d", i+2);
 
       // gray #
-      arms[i][0] = (patch_t *) W_CacheLumpName(namebuf, PU_STATIC);
+      arms[i][0] = (patch_t *) R_PatchByName(namebuf, PU_STATIC);
 
       // yellow #
       arms[i][1] = shortnum[i+2];
@@ -1011,11 +1011,11 @@ void ST_loadGraphics(void)
   for (i=0; i<MAXPLAYERS; i++)
     {
       sprintf(namebuf, "STFB%d", i);
-      faceback[i] = (patch_t *) W_CacheLumpName(namebuf, PU_STATIC);
+      faceback[i] = (patch_t *) R_PatchByName(namebuf, PU_STATIC);
     }
 
   // status bar background bits
-  sbar = (patch_t *) W_CacheLumpName("STBAR", PU_STATIC);
+  sbar = (patch_t *) R_PatchByName("STBAR", PU_STATIC);
 
   // face states
   facenum = 0;
@@ -1025,21 +1025,21 @@ void ST_loadGraphics(void)
       for (j=0;j<ST_NUMSTRAIGHTFACES;j++)
         {
           sprintf(namebuf, "STFST%d%d", i, j);
-          faces[facenum++] = W_CacheLumpName(namebuf, PU_STATIC);
+          faces[facenum++] = R_PatchByName(namebuf, PU_STATIC);
         }
       sprintf(namebuf, "STFTR%d0", i);        // turn right
-      faces[facenum++] = W_CacheLumpName(namebuf, PU_STATIC);
+      faces[facenum++] = R_PatchByName(namebuf, PU_STATIC);
       sprintf(namebuf, "STFTL%d0", i);        // turn left
-      faces[facenum++] = W_CacheLumpName(namebuf, PU_STATIC);
+      faces[facenum++] = R_PatchByName(namebuf, PU_STATIC);
       sprintf(namebuf, "STFOUCH%d", i);       // ouch!
-      faces[facenum++] = W_CacheLumpName(namebuf, PU_STATIC);
+      faces[facenum++] = R_PatchByName(namebuf, PU_STATIC);
       sprintf(namebuf, "STFEVL%d", i);        // evil grin ;)
-      faces[facenum++] = W_CacheLumpName(namebuf, PU_STATIC);
+      faces[facenum++] = R_PatchByName(namebuf, PU_STATIC);
       sprintf(namebuf, "STFKILL%d", i);       // pissed off
-      faces[facenum++] = W_CacheLumpName(namebuf, PU_STATIC);
+      faces[facenum++] = R_PatchByName(namebuf, PU_STATIC);
     }
-  faces[facenum++] = W_CacheLumpName("STFGOD0", PU_STATIC);
-  faces[facenum++] = W_CacheLumpName("STFDEAD0", PU_STATIC);
+  faces[facenum++] = R_PatchByName("STFGOD0", PU_STATIC);
+  faces[facenum++] = R_PatchByName("STFDEAD0", PU_STATIC);
 }
 
 void ST_loadData(void)

--- a/src/wi_stuff.c
+++ b/src/wi_stuff.c
@@ -449,7 +449,7 @@ static void WI_drawLF(void)
   }
   else if (wbs->lastmapinfo && wbs->lastmapinfo->levelpic[0])
   {
-    patch_t* lpic = W_CacheLumpName(wbs->lastmapinfo->levelpic, PU_CACHE);
+    patch_t* lpic = R_PatchByName(wbs->lastmapinfo->levelpic, PU_CACHE);
 
     V_DrawPatch((ORIGWIDTH - SHORT(lpic->width))/2,
                y, FB, lpic);
@@ -496,7 +496,7 @@ static void WI_drawEL(void)
   }
   else if (wbs->nextmapinfo && wbs->nextmapinfo->levelpic[0])
   {
-    patch_t* lpic = W_CacheLumpName(wbs->nextmapinfo->levelpic, PU_CACHE);
+    patch_t* lpic = R_PatchByName(wbs->nextmapinfo->levelpic, PU_CACHE);
 
     y += (5 * SHORT(lpic->height)) / 4;
 
@@ -1944,7 +1944,7 @@ void WI_DrawBackground(void)
     sprintf(name, "WIMAP%d", wbs->epsd);
 
   // background
-  V_DrawPatchFullScreen(1, W_CacheLumpName(name, PU_CACHE));
+  V_DrawPatchFullScreen(1, R_PatchByName(name, PU_CACHE));
 }
 
 // ====================================================================
@@ -2000,7 +2000,7 @@ void WI_loadData(void)
           sprintf(name, "WILV%d%d", wbs->epsd, i);
           if (W_CheckNumForName(name) != -1)
           {
-          lnames[i] = W_CacheLumpName(name, PU_STATIC);
+          lnames[i] = R_PatchByName(name, PU_STATIC);
           }
           else
           {
@@ -2009,13 +2009,13 @@ void WI_loadData(void)
         }
 
       // you are here
-      yah[0] = W_CacheLumpName("WIURH0", PU_STATIC);
+      yah[0] = R_PatchByName("WIURH0", PU_STATIC);
 
       // you are here (alt.)
-      yah[1] = W_CacheLumpName("WIURH1", PU_STATIC);
+      yah[1] = R_PatchByName("WIURH1", PU_STATIC);
 
       // splat
-      splat = W_CacheLumpName("WISPLAT", PU_STATIC); 
+      splat = R_PatchByName("WISPLAT", PU_STATIC); 
   
       if (wbs->epsd < 3)
         {
@@ -2029,7 +2029,7 @@ void WI_loadData(void)
                     {
                       // animations
                       M_snprintf(name, sizeof(name), "WIA%d%.2d%.2d", wbs->epsd, j, i);
-                      a->p[i] = W_CacheLumpName(name, PU_STATIC);
+                      a->p[i] = R_PatchByName(name, PU_STATIC);
                     }
                   else
                     {
@@ -2044,32 +2044,32 @@ void WI_loadData(void)
   // More hacks on minus sign.
   // [FG] allow playing with the Doom v1.2 IWAD which is missing the WIMINUS lump
   if (W_CheckNumForName("WIMINUS") >= 0)
-  wiminus = W_CacheLumpName("WIMINUS", PU_STATIC); 
+  wiminus = R_PatchByName("WIMINUS", PU_STATIC); 
 
   for (i=0;i<10;i++)
     {
       // numbers 0-9
       sprintf(name, "WINUM%d", i);     
-      num[i] = W_CacheLumpName(name, PU_STATIC);
+      num[i] = R_PatchByName(name, PU_STATIC);
     }
 
   // percent sign
-  percent = W_CacheLumpName("WIPCNT", PU_STATIC);
+  percent = R_PatchByName("WIPCNT", PU_STATIC);
 
   // "finished"
-  finished = W_CacheLumpName("WIF", PU_STATIC);
+  finished = R_PatchByName("WIF", PU_STATIC);
 
   // "entering"
-  entering = W_CacheLumpName("WIENTER", PU_STATIC);
+  entering = R_PatchByName("WIENTER", PU_STATIC);
 
   // "kills"
-  kills = W_CacheLumpName("WIOSTK", PU_STATIC);   
+  kills = R_PatchByName("WIOSTK", PU_STATIC);   
 
   // "scrt"
-  secret = W_CacheLumpName("WIOSTS", PU_STATIC);
+  secret = R_PatchByName("WIOSTS", PU_STATIC);
 
   // "secret"
-  sp_secret = W_CacheLumpName("WISCRT2", PU_STATIC);
+  sp_secret = R_PatchByName("WISCRT2", PU_STATIC);
 
   // Yuck. // Ty 03/27/98 - got that right :)  
   // french is an enum=1 always true.
@@ -2082,47 +2082,47 @@ void WI_loadData(void)
   //      items = W_CacheLumpName("WIOSTI", PU_STATIC);
   //    } else
 
-  items = W_CacheLumpName("WIOSTI", PU_STATIC);
+  items = R_PatchByName("WIOSTI", PU_STATIC);
 
   // "frgs"
-  frags = W_CacheLumpName("WIFRGS", PU_STATIC);    
+  frags = R_PatchByName("WIFRGS", PU_STATIC);    
 
   // ":"
-  colon = W_CacheLumpName("WICOLON", PU_STATIC); 
+  colon = R_PatchByName("WICOLON", PU_STATIC); 
 
   // "time"
-  witime = W_CacheLumpName("WITIME", PU_STATIC);
+  witime = R_PatchByName("WITIME", PU_STATIC);
 
   // "sucks"
-  sucks = W_CacheLumpName("WISUCKS", PU_STATIC);  
+  sucks = R_PatchByName("WISUCKS", PU_STATIC);  
 
   // "par"
-  par = W_CacheLumpName("WIPAR", PU_STATIC);   
+  par = R_PatchByName("WIPAR", PU_STATIC);   
 
   // "killers" (vertical)
-  killers = W_CacheLumpName("WIKILRS", PU_STATIC);
+  killers = R_PatchByName("WIKILRS", PU_STATIC);
   
   // "victims" (horiz)
-  victims = W_CacheLumpName("WIVCTMS", PU_STATIC);
+  victims = R_PatchByName("WIVCTMS", PU_STATIC);
 
   // "total"
-  total = W_CacheLumpName("WIMSTT", PU_STATIC);   
+  total = R_PatchByName("WIMSTT", PU_STATIC);   
 
   // your face
-  star = W_CacheLumpName("STFST01", PU_STATIC);
+  star = R_PatchByName("STFST01", PU_STATIC);
 
   // dead face
-  bstar = W_CacheLumpName("STFDEAD0", PU_STATIC);    
+  bstar = R_PatchByName("STFDEAD0", PU_STATIC);    
 
   for (i=0 ; i<MAXPLAYERS ; i++)
     {
       // "1,2,3,4"
       sprintf(name, "STPB%d", i);      
-      p[i] = W_CacheLumpName(name, PU_STATIC);
+      p[i] = R_PatchByName(name, PU_STATIC);
 
       // "1,2,3,4"
       sprintf(name, "WIBP%d", i+1);     
-      bp[i] = W_CacheLumpName(name, PU_STATIC);
+      bp[i] = R_PatchByName(name, PU_STATIC);
     }
 }
 


### PR DESCRIPTION
This is successfully loads DOOMPRES.WAD (see https://www.doomworld.com/idgames/historic/doomprbt) Also there is TEXTURE2.LMP in the folder for some reason, so I run it with this command line:
`woof -iwad DOOM.WAD -file DOOMPRES.WAD TEXTURE2.LMP`
All graphics are converted except for TITLEPIC, which is not used in the actual beta.

@fabiangreffrath  What do you think of this approach? Alternatively, we can try to convert the patches at the `w_wad.c` level, "transparently" to the rest of the codebase, but then we need to check each lump if it's a valid patch or not.