### PR TITLE
winmidi: Wait for stream when hot swapping modules

### DIFF
--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -1451,6 +1451,11 @@ static void I_WIN_ShutdownMusic(void)
 
     if (buffer.data)
     {
+        while (MidiStreamHdr.dwFlags & MHDR_INQUEUE)
+        {
+            Sleep(10);
+        }
+
         mmr = midiOutUnprepareHeader((HMIDIOUT)hMidiStream, &MidiStreamHdr,
                                      sizeof(MIDIHDR));
         if (mmr != MMSYSERR_NOERROR)

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -1451,11 +1451,7 @@ static void I_WIN_ShutdownMusic(void)
 
     if (buffer.data)
     {
-        while (MidiStreamHdr.dwFlags & MHDR_INQUEUE)
-        {
-            Sleep(10);
-        }
-
+        MidiStreamHdr.dwFlags &= ~MHDR_INQUEUE;
         mmr = midiOutUnprepareHeader((HMIDIOUT)hMidiStream, &MidiStreamHdr,
                                      sizeof(MIDIHDR));
         if (mmr != MMSYSERR_NOERROR)


### PR DESCRIPTION
When the winmidi module is shut down, Windows doesn't always immediately clear the `MHDR_INQUEUE` flag, even after `midiStreamStop()` is called. I guess Windows decides to hold onto the buffer a bit longer sometimes. Calling `midiOutUnprepareHeader()` at the wrong moment causes an error and freezes the game. This can be reproduced by switching music players a few times. A simple workaround is to wait until the flag is cleared. There may be a better solution but this works for now. Both Wine and PortMidi appear to make references to this, so I guess it's a known issue. I can't make the error occur when switching songs even though it may have the same issue.

https://user-images.githubusercontent.com/56656010/209710126-d4d6632a-1bf6-4a75-a3ec-6abc9b835c87.mp4

