### PR TITLE
open/close MIDI device on every song change

### DIFF
--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -416,6 +416,7 @@ static void I_WIN_SetMusicVolume(int volume)
 
 static void I_WIN_StopSong(void *handle)
 {
+    MIDIHDR *hdr = &buffer.MidiStreamHdr;
     MMRESULT mmr;
 
     if (hPlayerThread)


### PR DESCRIPTION
This is what SDL_Mixer does and maybe this will reset the device properly. Can fix these issues: [[doomworld]](https://www.doomworld.com/forum/topic/131558-midi-stutter-on-track-start-and-when-looping-on-hardware-module/), [[doomworld]](https://www.doomworld.com/forum/topic/131197-weird-glitch-audio-desyncs-black-screen-instead-of-endoom/)

@ceski-1 What do you think?