### PR TITLE
hot-swappable music modules, list of Windows MIDI devices

### DIFF
--- a/opl/opl_sdl.c
+++ b/opl/opl_sdl.c
@@ -172,7 +172,7 @@ static void FillBuffer(uint8_t *buffer, unsigned int nsamples)
 
 // Callback function to fill a new sound buffer:
 
-static void OPL_Mix_Callback(int chan, void *stream, int len, void *udata)
+static void OPL_Mix_Callback(void *udata, Uint8 *stream, int len)
 {
     unsigned int filled, buffer_samples;
     Uint8 *buffer = (Uint8*)stream;
@@ -349,10 +349,7 @@ static int OPL_SDL_Init(unsigned int port_base)
     callback_mutex = SDL_CreateMutex();
     callback_queue_mutex = SDL_CreateMutex();
 
-    // Set postmix that adds the OPL music. This is deliberately done
-    // as a postmix and not using Mix_HookMusic() as the latter disables
-    // normal SDL_mixer music mixing.
-    Mix_RegisterEffect(MIX_CHANNEL_POST, OPL_Mix_Callback, NULL, NULL);
+    Mix_HookMusic(OPL_Mix_Callback, NULL);
 
     return 1;
 }

--- a/src/d_quit.c
+++ b/src/d_quit.c
@@ -27,6 +27,7 @@
 #include "m_io.h"
 #include "w_wad.h"
 #include "i_glob.h"
+#include "i_sound.h"
 
 //
 // I_Quit
@@ -45,6 +46,8 @@ void I_QuitFirst(void)
     {
         G_CheckDemoStatus();
     }
+
+    I_ShutdownMusic();
 }
 
 extern char **tempdirs;

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -46,7 +46,7 @@ boolean precache_sounds;
 // [FG] optional low-pass filter
 boolean lowpass_filter;
 // [FG] music backend
-midi_player_t midi_player;
+midi_player_t midi_backend;
 // [FG] variable pitch bend range
 int pitch_bend_range;
 
@@ -698,7 +698,7 @@ static int GetSliceSize(void)
     return 1024;
 }
 
-void I_SetMIDIPlayer(void)
+void I_SetMidiPlayer(void)
 {
   if (midi_player_module)
   {
@@ -706,14 +706,14 @@ void I_SetMIDIPlayer(void)
     midi_player_module = NULL;
   }
 
-  if (midi_player == midi_player_opl)
+  if (midi_backend == midi_player_opl)
     midi_player_module = &music_opl_module;
 #if defined(_WIN32)
-  else if (midi_player == midi_player_win)
+  else if (midi_backend == midi_player_win)
     midi_player_module = &music_win_module;
 #endif
 #if defined(HAVE_FLUIDSYNTH)
-  else if (midi_player == midi_player_fl)
+  else if (midi_backend == midi_player_fl)
     midi_player_module = &music_fl_module;
   #endif
 
@@ -723,7 +723,7 @@ void I_SetMIDIPlayer(void)
     if (!active_module->I_InitMusic())
     {
       // fall back to Native/SDL on error
-      midi_player = 0;
+      midi_backend = 0;
       midi_player_module = NULL;
       active_module = &music_sdl_module;
     }
@@ -802,7 +802,7 @@ void I_InitSound(void)
          active_module->I_InitMusic();
          I_AtExit(active_module->I_ShutdownMusic, true);
 
-         I_SetMIDIPlayer();
+         I_SetMidiPlayer();
       }
    }   
 }

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -55,6 +55,7 @@ extern int pitch_bend_range;
 
 // Init at program start...
 void I_InitSound(void);
+void I_SetMIDIPlayer(void);
 
 // ... update sound buffer and audio device at runtime...
 void I_UpdateSound(void);

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -55,7 +55,7 @@ extern int pitch_bend_range;
 
 // Init at program start...
 void I_InitSound(void);
-void I_SetMIDIPlayer(void);
+void I_SetMidiPlayer(void);
 
 // ... update sound buffer and audio device at runtime...
 void I_UpdateSound(void);
@@ -124,7 +124,11 @@ typedef enum
     num_midi_players,
 } midi_player_t;
 
-extern midi_player_t midi_player;
+extern int midi_player;
+
+extern midi_player_t midi_backend;
+
+extern int winmm_num_devices;
 
 boolean I_InitMusic(void);
 void I_ShutdownMusic(void);

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -36,6 +36,8 @@ int winmm_reset_delay = 100;
 int winmm_reverb_level = 40;
 int winmm_chorus_level = 0;
 
+int winmm_num_devices;
+
 static byte gs_reset[] = {
     0xF0, 0x41, 0x10, 0x42, 0x12, 0x40, 0x00, 0x7F, 0x00, 0x41, 0xF7
 };
@@ -673,7 +675,7 @@ static DWORD WINAPI PlayerProc(void)
 
 static boolean I_WIN_InitMusic(void)
 {
-    UINT MidiDevice = MIDI_MAPPER;
+    UINT MidiDevice = midi_player;
     MMRESULT mmr;
 
     mmr = midiStreamOpen(&hMidiStream, &MidiDevice, (DWORD)1,
@@ -939,3 +941,23 @@ music_module_t music_win_module =
     I_WIN_StopSong,
     I_WIN_UnRegisterSong,
 };
+
+void I_WIN_DeviceList(const char* devices[], int max_devices)
+{
+    int i;
+    UINT numdevs = midiOutGetNumDevs();
+
+    for (i = 0; i < numdevs && i < max_devices; ++i)
+    {
+        MIDIOUTCAPS caps;
+        MMRESULT mmr;
+
+        mmr = midiOutGetDevCaps(i, &caps, sizeof(caps));
+        if (mmr == MMSYSERR_NOERROR)
+        {
+            devices[i] = M_StringDuplicate(caps.szPname);
+        }
+    }
+
+    winmm_num_devices = i;
+}

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -888,6 +888,11 @@ static void I_WIN_ShutdownMusic(void)
 {
     MMRESULT mmr;
 
+    if (!hMidiStream)
+    {
+        return;
+    }
+
     I_WIN_StopSong(NULL);
     I_WIN_UnRegisterSong(NULL);
 

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -3952,7 +3952,12 @@ setup_menu_t gen_settings1[] = { // General Settings screen1
    M_Y + gen1_fullsnd*M_SPC, {"full_sounds"}},
 
   // [FG] music backend
-  {"MIDI player", S_CHOICE, m_null, M_X - 150,
+  {"MIDI player", S_CHOICE, m_null,
+#if defined(_WIN32)
+   M_X - 150,
+#else
+   M_X,
+#endif
    M_Y + gen1_musicbackend*M_SPC, {"midi_player"}, 0, M_SetMidiPlayer, midi_player_strings},
 
   // Button for resetting to defaults

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -62,6 +62,7 @@
 #include "r_plane.h" // [FG] R_InitPlanes()
 #include "m_argv.h"
 #include "m_snapshot.h"
+#include "i_sound.h"
 
 // [crispy] remove DOS reference from the game quit confirmation dialogs
 #include "SDL_platform.h"
@@ -3874,10 +3875,18 @@ static const char *gamma_strings[] = {
   NULL
 };
 
-void static M_ResetGamma(void)
+static void M_ResetGamma(void)
 {
   usegamma = 0;
   I_SetPalette(W_CacheLumpName("PLAYPAL",PU_CACHE));
+}
+
+static void M_SetMIDIPlayer(void)
+{
+  S_StopMusic();
+  I_SetMIDIPlayer();
+  S_SetMusicVolume(snd_MusicVolume);
+  S_RestartMusic();
 }
 
 setup_menu_t gen_settings1[] = { // General Settings screen1
@@ -3928,8 +3937,8 @@ setup_menu_t gen_settings1[] = { // General Settings screen1
    M_Y + gen1_fullsnd*M_SPC, {"full_sounds"}},
 
   // [FG] music backend
-  {"MIDI player", S_CHOICE|S_PRGWARN, m_null, M_X,
-   M_Y + gen1_musicbackend*M_SPC, {"midi_player"}, 0, NULL, midi_player_strings},
+  {"MIDI player", S_CHOICE, m_null, M_X,
+   M_Y + gen1_musicbackend*M_SPC, {"midi_player"}, 0, M_SetMIDIPlayer, midi_player_strings},
 
   // Button for resetting to defaults
   {0,S_RESET,m_null,X_BUTTON,Y_BUTTON},

--- a/src/m_menu.h
+++ b/src/m_menu.h
@@ -194,6 +194,8 @@ typedef enum
 extern background_t menu_background;
 extern boolean M_MenuIsShaded(void);
 
+#define MAX_MIDI_PLAYERS 12
+
 #endif    
 
 //----------------------------------------------------------------------------

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -110,6 +110,7 @@ extern boolean screen_melt;
 extern boolean hangsolid;
 extern boolean blockmapfix;
 extern int extra_level_brightness;
+extern int midi_player;
 
 extern char *chat_macros[];  // killough 10/98
 
@@ -2272,16 +2273,16 @@ default_t defaults[] = {
   {
     "midi_player",
     (config_t *) &midi_player, NULL,
-    {0}, {0, num_midi_players-1}, number, ss_gen, wad_no,
+    {0}, {0, MAX_MIDI_PLAYERS}, number, ss_gen, wad_no,
 #if defined(_WIN32)
-    "0 for native MIDI (default), "
+  "MIDI player"
 #else
-    "0 for SDL2_Mixer (default), "
-#endif
-#if defined(HAVE_FLUIDSYNTH)
+    "0 for SDL2 (default), "
+  #if defined(HAVE_FLUIDSYNTH)
     "1 for FluidSynth, 2 for OPL Emulation"
-#else
+  #else
     "1 for OPL Emulation"
+  #endif
 #endif
   },
 


### PR DESCRIPTION
I think "MS GS Wavetable Synth" will be longest MIDI device name for most users, so it's fits:
![woof0000](https://user-images.githubusercontent.com/5077629/205463063-650e937e-36e8-4ab7-a7ef-a6358f80221e.png)
