### PR TITLE
winmidi: Enable SysEx messages from MIDI files

### DIFF
--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -476,6 +476,7 @@ static boolean IsMasterVolume(const byte *msg, int length, unsigned int *volume)
 static void SendSysExMsg(int time, const byte *data, int length)
 {
     native_event_t native_event;
+    const byte event_type = MIDI_EVENT_SYSEX;
 
     if (IsMasterVolume(data, length, &master_volume))
     {
@@ -490,7 +491,7 @@ static void SendSysExMsg(int time, const byte *data, int length)
     native_event.dwStreamID = 0;
     native_event.dwEvent = MAKE_EVT(length + sizeof(byte), 0, 0, MEVT_LONGMSG);
     WriteBuffer((byte *)&native_event, sizeof(native_event_t));
-    WriteBuffer(&(byte){MIDI_EVENT_SYSEX}, sizeof(byte));
+    WriteBuffer(&event_type, sizeof(byte));
     WriteBuffer(data, length);
     WriteBufferPad();
 

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -579,7 +579,6 @@ static void FillBuffer(void)
     for (num_events = 0; num_events < STREAM_MAX_EVENTS; )
     {
         midi_event_t *event;
-        DWORD data = 0;
         int min_time = INT_MAX;
         int idx = -1;
         int delta_time;

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -497,12 +497,6 @@ static void SendSysExMsg(int time, const byte *data, int length)
 
     if (IsSysExReset(data, length))
     {
-        // Delay after reset in case MIDI file is missing one.
-        if (winmm_reset_delay > 0)
-        {
-            SendDelayMsg();
-        }
-
         // SysEx reset also resets master volume. Take the default master
         // volume and scale it by the user's volume slider.
         master_volume = DEFAULT_MASTER_VOLUME;

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -34,7 +34,7 @@ int winmm_reset_type = 2;
 int winmm_reset_delay = 100;
 int winmm_reverb_level = 40;
 int winmm_chorus_level = 0;
-int winmm_allow_sysex = 0;
+int winmm_allow_sysex = 1;
 
 static byte gs_reset[] = {
     0xF0, 0x41, 0x10, 0x42, 0x12, 0x40, 0x00, 0x7F, 0x00, 0x41, 0xF7
@@ -52,8 +52,22 @@ static byte xg_system_on[] = {
     0xF0, 0x43, 0x10, 0x4C, 0x00, 0x00, 0x7E, 0x00, 0xF7
 };
 
-static int timediv;
-static int tempo;
+static byte master_volume_msg[] = {
+    0xF0, 0x7F, 0x7F, 0x04, 0x01, 0x7F, 0x7F, 0xF7
+};
+
+#define DEFAULT_MASTER_VOLUME 16383
+static unsigned int master_volume = DEFAULT_MASTER_VOLUME;
+static int last_volume = -1;
+static float volume_factor = 1.0f;
+static boolean update_volume = false;
+
+#define MAX_SYSEX_LENGTH 1024
+static byte sysex_buffer[MAX_SYSEX_LENGTH];
+static int sysex_buffer_length;
+
+static DWORD timediv;
+static DWORD tempo;
 
 static HMIDISTRM hMidiStream;
 static MIDIHDR MidiStreamHdr;
@@ -88,14 +102,6 @@ typedef struct
 
 static win_midi_song_t song;
 
-static float volume_factor = 1.0f;
-
-static boolean update_volume = false;
-
-// Save the last volume for each MIDI channel.
-
-static int channel_volume[MIDI_CHANNELS_PER_TRACK];
-
 #define BUFFER_INITIAL_SIZE 1024
 
 typedef struct
@@ -111,7 +117,7 @@ static buffer_t buffer;
 
 #define STREAM_MAX_EVENTS 4
 
-#define MAKE_EVT(a, b, c, d) ((uint32_t)((a) | ((b) << 8) | ((c) << 16) | ((d) << 24)))
+#define MAKE_EVT(a, b, c, d) ((DWORD)((a) | ((b) << 8) | ((c) << 16) | ((d) << 24)))
 
 #define PADDED_SIZE(x) (((x) + sizeof(DWORD) - 1) & ~(sizeof(DWORD) - 1))
 
@@ -209,19 +215,19 @@ static void StreamOut(void)
     }
 }
 
-static void SendShortMsg(int type, int param1, int param2)
+static void SendShortMsg(int time, int status, int channel, int param1, int param2)
 {
     native_event_t native_event;
-    native_event.dwDeltaTime = 0;
+    native_event.dwDeltaTime = time;
     native_event.dwStreamID = 0;
-    native_event.dwEvent = MAKE_EVT(type, param1, param2, MEVT_SHORTMSG);
+    native_event.dwEvent = MAKE_EVT(status | channel, param1, param2, MEVT_SHORTMSG);
     WriteBuffer((byte *)&native_event, sizeof(native_event_t));
 }
 
-static void SendLongMsg(const byte *ptr, int length)
+static void SendLongMsg(int time, const byte *ptr, int length)
 {
     native_event_t native_event;
-    native_event.dwDeltaTime = 0;
+    native_event.dwDeltaTime = time;
     native_event.dwStreamID = 0;
     native_event.dwEvent = MAKE_EVT(length, 0, 0, MEVT_LONGMSG);
     WriteBuffer((byte *)&native_event, sizeof(native_event_t));
@@ -229,13 +235,32 @@ static void SendLongMsg(const byte *ptr, int length)
     WriteBufferPad();
 }
 
-static void SendDelayMsg(int ticks)
+static void SendDelayMsg(void)
 {
+    // Convert ms to ticks (see "Standard MIDI Files 1.0" page 14).
+    int ticks = (float)winmm_reset_delay * 1000 * timediv / tempo + 0.5f;
     native_event_t native_event;
     native_event.dwDeltaTime = ticks;
     native_event.dwStreamID = 0;
     native_event.dwEvent = MAKE_EVT(0, 0, 0, MEVT_NOP);
     WriteBuffer((byte *)&native_event, sizeof(native_event_t));
+}
+
+static void UpdateTempo(int time)
+{
+    native_event_t native_event;
+    native_event.dwDeltaTime = time;
+    native_event.dwStreamID = 0;
+    native_event.dwEvent = MAKE_EVT(tempo, 0, 0, MEVT_TEMPO);
+    WriteBuffer((byte *)&native_event, sizeof(native_event_t));
+}
+
+static void UpdateVolume(int time)
+{
+    int volume = master_volume * volume_factor + 0.5f;
+    master_volume_msg[5] = volume & 0x7F;
+    master_volume_msg[6] = (volume >> 7) & 0x7F;
+    SendLongMsg(time, master_volume_msg, sizeof(master_volume_msg));
 }
 
 static void ResetDevice(void)
@@ -245,43 +270,43 @@ static void ResetDevice(void)
     for (i = 0; i < MIDI_CHANNELS_PER_TRACK; ++i)
     {
         // midiOutReset() sends "all notes off" and "reset all controllers."
-        SendShortMsg(MIDI_EVENT_CONTROLLER | i, MIDI_CONTROLLER_ALL_SOUND_OFF, 0);
+        SendShortMsg(0, MIDI_EVENT_CONTROLLER, i, MIDI_CONTROLLER_ALL_SOUND_OFF, 0);
 
         // Reset pitch bend sensitivity to +/- 2 semitones and 0 cents.
-        SendShortMsg(MIDI_EVENT_CONTROLLER | i, MIDI_CONTROLLER_RPN_MSB, 0);
-        SendShortMsg(MIDI_EVENT_CONTROLLER | i, MIDI_CONTROLLER_RPN_LSB, 0);
-        SendShortMsg(MIDI_EVENT_CONTROLLER | i, MIDI_CONTROLLER_DATA_ENTRY_MSB, 2);
-        SendShortMsg(MIDI_EVENT_CONTROLLER | i, MIDI_CONTROLLER_DATA_ENTRY_LSB, 0);
-        SendShortMsg(MIDI_EVENT_CONTROLLER | i, MIDI_CONTROLLER_RPN_MSB, 127);
-        SendShortMsg(MIDI_EVENT_CONTROLLER | i, MIDI_CONTROLLER_RPN_LSB, 127);
+        SendShortMsg(0, MIDI_EVENT_CONTROLLER, i, MIDI_CONTROLLER_RPN_MSB, 0);
+        SendShortMsg(0, MIDI_EVENT_CONTROLLER, i, MIDI_CONTROLLER_RPN_LSB, 0);
+        SendShortMsg(0, MIDI_EVENT_CONTROLLER, i, MIDI_CONTROLLER_DATA_ENTRY_MSB, 2);
+        SendShortMsg(0, MIDI_EVENT_CONTROLLER, i, MIDI_CONTROLLER_DATA_ENTRY_LSB, 0);
+        SendShortMsg(0, MIDI_EVENT_CONTROLLER, i, MIDI_CONTROLLER_RPN_MSB, 127);
+        SendShortMsg(0, MIDI_EVENT_CONTROLLER, i, MIDI_CONTROLLER_RPN_LSB, 127);
 
         // Reset channel volume and pan.
-        SendShortMsg(MIDI_EVENT_CONTROLLER | i, MIDI_CONTROLLER_MAIN_VOLUME, 100);
-        SendShortMsg(MIDI_EVENT_CONTROLLER | i, MIDI_CONTROLLER_PAN, 64);
+        SendShortMsg(0, MIDI_EVENT_CONTROLLER, i, MIDI_CONTROLLER_MAIN_VOLUME, 100);
+        SendShortMsg(0, MIDI_EVENT_CONTROLLER, i, MIDI_CONTROLLER_PAN, 64);
 
         // Reset instrument.
-        SendShortMsg(MIDI_EVENT_CONTROLLER | i, MIDI_CONTROLLER_BANK_SELECT_MSB, 0);
-        SendShortMsg(MIDI_EVENT_CONTROLLER | i, MIDI_CONTROLLER_BANK_SELECT_LSB, 0);
-        SendShortMsg(MIDI_EVENT_PROGRAM_CHANGE | i, 0, 0);
+        SendShortMsg(0, MIDI_EVENT_CONTROLLER, i, MIDI_CONTROLLER_BANK_SELECT_MSB, 0);
+        SendShortMsg(0, MIDI_EVENT_CONTROLLER, i, MIDI_CONTROLLER_BANK_SELECT_LSB, 0);
+        SendShortMsg(0, MIDI_EVENT_PROGRAM_CHANGE, i, 0, 0);
     }
 
     // Send SysEx reset message.
     switch (winmm_reset_type)
     {
         case 1: // GS Reset
-            SendLongMsg(gs_reset, sizeof(gs_reset));
+            SendLongMsg(0, gs_reset, sizeof(gs_reset));
             break;
 
         case 2: // GM System On
-            SendLongMsg(gm_system_on, sizeof(gm_system_on));
+            SendLongMsg(0, gm_system_on, sizeof(gm_system_on));
             break;
 
         case 3: // GM2 System On
-            SendLongMsg(gm2_system_on, sizeof(gm2_system_on));
+            SendLongMsg(0, gm2_system_on, sizeof(gm2_system_on));
             break;
 
         case 4: // XG System On
-            SendLongMsg(xg_system_on, sizeof(xg_system_on));
+            SendLongMsg(0, xg_system_on, sizeof(xg_system_on));
             break;
 
         default: // None
@@ -291,18 +316,237 @@ static void ResetDevice(void)
     // Send delay after reset.
     if (winmm_reset_delay > 0)
     {
-        // Convert ms to ticks (see "Standard MIDI Files 1.0" page 14).
-        int ticks = (float)winmm_reset_delay * 1000 * timediv / tempo + 0.5f;
-
-        SendDelayMsg(ticks);
+        SendDelayMsg();
     }
 
     for (i = 0; i < MIDI_CHANNELS_PER_TRACK; ++i)
     {
         // Reset reverb and chorus.
-        SendShortMsg(MIDI_EVENT_CONTROLLER | i, MIDI_CONTROLLER_REVERB, winmm_reverb_level);
-        SendShortMsg(MIDI_EVENT_CONTROLLER | i, MIDI_CONTROLLER_CHORUS, winmm_chorus_level);
+        SendShortMsg(0, MIDI_EVENT_CONTROLLER, i, MIDI_CONTROLLER_REVERB, winmm_reverb_level);
+        SendShortMsg(0, MIDI_EVENT_CONTROLLER, i, MIDI_CONTROLLER_CHORUS, winmm_chorus_level);
     }
+}
+
+static boolean IsSysExReset(const byte *msg, int length)
+{
+    if (length < 6)
+    {
+        return false;
+    }
+
+    switch (msg[1])
+    {
+        case 0x41: // Roland
+            switch (msg[3])
+            {
+                case 0x42: // GS
+                    switch (msg[4])
+                    {
+                        case 0x12: // DT1
+                            if (length == 11 &&
+                                msg[5] == 0x00 &&  // Address MSB
+                                msg[6] == 0x00 &&  // Address
+                                msg[7] == 0x7F &&  // Address LSB
+                              ((msg[8] == 0x00 &&  // Data     (MODE-1)
+                                msg[9] == 0x01) || // Checksum (MODE-1)
+                               (msg[8] == 0x01 &&  // Data     (MODE-2)
+                                msg[9] == 0x00)))  // Checksum (MODE-2)
+                            {
+                                // SC-88 System Mode Set
+                                // F0 41 <dev> 42 12 00 00 7F 00 01 F7 (MODE-1)
+                                // F0 41 <dev> 42 12 00 00 7F 01 00 F7 (MODE-2)
+                                return true;
+                            }
+                            else if (length == 11 &&
+                                     msg[5] == 0x40 && // Address MSB
+                                     msg[6] == 0x00 && // Address
+                                     msg[7] == 0x7F && // Address LSB
+                                     msg[8] == 0x00 && // Data (GS Reset)
+                                     msg[9] == 0x41)   // Checksum
+                            {
+                                // GS Reset
+                                // F0 41 <dev> 42 12 40 00 7F 00 41 F7
+                                return true;
+                            }
+                            break;
+                    }
+                    break;
+            }
+            break;
+
+        case 0x43: // Yamaha
+            switch (msg[3])
+            {
+                case 0x2B: // TG300
+                    if (length == 10 &&
+                        msg[4] == 0x00 && // Start Address b20 - b14
+                        msg[5] == 0x00 && // Start Address b13 - b7
+                        msg[6] == 0x7F && // Start Address b6 - b0
+                        msg[7] == 0x00 && // Data
+                        msg[8] == 0x01)   // Checksum
+                    {
+                        // TG300 All Parameter Reset
+                        // F0 43 <dev> 2B 00 00 7F 00 01 F7
+                        return true;
+                    }
+                    break;
+
+                case 0x4C: // XG
+                    if (length == 9 &&
+                        msg[4] == 0x00 && // Address High
+                        msg[5] == 0x00 && // Address Mid
+                        msg[6] == 0x7E && // Address Low
+                        msg[7] == 0x00)   // Data
+                    {
+                        // XG System On
+                        // F0 43 <dev> 4C 00 00 7E 00 F7
+                        return true;
+                    }
+                    else if (length == 9 &&
+                             msg[4] == 0x00 && // Address High
+                             msg[5] == 0x00 && // Address Mid
+                             msg[6] == 0x7F && // Address Low
+                             msg[7] == 0x00)   // Data
+                    {
+                        // XG All Parameter Reset
+                        // F0 43 <dev> 4C 00 00 7F 00 F7
+                        return true;
+                    }
+                    break;
+            }
+            break;
+
+        case 0x7E: // Universal Non-Real Time
+            switch (msg[3])
+            {
+                case 0x09: // General Midi
+                    if (length == 6 &&
+                       (msg[4] == 0x01 || // GM System On
+                        msg[4] == 0x02 || // GM System Off
+                        msg[4] == 0x03))  // GM2 System On
+                    {
+                        // GM System On/Off, GM2 System On
+                        // F0 7E <dev> 09 01 F7
+                        // F0 7E <dev> 09 02 F7
+                        // F0 7E <dev> 09 03 F7
+                        return true;
+                    }
+                    break;
+            }
+            break;
+    }
+    return false;
+}
+
+static boolean IsMasterVolume(byte *msg, int length, unsigned int *volume)
+{
+    // General Midi (F0 7F <dev> 04 01 <lsb> <msb> F7)
+    if (length == 8 &&
+        msg[1] == 0x7F && // Universal Real Time
+        msg[3] == 0x04 && // Device Control
+        msg[4] == 0x01)   // Master Volume
+    {
+        *volume = (msg[5] & 0x7F) | ((msg[6] & 0x7F) << 7);
+        return true;
+    }
+
+    // Roland (F0 41 <dev> 42 12 40 00 04 <vol> <sum> F7)
+    if (length == 11 &&
+        msg[1] == 0x41 && // Roland
+        msg[3] == 0x42 && // GS
+        msg[4] == 0x12 && // DT1
+        msg[5] == 0x40 && // Address MSB
+        msg[6] == 0x00 && // Address
+        msg[7] == 0x04)   // Address LSB
+    {
+        *volume = DEFAULT_MASTER_VOLUME * (msg[8] & 0x7F) / 127;
+        return true;
+    }
+
+    // Yamaha (F0 43 <dev> 4C 00 00 04 <vol> F7)
+    if (length == 9 &&
+        msg[1] == 0x43 && // Yamaha
+        msg[3] == 0x4C && // XG
+        msg[4] == 0x00 && // Address High
+        msg[5] == 0x00 && // Address Mid
+        msg[6] == 0x04)   // Address Low
+    {
+        *volume = DEFAULT_MASTER_VOLUME * (msg[7] & 0x7F) / 127;
+        return true;
+    }
+
+    return false;
+}
+
+static boolean SendSysExMsg(int time, midi_event_t *event)
+{
+    // SysEx messages in MIDI files (Standard MIDI Files 1.0 pages 6-7):
+    // Complete:        (F0 ... F7)
+    // Multi-packet:    (F0 ...) + (F7 ...) + ... + (F7 ... F7)
+    // Escape sequence: (F7 ...)
+
+    if (event->data.sysex.length + sysex_buffer_length > MAX_SYSEX_LENGTH - 1)
+    {
+        // Ignore messages that are too long.
+        sysex_buffer_length = 0;
+        return false;
+    }
+
+    if (event->event_type == MIDI_EVENT_SYSEX_SPLIT && sysex_buffer_length == 0)
+    {
+        // Ignore escape sequences (don't send illegal characters).
+        return false;
+    }
+
+    if (event->event_type == MIDI_EVENT_SYSEX)
+    {
+        // Start a new message (discards any previous incomplete message).
+        sysex_buffer[0] = MIDI_EVENT_SYSEX;
+        sysex_buffer_length = 1;
+    }
+
+    // Copy message to tracked buffer.
+    memcpy(&sysex_buffer[sysex_buffer_length], event->data.sysex.data,
+           event->data.sysex.length);
+    sysex_buffer_length += event->data.sysex.length;
+
+    // Process message if it's complete, otherwise do nothing yet.
+    if (sysex_buffer[sysex_buffer_length - 1] == MIDI_EVENT_SYSEX_SPLIT)
+    {
+        if (IsMasterVolume(sysex_buffer, sysex_buffer_length, &master_volume))
+        {
+            // Found a master volume message in the MIDI file. Take this new
+            // value and scale it by the user's volume slider.
+            UpdateVolume(time);
+            sysex_buffer_length = 0;
+            return true;
+        }
+
+        // Send the SysEx message.
+        SendLongMsg(time, sysex_buffer, sysex_buffer_length);
+
+        if (IsSysExReset(sysex_buffer, sysex_buffer_length))
+        {
+            // Delay after reset in case MIDI file is missing one.
+            if (winmm_reset_delay > 0)
+            {
+                SendDelayMsg();
+            }
+
+            // Allow the MIDI file to reset user settings (reverb and chorus).
+            // Do not reapply them here.
+
+            // SysEx reset also resets master volume. Take the default master
+            // volume and scale it by the user's volume slider.
+            master_volume = DEFAULT_MASTER_VOLUME;
+            UpdateVolume(0);
+        }
+
+        sysex_buffer_length = 0;
+        return true;
+    }
+
+    return false;
 }
 
 static void FillBuffer(void)
@@ -316,21 +560,20 @@ static void FillBuffer(void)
     {
         initial_playback = false;
 
+        master_volume = DEFAULT_MASTER_VOLUME;
+        sysex_buffer_length = 0;
         ResetDevice();
+        StreamOut();
+        return;
     }
 
-    // If the volume has changed, stick those events at the start of this buffer.
     if (update_volume)
     {
         update_volume = false;
 
-        for (i = 0; i < MIDI_CHANNELS_PER_TRACK; ++i)
-        {
-            int volume = (int)((float)channel_volume[i] * volume_factor + 0.5f);
-
-            SendShortMsg(MIDI_EVENT_CONTROLLER | i, MIDI_CONTROLLER_MAIN_VOLUME,
-                volume);
-        }
+        UpdateVolume(0);
+        StreamOut();
+        return;
     }
 
     for (num_events = 0; num_events < STREAM_MAX_EVENTS; )
@@ -339,6 +582,7 @@ static void FillBuffer(void)
         DWORD data = 0;
         int min_time = INT_MAX;
         int idx = -1;
+        int delta_time;
 
         // Look for an event with a minimal delta time.
         for (i = 0; i < MIDI_NumTracks(song.file); ++i)
@@ -385,6 +629,8 @@ static void FillBuffer(void)
             continue;
         }
 
+        delta_time = min_time - song.current_time;
+
         switch ((int)event->event_type)
         {
             case MIDI_EVENT_META:
@@ -392,77 +638,42 @@ static void FillBuffer(void)
                 {
                     tempo = MAKE_EVT(event->data.meta.data[2],
                         event->data.meta.data[1], event->data.meta.data[0], 0);
-                    data = MAKE_EVT(tempo, 0, 0, MEVT_TEMPO);
-                }
-                break;
-
-            case MIDI_EVENT_CONTROLLER:
-                // Adjust volume as needed.
-                if (event->data.channel.param1 == MIDI_CONTROLLER_MAIN_VOLUME)
-                {
-                    int volume = event->data.channel.param2;
-
-                    channel_volume[event->data.channel.channel] = volume;
-
-                    volume = (int)((float)volume * volume_factor + 0.5f);
-
-                    data = MAKE_EVT(event->event_type | event->data.channel.channel,
-                        event->data.channel.param1, (volume & 0x7F),
-                        MEVT_SHORTMSG);
-
+                    UpdateTempo(delta_time);
                     break;
                 }
-                // Fall through.
+                continue;
+
+            case MIDI_EVENT_CONTROLLER:
             case MIDI_EVENT_NOTE_OFF:
             case MIDI_EVENT_NOTE_ON:
             case MIDI_EVENT_AFTERTOUCH:
             case MIDI_EVENT_PITCH_BEND:
-                data = MAKE_EVT(event->event_type | event->data.channel.channel,
-                    event->data.channel.param1, event->data.channel.param2,
-                    MEVT_SHORTMSG);
+                SendShortMsg(delta_time, event->event_type, event->data.channel.channel,
+                    event->data.channel.param1, event->data.channel.param2);
                 break;
 
             case MIDI_EVENT_PROGRAM_CHANGE:
             case MIDI_EVENT_CHAN_AFTERTOUCH:
-                data = MAKE_EVT(event->event_type | event->data.channel.channel,
-                    event->data.channel.param1, 0, MEVT_SHORTMSG);
+                SendShortMsg(delta_time, event->event_type, event->data.channel.channel,
+                    event->data.channel.param1, 0);
                 break;
 
             case MIDI_EVENT_SYSEX:
             case MIDI_EVENT_SYSEX_SPLIT:
-                if (winmm_allow_sysex)
+                if (winmm_allow_sysex && SendSysExMsg(delta_time, event))
                 {
-                    uint32_t length = event->data.sysex.length + sizeof(byte);
-                    data = MAKE_EVT(length, 0, 0, MEVT_LONGMSG);
+                    song.current_time = min_time;
+                    StreamOut();
+                    return;
                 }
-                else
-                {
-                    // Preserve timing with a NOP.
-                    data = MAKE_EVT(0, 0, 0, MEVT_NOP);
-                }
-                break;
+                continue;
+
+            default:
+                continue;
         }
 
-        if (data)
-        {
-            native_event_t native_event;
-
-            native_event.dwDeltaTime = min_time - song.current_time;
-            native_event.dwStreamID = 0;
-            native_event.dwEvent = data;
-            WriteBuffer((byte *)&native_event, sizeof(native_event_t));
-
-            if (winmm_allow_sysex && (event->event_type == MIDI_EVENT_SYSEX ||
-                event->event_type == MIDI_EVENT_SYSEX_SPLIT))
-            {
-                WriteBuffer((byte *)&event->event_type, sizeof(byte));
-                WriteBuffer(event->data.sysex.data, event->data.sysex.length);
-                WriteBufferPad();
-            }
-
-            num_events++;
-            song.current_time = min_time;
-        }
+        num_events++;
+        song.current_time = min_time;
     }
 
     if (num_events)
@@ -518,6 +729,14 @@ static boolean I_WIN_InitMusic(void)
 
 static void I_WIN_SetMusicVolume(int volume)
 {
+    if (last_volume == volume)
+    {
+        // Ignore holding key down in volume menu.
+        return;
+    }
+
+    last_volume = volume;
+
     volume_factor = sqrtf((float)volume / 15);
 
     update_volume = true;
@@ -635,12 +854,6 @@ static void *I_WIN_RegisterSong(void *data, int len)
     {
         fprintf(stderr, "I_WIN_RegisterSong: Failed to load MID.\n");
         return NULL;
-    }
-
-    // Initialize channels volume.
-    for (i = 0; i < MIDI_CHANNELS_PER_TRACK; ++i)
-    {
-        channel_volume[i] = 100;
     }
 
     prop_timediv.cbStruct = sizeof(MIDIPROPTIMEDIV);

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -612,6 +612,7 @@ static void FillBuffer(void)
                     MIDI_RestartIterator(song.tracks[i].iter);
                     song.tracks[i].empty = false;
                 }
+                sysex_buffer_length = 0;
                 continue;
             }
             else

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -34,7 +34,6 @@ int winmm_reset_type = 2;
 int winmm_reset_delay = 100;
 int winmm_reverb_level = 40;
 int winmm_chorus_level = 0;
-int winmm_allow_sysex = 1;
 
 static byte gs_reset[] = {
     0xF0, 0x41, 0x10, 0x42, 0x12, 0x40, 0x00, 0x7F, 0x00, 0x41, 0xF7
@@ -612,14 +611,10 @@ static void FillBuffer(void)
                 break;
 
             case MIDI_EVENT_SYSEX:
-                if (winmm_allow_sysex)
-                {
-                    SendSysExMsg(delta_time, event->data.sysex.data, event->data.sysex.length);
-                    song.current_time = min_time;
-                    StreamOut();
-                    return;
-                }
-                continue;
+                SendSysExMsg(delta_time, event->data.sysex.data, event->data.sysex.length);
+                song.current_time = min_time;
+                StreamOut();
+                return;
 
             default:
                 continue;

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -99,7 +99,6 @@ extern int winmm_reset_type;
 extern int winmm_reset_delay;
 extern int winmm_reverb_level;
 extern int winmm_chorus_level;
-extern int winmm_allow_sysex;
 #endif
 extern boolean demobar;
 extern boolean smoothlight;
@@ -2348,13 +2347,6 @@ default_t defaults[] = {
     (config_t *) &winmm_reverb_level, NULL,
     {40}, {0, 127}, number, ss_none, wad_no,
     "fine tune default reverb level for native MIDI"
-  },
-
-  {
-    "winmm_allow_sysex",
-    (config_t *) &winmm_allow_sysex, NULL,
-    {1}, {0, 1}, number, ss_none, wad_no,
-    "Allow SysEx messages from MIDI files for native MIDI"
   },
 #endif
 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -2353,7 +2353,7 @@ default_t defaults[] = {
   {
     "winmm_allow_sysex",
     (config_t *) &winmm_allow_sysex, NULL,
-    {0}, {0, 1}, number, ss_none, wad_no,
+    {1}, {0, 1}, number, ss_none, wad_no,
     "Allow SysEx messages from MIDI files for native MIDI"
   },
 #endif


### PR DESCRIPTION
This PR allows SysEx messages to be safely read from MIDI files.

1. ~~Enable SysEx messages from MIDI files by default: `winmm_allow_sysex 1`~~
2. ~~Limit SysEx message length to `MAX_SYSEX_LENGTH` to handle malformed messages~~
3. Ignore escape sequences (don't send illegal characters)
4. ~~Discard partial/incomplete SysEx messages~~
5. Volume slider now controls master volume instead of individual channel volumes
6. Prevent volume message spam when holding key down in volume menu
7. Reapply master volume (scaled by user's slider value) after detecting a SysEx reset or master volume message in MIDI file
8. Call `StreamOut()` immediately after adding a SysEx message to the buffer
9. Cosmetic changes to improve legibility