### PR TITLE
enable MSVC CI for push requests

### DIFF
--- a/.github/workflows/win_msvc.yml
+++ b/.github/workflows/win_msvc.yml
@@ -1,10 +1,12 @@
-name: windows build
+name: artifacts
 
 on:
   push:
     branches: [ master ]
     tags: ['*']
     paths-ignore: ['**.md']
+  pull_request:
+    branches: [ master ]
 
 env:
   VCPKG_ROOT: C:\vcpkg


### PR DESCRIPTION
The author of the push request can change the workflow files anyway, so there is no point in limiting it. We have to be careful with PRs that change vcpkg.json or win_msvc.yml