### PR TITLE
implement check for MP3's

### DIFF
--- a/src/i_sdlmusic.c
+++ b/src/i_sdlmusic.c
@@ -179,6 +179,8 @@ static void I_SDL_UnRegisterSong(void *handle)
    }
 }
 
+// MP3 check adapted from https://github.com/lieff/minimp3
+
 static size_t mp3dec_skip_id3v2(const byte *buf, size_t buf_size)
 {
     if (buf_size >= 10 && !memcmp(buf, "ID3", 3) && !((buf[5] & 15) ||


### PR DESCRIPTION
SDL_Mixer just check for "ID3" or one frame header which is not enough: https://github.com/libsdl-org/SDL_mixer/blob/831a83fd4a9f73d8855c2e737b02c2e83d5a9ba2/src/music.c#L560
MP3 files don't have a magic number header, so we need to read a bunch of frame headers to check if the MP3 is valid. Code adapted from `minimp3.h`.
This fixes MP3 music in dvii-1u.wad