### PR TITLE
missed recoil for MBF21 codepointers

### DIFF
--- a/src/p_pspr.c
+++ b/src/p_pspr.c
@@ -1212,6 +1212,8 @@ void A_WeaponBulletAttack(player_t *player, pspdef_t *psp)
 
     P_LineAttack(player->mo, angle, MISSILERANGE, slope, damage);
   }
+
+  A_Recoil(player);
 }
 
 //
@@ -1258,6 +1260,8 @@ void A_WeaponMeleeAttack(player_t *player, pspdef_t *psp)
 
   // attack, dammit!
   P_LineAttack(player->mo, angle, range, slope, damage);
+
+  A_Recoil(player);
 
   // missed? ah, welp.
   if (!linetarget)


### PR DESCRIPTION
Tested on Vesper mod [[doomworld]](https://www.doomworld.com/forum/topic/123800-v100-vesper-mbf21-showcase-mod/), https://github.com/XaserAcheron/vesper (weapon 1 and 2 have no recoil effect)