### PR TITLE
update workflow files (deprecation warnings)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,8 @@ name: build
 on:
   push:
     branches: [ master ]
+    tags-ignore: ['*']
+    paths-ignore: ['**.md']
   pull_request:
     branches: [ master ]
 
@@ -18,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install libfluidsynth-dev libsdl2-dev libsdl2-mixer-dev libsdl2-net-dev ninja-build
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Configure
         env:
@@ -40,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install cppcheck
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Run cppcheck
         shell: bash
@@ -68,7 +70,7 @@ jobs:
             mingw-w64-x86_64-SDL2_mixer
             mingw-w64-x86_64-SDL2_net
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Configure
         run: cmake -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DENABLE_WERROR=ON
@@ -82,7 +84,7 @@ jobs:
           cpack -G ZIP
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Win64
           path: build/*.zip
@@ -91,7 +93,7 @@ jobs:
     runs-on: windows-2019
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Configure
         run: cmake -B build -T v141_xp -A Win32 -DENABLE_WERROR=ON
@@ -109,7 +111,7 @@ jobs:
           cpack -G ZIP
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: WinXP
           path: build/Woof*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,14 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Version
-        id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF##*_}
+        run: echo "VERSION=${GITHUB_REF##*_}" >> $GITHUB_ENV
 
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v1
         with:
-          name: Woof! ${{ steps.get_version.outputs.VERSION }}
+          name: Woof! ${{ env.VERSION }}
 
   win64_msys2:
     runs-on: windows-latest
@@ -41,7 +40,7 @@ jobs:
             mingw-w64-x86_64-SDL2_mixer
             mingw-w64-x86_64-SDL2_net
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Configure
         run: cmake -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DENABLE_WERROR=ON
@@ -65,7 +64,7 @@ jobs:
     runs-on: windows-2019
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Configure
         run: cmake -B build -T v141_xp -A Win32 -DENABLE_WERROR=ON


### PR DESCRIPTION
Note that [softprops/action-gh-release@v1](https://github.com/softprops/action-gh-release) is not updated.