### PR TITLE
Undo music volume slider changes

### DIFF
--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -140,10 +140,6 @@ static void FillBuffer(void)
             channel_volume[MIDIEVENT_CHANNEL(event->dwEvent)] = volume;
 
             volume *= volume_factor;
-            if (volume > 127)
-            {
-                volume = 127;
-            }
 
             event->dwEvent = (event->dwEvent & 0xFF00FFFF) |
                              ((volume & 0x7F) << 16);
@@ -447,10 +443,6 @@ static void UpdateVolume()
         DWORD msg = 0;
 
         int value = channel_volume[i] * volume_factor;
-        if (value > 127)
-        {
-            value = 127;
-        }
 
         msg = MIDI_EVENT_CONTROLLER | i | (MIDI_CONTROLLER_MAIN_VOLUME << 8) |
               (value << 16);
@@ -461,7 +453,7 @@ static void UpdateVolume()
 
 static void I_WIN_SetMusicVolume(int volume)
 {
-    volume_factor = (float)volume * 8 / 100;
+    volume_factor = (float)volume / 15;
 
     UpdateVolume();
 }


### PR DESCRIPTION
I did a lot of research into MIDI volume and realized I was too quick to make the previous pull request. I apologize and recommend preserving the dynamic range of the music in source ports like Chocolate, Crispy, and Woof. I did a lengthy write-up explaining why and for future reference here: https://github.com/chocolate-doom/chocolate-doom/pull/1508#issuecomment-1250443255