### PR TITLE
Adjust native MIDI volume slider curve to match midiOutSetVolume

### DIFF
--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -20,6 +20,7 @@
 #include <mmsystem.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <math.h>
 
 #include "doomtype.h"
 #include "i_sound.h"
@@ -453,7 +454,7 @@ static void UpdateVolume()
 
 static void I_WIN_SetMusicVolume(int volume)
 {
-    volume_factor = (float)volume / 15;
+    volume_factor = sqrt((float)volume / 15);
 
     UpdateVolume();
 }


### PR DESCRIPTION
This changes the volume scaling for native MIDI to match the curve used by older SDL_mixer implementations which used midiOutSetVolume and scaled volume non-linearly. This resolves the perceived lower volume across the music slider range. Additional details are documented [here](https://github.com/fabiangreffrath/woof/pull/737#issuecomment-1254557005).