### PR TITLE
winmidi: Optimize reset messages, change volume control, add instrument fallback support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,6 +53,7 @@ set(WOOF_SOURCES
     m_snapshot.c           m_snapshot.h
     m_swap.h
     memio.c                memio.h
+    midifallback.c         midifallback.h
     midifile.c             midifile.h
     mus2mid.c              mus2mid.h
     net_client.c           net_client.h

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -605,20 +605,20 @@ static void SendSysExMsg(int time, const byte *data, int length)
     WriteBuffer(data, length);
     WriteBufferPad();
 
-    if (IsMasterVolume(data, length, &master_volume))
-    {
-        // Found a master volume message in the MIDI file. Take this new
-        // value and scale it by the user's volume slider.
-        UpdateVolume(time);
-        return;
-    }
-
     if (is_sysex_reset)
     {
         // SysEx reset also resets master volume. Take the default master
         // volume and scale it by the user's volume slider.
         master_volume = DEFAULT_MASTER_VOLUME;
         UpdateVolume(0);
+        return;
+    }
+
+    if (IsMasterVolume(data, length, &master_volume))
+    {
+        // Found a master volume message in the MIDI file. Take this new
+        // value and scale it by the user's volume slider.
+        UpdateVolume(time);
     }
 }
 

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -764,21 +764,20 @@ static void FillBuffer(void)
             case MIDI_EVENT_PROGRAM_CHANGE:
                 if (fallback.type == FALLBACK_BANK_MSB)
                 {
-                    case FALLBACK_BANK_MSB:
-                        SendShortMsg(delta_time, MIDI_EVENT_CONTROLLER,
-                                     event->data.channel.channel,
-                                     MIDI_CONTROLLER_BANK_SELECT_MSB,
-                                     fallback.value);
-                        SendShortMsg(0, MIDI_EVENT_PROGRAM_CHANGE,
-                                     event->data.channel.channel,
-                                     event->data.channel.param1, 0);
+                    SendShortMsg(delta_time, MIDI_EVENT_CONTROLLER,
+                                 event->data.channel.channel,
+                                 MIDI_CONTROLLER_BANK_SELECT_MSB,
+                                 fallback.value);
+                    SendShortMsg(0, MIDI_EVENT_PROGRAM_CHANGE,
+                                 event->data.channel.channel,
+                                 event->data.channel.param1, 0);
                     break;
                 }
                 else if (fallback.type == FALLBACK_DRUMS)
                 {
                     SendShortMsg(delta_time, MIDI_EVENT_PROGRAM_CHANGE,
-                                    event->data.channel.channel,
-                                    fallback.value, 0);
+                                 event->data.channel.channel,
+                                 fallback.value, 0);
                     break;
                 }
                 // Fall through.

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -58,9 +58,9 @@ static byte master_volume_msg[] = {
 };
 
 #define DEFAULT_MASTER_VOLUME 16383
-static unsigned int master_volume = DEFAULT_MASTER_VOLUME;
+static unsigned int master_volume = 0;
 static int last_volume = -1;
-static float volume_factor = 1.0f;
+static float volume_factor = 0.0f;
 static boolean update_volume = false;
 
 static DWORD timediv;
@@ -718,7 +718,7 @@ static void I_WIN_SetMusicVolume(int volume)
 
     volume_factor = sqrtf((float)volume / 15);
 
-    update_volume = true;
+    update_volume = (song.file != NULL);
 }
 
 static void I_WIN_StopSong(void *handle)

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -562,7 +562,6 @@ static void SendSysExMsg(int time, const byte *data, int length)
         // SysEx reset also resets volume. Take the default channel volumes
         // and scale them by the user's volume slider.
         ResetVolume();
-        return;
     }
 }
 

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -315,8 +315,15 @@ static void ResetDevice(void)
 
     for (i = 0; i < MIDI_CHANNELS_PER_TRACK; ++i)
     {
-        // midiOutReset() sends "all notes off" and "reset all controllers."
+        // Stop sound prior to reset to prevent volume spikes.
+        SendShortMsg(0, MIDI_EVENT_CONTROLLER, i, MIDI_CONTROLLER_ALL_NOTES_OFF, 0);
         SendShortMsg(0, MIDI_EVENT_CONTROLLER, i, MIDI_CONTROLLER_ALL_SOUND_OFF, 0);
+    }
+
+    for (i = 0; i < MIDI_CHANNELS_PER_TRACK; ++i)
+    {
+        // Reset all controllers (see MIDI RP-015 for details).
+        SendShortMsg(0, MIDI_EVENT_CONTROLLER, i, MIDI_CONTROLLER_RESET_ALL_CTRLS, 0);
 
         // Reset pitch bend sensitivity to +/- 2 semitones and 0 cents.
         SendShortMsg(0, MIDI_EVENT_CONTROLLER, i, MIDI_CONTROLLER_RPN_MSB, 0);
@@ -782,11 +789,6 @@ static void I_WIN_StopSong(void *handle)
     if (mmr != MMSYSERR_NOERROR)
     {
         MidiError("midiStreamStop", mmr);
-    }
-    mmr = midiOutReset((HMIDIOUT)hMidiStream);
-    if (mmr != MMSYSERR_NOERROR)
-    {
-        MidiError("midiOutReset", mmr);
     }
 }
 

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -33,7 +33,7 @@
 #include "midifile.h"
 
 int winmm_reset_type = 2;
-int winmm_reset_delay = 100;
+int winmm_reset_delay = 0;
 int winmm_reverb_level = -1;
 int winmm_chorus_level = -1;
 

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -587,14 +587,6 @@ static void SendSysExMsg(int time, const byte *data, int length)
     boolean is_sysex_reset;
     const byte event_type = MIDI_EVENT_SYSEX;
 
-    if (IsMasterVolume(data, length, &master_volume))
-    {
-        // Found a master volume message in the MIDI file. Take this new
-        // value and scale it by the user's volume slider.
-        UpdateVolume(time);
-        return;
-    }
-
     is_sysex_reset = IsSysExReset(data, length);
 
     if (is_sysex_reset && MidiDevice == ms_gs_synth)
@@ -612,6 +604,14 @@ static void SendSysExMsg(int time, const byte *data, int length)
     WriteBuffer(&event_type, sizeof(byte));
     WriteBuffer(data, length);
     WriteBufferPad();
+
+    if (IsMasterVolume(data, length, &master_volume))
+    {
+        // Found a master volume message in the MIDI file. Take this new
+        // value and scale it by the user's volume slider.
+        UpdateVolume(time);
+        return;
+    }
 
     if (is_sysex_reset)
     {

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -526,7 +526,6 @@ static boolean IsSysExReset(const byte *msg, int length)
 
 static void SendSysExMsg(int time, const byte *data, int length)
 {
-    int i;
     native_event_t native_event;
     boolean is_sysex_reset;
     const byte event_type = MIDI_EVENT_SYSEX;

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -2332,7 +2332,7 @@ default_t defaults[] = {
   {
     "winmm_reset_delay",
     (config_t *) &winmm_reset_delay, NULL,
-    {100}, {0, 2000}, number, ss_none, wad_no,
+    {0}, {0, 2000}, number, ss_none, wad_no,
     "Delay after reset for native MIDI (milliseconds)"
   },
 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -2325,8 +2325,8 @@ default_t defaults[] = {
   {
     "winmm_reset_type",
     (config_t *) &winmm_reset_type, NULL,
-    {2}, {0, 4}, number, ss_none, wad_no,
-    "SysEx reset for native MIDI (0 = None, 1 = GS Reset, 2 = GM System On (Default), 3 = GM2 System On, 4 = XG System On"
+    {-1}, {-1, 4}, number, ss_none, wad_no,
+    "SysEx reset for native MIDI (-1 = Default, 0 = None, 1 = GS, 2 = GM, 3 = GM2, 4 = XG)"
   },
 
   {

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -2337,17 +2337,17 @@ default_t defaults[] = {
   },
 
   {
-    "winmm_chorus_level",
-    (config_t *) &winmm_chorus_level, NULL,
-    {0}, {0, 127}, number, ss_none, wad_no,
-    "fine tune default chorus level for native MIDI"
+    "winmm_reverb_level",
+    (config_t *) &winmm_reverb_level, NULL,
+    {-1}, {-1, 127}, number, ss_none, wad_no,
+    "Reverb send level for native MIDI (-1 = Default, 0 = Off, 127 = Max)"
   },
 
   {
-    "winmm_reverb_level",
-    (config_t *) &winmm_reverb_level, NULL,
-    {40}, {0, 127}, number, ss_none, wad_no,
-    "fine tune default reverb level for native MIDI"
+    "winmm_chorus_level",
+    (config_t *) &winmm_chorus_level, NULL,
+    {-1}, {-1, 127}, number, ss_none, wad_no,
+    "Chorus send level for native MIDI (-1 = Default, 0 = Off, 127 = Max)"
   },
 #endif
 

--- a/src/midifallback.c
+++ b/src/midifallback.c
@@ -97,7 +97,7 @@ void MIDI_CheckFallback(midi_event_t *event, midi_fallback_t *fallback)
     byte idx;
     unsigned int *program;
 
-    switch (event->event_type)
+    switch ((int)event->event_type)
     {
         case MIDI_EVENT_SYSEX:
             UpdateDrumMap(event->data.sysex.data, event->data.sysex.length);

--- a/src/midifallback.c
+++ b/src/midifallback.c
@@ -1,0 +1,345 @@
+//
+// Copyright(C) 2022 ceski
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//      MIDI instrument fallback support
+//
+
+
+#include <stdlib.h>
+#include "doomtype.h"
+#include "midifile.h"
+#include "midifallback.h"
+
+static const byte drums_table[128] = {
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
+    0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10,
+    0x18, 0x19, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18,
+    0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+    0x28, 0x28, 0x28, 0x28, 0x28, 0x28, 0x28, 0x28,
+    0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30,
+    0x38, 0x38, 0x38, 0x38, 0x38, 0x38, 0x38, 0x38,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x7F
+};
+
+static byte variation[128][128];
+static byte bank_msb[MIDI_CHANNELS_PER_TRACK];
+static byte drum_map[MIDI_CHANNELS_PER_TRACK];
+static boolean selected[MIDI_CHANNELS_PER_TRACK];
+
+static void UpdateDrumMap(byte *msg, unsigned int length)
+{
+    byte idx;
+    byte checksum;
+
+    // GS allows drums on any channel using SysEx messages.
+    // The message format is F0 followed by:
+    //
+    // 41 10 42 12 40 <ch> 15 <map> <sum> F7
+    //
+    // <ch> is [11-19, 10, 1A-1F] for channels 1-16. Note the position of 10.
+    // <map> is 00-02 for off (normal part), drum map 1, or drum map 2.
+    // <sum> is checksum.
+
+    if (length == 10 &&
+        msg[0] == 0x41 && // Roland
+        msg[1] == 0x10 && // Device ID
+        msg[2] == 0x42 && // GS
+        msg[3] == 0x12 && // DT1
+        msg[4] == 0x40 && // Address MSB
+        msg[6] == 0x15 && // Address LSB
+        msg[9] == 0xF7)   // SysEx EOX
+    {
+        checksum = 128 - ((int)msg[4] + msg[5] + msg[6] + msg[7]) % 128;
+
+        if (msg[8] != checksum)
+        {
+            return;
+        }
+
+        if (msg[5] == 0x10) // Channel 10
+        {
+            idx = 9;
+        }
+        else if (msg[5] < 0x1A) // Channels 1-9
+        {
+            idx = (msg[5] & 0x0F) - 1;
+        }
+        else // Channels 11-16
+        {
+            idx = msg[5] & 0x0F;
+        }
+
+        drum_map[idx] = msg[7];
+    }
+}
+
+void MIDI_CheckFallback(midi_event_t *event, midi_fallback_t *fallback)
+{
+    byte idx;
+    unsigned int *program;
+
+    switch (event->event_type)
+    {
+        case MIDI_EVENT_SYSEX:
+            UpdateDrumMap(event->data.sysex.data, event->data.sysex.length);
+            break;
+
+        case MIDI_EVENT_CONTROLLER:
+            idx = event->data.channel.channel;
+            switch (event->data.channel.param1)
+            {
+                case MIDI_CONTROLLER_BANK_SELECT_MSB:
+                    bank_msb[idx] = event->data.channel.param2;
+                    selected[idx] = false;
+                    break;
+
+                case MIDI_CONTROLLER_BANK_SELECT_LSB:
+                    selected[idx] = false;
+                    if (event->data.channel.param2 > 0)
+                    {
+                        // Bank select LSB > 0 not supported. This also
+                        // preserves user's current SC-XX map.
+                        fallback->type = FALLBACK_BANK_LSB;
+                        fallback->value = 0;
+                        return;
+                    }
+                    break;
+            }
+            break;
+
+        case MIDI_EVENT_PROGRAM_CHANGE:
+            idx = event->data.channel.channel;
+            program = &event->data.channel.param1;
+            if (drum_map[idx] == 0) // Normal channel
+            {
+                if (bank_msb[idx] == 0 || variation[bank_msb[idx]][*program])
+                {
+                    // Found a capital or variation for this bank select MSB.
+                    selected[idx] = true;
+                    break;
+                }
+
+                fallback->type = FALLBACK_BANK_MSB;
+
+                if (!selected[idx] || bank_msb[idx] > 63)
+                {
+                    // Fall to capital when no instrument has (successfully)
+                    // selected this variation or if the variation is above 63.
+                    fallback->value = 0;
+                    return;
+                }
+
+                // A previous instrument used this variation but it's not
+                // valid for the current instrument. Fall to the next valid
+                // "sub-capital" (next variation that is a multiple of 8).
+                fallback->value = (bank_msb[idx] / 8) * 8;
+                while (fallback->value > 0)
+                {
+                    if (variation[fallback->value][*program])
+                    {
+                        break;
+                    }
+                    fallback->value -= 8;
+                }
+                return;
+            }
+            else // Drums channel
+            {
+                if (*program != drums_table[*program])
+                {
+                    // Use drum set from drums fallback table.
+                    // Drums 0-63 and 127: same as original SC-55 (1.00 - 1.21).
+                    // Drums 64-126: standard drum set (0).
+                    fallback->type = FALLBACK_DRUMS;
+                    fallback->value = drums_table[*program];
+                    selected[idx] = true;
+                    return;
+                }
+            }
+            break;
+    }
+
+    fallback->type = FALLBACK_NONE;
+    fallback->value = 0xFF;
+}
+
+void MIDI_ResetFallback(void)
+{
+    int i;
+
+    for (i = 0; i < MIDI_CHANNELS_PER_TRACK; i++)
+    {
+        bank_msb[i] = 0;
+        drum_map[i] = 0;
+        selected[i] = false;
+    }
+
+    // Channel 10 (index 9) is set to drum map 1 by default.
+    drum_map[9] = 1;
+}
+
+void MIDI_InitFallback(void)
+{
+    int program;
+
+    MIDI_ResetFallback();
+
+    // Capital
+    for (program = 0; program < 128; program++)
+    {
+        variation[0][program] = 1;
+    }
+
+    // Variation #1
+    variation[1][38] = 1;
+    variation[1][57] = 1;
+    variation[1][60] = 1;
+    variation[1][80] = 1;
+    variation[1][81] = 1;
+    variation[1][98] = 1;
+    variation[1][102] = 1;
+    variation[1][104] = 1;
+    variation[1][120] = 1;
+    variation[1][121] = 1;
+    variation[1][122] = 1;
+    variation[1][123] = 1;
+    variation[1][124] = 1;
+    variation[1][125] = 1;
+    variation[1][126] = 1;
+    variation[1][127] = 1;
+
+    // Variation #2
+    variation[2][102] = 1;
+    variation[2][120] = 1;
+    variation[2][122] = 1;
+    variation[2][123] = 1;
+    variation[2][124] = 1;
+    variation[2][125] = 1;
+    variation[2][126] = 1;
+    variation[2][127] = 1;
+
+    // Variation #3
+    variation[3][122] = 1;
+    variation[3][123] = 1;
+    variation[3][124] = 1;
+    variation[3][125] = 1;
+    variation[3][126] = 1;
+    variation[3][127] = 1;
+
+    // Variation #4
+    variation[4][122] = 1;
+    variation[4][124] = 1;
+    variation[4][125] = 1;
+    variation[4][126] = 1;
+
+    // Variation #5
+    variation[5][122] = 1;
+    variation[5][124] = 1;
+    variation[5][125] = 1;
+    variation[5][126] = 1;
+
+    // Variation #6
+    variation[6][125] = 1;
+
+    // Variation #7
+    variation[7][125] = 1;
+
+    // Variation #8
+    variation[8][0] = 1;
+    variation[8][1] = 1;
+    variation[8][2] = 1;
+    variation[8][3] = 1;
+    variation[8][4] = 1;
+    variation[8][5] = 1;
+    variation[8][6] = 1;
+    variation[8][11] = 1;
+    variation[8][12] = 1;
+    variation[8][14] = 1;
+    variation[8][16] = 1;
+    variation[8][17] = 1;
+    variation[8][19] = 1;
+    variation[8][21] = 1;
+    variation[8][24] = 1;
+    variation[8][25] = 1;
+    variation[8][26] = 1;
+    variation[8][27] = 1;
+    variation[8][28] = 1;
+    variation[8][30] = 1;
+    variation[8][31] = 1;
+    variation[8][38] = 1;
+    variation[8][39] = 1;
+    variation[8][40] = 1;
+    variation[8][48] = 1;
+    variation[8][50] = 1;
+    variation[8][61] = 1;
+    variation[8][62] = 1;
+    variation[8][63] = 1;
+    variation[8][80] = 1;
+    variation[8][81] = 1;
+    variation[8][107] = 1;
+    variation[8][115] = 1;
+    variation[8][116] = 1;
+    variation[8][117] = 1;
+    variation[8][118] = 1;
+    variation[8][125] = 1;
+
+    // Variation #9
+    variation[9][14] = 1;
+    variation[9][118] = 1;
+    variation[9][125] = 1;
+
+    // Variation #16
+    variation[16][0] = 1;
+    variation[16][4] = 1;
+    variation[16][5] = 1;
+    variation[16][6] = 1;
+    variation[16][16] = 1;
+    variation[16][19] = 1;
+    variation[16][24] = 1;
+    variation[16][25] = 1;
+    variation[16][28] = 1;
+    variation[16][39] = 1;
+    variation[16][62] = 1;
+    variation[16][63] = 1;
+
+    // Variation #24
+    variation[24][4] = 1;
+    variation[24][6] = 1;
+
+    // Variation #32
+    variation[32][16] = 1;
+    variation[32][17] = 1;
+    variation[32][24] = 1;
+    variation[32][52] = 1;
+
+    // CM-64 Map (PCM)
+    for (program = 0; program < 64; program++)
+    {
+        variation[126][program] = 1;
+    }
+
+    // CM-64 Map (LA)
+    for (program = 0; program < 128; program++)
+    {
+        variation[127][program] = 1;
+    }
+}

--- a/src/midifallback.h
+++ b/src/midifallback.h
@@ -1,0 +1,38 @@
+//
+// Copyright(C) 2022 ceski
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//      MIDI instrument fallback support
+//
+
+
+#include "doomtype.h"
+#include "midifile.h"
+
+typedef enum midi_fallback_type_t
+{
+    FALLBACK_NONE,
+    FALLBACK_BANK_MSB,
+    FALLBACK_BANK_LSB,
+    FALLBACK_DRUMS,
+} midi_fallback_type_t;
+
+typedef struct midi_fallback_t
+{
+    midi_fallback_type_t type;
+    byte value;
+} midi_fallback_t;
+
+void MIDI_CheckFallback(midi_event_t *event, midi_fallback_t *fallback);
+void MIDI_ResetFallback(void);
+void MIDI_InitFallback(void);


### PR DESCRIPTION
This is a round-up of changes for native MIDI.

Edit: I also have capital tone fallback emulation ready which will allow MS GS Wavetable Synth, Roland SCVA, and Roland SC-55mkII and later devices to run in GS mode without any issues (e.g. MAYhem19.wad's title music with illegal bank select MSB messages).