### PR TITLE
Fix Windows native MIDI level transitions

### DIFF
--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -440,6 +440,26 @@ static void I_WIN_StopSong(void *handle)
         midiOutShortMsg((HMIDIOUT)hMidiStream, msg);
         msg = MIDI_EVENT_CONTROLLER | i | 0x65 << 8 | 0x7F << 16;
         midiOutShortMsg((HMIDIOUT)hMidiStream, msg);
+
+        // reset all controllers
+        msg = MIDI_EVENT_CONTROLLER | i | 0x79 << 8 | 0x00 << 16;
+        midiOutShortMsg((HMIDIOUT)hMidiStream, msg);
+
+        // reset pan to 64 (center)
+        msg = MIDI_EVENT_CONTROLLER | i | 0x0A << 8 | 0x40 << 16;
+        midiOutShortMsg((HMIDIOUT)hMidiStream, msg);
+
+        // reset reverb to 40 and other effect controllers to 0
+        msg = MIDI_EVENT_CONTROLLER | i | 0x5B << 8 | 0x28 << 16; // reverb
+        midiOutShortMsg((HMIDIOUT)hMidiStream, msg);
+        msg = MIDI_EVENT_CONTROLLER | i | 0x5C << 8 | 0x00 << 16; // tremolo
+        midiOutShortMsg((HMIDIOUT)hMidiStream, msg);
+        msg = MIDI_EVENT_CONTROLLER | i | 0x5D << 8 | 0x00 << 16; // chorus
+        midiOutShortMsg((HMIDIOUT)hMidiStream, msg);
+        msg = MIDI_EVENT_CONTROLLER | i | 0x5E << 8 | 0x00 << 16; // detune
+        midiOutShortMsg((HMIDIOUT)hMidiStream, msg);
+        msg = MIDI_EVENT_CONTROLLER | i | 0x5F << 8 | 0x00 << 16; // phaser
+        midiOutShortMsg((HMIDIOUT)hMidiStream, msg);
     }
 
     mmr = midiStreamStop(hMidiStream);


### PR DESCRIPTION
**Bug:**
When a music track changes to a new one, old midi settings carry over if the new track doesn't redefine them. This causes problems with tracks that assume default settings are being used. This was partially addressed [here](https://github.com/fabiangreffrath/woof/blob/2ef303abb033d7c51f3a75cf60ad720730497c3a/src/i_winmusic.c#L426-L442) but for pitch bend range only.

**How to recreate:**
Download [Sunlust](https://www.doomworld.com/idgames/levels/doom2/Ports/megawads/sunlust). Launch the game with `woof.exe -iwad doom2.wad -file sunlust.wad -warp 1` and listen to the music. Now launch the game with `woof.exe -iwad doom2.wad -file sunlust.wad`, start a new game manually, and listen again. The celesta (ch. 1 and 2) echoes badly and the slap bass (ch. 5) is positioned far to the right. Both have too much reverb. This is due to the pan, delay (detune), and reverb values carrying over from the title screen music.

**Fix:**
Set the above controllers, along with chorus and other effects, to their default values during a music change. The default values are from the [official midi specifications](https://www.midi.org/specifications).

**Note:**
This also works with Odamex, DSDA-Doom, PrBoom-Plus, Crispy Doom, Chocolate Doom, and likely others that use PortMidi or Windows native MIDI. For source ports that don't support Boom, here's a simple wad file with just the music for the title screen and map01: [MusicTest.zip](https://github.com/fabiangreffrath/woof/files/9388544/MusicTest.zip)

