### PR TITLE
don't draw HUD on the snapshots

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -74,6 +74,7 @@
 #include "p_map.h" // MELEERANGE
 #include "i_endoom.h"
 #include "d_quit.h"
+#include "m_snapshot.h"
 
 #include "dsdhacked.h"
 
@@ -281,6 +282,9 @@ void D_Display (void)
   // draw the view directly
   if (gamestate == GS_LEVEL && !automapactive && gametic)
     R_RenderPlayerView (&players[displayplayer]);
+
+  if (gameaction == ga_savegame)
+    M_TakeSnapshot();
 
   if (gamestate == GS_LEVEL && gametic)
     HU_Drawer ();

--- a/src/m_snapshot.c
+++ b/src/m_snapshot.c
@@ -24,6 +24,7 @@
 #include <time.h>
 
 #include "doomtype.h"
+#include "doomstat.h"
 
 #include "i_video.h"
 #include "m_io.h"
@@ -104,12 +105,22 @@ char *M_GetSavegameTime (int i)
 //      in hires mode only only each second pixel in each second row is saved,
 //      in widescreen mode only the non-widescreen part in the middle is saved
 
-static void M_TakeSnapshot (void)
+void M_TakeSnapshot (void)
 {
   const int inc = hires ? 2 : 1;
   int x, y;
   byte *p;
   const byte *s = screens[0];
+  static int old_gametic = -1;
+
+  if (old_gametic != gametic)
+  {
+    old_gametic = gametic;
+  }
+  else
+  {
+    return;
+  }
 
   if (!current_snapshot)
   {
@@ -128,8 +139,6 @@ static void M_TakeSnapshot (void)
 
 void M_WriteSnapshot (byte *p)
 {
-  M_TakeSnapshot();
-
   memcpy(p, snapshot_str, snapshot_len);
   p += snapshot_len;
 

--- a/src/m_snapshot.h
+++ b/src/m_snapshot.h
@@ -23,6 +23,7 @@
 #ifndef __M_SNAPSHOT__
 #define __M_SNAPSHOT__
 
+void M_TakeSnapshot (void);
 const int M_SnapshotDataSize (void);
 void M_ResetSnapshot (int i);
 boolean M_ReadSnapshot (int i, FILE *fp);


### PR DESCRIPTION
Feature request: [[doomworld]](https://www.doomworld.com/forum/topic/112333-this-is-woof-1030-sep-23-2022-updated-winmbf/?do=findComment&comment=2548578)

I think that we shouldn't draw STBAR too, but I don't know how to do it better.