### PR TITLE
remove SDL version check for Windows 11 "freezing" issue

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1205,6 +1205,7 @@ boolean I_WritePNGfile(char *filename)
   // [FG] allocate memory for screenshot image
   pitch = rect.w * format->BytesPerPixel;
   pixels = malloc(rect.h * pitch);
+  SDL_RenderCopy(renderer, texture, NULL, NULL);
   SDL_RenderReadPixels(renderer, &rect, format->format, pixels, pitch);
 
   {
@@ -1502,17 +1503,9 @@ static void I_InitGraphicsMode(void)
    I_GetWindowPosition(&window_x, &window_y, v_w, v_h);
 
 #ifdef _WIN32
-   // [JN] Windows 11 idiocy. Indicate that window using OpenGL mode (while it's
-   // a Direct3D in fact), so SDL texture will not be freezed upon vsync
-   // toggling.
+   if (I_CheckWindows11())
    {
-      SDL_version ver;
-      SDL_GetVersion(&ver);
-      if (I_CheckWindows11() &&
-          ver.major == 2 && ver.minor == 0 && (ver.patch == 20 || ver.patch == 22))
-      {
-        flags |= SDL_WINDOW_OPENGL;
-      }
+      SDL_SetHint(SDL_HINT_RENDER_DRIVER, "direct3d11");
    }
 #endif
 

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1205,7 +1205,6 @@ boolean I_WritePNGfile(char *filename)
   // [FG] allocate memory for screenshot image
   pitch = rect.w * format->BytesPerPixel;
   pixels = malloc(rect.h * pitch);
-  SDL_RenderCopy(renderer, texture, NULL, NULL);
   SDL_RenderReadPixels(renderer, &rect, format->format, pixels, pitch);
 
   {
@@ -1505,7 +1504,7 @@ static void I_InitGraphicsMode(void)
 #ifdef _WIN32
    if (I_CheckWindows11())
    {
-      SDL_SetHint(SDL_HINT_RENDER_DRIVER, "direct3d11");
+      SDL_SetHint(SDL_HINT_RENDER_DRIVER, "direct3d12");
    }
 #endif
 

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1502,9 +1502,12 @@ static void I_InitGraphicsMode(void)
    I_GetWindowPosition(&window_x, &window_y, v_w, v_h);
 
 #ifdef _WIN32
+   // [JN] Windows 11 idiocy. Indicate that window using OpenGL mode (while it's
+   // a Direct3D in fact), so SDL texture will not be freezed upon vsync
+   // toggling.
    if (I_CheckWindows11())
    {
-      SDL_SetHint(SDL_HINT_RENDER_DRIVER, "direct3d12");
+      flags |= SDL_WINDOW_OPENGL;
    }
 #endif
 

--- a/win32/win_version.c
+++ b/win32/win_version.c
@@ -19,7 +19,6 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#include <stdlib.h>
 
 typedef long (__stdcall *PRTLGETVERSION)(PRTL_OSVERSIONINFOEXW);
 
@@ -32,7 +31,7 @@ int I_CheckWindows11(void)
     {
         OSVERSIONINFOEXW info;
 
-        memset(&info, 0, sizeof(OSVERSIONINFOEXW));
+        ZeroMemory(&info, sizeof(OSVERSIONINFOEXW));
         info.dwOSVersionInfoSize = sizeof(RTL_OSVERSIONINFOEXW);
 
         pRtlGetVersion((PRTL_OSVERSIONINFOEXW)&info);


### PR DESCRIPTION
Fix freezing when changing video modes on Windows 11 by setting the direct3d11 driver by default. @JNechaevsky can you check, please?