### PR TITLE
fall back to `module 0 device 0` if the music module failed to initialize

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -2502,7 +2502,8 @@ void D_DoomMain(void)
   I_InitTimer();
   I_InitJoystick();
   I_InitSound();
-  I_InitMusic(midi_player);
+  I_InitMusic();
+  M_GetMidiDevices();
 
   puts("NET_Init: Init network subsystem.");
   NET_Init();

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -807,11 +807,15 @@ void I_SetMidiPlayer(int device)
         accum += num_devices;
     }
 
-    if (midi_player_module)
+    if (!midi_player_module->I_InitMusic(device))
     {
-        midi_player_module->I_InitMusic(device);
-        active_module = midi_player_module;
+        midi_player_module = music_modules[0].module;
+        if (midi_player_module != &music_sdl_module)
+        {
+            midi_player_module->I_InitMusic(0);
+        }
     }
+    active_module = midi_player_module;
 }
 
 boolean I_InitMusic(void)

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -110,12 +110,14 @@ typedef struct
     int (*I_DeviceList)(const char *devices[], int size, int *current_device);
 } music_module_t;
 
-boolean I_InitMusic(int device);
+extern int midi_player;
+
+boolean I_InitMusic(void);
 void I_ShutdownMusic(void);
 
 #define DEFAULT_MIDI_DEVICE -1 // use saved music module device
 
-void I_SetMidiPlayer(int *music_module_index, int device);
+void I_SetMidiPlayer(int device);
 
 // Volume.
 void I_SetMusicVolume(int volume);
@@ -139,8 +141,7 @@ void I_StopSong(void *handle);
 // See above (register), then think backwards
 void I_UnRegisterSong(void *handle);
 
-int I_DeviceList(const char *devices[], int size, int music_module_index,
-                 int *current_device);
+int I_DeviceList(const char *devices[], int size, int *current_device);
 
 // Determine whether memory block is a .mid file
 boolean IsMid(byte *mem, int len);

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -3871,11 +3871,9 @@ enum {
   gen1_end2,
 };
 
-int midi_player;
-
 int midi_player_menu;
 
-static const char *midi_player_menu_strings[MAX_MIDI_PLAYERS];
+static const char *midi_player_menu_strings[MAX_MIDI_PLAYER_MENU_ITEMS];
 
 void static M_SmoothLight(void)
 {
@@ -3909,7 +3907,7 @@ static void M_ResetGamma(void)
 static void M_SetMidiPlayer(void)
 {
   S_StopMusic();
-  I_SetMidiPlayer(&midi_player, midi_player_menu);
+  I_SetMidiPlayer(midi_player_menu);
   S_SetMusicVolume(snd_MusicVolume);
   S_RestartMusic();
 }
@@ -6908,10 +6906,10 @@ void M_InitHelpScreen()
     }
 }
 
-static void M_GetMidiDevices(void)
+void M_GetMidiDevices(void)
 {
-  int numdev = I_DeviceList(midi_player_menu_strings, MAX_MIDI_PLAYERS - 1,
-        midi_player, &midi_player_menu);
+  int numdev = I_DeviceList(midi_player_menu_strings,
+        MAX_MIDI_PLAYER_MENU_ITEMS - 1, &midi_player_menu);
 
   midi_player_menu_strings[numdev] = NULL;
 }
@@ -6921,8 +6919,6 @@ static void M_GetMidiDevices(void)
 //
 void M_Init(void)
 {
-  M_GetMidiDevices();
-
   M_InitDefaults();                // killough 11/98
   currentMenu = &MainDef;
   menuactive = 0;

--- a/src/m_menu.h
+++ b/src/m_menu.h
@@ -198,8 +198,8 @@ typedef enum
 extern background_t menu_background;
 extern boolean M_MenuIsShaded(void);
 
-extern int midi_player;
-#define MAX_MIDI_PLAYERS 16
+#define MAX_MIDI_PLAYER_MENU_ITEMS 16
+extern void M_GetMidiDevices(void);
 
 #endif    
 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -2293,7 +2293,7 @@ default_t defaults[] = {
   {
     "midi_player_menu",
     (config_t *) &midi_player_menu, NULL,
-    {0}, {0, MAX_MIDI_PLAYERS - 1}, number, ss_gen, wad_no,
+    {0}, {0, MAX_MIDI_PLAYER_MENU_ITEMS - 1}, number, ss_gen, wad_no,
     "MIDI Player menu index"
   },
 


### PR DESCRIPTION
Remove `music_module_index`, use `midi_player` instead - it's global anyway.