### PR TITLE
fix wrong `m_flags` checks

### DIFF
--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -2344,7 +2344,7 @@ void M_DrawSetting(setup_menu_t* s)
 
   // Is the item a paint chip?
 
-  if (flags & S_COLOR) // Automap paint chip
+  if (flags & S_AM_COLOR) // Automap paint chip
     {
       int i, ch;
       byte *ptr = colorblock;

--- a/src/m_menu.h
+++ b/src/m_menu.h
@@ -134,7 +134,7 @@ extern int warning_about_changes, print_warning_about_changes;
 
 #define S_SHOWSET  (S_YESNO|S_CRITEM|S_COLOR|S_CHAT|S_INPUT|S_WEAP|S_NUM|S_CHOICE|S_THERMO|S_NAME)
 
-#define S_STRING (S_CHAT|S_NAME)
+#define S_STRING (S_CHAT_MACRO|S_NAME)
 
 #define S_HASDEFPTR (S_STRING|S_YESNO|S_NUM|S_WEAP|S_COLOR|S_CRITEM|S_CHOICE|S_THERMO)
 


### PR DESCRIPTION
Fixes colored automap chips appearing in the wrong menus. Bug report: [[doomworld]](https://www.doomworld.com/forum/topic/112333-this-is-woof-1050-dec-21-2022-updated-winmbf/?do=findComment&comment=2586612)
