### PR TITLE
fix NULL string comparison in deh parser

### DIFF
--- a/src/d_deh.c
+++ b/src/d_deh.c
@@ -1208,7 +1208,6 @@ static const struct deh_flag_s deh_mobjflags_mbf21[] = {
   {"E4M8BOSS",       MF2_E4M8BOSS}, // E4M8 boss
   {"RIP",            MF2_RIP}, // projectile rips through targets
   {"FULLVOLSOUNDS",  MF2_FULLVOLSOUNDS}, // full volume see / death sound
-  { NULL }
 };
 
 static const struct deh_flag_s deh_weaponflags_mbf21[] = {


### PR DESCRIPTION
This fixes [Hellcinerator.wad](https://www.doomworld.com/idgames/levels/doom2/Ports/g-i/hellcnerator) Bug report: [[doomworld]](https://www.doomworld.com/forum/topic/112333-this-is-woof-1040-oct-26-2022-updated-winmbf/?do=findComment&comment=2576462) The crash happens here: https://github.com/fabiangreffrath/woof/blob/b3ff45d15cf8e520bf5fba8db67b27674b8c5e9f/src/d_deh.c#L1817