### PR TITLE
Set 'fastdemo_timer' to false before warping

### DIFF
--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -5423,12 +5423,15 @@ boolean M_Responder (event_t* ev)
 	  M_SetupNextMenu(&SetupDef);
 	  return true;
 	}
+	  
+	static boolean fastdemo_timer = false;
 
 	// [FG] reload current level / go to next level
 	if (M_InputActivated(input_menu_nextlevel))
 	{
 		if (demoplayback && singledemo && !PLAYBACK_SKIP)
 		{
+			fastdemo_timer = false;
 			playback_nextlevel = true;
 			G_EnableWarp(true);
 			return true;
@@ -5442,7 +5445,6 @@ boolean M_Responder (event_t* ev)
           if (demoplayback && !PLAYBACK_SKIP && !fastdemo
               && !D_CheckNetConnect())
           {
-            static boolean fastdemo_timer = false;
             fastdemo_timer = !fastdemo_timer;
             I_SetFastdemoTimer(fastdemo_timer);
             return true;

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -5259,6 +5259,8 @@ boolean M_Responder (event_t* ev)
 
   if (!menuactive && !chat_on)                                // phares
     {                                                         //  |
+      static boolean fastdemo_timer = false;
+	  
       if (M_InputActivated(input_autorun)) // Autorun         //  V
 	{
 	  autorun = !autorun;
@@ -5423,8 +5425,6 @@ boolean M_Responder (event_t* ev)
 	  M_SetupNextMenu(&SetupDef);
 	  return true;
 	}
-	  
-	static boolean fastdemo_timer = false;
 
 	// [FG] reload current level / go to next level
 	if (M_InputActivated(input_menu_nextlevel))


### PR DESCRIPTION
Apparently there is a bug that causes multiple level demos to get stuck in a single tic loop.

Steps to reproduce:
1. Record a demo consisting of at least 2 levels.
2. Turn on 'fast-forward' on the first level with a hotkey.
3. Without turning off 'fast-forward' press 'next level' hotkey.
4. Let the next level play a bit at normal speed.
5. Press 'fast-forward' again.
6. Depending on the amount of tics passed in step 4 the demo will be stuck for X amount of tics after pressing 'fast-forward' hotkey.