### PR TITLE
More demo playback QOL

### DIFF
--- a/src/d_loop.c
+++ b/src/d_loop.c
@@ -109,13 +109,14 @@ static int player_class;
 
 static int GetAdjustedTime(void)
 {
-    if (new_sync && offsetms)
+    // Use the adjustments from net_client.c only if we are
+    // using the new sync mode.
+
+    if (new_sync && net_client_connected)
     {
         int time_ms;
 
         time_ms = I_GetTimeMS();
-	// Use the adjustments from net_client.c only if we are
-	// using the new sync mode.
 
         time_ms += (offsetms / FRACUNIT);
 
@@ -522,6 +523,26 @@ boolean D_InitNetGame(net_connect_data_t *connect_data)
     return result;
 }
 
+boolean D_CheckNetConnect(void)
+{
+    return net_client_connected;
+}
+
+void D_CheckNetPlaybackSkip(void)
+{
+    if (!net_client_connected)
+    {
+        return;
+    }
+
+    if (fastdemo || PLAYBACK_SKIP)
+    {
+        printf("Demo playback skipping is suppressed in multiplayer.\n");
+        fastdemo = false;
+        playback_warp = -1;
+        playback_skiptics = 0;
+    }
+}
 
 //
 // D_QuitNetGame
@@ -628,6 +649,23 @@ static boolean PlayersInGame(void)
     if (!drone)
     {
         result = true;
+    }
+
+    return result;
+}
+
+int D_GetPlayersInNetGame(void)
+{
+    int i;
+    int result = 0;
+
+    if (net_client_connected)
+    {
+        for (i = 0; i < NET_MAXPLAYERS; ++i)
+        {
+            if (local_playeringame[i])
+                ++result;
+        }
     }
 
     return result;

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -2503,11 +2503,6 @@ void D_DoomMain(void)
   I_InitJoystick();
   I_InitSound();
 
-  if (fastdemo)
-  {
-    I_SetFastdemoTimer(true);
-  }
-
   puts("NET_Init: Init network subsystem.");
   NET_Init();
 
@@ -2661,6 +2656,11 @@ void D_DoomMain(void)
 	    playback_warp = -1;
 	    playback_skiptics = 0;
 	  }
+
+  if (fastdemo)
+  {
+    I_SetFastdemoTimer(true);
+  }
 
   // [FG] init graphics (WIDESCREENDELTA) before HUD widgets
   I_InitGraphics();

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -2572,8 +2572,6 @@ void D_DoomMain(void)
       {
         I_Error("Invalid parameter '%s' for -skipsec, should be min:sec", myargv[p+1]);
       }
-
-      demoskip_tics = abs(demoskip_tics);
     }
 
   // start the apropriate game based on parms
@@ -2661,7 +2659,7 @@ void D_DoomMain(void)
 	  {
 	    // [FG] no demo playback
 	    demowarp = -1;
-	    demoskip_tics = -1;
+	    demoskip_tics = 0;
 	  }
 
   // [FG] init graphics (WIDESCREENDELTA) before HUD widgets

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -223,7 +223,7 @@ void D_Display (void)
   int wipestart;
   boolean done, wipe, redrawsbar;
 
-  if (demobar && DEMOSKIP)
+  if (demobar && PLAYBACK_SKIP)
   {
     if (HU_DemoProgressBar(false))
     {
@@ -1815,7 +1815,7 @@ static void D_EndDoom(void)
 }
 
 // [FG] fast-forward demo to the desired map
-int demowarp = -1;
+int playback_warp = -1;
 
 //
 // D_DoomMain
@@ -2317,7 +2317,7 @@ void D_DoomMain(void)
           autostart = true;
         }
     // [FG] fast-forward demo to the desired map
-    demowarp = startmap;
+    playback_warp = startmap;
   }
 
   //jff 1/22/98 add command line parms to disable sound and music
@@ -2562,11 +2562,11 @@ void D_DoomMain(void)
 
       if (sscanf(myargv[p+1], "%f:%f", &min, &sec) == 2)
       {
-        demoskip_tics = (int) ((60 * min + sec) * TICRATE);
+        playback_skiptics = (int) ((60 * min + sec) * TICRATE);
       }
       else if (sscanf(myargv[p+1], "%f", &sec) == 1)
       {
-        demoskip_tics = (int) (sec * TICRATE);
+        playback_skiptics = (int) (sec * TICRATE);
       }
       else
       {
@@ -2658,8 +2658,8 @@ void D_DoomMain(void)
 	else
 	  {
 	    // [FG] no demo playback
-	    demowarp = -1;
-	    demoskip_tics = 0;
+	    playback_warp = -1;
+	    playback_skiptics = 0;
 	  }
 
   // [FG] init graphics (WIDESCREENDELTA) before HUD widgets

--- a/src/d_net.c
+++ b/src/d_net.c
@@ -292,26 +292,5 @@ void D_CheckNetGame (void)
 
     printf("player %i of %i (%i nodes)\n",
                consoleplayer+1, settings.num_players, settings.num_players);
-
-    // Show players here; the server might have specified a time limit
-/*
-    if (timelimit > 0 && deathmatch)
-    {
-        // Gross hack to work like Vanilla:
-
-        if (timelimit == 20 && M_CheckParm("-avg"))
-        {
-            printf("Austin Virtual Gaming: Levels will end "
-                           "after 20 minutes\n");
-        }
-        else
-        {
-            printf("Levels will end after %d minute", timelimit);
-            if (timelimit > 1)
-                printf("s");
-            printf(".\n");
-        }
-    }
-*/
 }
 

--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -203,6 +203,8 @@ extern  boolean         respawnmonsters;
 // Netgame? Only true if >1 player.
 extern  boolean netgame;
 
+extern boolean D_CheckNetConnect(void);
+
 // Flag: true only if started as net deathmatch.
 // An enum might handle altdeath/cooperative better.
 extern  boolean deathmatch;

--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -304,7 +304,7 @@ extern  boolean   demonext;
 // skipping demo
 extern  int       demoskip_tics;
 
-#define DEMOSKIP (demowarp >= 0 || demoskip_tics > 0 || demonext)
+#define DEMOSKIP (demowarp >= 0 || demoskip_tics || demonext)
 
 extern  boolean   strictmode, default_strictmode;
 

--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -298,13 +298,13 @@ extern  boolean   timingdemo;
 // Run tick clock at fastest speed possible while playing demo.  killough
 extern  boolean   fastdemo;
 // [FG] fast-forward demo to the desired map
-extern  int       demowarp;
+extern  int       playback_warp;
 // fast-forward demo to the next map
-extern  boolean   demonext;
+extern  boolean   playback_nextlevel;
 // skipping demo
-extern  int       demoskip_tics;
+extern  int       playback_skiptics;
 
-#define DEMOSKIP (demowarp >= 0 || demoskip_tics || demonext)
+#define PLAYBACK_SKIP (playback_warp >= 0 || playback_skiptics || playback_nextlevel)
 
 extern  boolean   strictmode, default_strictmode;
 

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -313,13 +313,13 @@ void G_EnableWarp(boolean warp)
   }
 }
 
-int demoskip_tics = -1;
+int demoskip_tics = 0;
 
 static void G_DemoSkipTics(void)
 {
   static boolean warp = false;
 
-  if (demoskip_tics == -1)
+  if (!demoskip_tics || !deftotaldemotics)
     return;
 
   if (demowarp >= 0)
@@ -327,12 +327,20 @@ static void G_DemoSkipTics(void)
 
   if (demowarp == -1)
   {
+    if (demoskip_tics < 0)
+    {
+      if (warp)
+        demoskip_tics = deftotaldemotics - levelstarttic + demoskip_tics;
+      else
+        demoskip_tics = deftotaldemotics + demoskip_tics;
+    }
+
     if ((warp && demoskip_tics < gametic - levelstarttic) ||
         (!warp && demoskip_tics < gametic))
     {
       G_EnableWarp(false);
       S_RestartMusic();
-      demoskip_tics = -1;
+      demoskip_tics = 0;
     }
   }
 }
@@ -983,7 +991,7 @@ boolean G_Responder(event_t* ev)
 //
 
 // [crispy] demo progress bar
-int defdemotics = 0, deftotaldemotics;
+int defdemotics = 0, deftotaldemotics = 0;
 
 static char *defdemoname;
 
@@ -3626,7 +3634,7 @@ void G_DeferedPlayDemo(char* name)
   gameaction = ga_playdemo;
 
   // [FG] fast-forward demo to the desired map
-  if (demowarp >= 0 || demoskip_tics > 0)
+  if (demowarp >= 0 || demoskip_tics)
   {
     G_EnableWarp(true);
   }

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -335,8 +335,8 @@ static void G_DemoSkipTics(void)
         demoskip_tics = deftotaldemotics + demoskip_tics;
     }
 
-    if ((warp && demoskip_tics < gametic - levelstarttic) ||
-        (!warp && demoskip_tics < gametic))
+    if ((warp && demoskip_tics < defdemotics - levelstarttic) ||
+        (!warp && demoskip_tics < defdemotics))
     {
       G_EnableWarp(false);
       S_RestartMusic();
@@ -847,7 +847,6 @@ boolean G_Responder(event_t* ev)
 
   if (M_InputActivated(input_menu_reloadlevel) &&
       (gamestate == GS_LEVEL || gamestate == GS_INTERMISSION) &&
-      !demoplayback &&
       !deathmatch &&
       !menuactive)
   {
@@ -2192,6 +2191,15 @@ void G_Ticker(void)
 	      // catch BT_JOIN before G_ReadDemoTiccmd overwrites it
 	      if (demoplayback && cmd->buttons & BT_JOIN)
 		G_JoinDemo();
+
+	      // catch BTS_RELOAD for demo playback restart
+	      if (demoplayback &&
+	          cmd->buttons & BT_SPECIAL && cmd->buttons & BT_SPECIALMASK &&
+	          cmd->buttons & BTS_RELOAD)
+	      {
+	        defdemotics = 0;
+	        gameaction = ga_playdemo;
+	      }
 
 	      if (demoplayback)
 		G_ReadDemoTiccmd(cmd);

--- a/src/hu_stuff.c
+++ b/src/hu_stuff.c
@@ -1082,10 +1082,10 @@ static void HU_DrawCrosshair(void)
 // [crispy] print a bar indicating demo progress at the bottom of the screen
 boolean HU_DemoProgressBar(boolean force)
 {
-  const int progress = SCREENWIDTH * defdemotics / deftotaldemotics;
+  const int progress = SCREENWIDTH * playback_tic / playback_totaltics;
   static int old_progress = 0;
 
-  if (progress - old_progress)
+  if (old_progress < progress)
   {
     old_progress = progress;
   }

--- a/src/hu_stuff.h
+++ b/src/hu_stuff.h
@@ -89,7 +89,7 @@ extern int hud_timests; // Time/STS above status bar
 extern boolean message_centered; // center messages
 extern boolean message_colorized; // colorize player messages
 
-extern int defdemotics, deftotaldemotics;
+extern int playback_tic, playback_totaltics;
 
 extern int crispy_hud;
 

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1422,7 +1422,7 @@ static void I_InitGraphicsMode(void)
       // Don't scale up the screen. Implies -window.
       //
 
-      if (p = M_CheckParm("-1"))
+      if ((p = M_CheckParm("-1")))
          tmp_scalefactor = 1;
 
       //!
@@ -1431,7 +1431,7 @@ static void I_InitGraphicsMode(void)
       // Double up the screen to 2x its normal size. Implies -window.
       //
 
-      else if (p = M_CheckParm("-2"))
+      else if ((p = M_CheckParm("-2")))
          tmp_scalefactor = 2;
 
       //!
@@ -1440,11 +1440,11 @@ static void I_InitGraphicsMode(void)
       // Triple up the screen to 3x its normal size. Implies -window.
       //
 
-      else if (p = M_CheckParm("-3"))
+      else if ((p = M_CheckParm("-3")))
          tmp_scalefactor = 3;
-      else if (p = M_CheckParm("-4"))
+      else if ((p = M_CheckParm("-4")))
          tmp_scalefactor = 4;
-      else if (p = M_CheckParm("-5"))
+      else if ((p = M_CheckParm("-5")))
          tmp_scalefactor = 5;
 
       if (p && strcasecmp("-skipsec", myargv[p - 1]))

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1447,6 +1447,7 @@ static void I_InitGraphicsMode(void)
       else if ((p = M_CheckParm("-5")))
          tmp_scalefactor = 5;
 
+      // -skipsec can take a negative number as a parameter
       if (p && strcasecmp("-skipsec", myargv[p - 1]))
         scalefactor = tmp_scalefactor;
 

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1009,7 +1009,7 @@ void I_BeginRead(unsigned int bytes)
 
 static void I_DrawDiskIcon(void)
 {
-  if (!disk_icon || !in_graphics_mode || DEMOSKIP)
+  if (!disk_icon || !in_graphics_mode || PLAYBACK_SKIP)
     return;
 
   if (disk_to_draw >= DISK_ICON_THRESHOLD)
@@ -1032,7 +1032,7 @@ void I_EndRead(void)
 
 static void I_RestoreDiskBackground(void)
 {
-  if (!disk_icon || !in_graphics_mode || DEMOSKIP)
+  if (!disk_icon || !in_graphics_mode || PLAYBACK_SKIP)
     return;
 
   if (disk_to_restore)

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1383,6 +1383,7 @@ static void I_InitGraphicsMode(void)
 
    if (firsttime)
    {
+      int p, tmp_scalefactor;
       firsttime = false;
 
       //!
@@ -1421,8 +1422,8 @@ static void I_InitGraphicsMode(void)
       // Don't scale up the screen. Implies -window.
       //
 
-      if (M_CheckParm("-1"))
-         scalefactor = 1;
+      if (p = M_CheckParm("-1"))
+         tmp_scalefactor = 1;
 
       //!
       // @category video
@@ -1430,8 +1431,8 @@ static void I_InitGraphicsMode(void)
       // Double up the screen to 2x its normal size. Implies -window.
       //
 
-      else if (M_CheckParm("-2"))
-         scalefactor = 2;
+      else if (p = M_CheckParm("-2"))
+         tmp_scalefactor = 2;
 
       //!
       // @category video
@@ -1439,12 +1440,15 @@ static void I_InitGraphicsMode(void)
       // Triple up the screen to 3x its normal size. Implies -window.
       //
 
-      else if (M_CheckParm("-3"))
-         scalefactor = 3;
-      else if (M_CheckParm("-4"))
-         scalefactor = 4;
-      else if (M_CheckParm("-5"))
-         scalefactor = 5;
+      else if (p = M_CheckParm("-3"))
+         tmp_scalefactor = 3;
+      else if (p = M_CheckParm("-4"))
+         tmp_scalefactor = 4;
+      else if (p = M_CheckParm("-5"))
+         tmp_scalefactor = 5;
+
+      if (p && strcasecmp("-skipsec", myargv[p - 1]))
+        scalefactor = tmp_scalefactor;
 
       //!
       // @category video

--- a/src/m_argv.c
+++ b/src/m_argv.c
@@ -178,10 +178,20 @@ void M_CheckCommandLine(void)
       else if (!strcasecmp(myargv[p], "-warp"))
       {
         check = CheckNumArgs(p, 1);
-        if (!check)
-          I_Error("No parameter for '-warp'.");
-        else
+        if (check)
           p = check;
+        else
+          I_Error("No parameter for '-warp'.");
+      }
+      // -skipsec can be negative
+      else if (!strcasecmp(myargv[p], "-skipsec") && p + 1 < myargc)
+      {
+        float min, sec;
+        if (sscanf(myargv[p + 1], "%f:%f", &min, &sec) == 2 ||
+            sscanf(myargv[p + 1], "%f", &sec) == 1)
+          p += 2;
+        else
+          I_Error("No parameter for '-skipsec'.");
       }
       // -turbo has default value
       else if (!strcasecmp(myargv[p], "-turbo"))

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -5359,7 +5359,8 @@ boolean M_Responder (event_t* ev)
 
         if (M_InputActivated(input_demo_fforward))
         {
-          if (demoplayback && singledemo && !PLAYBACK_SKIP && !fastdemo)
+          if (demoplayback && !PLAYBACK_SKIP && !fastdemo
+              && !D_CheckNetConnect())
           {
             static boolean fastdemo_timer = false;
             fastdemo_timer = !fastdemo_timer;
@@ -5368,7 +5369,7 @@ boolean M_Responder (event_t* ev)
           }
         }
 
-        if (M_InputActivated(input_speed_up) && (!netgame || demoplayback)
+        if (M_InputActivated(input_speed_up) && !D_CheckNetConnect()
             && !strictmode)
         {
           realtic_clock_rate += 10;
@@ -5377,7 +5378,7 @@ boolean M_Responder (event_t* ev)
           I_SetTimeScale(realtic_clock_rate);
         }
 
-        if (M_InputActivated(input_speed_down) && (!netgame || demoplayback)
+        if (M_InputActivated(input_speed_down) && !D_CheckNetConnect()
             && !strictmode)
         {
           realtic_clock_rate -= 10;
@@ -5386,7 +5387,7 @@ boolean M_Responder (event_t* ev)
           I_SetTimeScale(realtic_clock_rate);
         }
 
-        if (M_InputActivated(input_speed_default) && (!netgame || demoplayback)
+        if (M_InputActivated(input_speed_default) && !D_CheckNetConnect()
             && !strictmode)
         {
           realtic_clock_rate = 100;

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -5347,9 +5347,9 @@ boolean M_Responder (event_t* ev)
 	// [FG] reload current level / go to next level
 	if (M_InputActivated(input_menu_nextlevel))
 	{
-		if (demoplayback && singledemo && !DEMOSKIP)
+		if (demoplayback && singledemo && !PLAYBACK_SKIP)
 		{
-			demonext = true;
+			playback_nextlevel = true;
 			G_EnableWarp(true);
 			return true;
 		}
@@ -5359,7 +5359,7 @@ boolean M_Responder (event_t* ev)
 
         if (M_InputActivated(input_demo_fforward))
         {
-          if (demoplayback && singledemo && !DEMOSKIP && !fastdemo)
+          if (demoplayback && singledemo && !PLAYBACK_SKIP && !fastdemo)
           {
             static boolean fastdemo_timer = false;
             fastdemo_timer = !fastdemo_timer;

--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -1524,7 +1524,7 @@ void P_SetupLevel(int episode, int map, int playermask, skill_t skill)
   // [FG] fast-forward demo to the desired map
   if (demowarp == map || demonext)
   {
-    if (demoskip_tics == -1)
+    if (!demoskip_tics)
       G_EnableWarp(false);
 
     demowarp = -1;

--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -1501,7 +1501,7 @@ static boolean P_LoadReject(int lumpnum, int totallines)
 // killough 5/3/98: reformatted, cleaned up
 
 // fast-forward demo to the next map
-boolean demonext = false;
+boolean playback_nextlevel = false;
 
 void P_SetupLevel(int episode, int map, int playermask, skill_t skill)
 {
@@ -1522,13 +1522,13 @@ void P_SetupLevel(int episode, int map, int playermask, skill_t skill)
   players[consoleplayer].viewz = 1;
 
   // [FG] fast-forward demo to the desired map
-  if (demowarp == map || demonext)
+  if (playback_warp == map || playback_nextlevel)
   {
-    if (!demoskip_tics)
+    if (!playback_skiptics)
       G_EnableWarp(false);
 
-    demowarp = -1;
-    demonext = false;
+    playback_warp = -1;
+    playback_nextlevel = false;
   }
 
   // Make sure all sounds are stopped before Z_FreeTags.


### PR DESCRIPTION
- `-skipsec` takes negative numbers to skip from the end of the demo instead of from the start

- restart level/demo key also restarts demo playback