### PR TITLE
winmidi: Fix looping

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,8 @@ Copyright:
  © 2019 Jonathan Dowland;  
  © 2020-2022 Fabian Greffrath;  
  © 2020 Alex Mayfield;  
- © 2020-2022 Roman Fomin.  
+ © 2020-2022 Roman Fomin;  
+ © 2022 ceski.  
 License: [GPL-2.0+](https://www.gnu.org/licenses/old-licenses/gpl-2.0.html)
 
 Files: `src/beta.h`  

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -1,5 +1,6 @@
 //
-// Copyright(C) 2021 Roman Fomin
+// Copyright(C) 2021-2022 Roman Fomin
+// Copyright(C) 2022 ceski
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -634,8 +634,7 @@ static void FillBuffer(void)
                 return;
 
             default:
-                SendNOPMsg(delta_time);
-                break;
+                continue;
         }
 
         num_events++;

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -230,15 +230,21 @@ static void SendLongMsg(int time, const byte *ptr, int length)
     WriteBufferPad();
 }
 
+static void SendNOPMsg(int time)
+{
+    native_event_t native_event;
+    native_event.dwDeltaTime = time;
+    native_event.dwStreamID = 0;
+    native_event.dwEvent = MAKE_EVT(0, 0, 0, MEVT_NOP);
+    WriteBuffer((byte *)&native_event, sizeof(native_event_t));
+}
+
 static void SendDelayMsg(void)
 {
     // Convert ms to ticks (see "Standard MIDI Files 1.0" page 14).
     int ticks = (float)winmm_reset_delay * 1000 * timediv / tempo + 0.5f;
-    native_event_t native_event;
-    native_event.dwDeltaTime = ticks;
-    native_event.dwStreamID = 0;
-    native_event.dwEvent = MAKE_EVT(0, 0, 0, MEVT_NOP);
-    WriteBuffer((byte *)&native_event, sizeof(native_event_t));
+
+    SendNOPMsg(ticks);
 }
 
 static void UpdateTempo(int time)
@@ -563,9 +569,11 @@ static void FillBuffer(void)
             {
                 for (i = 0; i < MIDI_NumTracks(song.file); ++i)
                 {
+                    song.tracks[i].absolute_time = 0;
                     MIDI_RestartIterator(song.tracks[i].iter);
                     song.tracks[i].empty = false;
                 }
+                song.current_time = 0;
                 continue;
             }
             else
@@ -587,14 +595,22 @@ static void FillBuffer(void)
         switch ((int)event->event_type)
         {
             case MIDI_EVENT_META:
-                if (event->data.meta.type == MIDI_META_SET_TEMPO)
+                switch (event->data.meta.type)
                 {
-                    tempo = MAKE_EVT(event->data.meta.data[2],
-                        event->data.meta.data[1], event->data.meta.data[0], 0);
-                    UpdateTempo(delta_time);
-                    break;
+                    case MIDI_META_SET_TEMPO:
+                        tempo = MAKE_EVT(event->data.meta.data[2],
+                            event->data.meta.data[1], event->data.meta.data[0], 0);
+                        UpdateTempo(delta_time);
+                        break;
+
+                    case MIDI_META_END_OF_TRACK:
+                        SendNOPMsg(delta_time);
+                        break;
+
+                    default:
+                        continue;
                 }
-                continue;
+                break;
 
             case MIDI_EVENT_CONTROLLER:
             case MIDI_EVENT_NOTE_OFF:
@@ -618,7 +634,8 @@ static void FillBuffer(void)
                 return;
 
             default:
-                continue;
+                SendNOPMsg(delta_time);
+                break;
         }
 
         num_events++;

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -595,14 +595,21 @@ static void FillBuffer(void)
         switch ((int)event->event_type)
         {
             case MIDI_EVENT_META:
-                if (event->data.meta.type == MIDI_META_SET_TEMPO)
+                switch (event->data.meta.type)
                 {
-                    tempo = MAKE_EVT(event->data.meta.data[2],
-                        event->data.meta.data[1], event->data.meta.data[0], 0);
-                    UpdateTempo(delta_time);
-                    break;
+                    case MIDI_META_SET_TEMPO:
+                        tempo = MAKE_EVT(event->data.meta.data[2],
+                            event->data.meta.data[1], event->data.meta.data[0], 0);
+                        UpdateTempo(delta_time);
+                        break;
+
+                    case MIDI_META_END_OF_TRACK:
+                        SendNOPMsg(delta_time);
+                        break;
+
+                    default:
+                        continue;
                 }
-                SendNOPMsg(delta_time);
                 break;
 
             case MIDI_EVENT_CONTROLLER:

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -595,21 +595,14 @@ static void FillBuffer(void)
         switch ((int)event->event_type)
         {
             case MIDI_EVENT_META:
-                switch (event->data.meta.type)
+                if (event->data.meta.type == MIDI_META_SET_TEMPO)
                 {
-                    case MIDI_META_SET_TEMPO:
-                        tempo = MAKE_EVT(event->data.meta.data[2],
-                            event->data.meta.data[1], event->data.meta.data[0], 0);
-                        UpdateTempo(delta_time);
-                        break;
-
-                    case MIDI_META_END_OF_TRACK:
-                        SendNOPMsg(delta_time);
-                        break;
-
-                    default:
-                        continue;
+                    tempo = MAKE_EVT(event->data.meta.data[2],
+                        event->data.meta.data[1], event->data.meta.data[0], 0);
+                    UpdateTempo(delta_time);
+                    break;
                 }
+                SendNOPMsg(delta_time);
                 break;
 
             case MIDI_EVENT_CONTROLLER:


### PR DESCRIPTION
This bug was actually present back in: https://github.com/fabiangreffrath/woof/pull/816. The fix is reverting this change: https://github.com/fabiangreffrath/woof/commit/ec7cd7c1d7171769eee2369b566ab1f7e32ded4a and then doing a NOP for end of track events to preserve the final delta time for each one.

I noticed this with Alien Vendetta MAP24. The song sounds worse each loop. It's a long song, so I made a short MIDI file that replicates the issue: [endoftracktest.zip](https://github.com/fabiangreffrath/woof/files/10146204/endoftracktest.zip)
```
woof.exe -iwad doom2.wad -file endoftracktest.wad -warp 1
```
The piano should play twice and then the song loops. Without the fix, it sounds broken.