### PR TITLE
Implement dark automap overlay

### DIFF
--- a/src/am_map.c
+++ b/src/am_map.c
@@ -72,9 +72,6 @@ int map_keyed_door_flash; // keyed doors are flashing
 
 int map_smooth_lines;
 
-// [Alaux] Dark automap overlay
-static int overlayshade;
-
 //jff 4/3/98 add symbols for "no-color" for disable and "black color" for black
 #define NC 0
 #define BC 247
@@ -1073,10 +1070,8 @@ void AM_Coordinates(const mobj_t *mo, fixed_t *x, fixed_t *y, fixed_t *z)
 //
 void AM_Ticker (void)
 {
-  if (!automapactive) {
-    overlayshade = 0;
+  if (!automapactive)
     return;
-  }
 
   amclock++;
 
@@ -2283,6 +2278,9 @@ void AM_drawCrosshair(int color)
 //
 void AM_Drawer (void)
 {
+  extern boolean setup_active;
+  extern int menu_background;
+
   if (!automapactive) return;
 
   // move AM_doFollowPlayer and AM_changeWindowLoc from AM_Ticker for
@@ -2318,10 +2316,8 @@ void AM_Drawer (void)
     pspr_interp = false;
   }
   // [Alaux] Dark automap overlay
-  else if (automapoverlay == 2)
-    overlayshade = V_ShadeScreen(overlayshade, 20);
-  else
-    overlayshade = 0;
+  else if (automapoverlay == 2 && !(setup_active && menu_background == 2))
+    V_ShadeScreen();
 
   if (automap_grid)                  // killough 2/28/98: change var name
     AM_drawGrid(mapcolor_grid);      //jff 1/7/98 grid default color

--- a/src/am_map.c
+++ b/src/am_map.c
@@ -40,6 +40,7 @@
 #include "dstrings.h"
 #include "d_deh.h"    // Ty 03/27/98 - externalizations
 #include "m_input.h"
+#include "m_menu.h"
 
 //jff 1/7/98 default automap colors added
 int mapcolor_back;    // map background
@@ -247,7 +248,7 @@ int automap_grid = 0;
 
 boolean automapactive = false;
 
-int automapoverlay = false;
+overlay_t automapoverlay = overlay_off;
 
 // location of window on screen
 static int  f_x;
@@ -943,10 +944,11 @@ boolean AM_Responder
     else
     if (M_InputActivated(input_map_overlay))
     {
-      if (++automapoverlay > 2)
-        automapoverlay = 0;
+      if (++automapoverlay > overlay_dark)
+        automapoverlay = overlay_off;
 
-      switch (automapoverlay) {
+      switch (automapoverlay)
+      {
         case 2:  plr->message = "Dark Overlay On";  break;
         case 1:  plr->message = s_AMSTR_OVERLAYON;  break;
         default: plr->message = s_AMSTR_OVERLAYOFF; break;
@@ -2278,9 +2280,6 @@ void AM_drawCrosshair(int color)
 //
 void AM_Drawer (void)
 {
-  extern boolean setup_active;
-  extern int menu_background;
-
   if (!automapactive) return;
 
   // move AM_doFollowPlayer and AM_changeWindowLoc from AM_Ticker for
@@ -2316,7 +2315,7 @@ void AM_Drawer (void)
     pspr_interp = false;
   }
   // [Alaux] Dark automap overlay
-  else if (automapoverlay == 2 && !(setup_active && menu_background == 2))
+  else if (automapoverlay == overlay_dark && !(setup_active && menu_background == 2))
     V_ShadeScreen();
 
   if (automap_grid)                  // killough 2/28/98: change var name

--- a/src/am_map.c
+++ b/src/am_map.c
@@ -73,7 +73,7 @@ int map_keyed_door_flash; // keyed doors are flashing
 int map_smooth_lines;
 
 // [Alaux] Dark automap overlay
-static int viewshade;
+static int overlayshade;
 
 //jff 4/3/98 add symbols for "no-color" for disable and "black color" for black
 #define NC 0
@@ -1074,7 +1074,7 @@ void AM_Coordinates(const mobj_t *mo, fixed_t *x, fixed_t *y, fixed_t *z)
 void AM_Ticker (void)
 {
   if (!automapactive) {
-    viewshade = 0;
+    overlayshade = 0;
     return;
   }
 
@@ -2319,22 +2319,9 @@ void AM_Drawer (void)
   }
   // [Alaux] Dark automap overlay
   else if (automapoverlay == 2)
-  {
-    int y;
-    byte *dest = screens[0];
-    static int firsttic;
-
-    for (y = 0; y < (SCREENWIDTH << hires) * (SCREENHEIGHT << hires); y++)
-      dest[y] = colormaps[0][viewshade * 256 + dest[y]];
-
-    if (viewshade < 20 && gametic != firsttic)
-    {
-      viewshade += 2;
-      firsttic = gametic;
-    }
-  }
+    overlayshade = V_ShadeScreen(overlayshade, 20);
   else
-    viewshade = 0;
+    overlayshade = 0;
 
   if (automap_grid)                  // killough 2/28/98: change var name
     AM_drawGrid(mapcolor_grid);      //jff 1/7/98 grid default color

--- a/src/am_map.c
+++ b/src/am_map.c
@@ -2315,7 +2315,7 @@ void AM_Drawer (void)
     pspr_interp = false;
   }
   // [Alaux] Dark automap overlay
-  else if (automapoverlay == overlay_dark && !(setup_active && menu_background == 2))
+  else if (automapoverlay == overlay_dark && !M_MenuIsShaded())
     V_ShadeScreen();
 
   if (automap_grid)                  // killough 2/28/98: change var name

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -255,9 +255,16 @@ void D_Display (void)
     case GS_LEVEL:
       if (!gametic)
         break;
+      if (automapactive && !automapoverlay)
+      {
+        // [FG] update automap while playing
+        R_RenderPlayerView (&players[displayplayer]);
+        AM_Drawer();
+      }
       if (wipe || (scaledviewheight != 200 && fullscreen) // killough 11/98
           || (inhelpscreensstate && !inhelpscreens))
         redrawsbar = true;              // just put away the help screen
+      ST_Drawer(scaledviewheight == 200, redrawsbar );    // killough 11/98
       fullscreen = scaledviewheight == 200;               // killough 11/98
       break;
     case GS_INTERMISSION:
@@ -272,8 +279,11 @@ void D_Display (void)
     }
 
   // draw the view directly
-  if (gamestate == GS_LEVEL && gametic)
+  if (gamestate == GS_LEVEL && (!automapactive || automapoverlay) && gametic)
     R_RenderPlayerView (&players[displayplayer]);
+
+  if (gamestate == GS_LEVEL && gametic)
+    HU_Drawer ();
 
   // clean up border stuff
   if (gamestate != oldgamestate && gamestate != GS_LEVEL)
@@ -303,19 +313,16 @@ void D_Display (void)
   inhelpscreensstate = inhelpscreens;
   oldgamestate = wipegamestate = gamestate;
 
-  if (gamestate == GS_LEVEL && automapactive)
+  if (gamestate == GS_LEVEL && automapactive && automapoverlay)
     {
       AM_Drawer();
+      ST_Drawer(scaledviewheight == 200, redrawsbar);
+      HU_Drawer();
 
       // [crispy] force redraw of status bar and border
       viewactivestate = false;
       inhelpscreensstate = true;
     }
-
-  if (gamestate == GS_LEVEL && gametic) {
-    ST_Drawer(scaledviewheight == 200, redrawsbar);
-    HU_Drawer();
-  }
 
   // draw pause pic
   if (paused)

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -221,6 +221,12 @@ void D_Display (void)
   static int borderdrawcount;
   int wipestart;
   boolean done, wipe, redrawsbar;
+  extern boolean setup_active;
+  extern int menu_background;
+
+  if (!((automapactive && automapoverlay == 2)
+        || (setup_active && menu_background == 2)))
+    screenshade = 0;
 
   if (demobar && PLAYBACK_SKIP)
   {

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -255,16 +255,9 @@ void D_Display (void)
     case GS_LEVEL:
       if (!gametic)
         break;
-      if (automapactive)
-      {
-        // [FG] update automap while playing
-        R_RenderPlayerView (&players[displayplayer]);
-        AM_Drawer();
-      }
       if (wipe || (scaledviewheight != 200 && fullscreen) // killough 11/98
           || (inhelpscreensstate && !inhelpscreens))
         redrawsbar = true;              // just put away the help screen
-      ST_Drawer(scaledviewheight == 200, redrawsbar );    // killough 11/98
       fullscreen = scaledviewheight == 200;               // killough 11/98
       break;
     case GS_INTERMISSION:
@@ -279,11 +272,8 @@ void D_Display (void)
     }
 
   // draw the view directly
-  if (gamestate == GS_LEVEL && !automapactive && gametic)
-    R_RenderPlayerView (&players[displayplayer]);
-
   if (gamestate == GS_LEVEL && gametic)
-    HU_Drawer ();
+    R_RenderPlayerView (&players[displayplayer]);
 
   // clean up border stuff
   if (gamestate != oldgamestate && gamestate != GS_LEVEL)
@@ -313,15 +303,19 @@ void D_Display (void)
   inhelpscreensstate = inhelpscreens;
   oldgamestate = wipegamestate = gamestate;
 
-  if (gamestate == GS_LEVEL && automapactive && automapoverlay)
+  if (gamestate == GS_LEVEL && automapactive)
     {
       AM_Drawer();
-      HU_Drawer();
 
       // [crispy] force redraw of status bar and border
       viewactivestate = false;
       inhelpscreensstate = true;
     }
+
+  if (gamestate == GS_LEVEL && gametic) {
+    ST_Drawer(scaledviewheight == 200, redrawsbar);
+    HU_Drawer();
+  }
 
   // draw pause pic
   if (paused)

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -221,12 +221,6 @@ void D_Display (void)
   static int borderdrawcount;
   int wipestart;
   boolean done, wipe, redrawsbar;
-  extern boolean setup_active;
-  extern int menu_background;
-
-  if (!((automapactive && automapoverlay == 2)
-        || (setup_active && menu_background == 2)))
-    screenshade = 0;
 
   if (demobar && PLAYBACK_SKIP)
   {

--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -248,7 +248,7 @@ extern int snd_DesiredSfxDevice;
 extern  boolean statusbaractive;
 
 extern  boolean automapactive; // In AutoMap mode?
-extern  boolean automapoverlay;
+extern  int     automapoverlay;
 extern  boolean automaprotate;
 extern  boolean menuactive;    // Menu overlayed?
 extern  boolean paused;        // Game Pause?

--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -248,7 +248,15 @@ extern int snd_DesiredSfxDevice;
 extern  boolean statusbaractive;
 
 extern  boolean automapactive; // In AutoMap mode?
-extern  int     automapoverlay;
+
+typedef enum
+{
+  overlay_off,
+  overlay_on,
+  overlay_dark,
+} overlay_t;
+
+extern  overlay_t automapoverlay;
 extern  boolean automaprotate;
 extern  boolean menuactive;    // Menu overlayed?
 extern  boolean paused;        // Game Pause?

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -6531,9 +6531,14 @@ void M_StartControlPanel (void)
 // killough 9/29/98: Significantly reformatted source
 //
 
+boolean M_MenuIsShaded(void)
+{
+  return setup_active && menu_background == 2;
+}
+
 void M_Drawer (void)
 {
-   if (setup_active && menu_background == 2)
+   if (M_MenuIsShaded())
       V_ShadeScreen();
 
    inhelpscreens = false;

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -3429,7 +3429,7 @@ enum {
   auto1_flash,
 };
 
-static const char *background_strings[] = {
+static const char *overlay_strings[] = {
   "Off", "On", "Dark", NULL
 };
 
@@ -3445,7 +3445,7 @@ setup_menu_t auto_settings1[] =  // 1st AutoMap Settings screen
   {"Modes",S_SKIP|S_TITLE,m_null,M_X,M_Y},
   {"Follow Player"        ,S_YESNO ,m_null,M_X,M_Y+auto1_follow*M_SPC,  {"followplayer"}},
   {"Rotate Automap"       ,S_YESNO ,m_null,M_X,M_Y+auto1_rotate*M_SPC,  {"automaprotate"}},
-  {"Overlay Automap"      ,S_CHOICE,m_null,M_X,M_Y+auto1_overlay*M_SPC, {"automapoverlay"}, 0, NULL, background_strings},
+  {"Overlay Automap"      ,S_CHOICE,m_null,M_X,M_Y+auto1_overlay*M_SPC, {"automapoverlay"}, 0, NULL, overlay_strings},
 
   {"",S_SKIP,m_null,M_X,M_Y+auto1_stub1*M_SPC},
 
@@ -4062,6 +4062,10 @@ static const char *death_use_action_strings[] = {
   "default", "last save", "nothing", NULL
 };
 
+static const char *menu_background_strings[] = {
+  "on", "off", "dark", NULL
+};
+
 setup_menu_t gen_settings2[] = { // General Settings screen2
 
   {"Mouse Settings"     ,S_SKIP|S_TITLE, m_null, M_X, M_Y},
@@ -4103,7 +4107,7 @@ setup_menu_t gen_settings2[] = { // General Settings screen2
    M_Y + gen2_solidbackground*M_SPC, {"st_solidbackground"}},
 
   {"Draw Menu Background", S_CHOICE, m_null, M_X,
-   M_Y + gen2_menu_background*M_SPC, {"menu_background"}, 0, NULL, background_strings},
+   M_Y + gen2_menu_background*M_SPC, {"menu_background"}, 0, NULL, menu_background_strings},
 
   {"Flash Icon During Disk IO", S_YESNO, m_null, M_X,
    M_Y + gen2_diskicon*M_SPC, {"disk_icon"}},

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -3429,6 +3429,10 @@ enum {
   auto1_flash,
 };
 
+static const char *overlay_strings[] = {
+  "Off", "On", "Dark", NULL
+};
+
 // [FG] show level statistics and level time widgets
 static const char *show_widgets_strings[] = {
   "Off", "On Automap", "Always", NULL
@@ -3439,9 +3443,9 @@ extern void AM_enableSmoothLines(void);
 setup_menu_t auto_settings1[] =  // 1st AutoMap Settings screen       
 {
   {"Modes",S_SKIP|S_TITLE,m_null,M_X,M_Y},
-  {"Follow Player"        ,S_YESNO,m_null,M_X,M_Y+auto1_follow*M_SPC,  {"followplayer"}},
-  {"Rotate Automap"       ,S_YESNO,m_null,M_X,M_Y+auto1_rotate*M_SPC,  {"automaprotate"}},
-  {"Overlay Automap"      ,S_YESNO,m_null,M_X,M_Y+auto1_overlay*M_SPC, {"automapoverlay"}},
+  {"Follow Player"        ,S_YESNO ,m_null,M_X,M_Y+auto1_follow*M_SPC,  {"followplayer"}},
+  {"Rotate Automap"       ,S_YESNO ,m_null,M_X,M_Y+auto1_rotate*M_SPC,  {"automaprotate"}},
+  {"Overlay Automap"      ,S_CHOICE,m_null,M_X,M_Y+auto1_overlay*M_SPC, {"automapoverlay"}, 0, NULL, overlay_strings},
 
   {"",S_SKIP,m_null,M_X,M_Y+auto1_stub1*M_SPC},
 

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -6529,12 +6529,8 @@ void M_StartControlPanel (void)
 
 void M_Drawer (void)
 {
-   static int menushade;
-
    if (setup_active && menu_background == 2)
-      menushade = V_ShadeScreen(menushade, 16);
-   else
-      menushade = 0;
+      V_ShadeScreen();
 
    inhelpscreens = false;
    

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -3429,7 +3429,7 @@ enum {
   auto1_flash,
 };
 
-static const char *overlay_strings[] = {
+static const char *background_strings[] = {
   "Off", "On", "Dark", NULL
 };
 
@@ -3445,7 +3445,7 @@ setup_menu_t auto_settings1[] =  // 1st AutoMap Settings screen
   {"Modes",S_SKIP|S_TITLE,m_null,M_X,M_Y},
   {"Follow Player"        ,S_YESNO ,m_null,M_X,M_Y+auto1_follow*M_SPC,  {"followplayer"}},
   {"Rotate Automap"       ,S_YESNO ,m_null,M_X,M_Y+auto1_rotate*M_SPC,  {"automaprotate"}},
-  {"Overlay Automap"      ,S_CHOICE,m_null,M_X,M_Y+auto1_overlay*M_SPC, {"automapoverlay"}, 0, NULL, overlay_strings},
+  {"Overlay Automap"      ,S_CHOICE,m_null,M_X,M_Y+auto1_overlay*M_SPC, {"automapoverlay"}, 0, NULL, background_strings},
 
   {"",S_SKIP,m_null,M_X,M_Y+auto1_stub1*M_SPC},
 
@@ -4062,10 +4062,6 @@ static const char *death_use_action_strings[] = {
   "default", "last save", "nothing", NULL
 };
 
-static const char *menu_background_strings[] = {
-  "on", "off", "dark", NULL
-};
-
 setup_menu_t gen_settings2[] = { // General Settings screen2
 
   {"Mouse Settings"     ,S_SKIP|S_TITLE, m_null, M_X, M_Y},
@@ -4107,7 +4103,7 @@ setup_menu_t gen_settings2[] = { // General Settings screen2
    M_Y + gen2_solidbackground*M_SPC, {"st_solidbackground"}},
 
   {"Draw Menu Background", S_CHOICE, m_null, M_X,
-   M_Y + gen2_menu_background*M_SPC, {"menu_background"}, 0, NULL, menu_background_strings},
+   M_Y + gen2_menu_background*M_SPC, {"menu_background"}, 0, NULL, background_strings},
 
   {"Flash Icon During Disk IO", S_YESNO, m_null, M_X,
    M_Y + gen2_diskicon*M_SPC, {"disk_icon"}},
@@ -6536,23 +6532,8 @@ void M_Drawer (void)
    static int menushade;
 
    if (setup_active && menu_background == 2)
-   {
-      int y;
-      byte *dest = screens[0];
-      static int firsttic;
-
-      for (y = 0; y < (SCREENWIDTH << hires) * (SCREENHEIGHT << hires); y++)
-      {
-         dest[y] = colormaps[0][menushade * 256 + dest[y]];
-      }
-
-      if (menushade < 16 && gametic != firsttic)
-      {
-         menushade += 2;
-         firsttic = gametic;
-      }
-   }
-   else if (menushade)
+      menushade = V_ShadeScreen(menushade, 16);
+   else
       menushade = 0;
 
    inhelpscreens = false;

--- a/src/m_menu.h
+++ b/src/m_menu.h
@@ -184,6 +184,9 @@ typedef struct setup_menu_s
   const char **selectstrings; // [FG] selection of choices
 } setup_menu_t;
 
+extern int menu_background;
+extern boolean setup_active;
+
 #endif    
 
 //----------------------------------------------------------------------------

--- a/src/m_menu.h
+++ b/src/m_menu.h
@@ -185,7 +185,7 @@ typedef struct setup_menu_s
 } setup_menu_t;
 
 extern int menu_background;
-extern boolean setup_active;
+extern boolean M_MenuIsShaded(void);
 
 #endif    
 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -108,7 +108,6 @@ extern boolean screen_melt;
 extern boolean hangsolid;
 extern boolean blockmapfix;
 extern int extra_level_brightness;
-extern int menu_background;
 
 extern char *chat_macros[];  // killough 10/98
 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -1815,8 +1815,8 @@ default_t defaults[] = {
   {
     "automapoverlay",
     (config_t *) &automapoverlay, NULL,
-    {0}, {0,1}, number, ss_auto, wad_no,
-    "1 to enable automap overlay mode"
+    {0}, {0,2}, number, ss_auto, wad_no,
+    "automap overlay mode (1 = on, 2 = dark)"
   },
 
   {

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -858,27 +858,27 @@ void V_DrawHorizLine(int x, int y, int scrn, int width, byte color)
   }
 }
 
-int V_ShadeScreen(int curshade, int targshade)
+int screenshade;
+void V_ShadeScreen(void)
 {
   int y;
   byte *dest = screens[0];
+  const int targshade = 20;
   static int oldtic;
   
   for (y = 0; y < (SCREENWIDTH << hires) * (SCREENHEIGHT << hires); y++)
   {
-    dest[y] = colormaps[0][curshade * 256 + dest[y]];
+    dest[y] = colormaps[0][screenshade * 256 + dest[y]];
   }
 
-  if (curshade < targshade && gametic != oldtic)
+  if (screenshade < targshade && gametic != oldtic)
   {
-    curshade += 2;
+    screenshade += 2;
     oldtic = gametic;
 
-    if (curshade > targshade)
-      curshade = targshade;
+    if (screenshade > targshade)
+      screenshade = targshade;
   }
-
-  return curshade;
 }
 
 //

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -858,14 +858,20 @@ void V_DrawHorizLine(int x, int y, int scrn, int width, byte color)
   }
 }
 
-int screenshade;
 void V_ShadeScreen(void)
 {
   int y;
   byte *dest = screens[0];
   const int targshade = 20;
-  static int oldtic;
+  static int oldtic = -1;
+  static int screenshade;
   
+  // [FG] longer than one tic ago? start a new sequence
+  if (gametic - oldtic > 1)
+  {
+    screenshade = 0;
+  }
+
   for (y = 0; y < (SCREENWIDTH << hires) * (SCREENHEIGHT << hires); y++)
   {
     dest[y] = colormaps[0][screenshade * 256 + dest[y]];
@@ -874,11 +880,12 @@ void V_ShadeScreen(void)
   if (screenshade < targshade && gametic != oldtic)
   {
     screenshade += 2;
-    oldtic = gametic;
 
     if (screenshade > targshade)
       screenshade = targshade;
   }
+  
+  oldtic = gametic;
 }
 
 //

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -858,6 +858,29 @@ void V_DrawHorizLine(int x, int y, int scrn, int width, byte color)
   }
 }
 
+int V_ShadeScreen(int curshade, int targshade)
+{
+  int y;
+  byte *dest = screens[0];
+  static int oldtic;
+  
+  for (y = 0; y < (SCREENWIDTH << hires) * (SCREENHEIGHT << hires); y++)
+  {
+    dest[y] = colormaps[0][curshade * 256 + dest[y]];
+  }
+
+  if (curshade < targshade && gametic != oldtic)
+  {
+    curshade += 2;
+    oldtic = gametic;
+
+    if (curshade > targshade)
+      curshade = targshade;
+  }
+
+  return curshade;
+}
+
 //
 // V_Init
 //

--- a/src/v_video.h
+++ b/src/v_video.h
@@ -135,6 +135,8 @@ void V_PutBlock(int x, int y, int scrn, int width, int height, byte *src);
 
 void V_DrawHorizLine(int x, int y, int scrn, int width, byte color);
 
+int V_ShadeScreen(int curshade, int targshade);
+
 // [FG] colored blood and gibs
 
 int V_BloodColor(int blood);

--- a/src/v_video.h
+++ b/src/v_video.h
@@ -135,7 +135,8 @@ void V_PutBlock(int x, int y, int scrn, int width, int height, byte *src);
 
 void V_DrawHorizLine(int x, int y, int scrn, int width, byte color);
 
-int V_ShadeScreen(int curshade, int targshade);
+extern int screenshade;
+void V_ShadeScreen(void);
 
 // [FG] colored blood and gibs
 

--- a/src/v_video.h
+++ b/src/v_video.h
@@ -135,7 +135,6 @@ void V_PutBlock(int x, int y, int scrn, int width, int height, byte *src);
 
 void V_DrawHorizLine(int x, int y, int scrn, int width, byte color);
 
-extern int screenshade;
 void V_ShadeScreen(void);
 
 // [FG] colored blood and gibs


### PR DESCRIPTION
Well, this PR might get a bit ugly.

Leaving aside the implementation of the dark overlay itself, you may notice that I changed quite a few calls in `D_Display()`. This proved to be necessary to accurately replicate the feature as it is currently implemented in Nugget Doom - not that it matters, but I figured I'd start by implementing it just like I did before.

Now, details about what I changed in `D_Display()` and why I did so:

First, I removed the `ST_Drawer()` call from `switch (gamestate) case GS_LEVEL`, because it must be called _after_ `AM_Drawer()` as to prevent the Status Bar from being affected by the shading.
In doing so, `ST_Drawer()` would be called after `HU_Drawer()`, which might not matter as of now, but I decided to also move the first `HU_Drawer()` call as to maintain the same order. Because of this, the _other_ `HU_Drawer()` call - the one in the `if (gamestate == GS_LEVEL && automapactive)` code block - becomes redundant, so I removed it too.

When testing it with those changes, it was apparent that the shading was behaving different from Nugget. The gradual darkening effect was much faster, which made sense given the multiple `AM_Drawer()` calls, but for some reason it also ended up darker. To avoid this, I removed the `if (automapactive)` code block from the same `switch` as before, and I also removed a few conditions from other calls as to theoretically keep everything working normally.

Indeed, I may have made this more complicated than it had to be. I've no issue with reverting some of the changes if considered appropriate, but assuming that everything _does_ work as it did before these changes, I personally believe it'd be better to leave it like this, without multiple calls of the same functions.