### PR TITLE
Fix plat infinite sound loop

### DIFF
--- a/src/p_plats.c
+++ b/src/p_plats.c
@@ -368,6 +368,7 @@ int EV_StopPlat(line_t* line)
     plat_t *plat = pl->plat;             // for one with the tag not in stasis
     if (plat->status != in_stasis && plat->tag == line->tag)
     {
+      S_StopLoop((mobj_t *)&plat->sector->soundorg);
       plat->oldstatus = plat->status;    // put it in stasis
       plat->status = in_stasis;
       plat->thinker.function.v = NULL;

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -488,6 +488,27 @@ void S_StopSound(const mobj_t *origin)
    }
 }
 
+//
+// S_StopLoop
+//
+void S_StopLoop(const mobj_t *origin)
+{
+   int cnum;
+
+   //jff 1/22/98 return if sound is not enabled
+   if(nosfxparm)
+      return;
+
+   for(cnum = 0; cnum < numChannels; ++cnum)
+   {
+      if(channels[cnum].sfxinfo && channels[cnum].origin == origin && channels[cnum].loop)
+      {
+         S_StopChannel(cnum);
+         break;
+      }
+   }
+}
+
 // [FG] play sounds in full length
 boolean full_sounds;
 // [FG] removed map objects may finish their sounds

--- a/src/s_sound.h
+++ b/src/s_sound.h
@@ -54,6 +54,7 @@ void S_LoopSound(const mobj_t *origin, int sound_id);
 
 // Stop sound for thing at <origin>
 void S_StopSound(const mobj_t *origin);
+void S_StopLoop(const mobj_t *origin);
 void S_StopLoopSounds(void);
 
 // [FG] play sounds in full length


### PR DESCRIPTION
If a moving plat with a looping sound was interrupted silently (i.e., no sound replaced the looping one), the sound would loop forever. This PR fixes the case with EV_StopPlat. There may be other cases but this was the only one that came to mind. I adopted the dsda-doom implementation of stopping only looping sounds, rather than stopping all sounds, but feel free to change it :^)