### PR TITLE
use M_BaseName()/M_DirName() more consistently

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -664,52 +664,26 @@ void D_AddFile(const char *file)
 // Return the path where the executable lies -- Lee Killough
 char *D_DoomExeDir(void)
 {
-   // haleyjd: modified to prevent returning empty string
-   static char *base;
-   if(!base)        // cache multiple requests
-   {
-      size_t len = strlen(*myargv) + 1;
-      char *p;
+  static char *base;
 
-      base = malloc(len);
-      memset(base, 0, len);
+  if (!base) // cache multiple requests
+  {
+    base = M_DirName(myargv[0]);
+  }
 
-      p = base + len - 1;
-      
-      strncpy(base, *myargv, len);
-      
-      while(p >= base)
-      {
-         if(*p == '/' || *p == '\\')
-         {
-            *p = '\0';
-            break;
-         }
-         *p = '\0';
-         p--;
-      }
-   }
-
-   if(*base == '\0')
-      *base = '.';
-
-   return base;
+  return base;
 }
 
 // killough 10/98: return the name of the program the exe was invoked as
-char *D_DoomExeName(void)
+const char *D_DoomExeName(void)
 {
-  static char *name;    // cache multiple requests
-  if (!name)
-    {
-      char *p = *myargv + strlen(*myargv);
-      int i = 0;
-      while (p > *myargv && p[-1] != '/' && p[-1] != '\\' && p[-1] != ':')
-        p--;
-      while (p[i] && p[i] != '.')
-        i++;
-      strncpy(name = malloc(i+1), p, i)[i] = 0;
-    }
+  static const char *name;
+
+  if (!name) // cache multiple requests
+  {
+    name = M_BaseName(myargv[0]);
+  }
+
   return name;
 }
 

--- a/src/d_main.h
+++ b/src/d_main.h
@@ -38,7 +38,7 @@ extern char **wadfiles;       // killough 11/98
 void D_AddFile(const char *file);
 
 char *D_DoomExeDir(void);       // killough 2/16/98: path to executable's dir
-char *D_DoomExeName(void);      // killough 10/98: executable's name
+const char *D_DoomExeName(void);      // killough 10/98: executable's name
 extern char *basesavegame;     // killough 2/16/98: savegame path
 extern char *screenshotdir; // [FG] screenshot path
 char *D_DoomPrefDir(void); // [FG] default configuration dir

--- a/src/m_misc2.c
+++ b/src/m_misc2.c
@@ -194,6 +194,7 @@ const char *M_BaseName(const char *path)
     pf = strrchr(path, '/');
 #ifdef _WIN32
     pb = strrchr(path, '\\');
+    // [FG] allow C:filename
     if (pf == NULL && pb == NULL)
     {
         pb = strrchr(path, ':');

--- a/src/m_misc2.c
+++ b/src/m_misc2.c
@@ -167,6 +167,14 @@ char *M_DirName(const char *path)
     pf = strrchr(path, '/');
 #ifdef _WIN32
     pb = strrchr(path, '\\');
+    if (pf == NULL && pb == NULL)
+    {
+        pb = strrchr(path, ':');
+        if (pb)
+        {
+            pb++;
+        }
+    }
 #else
     pb = NULL;
 #endif
@@ -194,6 +202,10 @@ const char *M_BaseName(const char *path)
     pf = strrchr(path, '/');
 #ifdef _WIN32
     pb = strrchr(path, '\\');
+    if (pf == NULL && pb == NULL)
+    {
+        pb = strrchr(path, ':');
+    }
 #else
     pb = NULL;
 #endif

--- a/src/m_misc2.c
+++ b/src/m_misc2.c
@@ -167,14 +167,6 @@ char *M_DirName(const char *path)
     pf = strrchr(path, '/');
 #ifdef _WIN32
     pb = strrchr(path, '\\');
-    if (pf == NULL && pb == NULL)
-    {
-        pb = strrchr(path, ':');
-        if (pb)
-        {
-            pb++;
-        }
-    }
 #else
     pb = NULL;
 #endif

--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -55,14 +55,10 @@ static int W_FileLength(int handle)
 
 void ExtractFileBase(const char *path, char *dest)
 {
-  const char *src = path + strlen(path) - 1;
+  const char *src;
   int length;
 
-  // back up until a \ or the start
-  while (src != path && src[-1] != ':' // killough 3/22/98: allow c:filename
-         && *(src-1) != '\\'
-         && *(src-1) != '/')
-    src--;
+  src = M_BaseName(path);
 
   // copy up to eight characters
   memset(dest,0,8);


### PR DESCRIPTION
Not sure what to do with `C:filename` style paths, though, that Lee Killough explicitly enabled.