### PR TITLE
Have "Clear Marks" key clear just the last mark

### DIFF
--- a/src/am_map.c
+++ b/src/am_map.c
@@ -647,6 +647,13 @@ void AM_clearMarks(void)
   markpointnum = 0;
 }
 
+// [Alaux] Clear just the last mark
+static void AM_clearLastMark(void)
+{
+  if (markpointnum)
+    markpointnum--;
+}
+
 void AM_enableSmoothLines(void)
 {
   AM_drawFline = map_smooth_lines ? AM_drawFline_Smooth : AM_drawFline_Vanilla;
@@ -925,10 +932,15 @@ boolean AM_Responder
     }
     else if (M_InputActivated(input_map_clear))
     {
-      AM_clearMarks();  // Ty 03/27/98 - *not* externalized
-      plr->message = s_AMSTR_MARKSCLEARED;                      //    ^
-    }                                                           //    |
-    else                                                        // phares
+      // [Alaux] Clear just the last mark
+      if (!markpointnum)
+        plr->message = s_AMSTR_MARKSCLEARED;
+      else {
+        AM_clearLastMark();
+        doomprintf("Cleared spot %d", markpointnum);
+      }
+    }
+    else
     if (M_InputActivated(input_map_overlay))
     {
       automapoverlay = !automapoverlay;

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -2997,7 +2997,7 @@ setup_menu_t keys_settings6[] =  // Key Binding screen strings
   {"SHIFT LEFT" ,S_INPUT     ,m_map ,KB_X,M_Y+10*M_SPC,{0},input_map_left},
   {"SHIFT RIGHT",S_INPUT     ,m_map ,KB_X,M_Y+11*M_SPC,{0},input_map_right},
   {"MARK PLACE" ,S_INPUT     ,m_map ,KB_X,M_Y+12*M_SPC,{0},input_map_mark},
-  {"CLEAR MARKS",S_INPUT     ,m_map ,KB_X,M_Y+13*M_SPC,{0},input_map_clear},
+  {"CLEAR LAST MARK",S_INPUT ,m_map ,KB_X,M_Y+13*M_SPC,{0},input_map_clear},
   {"FULL/ZOOM"  ,S_INPUT     ,m_map ,KB_X,M_Y+14*M_SPC,{0},input_map_gobig},
   {"GRID"       ,S_INPUT     ,m_map ,KB_X,M_Y+15*M_SPC,{0},input_map_grid},
 


### PR DESCRIPTION
Every now and then, I accidentally press the _Mark Place_ key and place an undesired mark. If I was already using marks in that session (that is, if I had placed marks intentionally to pinpoint points of interest), it's fairly annoying that I have to either leave the undesired mark where it is, or clear all other marks with it.

As implied, this PR aims to change that by having the key only clear the last placed mark. In its current state, it does indeed get rid of the possibility to clear all marks at once, but the key can still be held down to quickly clear multiple marks, and out of the seemingly few people that use marks, I personally don't believe any would place a considerable amount of them to warrant keeping that functionality.

All in all, I believe this'd be a good addition for Woof.