### PR TITLE
Make color of health count gray when invulnerable

### DIFF
--- a/src/hu_stuff.c
+++ b/src/hu_stuff.c
@@ -1328,6 +1328,12 @@ void HU_Drawer(void)
         hud_healthstr[i] = '\0';
         strcat(hud_healthstr,healthstr);
 
+        // [Alaux] Make color of health gray when invulnerable
+        if ((plr->powers[pw_invulnerability] > 4*32
+             || plr->powers[pw_invulnerability] & 8)
+            || plr->cheats & CF_GODMODE)
+          w_health.cr = colrngs[CR_GRAY];
+        else
         // set the display color from the amount of health posessed
         if (health<health_red)
           w_health.cr = colrngs[CR_RED];

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -899,6 +899,12 @@ void ST_drawWidgets(void)
       STlib_updateNum(&w_maxammo[i], NULL);
     }
 
+  // [Alaux] Make color of health gray when invulnerable
+  if ((plyr->powers[pw_invulnerability] > 4*32
+       || plyr->powers[pw_invulnerability] & 8)
+      || plyr->cheats & CF_GODMODE)
+    STlib_updatePercent(&w_health, cr_gray);
+  else
   //jff 2/16/98 make color of health depend on amount
   if (*w_health.n.num<health_red)
     STlib_updatePercent(&w_health, cr_red);


### PR DESCRIPTION
Might look like just a fancy thing at first, but I can think of a scenario where it might actually be useful:

When _Pain/Pickup/Powerup Flashes_ are disabled, there doesn't seem to be an unique indicator for Invulnerability (we're talking about the powerup) being active when using a fullscreen HUD; you know, only the Status Bar has the face.
The Light Amp Goggles effect is applied, yes, but that's what makes it not "unique".
With this PR, not only does the coloring of the Health count change to gray to indicate Invulnerability, but it also flashes just like a powerup would when running out, which is another feature that's missing when disabling, well, flashes. However, while the flashing of the Health count is definitely much more tame than the flashing of the whole screen, it _could_ still be annoying for some people. Not sure about that, though, we'll have to see how it goes if the PR is merged.