### PR TITLE
Fix bullet puff eaters and calculate puff spawn height (taken from Cr…

### DIFF
--- a/src/m_random.c
+++ b/src/m_random.c
@@ -140,6 +140,18 @@ int Woof_Random(void)
   return rndtable[wrndindex];
 }
 
+int P_SubRandom(pr_class_t pr_class)
+{
+    int r = P_Random(pr_class);
+    return r - P_Random(pr_class);
+}
+
+int Woof_SubRandom(void)
+{
+    int r = Woof_Random();
+    return r - Woof_Random();
+}
+
 // mbf21: [XA] Common random formulas used by codepointers
 
 //

--- a/src/m_random.h
+++ b/src/m_random.h
@@ -144,7 +144,7 @@ int P_Random(pr_class_t);
 // [crispy] our own private random function
 int Woof_Random(void);
 
-int P_SubRandom(void);
+int P_SubRandom(pr_class_t pr_class);
 int Woof_SubRandom(void);
 
 // Fix randoms for demos.

--- a/src/m_random.h
+++ b/src/m_random.h
@@ -144,6 +144,9 @@ int P_Random(pr_class_t);
 // [crispy] our own private random function
 int Woof_Random(void);
 
+int P_SubRandom(void);
+int Woof_SubRandom(void);
+
 // Fix randoms for demos.
 void M_ClearRandom(void);
 

--- a/src/p_map.c
+++ b/src/p_map.c
@@ -1562,7 +1562,7 @@ static boolean PTR_ShootTraverse(intercept_t *in)
         safe = true;
     }
 	}
-  if(aimslope)
+  if(CRITICAL(aimslope))
   {
     const int lineside = P_PointOnLineSide(x, y, li);
     int side;

--- a/src/p_map.c
+++ b/src/p_map.c
@@ -1414,11 +1414,9 @@ static boolean PTR_AimTraverse (intercept_t *in)
   fixed_t slope, thingtopslope, thingbottomslope, dist;
   line_t *li;
   mobj_t *th;
-  boolean safe;
 
   if (in->isaline)
     {
-      safe = false;
       li = in->d.line;
 
       if (!(li->flags & ML_TWOSIDED))
@@ -1510,6 +1508,7 @@ static boolean PTR_ShootTraverse(intercept_t *in)
 
   if (in->isaline)
     {
+      boolean safe = false;
       line_t *li = in->d.line;
 
       if (li->special)

--- a/src/p_map.c
+++ b/src/p_map.c
@@ -1414,9 +1414,11 @@ static boolean PTR_AimTraverse (intercept_t *in)
   fixed_t slope, thingtopslope, thingbottomslope, dist;
   line_t *li;
   mobj_t *th;
+  boolean safe;
 
   if (in->isaline)
     {
+      safe = false;
       li = in->d.line;
 
       if (!(li->flags & ML_TWOSIDED))
@@ -1554,13 +1556,35 @@ static boolean PTR_ShootTraverse(intercept_t *in)
 	  // it's a sky hack wall
 	  // fix bullet-eaters -- killough:
 	  if  (li->backsector && li->backsector->ceilingpic == skyflatnum)
-	    if (demo_compatibility || li->backsector->ceilingheight < z)
-	      return false;
+    {
+      if (li->backsector->ceilingheight < z)
+        return false;
+      else if (demo_compatibility)
+        safe = true;
+    }
 	}
+  if(aimslope)
+  {
+    const int lineside = P_PointOnLineSide(x, y, li);
+    int side;
+
+    if ((side = li->sidenum[lineside]) != NO_INDEX)
+    {
+      const sector_t* const sector = sides[side].sector;
+
+      if (z < sector->floorheight || (z > sector->ceilingheight && sector->ceilingpic != skyflatnum))
+      {
+        z = BETWEEN(sector->floorheight, sector->ceilingheight, z);
+        frac = FixedDiv(z - shootz, FixedMul(aimslope, attackrange));
+        x = trace.x + FixedMul(trace.dx, frac);
+        y = trace.y + FixedMul(trace.dy, frac);
+      }
+    }
+  }
 
       // Spawn bullet puffs.
 
-      P_SpawnPuff (x,y,z);
+      P_SpawnPuffSafe (x,y,z, safe);
 
       // don't go any farther
 

--- a/src/p_map.c
+++ b/src/p_map.c
@@ -1555,31 +1555,31 @@ static boolean PTR_ShootTraverse(intercept_t *in)
 	  // it's a sky hack wall
 	  // fix bullet-eaters -- killough:
 	  if  (li->backsector && li->backsector->ceilingpic == skyflatnum)
-    {
-      if (li->backsector->ceilingheight < z)
-        return false;
-      else if (demo_compatibility)
-        safe = true;
-    }
+    	  {
+      	    if (li->backsector->ceilingheight < z)
+              return false;
+            else if (demo_compatibility)
+              safe = true;
+    	  }
 	}
-  if(CRITICAL(aimslope))
-  {
-    const int lineside = P_PointOnLineSide(x, y, li);
-    int side;
+      if(CRITICAL(aimslope))
+  	{
+    	  const int lineside = P_PointOnLineSide(x, y, li);
+    	  int side;
 
-    if ((side = li->sidenum[lineside]) != NO_INDEX)
-    {
-      const sector_t* const sector = sides[side].sector;
+    	  if ((side = li->sidenum[lineside]) != NO_INDEX)
+    	  {
+      	    const sector_t* const sector = sides[side].sector;
 
-      if (z < sector->floorheight || (z > sector->ceilingheight && sector->ceilingpic != skyflatnum))
-      {
-        z = BETWEEN(sector->floorheight, sector->ceilingheight, z);
-        frac = FixedDiv(z - shootz, FixedMul(aimslope, attackrange));
-        x = trace.x + FixedMul(trace.dx, frac);
-        y = trace.y + FixedMul(trace.dy, frac);
-      }
-    }
-  }
+      	    if (z < sector->floorheight || (z > sector->ceilingheight && sector->ceilingpic != skyflatnum))
+      	    {
+              z = BETWEEN(sector->floorheight, sector->ceilingheight, z);
+              frac = FixedDiv(z - shootz, FixedMul(aimslope, attackrange));
+              x = trace.x + FixedMul(trace.dx, frac);
+              y = trace.y + FixedMul(trace.dy, frac);
+      	    }
+    	  }
+  	}
 
       // Spawn bullet puffs.
 

--- a/src/p_map.c
+++ b/src/p_map.c
@@ -1562,7 +1562,7 @@ static boolean PTR_ShootTraverse(intercept_t *in)
               safe = true;
     	  }
 	}
-      if(CRITICAL(aimslope))
+      if(aimslope)
   	{
     	  const int lineside = P_PointOnLineSide(x, y, li);
     	  int side;

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -135,7 +135,7 @@ static statenum_t P_LatestSafeState(statenum_t state)
     }
 
     // [crispy] a state with -1 tics never changes
-    if (states[state].tics == -1 || state == states[state].nextstate)
+    if (states[state].tics == -1 || state >= states[state].nextstate)
     {
       break;
     }

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -45,6 +45,8 @@
 #include "p_inter.h"
 #include "v_video.h"
 
+#define STATE_CYCLE_LIMIT 1000000
+
 // [FG] colored blood and gibs
 boolean colored_blood;
 
@@ -116,6 +118,7 @@ static statenum_t P_LatestSafeState(statenum_t state)
 {
   statenum_t safestate = S_NULL;
   static statenum_t laststate, lastsafestate;
+  int cycle_counter = 0;
 
   if (state == laststate)
   {
@@ -135,9 +138,14 @@ static statenum_t P_LatestSafeState(statenum_t state)
     }
 
     // [crispy] a state with -1 tics never changes
-    if (states[state].tics == -1 || state >= states[state].nextstate)
+    if (states[state].tics == -1 || state == states[state].nextstate)
     {
       break;
+    }
+
+    if (cycle_counter++ > STATE_CYCLE_LIMIT)
+    {
+      I_Error("P_LatestSafeState: Infinite state cycle detected!");
     }
   }
 

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -1339,6 +1339,8 @@ spawnit:
 // P_SpawnPuff
 //
 
+extern fixed_t attackrange;
+
 void P_SpawnPuff(fixed_t x, fixed_t y, fixed_t z)
 {
     return P_SpawnPuffSafe(x, y, z, false);

--- a/src/p_mobj.h
+++ b/src/p_mobj.h
@@ -436,6 +436,7 @@ mobj_t  *P_SpawnPlayerMissile(mobj_t *source, mobjtype_t type);
 void    P_SpawnMapThing (mapthing_t*  mthing);
 boolean P_CheckMissileSpawn(mobj_t*);  // killough 8/2/98
 void    P_ExplodeMissile(mobj_t*);    // killough
+void	P_SpawnPuffSafe(fixed_t x, fixed_t y, fixed_t z, boolean safe);
 
 boolean P_SeekerMissile(mobj_t *actor, mobj_t **seekTarget, angle_t thresh, angle_t turnMax, boolean seekcenter);
 int     P_FaceMobj(mobj_t *source, mobj_t *target, angle_t *delta);


### PR DESCRIPTION
…ispy Doom)

When shooting walls outside some bullet puffs don't render properly (they simply disappear). Also, when bullets land on slopes, bullet puffs move to the closest wall instead of rendering at the impact location. This code fixes that behavior.