### PR TITLE
add "linear" resampling mode and make it the default instead of "default"

### DIFF
--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -2268,8 +2268,8 @@ default_t defaults[] = {
   {
     "snd_resampling_mode",
     (config_t *) &snd_resampling_mode, NULL,
-    {.s = "default"}, {0}, string, ss_none, wad_no,
-    "audio resampling mode (\"default\", \"fast\", \"medium\", \"best\")"
+    {.s = "linear"}, {0}, string, ss_none, wad_no,
+    "audio resampling mode (\"default\", \"linear\" (default), \"fast\", \"medium\", \"best\")"
   },
 
   // [FG] play sounds in full length


### PR DESCRIPTION
Fixes #884 