### PR TITLE
don't interpolate accelerated sidescrollers

### DIFF
--- a/src/p_spec.c
+++ b/src/p_spec.c
@@ -2676,6 +2676,9 @@ void R_InterpolateTextureOffsets (void)
       scroll_t *s = sidescrollers[i];
       side_t *side = sides + s->affectee;
 
+      if (s->accel)
+        continue;
+
       side->textureoffset = side->basetextureoffset + FixedMul(s->dx, fractionaltic);
       side->rowoffset = side->baserowoffset + FixedMul(s->dy, fractionaltic);
     }


### PR DESCRIPTION
This fixes waterfall animation in Saturnine Chapel https://doomwiki.org/wiki/Saturnine_Chapel reported on [[doomworld]](https://www.doomworld.com/forum/topic/112333-this-is-woof-1020-aug-11-2022-updated-winmbf/?do=findComment&comment=2546075)

Surely there is a better solution 😄

By the way, what about other types of scrollers (ceiling, floor, etc.)? PrBoom+ interpolates everything. See BOOMEDIT.WAD