### PR TITLE
level brightness feature and ability to disable menu background

### DIFF
--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -256,6 +256,8 @@ extern  boolean noblit;
 extern  boolean nosfxparm;
 extern  boolean nomusicparm;
 
+extern  boolean draw_menu_background;
+
 // This one is related to the 3-screen display mode.
 // ANG90 = left side, ANG270 = right
 extern  int viewangleoffset;

--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -256,8 +256,6 @@ extern  boolean noblit;
 extern  boolean nosfxparm;
 extern  boolean nomusicparm;
 
-extern  boolean draw_menu_background;
-
 // This one is related to the 3-screen display mode.
 // ANG90 = left side, ANG270 = right
 extern  int viewangleoffset;

--- a/src/f_finale.c
+++ b/src/f_finale.c
@@ -38,6 +38,7 @@
 #include "d_deh.h"  // Ty 03/22/98 - externalizations
 #include "m_misc2.h" // [FG] M_StringDuplicate()
 #include "m_swap.h"
+#include "r_draw.h"
 
 // Stage of animation:
 //  0 = text, 1 = art screen, 2 = character cast

--- a/src/f_finale.c
+++ b/src/f_finale.c
@@ -395,7 +395,7 @@ void F_TextWrite (void)
   // erase the entire screen to a tiled background
 
   // killough 11/98: the background-filling code was already in m_menu.c
-  M_DrawBackground(finaleflat, screens[0]);
+  R_DrawBackground(finaleflat, screens[0]);
   }
 
   // draw some of the text onto the screen

--- a/src/f_finale.c
+++ b/src/f_finale.c
@@ -34,7 +34,6 @@
 #include "s_sound.h"
 #include "sounds.h"
 #include "dstrings.h"
-#include "m_menu.h"
 #include "d_deh.h"  // Ty 03/22/98 - externalizations
 #include "m_misc2.h" // [FG] M_StringDuplicate()
 #include "m_swap.h"

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -6431,7 +6431,7 @@ void M_Drawer (void)
 
       if (menushade < 16 && gametic != firsttic)
       {
-         menushade += 4;
+         menushade += 2;
          firsttic = gametic;
       }
    }

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -3843,7 +3843,7 @@ enum {
   general_swirl,
   general_smoothlight,
   general_brightmaps,
-  general_stab1,
+  general_stub2,
   general_solidbackground,
   general_menu_background,
   general_diskicon,
@@ -3995,7 +3995,7 @@ setup_menu_t gen_settings2[] = { // General Settings screen2
   {"Brightmaps for Textures and Sprites", S_YESNO, m_null, M_X,
    M_Y + general_brightmaps*M_SPC, {"brightmaps"}},
 
-  {"", S_SKIP, m_null, M_X, M_Y + general_stab1*M_SPC},
+  {"", S_SKIP, m_null, M_X, M_Y + general_stub2*M_SPC},
 
   {"Solid Status Bar Background", S_YESNO, m_null, M_X,
    M_Y + general_solidbackground*M_SPC, {"st_solidbackground"}},

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -3744,13 +3744,14 @@ void M_DrawEnemy(void)
 
 extern int realtic_clock_rate, tran_filter_pct;
 
-setup_menu_t gen_settings1[], gen_settings2[], gen_settings3[];
+setup_menu_t gen_settings1[], gen_settings2[], gen_settings3[], gen_settings4[];
 
 setup_menu_t* gen_settings[] =
 {
   gen_settings1,
   gen_settings2,
   gen_settings3,
+  gen_settings4,
   NULL
 };
 
@@ -3899,8 +3900,8 @@ enum {
   general_swirl,
   general_smoothlight,
   general_brightmaps,
+  general_stab1,
   general_solidbackground,
-  general_level_brightness,
   general_menu_background,
   general_diskicon,
   general_endoom,
@@ -3916,13 +3917,18 @@ enum {
   general_death_action,
   general_palette_changes,
   general_screen_melt,
+  general_level_brightness,
   general_end5,
 
   general_title6,
   general_blockmapfix,
   general_pistolstart,
   general_end6,
+};
 
+// Page 4
+
+enum {
   general_title7,
   general_realtic,
   general_compat,
@@ -3940,9 +3946,9 @@ static void M_UpdateStrictModeItems(void)
   DISABLE_STRICT(auto_settings1[5]);
   DISABLE_ITEM(strictmode || deh_set_blood_color, enem_settings1[enem_colored_blood]);
   DISABLE_STRICT(enem_settings1[enem_flipcorpses]);
-  DISABLE_STRICT(gen_settings3[general_realtic]);
+  DISABLE_STRICT(gen_settings4[general_realtic]);
   DISABLE_STRICT(gen_settings2[general_brightmaps]);
-  DISABLE_STRICT(gen_settings2[general_level_brightness]);
+  DISABLE_STRICT(gen_settings3[general_level_brightness]);
   DISABLE_ITEM(strictmode && demo_compatibility, gen_settings1[general_trans]);
   DISABLE_STRICT(gen_settings3[general_palette_changes]);
   DISABLE_STRICT(gen_settings3[general_screen_melt]);
@@ -4046,11 +4052,10 @@ setup_menu_t gen_settings2[] = { // General Settings screen2
   {"Brightmaps for Textures and Sprites", S_YESNO, m_null, M_X,
    M_Y + general_brightmaps*M_SPC, {"brightmaps"}},
 
+  {"", S_SKIP, m_null, M_X, M_Y + general_stab1*M_SPC},
+
   {"Solid Status Bar Background", S_YESNO, m_null, M_X,
    M_Y + general_solidbackground*M_SPC, {"st_solidbackground"}},
-
-  {"Level Brightness", S_THERMO, m_null, M_X_THRM,
-   M_Y + general_level_brightness*M_SPC, {"extra_level_brightness"}},
 
   {"Draw Menu Background", S_CHOICE, m_null, M_X,
    M_Y + general_menu_background*M_SPC, {"menu_background"}, 0, NULL, menu_background_strings},
@@ -4088,6 +4093,9 @@ setup_menu_t gen_settings3[] = { // General Settings screen3
   {"Screen melt", S_YESNO, m_null, M_X,
    M_Y + general_screen_melt*M_SPC, {"screen_melt"}},
 
+  {"Level Brightness", S_THERMO, m_null, M_X_THRM,
+   M_Y + general_level_brightness*M_SPC, {"extra_level_brightness"}},
+
   {"", S_SKIP, m_null, M_X, M_Y + general_end5*M_SPC},
 
   {"Compatibility-breaking Features"  ,S_SKIP|S_TITLE, m_null, M_X,
@@ -4099,7 +4107,15 @@ setup_menu_t gen_settings3[] = { // General Settings screen3
   {"Pistol Start", S_YESNO, m_null, M_X,
    M_Y + general_pistolstart*M_SPC, {"pistolstart"}},
 
-  {"", S_SKIP, m_null, M_X, M_Y + general_end6*M_SPC},
+  {"<- PREV",S_SKIP|S_PREV, m_null, M_X_PREV, M_Y_PREVNEXT, {gen_settings2}},
+  {"NEXT ->",S_SKIP|S_NEXT, m_null, M_X_NEXT, M_Y_PREVNEXT, {gen_settings4}},
+
+  // Final entry
+
+  {0,S_SKIP|S_END,m_null}
+};
+
+setup_menu_t gen_settings4[] = { // General Settings screen4
 
   {"Miscellaneous"  ,S_SKIP|S_TITLE, m_null, M_X, M_Y + general_title7*M_SPC},
 
@@ -4115,7 +4131,7 @@ setup_menu_t gen_settings3[] = { // General Settings screen3
   {"Player Name", S_NAME, m_null, M_X,
    M_Y + general_playername*M_SPC, {"net_player_name"}},
 
-  {"<- PREV",S_SKIP|S_PREV, m_null, M_X_PREV, M_Y_PREVNEXT, {gen_settings2}},
+  {"<- PREV",S_SKIP|S_PREV, m_null, M_X_PREV, M_Y_PREVNEXT, {gen_settings3}},
 
   // Final entry
 

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -133,7 +133,7 @@ boolean inhelpscreens; // indicates we are in or just left a help screen
 
 boolean menuactive;    // The menus are up
 
-boolean draw_menu_background;
+int menu_background;
 
 #define SKULLXOFF  -32
 #define LINEHEIGHT  16
@@ -2084,7 +2084,7 @@ void R_DrawBackground(char *patchname, byte *back_dest)
 
 void M_DrawBackground(char *patchname, byte *back_dest)
 {
-  if (setup_active && !draw_menu_background)
+  if (setup_active && menu_background)
     return;
 
   R_DrawBackground(patchname, back_dest);
@@ -3901,7 +3901,7 @@ enum {
   general_brightmaps,
   general_solidbackground,
   general_level_brightness,
-  general_draw_menu_background,
+  general_menu_background,
   general_diskicon,
   general_endoom,
   general_end4,
@@ -4007,6 +4007,10 @@ static const char *death_use_action_strings[] = {
   "default", "last save", "nothing", NULL
 };
 
+static const char *menu_background_strings[] = {
+  "on", "off", "dark tint", NULL
+};
+
 setup_menu_t gen_settings2[] = { // General Settings screen2
 
   {"Mouse Settings"     ,S_SKIP|S_TITLE, m_null, M_X, M_Y},
@@ -4048,8 +4052,8 @@ setup_menu_t gen_settings2[] = { // General Settings screen2
   {"Level Brightness", S_THERMO, m_null, M_X_THRM,
    M_Y + general_level_brightness*M_SPC, {"extra_level_brightness"}},
 
-  {"Draw Menu Background", S_YESNO, m_null, M_X,
-   M_Y + general_draw_menu_background*M_SPC, {"draw_menu_background"}},
+  {"Draw Menu Background", S_CHOICE, m_null, M_X,
+   M_Y + general_menu_background*M_SPC, {"menu_background"}, 0, NULL, menu_background_strings},
 
   {"Flash Icon During Disk IO", S_YESNO, m_null, M_X,
    M_Y + general_diskicon*M_SPC, {"disk_icon"}},
@@ -6453,7 +6457,7 @@ void M_StartControlPanel (void)
 
 void M_Drawer (void)
 {
-   if (setup_active && !draw_menu_background)
+   if (setup_active && menu_background == 2)
    {
       int y;
       byte *dest = screens[0];

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -6473,15 +6473,27 @@ void M_StartControlPanel (void)
 
 void M_Drawer (void)
 {
+   static int menushade;
+
    if (setup_active && menu_background == 2)
    {
       int y;
       byte *dest = screens[0];
+      static int firsttic;
+
       for (y = 0; y < (SCREENWIDTH << hires) * (SCREENHEIGHT << hires); y++)
       {
-         dest[y] = colormaps[0][15 * 256 + dest[y]];
+         dest[y] = colormaps[0][menushade * 256 + dest[y]];
+      }
+
+      if (menushade < 16 && gametic != firsttic)
+      {
+         menushade += 4;
+         firsttic = gametic;
       }
    }
+   else if (menushade)
+      menushade = 0;
 
    inhelpscreens = false;
    

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -4014,7 +4014,7 @@ static const char *death_use_action_strings[] = {
 };
 
 static const char *menu_background_strings[] = {
-  "on", "off", "dark tint", NULL
+  "on", "off", "dark", NULL
 };
 
 setup_menu_t gen_settings2[] = { // General Settings screen2

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -146,8 +146,8 @@ int menu_background;
 #define M_X_WARN     (ORIGWIDTH/2 - M_GetPixelWidth(menu_buffer)/2)
 #define M_Y_WARN     (29 + 17 * M_SPC)
 #define M_Y_PREVNEXT (29 + 18 * M_SPC)
-#define M_THRM_SIZE  15
-#define M_THRM_STEP  6
+#define M_THRM_SIZE  13
+#define M_THRM_STEP  8
 #define M_THRM_WIDTH (M_THRM_STEP * (M_THRM_SIZE + 2))
 #define M_X_THRM     (M_X - M_THRM_WIDTH)
 #define M_X_LOADSAVE 80
@@ -2253,7 +2253,7 @@ static void M_DrawMiniThermo(int x, int y, int size, int dot, int color)
   if (dot > size)
       dot = size;
 
-  V_DrawPatchTranslated(x + 4 + dot * step, y, 0,
+  V_DrawPatchTranslated(x + M_THRM_STEP / 2 + dot * step, y, 0,
                         W_CacheLumpName("M_MTHRMO", PU_CACHE), colrngs[color], 0);
 }
 

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -2025,63 +2025,6 @@ menu_t CompatDef =                                           // killough 10/98
 //
 // killough 11/98: rewritten to support hires
 
-void R_DrawBackground(char *patchname, byte *back_dest)
-{
-  int x,y;
-  byte *back_src, *src;
-
-  V_MarkRect (0, 0, SCREENWIDTH, SCREENHEIGHT);
-
-  src = back_src = 
-    W_CacheLumpNum(firstflat+R_FlatNumForName(patchname),PU_CACHE);
-
-  if (hires)       // killough 11/98: hires support
-#if 0              // this tiles it in hires
-    for (y = 0 ; y < SCREENHEIGHT*2 ; src = ((++y & 63)<<6) + back_src)
-      for (x = 0 ; x < SCREENWIDTH*2/64 ; x++)
-	{
-	  memcpy (back_dest,back_src+((y & 63)<<6),64);
-	  back_dest += 64;
-	}
-#else              // while this pixel-doubles it
-/*
-      for (y = 0 ; y < SCREENHEIGHT ; src = ((++y & 63)<<6) + back_src,
-	     back_dest += SCREENWIDTH*2)
-	for (x = 0 ; x < SCREENWIDTH/64 ; x++)
-	  {
-	    int i = 63;
-	    do
-	      back_dest[i*2] = back_dest[i*2+SCREENWIDTH*2] =
-		back_dest[i*2+1] = back_dest[i*2+SCREENWIDTH*2+1] = src[i];
-	    while (--i>=0);
-	    back_dest += 128;
-	  }
-*/
-    for (y = 0; y < SCREENHEIGHT<<1; y++)
-      for (x = 0; x < SCREENWIDTH<<1; x += 2)
-      {
-          const byte dot = src[(((y>>1)&63)<<6) + ((x>>1)&63)];
-
-          *back_dest++ = dot;
-          *back_dest++ = dot;
-      }
-#endif
-  else
-/*
-    for (y = 0 ; y < SCREENHEIGHT ; src = ((++y & 63)<<6) + back_src)
-      for (x = 0 ; x < SCREENWIDTH/64 ; x++)
-	{
-	  memcpy (back_dest,back_src+((y & 63)<<6),64);
-	  back_dest += 64;
-	}
-*/
-    for (y = 0; y < SCREENHEIGHT; y++)
-      for (x = 0; x < SCREENWIDTH; x++)
-      {
-        *back_dest++ = src[((y&63)<<6) + (x&63)];
-      }
-}
-
 void M_DrawBackground(char *patchname, byte *back_dest)
 {
   if (setup_active && menu_background)

--- a/src/m_menu.h
+++ b/src/m_menu.h
@@ -79,8 +79,6 @@ void M_ResetTimeScale(void);
 
 void M_UpdateCriticalItems(void);
 
-void R_DrawBackground(char *patch, byte *screen);  // killough 11/98
-
 void M_DrawCredits(void);    // killough 11/98
 
 // killough 8/15/98: warn about changes not being committed until next game

--- a/src/m_menu.h
+++ b/src/m_menu.h
@@ -79,7 +79,7 @@ void M_ResetTimeScale(void);
 
 void M_UpdateCriticalItems(void);
 
-void M_DrawBackground(char *patch, byte *screen);  // killough 11/98
+void R_DrawBackground(char *patch, byte *screen);  // killough 11/98
 
 void M_DrawCredits(void);    // killough 11/98
 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -107,6 +107,7 @@ extern boolean palette_changes;
 extern boolean screen_melt;
 extern boolean blockmapfix;
 extern int extra_level_brightness;
+extern boolean draw_menu_background;
 
 extern char *chat_macros[];  // killough 10/98
 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -284,7 +284,7 @@ default_t defaults[] = {
     "menu_background",
     (config_t *) &menu_background, NULL,
     {0}, {0,2}, number, ss_gen, wad_no,
-    "draw menu background (0 = on, 1 = off, 2 = dark tint)"
+    "draw menu background (0 = on, 1 = off, 2 = dark)"
   },
 
   { // killough 2/8/98

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -106,6 +106,7 @@ extern int death_use_action;
 extern boolean palette_changes;
 extern boolean screen_melt;
 extern boolean blockmapfix;
+extern int extra_level_brightness;
 
 extern char *chat_macros[];  // killough 10/98
 
@@ -269,6 +270,20 @@ default_t defaults[] = {
     (config_t *) &gamma2, NULL,
     {9}, {0,17}, number, ss_gen, wad_no,
     "custom gamma level (0 = 0.5, 9 = 1.0, 17 = 2.0)"
+  },
+
+  {
+    "extra_level_brightness",
+    (config_t *) &extra_level_brightness, NULL,
+    {0}, {0,6}, number, ss_gen, wad_no,
+    "level brightness"
+  },
+
+  {
+    "draw_menu_background",
+    (config_t *) &draw_menu_background, NULL,
+    {1}, {0,1}, number, ss_gen, wad_no,
+    "draw menu background"
   },
 
   { // killough 2/8/98

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -276,7 +276,7 @@ default_t defaults[] = {
   {
     "extra_level_brightness",
     (config_t *) &extra_level_brightness, NULL,
-    {0}, {0,6}, number, ss_gen, wad_no,
+    {0}, {0,4}, number, ss_gen, wad_no,
     "level brightness"
   },
 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -107,7 +107,7 @@ extern boolean palette_changes;
 extern boolean screen_melt;
 extern boolean blockmapfix;
 extern int extra_level_brightness;
-extern boolean draw_menu_background;
+extern int menu_background;
 
 extern char *chat_macros[];  // killough 10/98
 
@@ -281,10 +281,10 @@ default_t defaults[] = {
   },
 
   {
-    "draw_menu_background",
-    (config_t *) &draw_menu_background, NULL,
-    {1}, {0,1}, number, ss_gen, wad_no,
-    "draw menu background"
+    "menu_background",
+    (config_t *) &menu_background, NULL,
+    {0}, {0,2}, number, ss_gen, wad_no,
+    "draw menu background (0 = on, 1 = off, 2 = dark tint)"
   },
 
   { // killough 2/8/98

--- a/src/r_draw.c
+++ b/src/r_draw.c
@@ -842,6 +842,32 @@ void R_InitBuffer(int width, int height)
 // Also draws a beveled edge.
 //
 
+void R_DrawBackground(char *patchname, byte *back_dest)
+{
+  int x, y;
+  byte *src = W_CacheLumpNum(firstflat + R_FlatNumForName(patchname), PU_CACHE);
+
+  if (hires)       // killough 11/98: hires support
+  {
+    for (y = 0; y < SCREENHEIGHT<<1; y++)
+      for (x = 0; x < SCREENWIDTH<<1; x += 2)
+      {
+        const byte dot = src[(((y>>1)&63)<<6) + ((x>>1)&63)];
+
+        *back_dest++ = dot;
+        *back_dest++ = dot;
+      }
+  }
+  else
+  {
+    for (y = 0; y < SCREENHEIGHT; y++)
+      for (x = 0; x < SCREENWIDTH; x++)
+      {
+        *back_dest++ = src[((y&63)<<6) + (x&63)];
+      }
+  }
+}
+
 void R_DrawBorder (int x, int y, int w, int h, int s)
 {
   int i, j;

--- a/src/r_draw.c
+++ b/src/r_draw.c
@@ -887,7 +887,7 @@ void R_FillBackScreen (void)
     return;
 
   // killough 11/98: use the function in m_menu.c
-  M_DrawBackground(gamemode==commercial ? "GRNROCK" : "FLOOR7_2", screens[1]);
+  R_DrawBackground(gamemode==commercial ? "GRNROCK" : "FLOOR7_2", screens[1]);
 
   R_DrawBorder(viewwindowx >> hires, viewwindowy >> hires, scaledviewwidth, scaledviewheight, 1);
 }

--- a/src/r_draw.h
+++ b/src/r_draw.h
@@ -95,6 +95,7 @@ void R_InitTranslationTables(void);
 
 // Rendering function.
 void R_FillBackScreen(void);
+void R_DrawBackground(char *patch, byte *back_dest);
 void R_DrawBorder(int x, int y, int w, int h, int s);
 
 // If the view size is not full screen, draws a border around it.

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -105,6 +105,8 @@ lighttable_t **colormaps;
 
 int extralight;                           // bumped light from gun blasts
 
+int extra_level_brightness;               // level brightness feature
+
 void (*colfunc)(void) = R_DrawColumn;     // current column draw function
 
 //
@@ -652,6 +654,7 @@ void R_SetupFrame (player_t *player)
   pitch = player->lookdir / MLOOKUNIT + player->recoilpitch;
   }
   extralight = player->extralight;
+  extralight += STRICTMODE(extra_level_brightness); // level brightness feature
     
   if (pitch > LOOKDIRMAX)
     pitch = LOOKDIRMAX;


### PR DESCRIPTION
Feature request: [[doomworld]](https://www.doomworld.com/forum/topic/112333-this-is-woof-1030-sep-23-2022-updated-winmbf/?do=findComment&comment=2560143)

Taken from International Doom and Unity port. I believe this option is more convenient without menu background.