### PR TITLE
experiment: copy frame buffer to renderer pixel-wise

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1426,7 +1426,6 @@ static void I_InitGraphicsMode(void)
    int scalefactor = 0;
 
    // [FG] SDL2
-   uint32_t pixel_format;
    SDL_DisplayMode mode;
 
    v_w = window_width;
@@ -1633,8 +1632,6 @@ static void I_InitGraphicsMode(void)
    {
       SDL_SetWindowSize(screen, window_width, window_height);
    }
-
-   pixel_format = SDL_GetWindowPixelFormat(screen);
 
    // [FG] renderer flags
    flags = 0;

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -896,7 +896,7 @@ static void Blit (SDL_Surface *surface, SDL_Renderer *renderer)
   {
     for (y = 0; x < blit_rect.h; y++)
     {
-      Uint8 color = colors[*s++];
+      SDL_Color color = colors[*s++];
       SDL_SetRenderDrawColor(renderer, color.r, color.g, color.b, SDL_ALPHA_OPAQUE);
       SDL_RenderDrawPoint(renderer, x, y);
     }


### PR DESCRIPTION
This is really just an experiment to satisfy my personal curiosity.

Instead of converting the paletted frame buffer to ARGB color space and then loading this into a texture and then loading this texture into the renderer during each rendered frame, this writes the paletted pixel indices from the frame buffer straight into the renderer.

Let's see how it performs... :wink: