### PR TITLE
fix save menu displayed in snapshot if save while demo is playing

### DIFF
--- a/src/g_game.c
+++ b/src/g_game.c
@@ -2186,7 +2186,7 @@ void G_Ticker(void)
   if (demoplayback && sendsave)
     {
       sendsave = false;
-      G_DoSaveGame();
+      gameaction = ga_savegame;
     }
 
   // killough 9/29/98: Skip some commands while pausing during demo


### PR DESCRIPTION
Fix this issue:
![woof0002](https://user-images.githubusercontent.com/5077629/192125840-eac0b25d-0d3e-444a-993a-fd10a78ab563.png)
