### PR TITLE
switch from softprops/action-gh-release to ncipollo/release-action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,13 +99,11 @@ jobs:
         run: cmake -B build -T v141_xp -A Win32 -DENABLE_WERROR=ON
 
       - name: Build
-        shell: bash
         run: |
           cd build
           cmake --build . --config Release -- -maxcpucount -verbosity:minimal
 
       - name: Package
-        shell: bash
         run: |
           cd build
           cpack -G ZIP

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,6 +99,7 @@ jobs:
         run: cmake -B build -T v141_xp -A Win32 -DENABLE_WERROR=ON
 
       - name: Build
+        shell: bash
         run: |
           cd build
           cmake --build . --config Release -- -maxcpucount -verbosity:minimal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,7 @@ jobs:
         run: cmake -B build -T v141_xp -A Win32 -DENABLE_WERROR=ON
 
       - name: Build
+        shell: bash
         run: |
           cd build
           cmake --build . --config Release -- -maxcpucount -verbosity:minimal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,19 +6,6 @@ on:
       - '*'
 
 jobs:
-  create_release:
-    name: Create Release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Version
-        run: echo "VERSION=${GITHUB_REF##*_}" >> $GITHUB_ENV
-
-      - name: Create Release
-        id: create_release
-        uses: softprops/action-gh-release@v1
-        with:
-          name: Woof! ${{ env.VERSION }}
-
   win64_msys2:
     runs-on: windows-latest
 
@@ -27,6 +14,10 @@ jobs:
         shell: msys2 {0}
 
     steps:
+      - name: Extract Version Number
+        shell: bash
+        run: echo "VERSION=${GITHUB_REF##*_}" >> $GITHUB_ENV
+
       - name: Setup MSYS2
         uses: msys2/setup-msys2@v2
         with:
@@ -54,36 +45,40 @@ jobs:
           cpack -G ZIP
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: ncipollo/release-action@v1.11.1
         with:
-          tag_name: ${{ needs.create_release.outputs.tag-name }}
-          body_path: CHANGELOG.md
-          files: build/Woof*.zip
+          name: Woof! ${{ env.VERSION }}
+          bodyFile: CHANGELOG.md
+          allowUpdates: true
+          artifacts: build/Woof*.zip
 
   win32_msvc:
     runs-on: windows-2019
 
     steps:
+      - name: Extract Version Number
+        shell: bash
+        run: echo "VERSION=${GITHUB_REF##*_}" >> $GITHUB_ENV
+
       - uses: actions/checkout@v3
 
       - name: Configure
         run: cmake -B build -T v141_xp -A Win32 -DENABLE_WERROR=ON
 
       - name: Build
-        shell: bash
         run: |
           cd build
           cmake --build . --config Release -- -maxcpucount -verbosity:minimal
 
       - name: Package
-        shell: bash
         run: |
           cd build
           cpack -G ZIP
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: ncipollo/release-action@v1.11.1
         with:
-          tag_name: ${{ needs.create_release.outputs.tag-name }}
-          body_path: CHANGELOG.md
-          files: build/Woof*.zip
+          name: Woof! ${{ env.VERSION }}
+          bodyFile: CHANGELOG.md
+          allowUpdates: true
+          artifacts: build/Woof*.zip


### PR DESCRIPTION
Fix the rest of the deprecation warnings. It seems softprops/action-gh-release is no longer active.
Tested on my fork: https://github.com/rfomin/woof/releases