### PR TITLE
fix of hanging decoration disappearing

### DIFF
--- a/src/r_main.c
+++ b/src/r_main.c
@@ -488,7 +488,7 @@ void R_ExecuteSetViewSize (void)
   centeryfrac = centery<<FRACBITS;
   centerxfrac_nonwide = (viewwidth_nonwide/2)<<FRACBITS;
   projection = centerxfrac_nonwide;
-  viewheightfrac = viewheight<<FRACBITS; // [FG] sprite clipping optimizations
+  viewheightfrac = viewheight<<(FRACBITS+1); // [FG] sprite clipping optimizations
 
   R_InitBuffer(scaledviewwidth, scaledviewheight);       // killough 11/98
         

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -567,7 +567,7 @@ void R_ProjectSprite (mobj_t* thing)
   gzt = interpz + spritetopoffset[lump];
 
   // killough 4/9/98: clip things which are out of view due to height
-  if (interpz > viewz + FixedDiv(viewheightfrac, xscale) ||
+  if (interpz > (int64_t)viewz + FixedDiv(viewheightfrac, xscale) ||
       gzt < (int64_t)viewz - FixedDiv(viewheightfrac - viewheight, xscale))
     return;
 


### PR DESCRIPTION
Fix #687 

Maybe it's worth implementing a fix from PrBoom+: https://github.com/coelckers/prboom-plus/commit/6eb2cbb6155946db98f65ab7588f1cad9132d529 (ludicrm.wad map03 works in Woof)