### PR TITLE
Implement custom rules for swirl animations

### DIFF
--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -106,6 +106,7 @@ extern int death_use_action;
 extern boolean palette_changes;
 extern boolean screen_melt;
 extern boolean blockmapfix;
+extern int swirl_custom_rule;
 
 extern char *chat_macros[];  // killough 10/98
 
@@ -241,6 +242,13 @@ default_t defaults[] = {
     (config_t *) &r_swirl, NULL,
     {0}, {0,1}, number, ss_gen, wad_yes,
     "1 to enable swirling animated flats"
+  },
+  
+  {
+    "swirl_custom_rule",
+    (config_t*)&swirl_custom_rule, NULL,
+    {0}, {0,255}, number, ss_stat, wad_yes,
+    "Bits order (from left to right): NUKAGE1; FWATER1; LAVA1; BLOOD1; RROCK05; SLIME01; SLIME05; SLIME09"
   },
 
   {

--- a/src/p_spec.c
+++ b/src/p_spec.c
@@ -2264,6 +2264,20 @@ boolean         levelFragLimit;      // Ty 03/18/98 Added -frags support
 int             levelFragLimitCount; // Ty 03/18/98 Added -frags support
 
 int             r_swirl;
+int             swirl_custom_rule;
+
+//51 = NUKAGE1 69 = FWATER1 73 = LAVA1 89 = BLOOD1 120 = RROCK05 136 = SLIME01 140 = SLIME05 144 = SLIME09
+boolean Swirl_CustomRule(int basepic, int val)
+{
+  return (((val >> 7) & 1) && basepic == 51)  ? true : false ||
+         (((val >> 6) & 1) && basepic == 69)  ? true : false ||
+         (((val >> 5) & 1) && basepic == 73)  ? true : false ||
+         (((val >> 4) & 1) && basepic == 89)  ? true : false ||
+         (((val >> 3) & 1) && basepic == 120) ? true : false ||
+         (((val >> 2) & 1) && basepic == 136) ? true : false ||
+         (((val >> 1) & 1) && basepic == 140) ? true : false ||
+         (((val >> 0) & 1) && basepic == 144) ? true : false;
+}
 
 void P_UpdateSpecials (void)
 {
@@ -2309,7 +2323,8 @@ void P_UpdateSpecials (void)
           flattranslation[anim->basepic + i] = pic;
           // [crispy] add support for SMMU swirling flats
           if (anim->speed > 65535 || anim->numpics == 1 || r_swirl)
-            flattranslation[anim->basepic + i] = -1;
+            if (!Swirl_CustomRule(anim->basepic, swirl_custom_rule))
+              flattranslation[anim->basepic + i] = -1;
         }
       }
 


### PR DESCRIPTION
Addressing my own feature request mentioned on Doomworld forums: https://www.doomworld.com/forum/topic/112333-this-is-woof-1030-sep-23-2022-updated-winmbf/?page=46&tab=comments#comment-2531774

I've been following a suggestion provided by rfomin to use A﻿NIMATED.lmp to exclude animated flats when needed for some time now, but it turned out to be too cumbersome to edit animated.lmp file every time I want to change animated flats behavior. So this is the solution I come up with today.

Not sure if it would be of any use to anyone other than me though, so feel free to discard this pr...