### PR TITLE
fix desync due to randomly mirrored corpses feature

### DIFF
--- a/src/p_inter.c
+++ b/src/p_inter.c
@@ -753,7 +753,10 @@ static void P_KillMobj(mobj_t *source, mobj_t *target)
   // [crispy] randomly flip corpse, blood and death animation sprites
   if (target->flags2 & MF2_FLIPPABLE)
   {
-    target->health = (target->health & (int)~1) - (Woof_Random() & 1);
+    if (Woof_Random() & 1)
+      target->intflags |= MIF_FLIP;
+    else
+      target->intflags &= ~MIF_FLIP;
   }
 
   if (target->tics < 1)

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -872,7 +872,10 @@ mobj_t *P_SpawnMobj(fixed_t x, fixed_t y, fixed_t z, mobjtype_t type)
   // [crispy] randomly flip corpse, blood and death animation sprites
   if (mobj->flags2 & MF2_FLIPPABLE && !(mobj->flags & MF_SHOOTABLE))
   {
-    mobj->health = (mobj->health & (int)~1) - (Woof_Random() & 1);
+    if (Woof_Random() & 1)
+      mobj->intflags |= MIF_FLIP;
+    else
+      mobj->intflags &= ~MIF_FLIP;
   }
 
   P_AddThinker(&mobj->thinker);

--- a/src/p_mobj.h
+++ b/src/p_mobj.h
@@ -240,7 +240,8 @@ enum {
   MIF_LINEDONE = 4,     // Object has activated W1 or S1 linedef via DEH frame
   // mbf21
   MIF_SCROLLING = 8,    // Object is affected by scroller / pusher / puller
-  MIF_FLIP = 10,
+  // cosmetic
+  MIF_FLIP = 16,
 };
 
 // Map Object definition.

--- a/src/p_mobj.h
+++ b/src/p_mobj.h
@@ -240,6 +240,7 @@ enum {
   MIF_LINEDONE = 4,     // Object has activated W1 or S1 linedef via DEH frame
   // mbf21
   MIF_SCROLLING = 8,    // Object is affected by scroller / pusher / puller
+  MIF_FLIP = 10,
 };
 
 // Map Object definition.

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -544,7 +544,7 @@ void R_ProjectSprite (mobj_t* thing)
   if (STRICTMODE(flipcorpses) &&
       (thing->flags2 & MF2_FLIPPABLE) &&
       !(thing->flags & MF_SHOOTABLE) &&
-      (thing->health & 1))
+      (thing->intflags & MIF_FLIP))
     {
       flip = !flip;
     }


### PR DESCRIPTION
[DBP31.wad](https://www.doomworld.com/idgames/themes/xmas/dbp31) has a DEHACKED lump that sets MT_KEEN spawnhealth to 1.
Crispy works because the `flags` are reset to 0, we added the `flags2` field in Woof with `MF2_FLIPPED`.