### PR TITLE
reset weapon bobbing interpolation when changing sprite scale

### DIFF
--- a/src/am_map.c
+++ b/src/am_map.c
@@ -30,6 +30,7 @@
 #include "doomkeys.h"
 #include "st_stuff.h"
 #include "r_main.h"
+#include "r_things.h"
 #include "p_setup.h"
 #include "p_maputl.h"
 #include "w_wad.h"
@@ -2281,7 +2282,10 @@ void AM_Drawer (void)
   }
 
   if (!automapoverlay)
-  AM_clearFB(mapcolor_back);         //jff 1/5/98 background default color
+  {
+    AM_clearFB(mapcolor_back);       //jff 1/5/98 background default color
+    pspr_interp = false;
+  }
   if (automap_grid)                  // killough 2/28/98: change var name
     AM_drawGrid(mapcolor_grid);      //jff 1/7/98 grid default color
   AM_drawWalls();

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -441,7 +441,6 @@ void R_SetViewSize(int blocks)
 void R_ExecuteSetViewSize (void)
 {
   int i, j;
-  extern boolean pspr_interp;
 
   setsizeneeded = false;
 

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -441,6 +441,7 @@ void R_SetViewSize(int blocks)
 void R_ExecuteSetViewSize (void)
 {
   int i, j;
+  extern boolean pspr_interp;
 
   setsizeneeded = false;
 
@@ -553,6 +554,8 @@ void R_ExecuteSetViewSize (void)
 
     // [FG] spectre drawing mode
     R_SetFuzzColumnMode();
+
+    pspr_interp = false;
 }
 
 //

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -784,6 +784,7 @@ void R_DrawPSprite (pspdef_t *psp)
     static int     oldx1, x1_saved;
     static fixed_t oldtexturemid, texturemid_saved;
     static int     oldlump = -1;
+    static fixed_t oldpspritescale = 0;
     static int     oldgametic = -1;
 
     if (oldgametic < gametic)
@@ -800,7 +801,7 @@ void R_DrawPSprite (pspdef_t *psp)
     // otherwise oldx1 and oldtexturemid are not reset
     if (leveltime > 1)
     {
-      if (lump == oldlump)
+      if (lump == oldlump && pspritescale == oldpspritescale)
       {
         int deltax = vis->x2 - vis->x1;
         vis->x1 = oldx1 + FixedMul(vis->x1 - oldx1, fractionaltic);
@@ -812,6 +813,7 @@ void R_DrawPSprite (pspdef_t *psp)
         oldx1 = vis->x1;
         oldtexturemid = vis->texturemid;
         oldlump = lump;
+        oldpspritescale = pspritescale;
       }
     }
   }

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -684,6 +684,8 @@ void R_AddSprites(sector_t* sec, int lightlevel)
 // R_DrawPSprite
 //
 
+boolean pspr_interp = true; // weapon bobbing interpolation
+
 void R_DrawPSprite (pspdef_t *psp)
 {
   fixed_t       tx;
@@ -784,7 +786,6 @@ void R_DrawPSprite (pspdef_t *psp)
     static int     oldx1, x1_saved;
     static fixed_t oldtexturemid, texturemid_saved;
     static int     oldlump = -1;
-    static fixed_t oldpspritescale = 0;
     static int     oldgametic = -1;
 
     if (oldgametic < gametic)
@@ -797,24 +798,19 @@ void R_DrawPSprite (pspdef_t *psp)
     x1_saved = vis->x1;
     texturemid_saved = vis->texturemid;
 
-    // Do not interpolate on the first tic of the level,
-    // otherwise oldx1 and oldtexturemid are not reset
-    if (leveltime > 1)
+    if (lump == oldlump && pspr_interp)
     {
-      if (lump == oldlump && pspritescale == oldpspritescale)
-      {
-        int deltax = vis->x2 - vis->x1;
-        vis->x1 = oldx1 + FixedMul(vis->x1 - oldx1, fractionaltic);
-        vis->x2 = vis->x1 + deltax;
-        vis->texturemid = oldtexturemid + FixedMul(vis->texturemid - oldtexturemid, fractionaltic);
-      }
-      else
-      {
-        oldx1 = vis->x1;
-        oldtexturemid = vis->texturemid;
-        oldlump = lump;
-        oldpspritescale = pspritescale;
-      }
+      int deltax = vis->x2 - vis->x1;
+      vis->x1 = oldx1 + FixedMul(vis->x1 - oldx1, fractionaltic);
+      vis->x2 = vis->x1 + deltax;
+      vis->texturemid = oldtexturemid + FixedMul(vis->texturemid - oldtexturemid, fractionaltic);
+    }
+    else
+    {
+      oldx1 = vis->x1;
+      oldtexturemid = vis->texturemid;
+      oldlump = lump;
+      pspr_interp = true;
     }
   }
 

--- a/src/r_things.h
+++ b/src/r_things.h
@@ -48,6 +48,8 @@ extern int64_t sprtopscreen; // [FG] 64-bit integer math
 extern fixed_t pspritescale;
 extern fixed_t pspriteiscale;
 
+extern boolean pspr_interp; // weapon bobbing interpolation
+
 void R_DrawMaskedColumn(column_t *column);
 void R_SortVisSprites(void);
 void R_AddSprites(sector_t *sec,int); // killough 9/18/98


### PR DESCRIPTION
Fixes weapon "shaking" when changing `screenblocks`. Discussion: https://github.com/JNechaevsky/inter-doom/commit/059a6a6778cf8ec440c5e53448292b7ba24c553a#comments

Perhaps at this point we should add another global flag.