### PR TITLE
Disable menu items with flags

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -2319,6 +2319,8 @@ void D_DoomMain(void)
 
   PostProcessDeh();
 
+  D_ProcessInWads("BRGHTMPS", R_ParseBrightmaps, false);
+
   putchar('\n');     // killough 3/6/98: add a newline, by popular demand :)
 
   // Moved after WAD initialization because we are checking the COMPLVL lump
@@ -2349,8 +2351,6 @@ void D_DoomMain(void)
     }
 
   D_ProcessInWads("UMAPDEF", U_ParseMapDefInfo, false);
-
-  D_ProcessInWads("BRGHTMPS", R_ParseBrightmaps, false);
 
   //!
   // @category mod

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -768,7 +768,6 @@ static void G_DoLoadLevel(void)
    }
 
   critical = (gameaction == ga_playdemo || demorecording || demoplayback || D_CheckNetConnect());
-  M_UpdateCriticalItems();
 
   // [crispy] pistol start
   if (CRITICAL(pistolstart))

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -2146,7 +2146,7 @@ void M_DrawItem(setup_menu_t* s)
 {
   int x = s->m_x;
   int y = s->m_y;
-  uint32_t flags = s->m_flags;
+  int flags = s->m_flags;
   if (flags & S_RESET)
 
     // This item is the reset button
@@ -2238,8 +2238,7 @@ static void M_DrawMiniThermo(int x, int y, int size, int dot, char *color)
 
 void M_DrawSetting(setup_menu_t* s)
 {
-  int x = s->m_x, y = s->m_y, color;
-  uint32_t flags = s->m_flags;
+  int x = s->m_x, y = s->m_y, color, flags = s->m_flags;
 
   // Determine color of the text. This may or may not be used
   // later, depending on whether the item is a text string or not.
@@ -2348,7 +2347,7 @@ void M_DrawSetting(setup_menu_t* s)
 
   // Is the item a paint chip?
 
-  if (flags & S_AM_COLOR) // Automap paint chip
+  if (flags & S_COLOR) // Automap paint chip
     {
       int i, ch;
       byte *ptr = colorblock;
@@ -2635,7 +2634,7 @@ static void M_DrawDelVerify(void)
 void M_DrawInstructions()
 {
   default_t *def = current_setup_menu[set_menu_itemon].var.def;
-  uint32_t flags = current_setup_menu[set_menu_itemon].m_flags;
+  int flags = current_setup_menu[set_menu_itemon].m_flags;
 
   if (ItemDisabled(flags))
     return;
@@ -2676,8 +2675,7 @@ void M_DrawInstructions()
       flags & S_WEAP   ? (s = "Enter weapon number", 97)                     :
       flags & S_NUM    ? (s = "Enter value. Press ENTER when finished.", 37) :
       flags & S_COLOR  ? (s = "Select color and press enter", 70)            :
-      flags & S_CHAT   ? (s = "Type/edit chat string and Press ENTER", 43)   :
-      flags & S_NAME   ? (s = "Type/edit player name and Press ENTER", 43)   :
+      flags & S_STRING ? (s = "Type/edit and Press ENTER", 78)               :
       flags & S_RESET  ? 43 : 0  /* when you're changing something */        :
       flags & S_RESET  ? (s = "Press ENTER key to reset to defaults", 43)    :
       // [FG] clear key bindings with the DEL key
@@ -3541,18 +3539,18 @@ enum {
 
 setup_menu_t auto_settings2[] =  // 2nd AutoMap Settings screen
 {
-  {"background"                         ,S_COLOR,m_null,M_X,M_Y,                      {"mapcolor_back"}},
-  {"grid lines"                         ,S_COLOR,m_null,M_X,M_Y+auto2_col_grid*M_SPC, {"mapcolor_grid"}},
-  {"normal 1s wall"                     ,S_COLOR,m_null,M_X,M_Y+auto2_col_wall*M_SPC, {"mapcolor_wall"}},
-  {"line at floor height change"        ,S_COLOR,m_null,M_X,M_Y+auto2_col_fchg*M_SPC, {"mapcolor_fchg"}},
-  {"line at ceiling height change"      ,S_COLOR,m_null,M_X,M_Y+auto2_col_cchg*M_SPC, {"mapcolor_cchg"}},
-  {"line at sector with floor = ceiling",S_COLOR,m_null,M_X,M_Y+auto2_col_clsd*M_SPC, {"mapcolor_clsd"}},
-  {"red key"                            ,S_COLOR,m_null,M_X,M_Y+auto2_col_rkey*M_SPC, {"mapcolor_rkey"}},
-  {"blue key"                           ,S_COLOR,m_null,M_X,M_Y+auto2_col_bkey*M_SPC, {"mapcolor_bkey"}},
-  {"yellow key"                         ,S_COLOR,m_null,M_X,M_Y+auto2_col_ykey*M_SPC, {"mapcolor_ykey"}},
-  {"red door"                           ,S_COLOR,m_null,M_X,M_Y+auto2_col_rdor*M_SPC, {"mapcolor_rdor"}},
-  {"blue door"                          ,S_COLOR,m_null,M_X,M_Y+auto2_col_bdor*M_SPC, {"mapcolor_bdor"}},
-  {"yellow door"                        ,S_COLOR,m_null,M_X,M_Y+auto2_col_ydor*M_SPC, {"mapcolor_ydor"}},
+  {"background"                         ,S_COLOR|S_COSMETIC,m_null,M_X,M_Y,                      {"mapcolor_back"}},
+  {"grid lines"                         ,S_COLOR|S_COSMETIC,m_null,M_X,M_Y+auto2_col_grid*M_SPC, {"mapcolor_grid"}},
+  {"normal 1s wall"                     ,S_COLOR|S_COSMETIC,m_null,M_X,M_Y+auto2_col_wall*M_SPC, {"mapcolor_wall"}},
+  {"line at floor height change"        ,S_COLOR|S_COSMETIC,m_null,M_X,M_Y+auto2_col_fchg*M_SPC, {"mapcolor_fchg"}},
+  {"line at ceiling height change"      ,S_COLOR|S_COSMETIC,m_null,M_X,M_Y+auto2_col_cchg*M_SPC, {"mapcolor_cchg"}},
+  {"line at sector with floor = ceiling",S_COLOR|S_COSMETIC,m_null,M_X,M_Y+auto2_col_clsd*M_SPC, {"mapcolor_clsd"}},
+  {"red key"                            ,S_COLOR|S_COSMETIC,m_null,M_X,M_Y+auto2_col_rkey*M_SPC, {"mapcolor_rkey"}},
+  {"blue key"                           ,S_COLOR|S_COSMETIC,m_null,M_X,M_Y+auto2_col_bkey*M_SPC, {"mapcolor_bkey"}},
+  {"yellow key"                         ,S_COLOR|S_COSMETIC,m_null,M_X,M_Y+auto2_col_ykey*M_SPC, {"mapcolor_ykey"}},
+  {"red door"                           ,S_COLOR|S_COSMETIC,m_null,M_X,M_Y+auto2_col_rdor*M_SPC, {"mapcolor_rdor"}},
+  {"blue door"                          ,S_COLOR|S_COSMETIC,m_null,M_X,M_Y+auto2_col_bdor*M_SPC, {"mapcolor_bdor"}},
+  {"yellow door"                        ,S_COLOR|S_COSMETIC,m_null,M_X,M_Y+auto2_col_ydor*M_SPC, {"mapcolor_ydor"}},
 
   {"",S_SKIP,m_null,M_X,M_Y+auto2_stub1*M_SPC},
 
@@ -3587,23 +3585,23 @@ enum {
 
 setup_menu_t auto_settings3[] =  // 3rd AutoMap Settings screen
 {
-  {"teleporter line"                ,S_COLOR ,m_null,M_X,M_Y,                      {"mapcolor_tele"}},
-  {"secret sector boundary"         ,S_COLOR ,m_null,M_X,M_Y+auto3_col_secr*M_SPC, {"mapcolor_secr"}},
+  {"teleporter line"                ,S_COLOR|S_COSMETIC ,m_null,M_X,M_Y,                      {"mapcolor_tele"}},
+  {"secret sector boundary"         ,S_COLOR|S_COSMETIC ,m_null,M_X,M_Y+auto3_col_secr*M_SPC, {"mapcolor_secr"}},
   //jff 4/23/98 add exit line to automap
-  {"exit line"                      ,S_COLOR ,m_null,M_X,M_Y+auto3_col_exit*M_SPC, {"mapcolor_exit"}},
-  {"computer map unseen line"       ,S_COLOR ,m_null,M_X,M_Y+auto3_col_unsn*M_SPC, {"mapcolor_unsn"}},
-  {"line w/no floor/ceiling changes",S_COLOR ,m_null,M_X,M_Y+auto3_col_flat*M_SPC, {"mapcolor_flat"}},
-  {"general sprite"                 ,S_COLOR ,m_null,M_X,M_Y+auto3_col_sprt*M_SPC, {"mapcolor_sprt"}},
-  {"crosshair"                      ,S_COLOR ,m_null,M_X,M_Y+auto3_col_hair*M_SPC, {"mapcolor_hair"}},
-  {"single player arrow"            ,S_COLOR ,m_null,M_X,M_Y+auto3_col_sngl*M_SPC, {"mapcolor_sngl"}},
-  {"player 1 arrow"                 ,S_COLOR ,m_null,M_X,M_Y+auto3_col_ply1*M_SPC, {"mapcolor_ply1"}},
-  {"player 2 arrow"                 ,S_COLOR ,m_null,M_X,M_Y+auto3_col_ply2*M_SPC, {"mapcolor_ply2"}},
-  {"player 3 arrow"                 ,S_COLOR ,m_null,M_X,M_Y+auto3_col_ply3*M_SPC, {"mapcolor_ply3"}},
-  {"player 4 arrow"                 ,S_COLOR ,m_null,M_X,M_Y+auto3_col_ply4*M_SPC, {"mapcolor_ply4"}},
+  {"exit line"                      ,S_COLOR|S_COSMETIC ,m_null,M_X,M_Y+auto3_col_exit*M_SPC, {"mapcolor_exit"}},
+  {"computer map unseen line"       ,S_COLOR|S_COSMETIC ,m_null,M_X,M_Y+auto3_col_unsn*M_SPC, {"mapcolor_unsn"}},
+  {"line w/no floor/ceiling changes",S_COLOR|S_COSMETIC ,m_null,M_X,M_Y+auto3_col_flat*M_SPC, {"mapcolor_flat"}},
+  {"general sprite"                 ,S_COLOR|S_COSMETIC ,m_null,M_X,M_Y+auto3_col_sprt*M_SPC, {"mapcolor_sprt"}},
+  {"crosshair"                      ,S_COLOR|S_COSMETIC ,m_null,M_X,M_Y+auto3_col_hair*M_SPC, {"mapcolor_hair"}},
+  {"single player arrow"            ,S_COLOR|S_COSMETIC ,m_null,M_X,M_Y+auto3_col_sngl*M_SPC, {"mapcolor_sngl"}},
+  {"player 1 arrow"                 ,S_COLOR|S_COSMETIC ,m_null,M_X,M_Y+auto3_col_ply1*M_SPC, {"mapcolor_ply1"}},
+  {"player 2 arrow"                 ,S_COLOR|S_COSMETIC ,m_null,M_X,M_Y+auto3_col_ply2*M_SPC, {"mapcolor_ply2"}},
+  {"player 3 arrow"                 ,S_COLOR|S_COSMETIC ,m_null,M_X,M_Y+auto3_col_ply3*M_SPC, {"mapcolor_ply3"}},
+  {"player 4 arrow"                 ,S_COLOR|S_COSMETIC ,m_null,M_X,M_Y+auto3_col_ply4*M_SPC, {"mapcolor_ply4"}},
 
   {"",S_SKIP,m_null,M_X,M_Y+auto3_stub1*M_SPC},
 
-  {"friends"                        ,S_COLOR ,m_null,M_X,M_Y+auto3_col_frnd*M_SPC, {"mapcolor_frnd"}}, // killough 8/8/98
+  {"friends"                        ,S_COLOR|S_COSMETIC ,m_null,M_X,M_Y+auto3_col_frnd*M_SPC, {"mapcolor_frnd"}}, // killough 8/8/98
 
   {"<- PREV",S_SKIP|S_PREV,m_null,M_X_PREV,M_Y_PREVNEXT, {auto_settings2}},
 
@@ -4210,7 +4208,7 @@ setup_menu_t gen_settings4[] = { // General Settings screen4
   {"Default skill level", S_CHOICE|S_LEVWARN, m_null, M_X,
    M_Y + gen4_skill*M_SPC, {"default_skill"}, 0, NULL, default_skill_strings},
 
-  {"Player Name", S_NAME, m_null, M_X,
+  {"Player Name", S_STRING, m_null, M_X,
    M_Y + gen4_playername*M_SPC, {"net_player_name"}},
 
   {"<- PREV",S_SKIP|S_PREV, m_null, M_X_PREV, M_Y_PREVNEXT, {gen_settings3}},
@@ -4606,16 +4604,16 @@ setup_menu_t* chat_settings[] =
 
 setup_menu_t chat_settings1[] =  // Chat Strings screen       
 {
-  {"1",S_CHAT,m_null,CS_X,M_Y, {"chatmacro1"}},
-  {"2",S_CHAT,m_null,CS_X,M_Y+ 1*M_SPC, {"chatmacro2"}},
-  {"3",S_CHAT,m_null,CS_X,M_Y+ 2*M_SPC, {"chatmacro3"}},
-  {"4",S_CHAT,m_null,CS_X,M_Y+ 3*M_SPC, {"chatmacro4"}},
-  {"5",S_CHAT,m_null,CS_X,M_Y+ 4*M_SPC, {"chatmacro5"}},
-  {"6",S_CHAT,m_null,CS_X,M_Y+ 5*M_SPC, {"chatmacro6"}},
-  {"7",S_CHAT,m_null,CS_X,M_Y+ 6*M_SPC, {"chatmacro7"}},
-  {"8",S_CHAT,m_null,CS_X,M_Y+ 7*M_SPC, {"chatmacro8"}},
-  {"9",S_CHAT,m_null,CS_X,M_Y+ 8*M_SPC, {"chatmacro9"}},
-  {"0",S_CHAT,m_null,CS_X,M_Y+ 9*M_SPC, {"chatmacro0"}},
+  {"1",S_STRING|S_COSMETIC,m_null,CS_X,M_Y, {"chatmacro1"}},
+  {"2",S_STRING|S_COSMETIC,m_null,CS_X,M_Y+ 1*M_SPC, {"chatmacro2"}},
+  {"3",S_STRING|S_COSMETIC,m_null,CS_X,M_Y+ 2*M_SPC, {"chatmacro3"}},
+  {"4",S_STRING|S_COSMETIC,m_null,CS_X,M_Y+ 3*M_SPC, {"chatmacro4"}},
+  {"5",S_STRING|S_COSMETIC,m_null,CS_X,M_Y+ 4*M_SPC, {"chatmacro5"}},
+  {"6",S_STRING|S_COSMETIC,m_null,CS_X,M_Y+ 5*M_SPC, {"chatmacro6"}},
+  {"7",S_STRING|S_COSMETIC,m_null,CS_X,M_Y+ 6*M_SPC, {"chatmacro7"}},
+  {"8",S_STRING|S_COSMETIC,m_null,CS_X,M_Y+ 7*M_SPC, {"chatmacro8"}},
+  {"9",S_STRING|S_COSMETIC,m_null,CS_X,M_Y+ 8*M_SPC, {"chatmacro9"}},
+  {"0",S_STRING|S_COSMETIC,m_null,CS_X,M_Y+ 9*M_SPC, {"chatmacro0"}},
 
   // Button for resetting to defaults
   {0,S_RESET,m_null,X_BUTTON,Y_BUTTON},
@@ -6230,7 +6228,7 @@ boolean M_Responder (event_t* ev)
 
       if (action == MENU_ENTER)               
 	{
-	  uint32_t flags = ptr1->m_flags;
+	  int flags = ptr1->m_flags;
 
 	  // You've selected an item to change. Highlight it, post a new
 	  // message about what to do, and get ready to process the
@@ -6249,7 +6247,7 @@ boolean M_Responder (event_t* ev)
 	      print_warning_about_changes = false;
 	      gather_count = 0;
 	    }
-	  else if ((flags & S_COLOR) == S_COLOR)
+	  else if (flags & S_COLOR)
 	    {
 	      int color = ptr1->var.def->location->i;
         

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -4388,6 +4388,12 @@ enum
   comp3_emu4,
 };
 
+static void M_UpdateCriticalItems(void)
+{
+  DISABLE_ITEM(demo_compatibility && overflow[emu_intercepts].enabled,
+               gen_settings3[gen3_blockmapfix]);
+}
+
 setup_menu_t comp_settings3[] =  // Compatibility Settings screen #3
 {
   {"Overflow Emulation", S_SKIP|S_TITLE, m_null, C_X,
@@ -7060,12 +7066,6 @@ void M_ResetSetupMenu(void)
   M_UpdateCenteredWeaponItem();
   M_UpdateMultiLineMsgItem();
   M_UpdateCriticalItems();
-}
-
-void M_UpdateCriticalItems(void)
-{
-  DISABLE_ITEM(demo_compatibility && overflow[emu_intercepts].enabled,
-               gen_settings3[gen3_blockmapfix]);
 }
 
 void M_ResetSetupMenuVideo(void)

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -2238,7 +2238,7 @@ static void M_DrawMiniThermo(int x, int y, int size, int dot, char *color)
 
 void M_DrawSetting(setup_menu_t* s)
 {
-  int x = s->m_x, y = s->m_y, color, flags = s->m_flags;
+  int x = s->m_x, y = s->m_y, flags = s->m_flags, color;
 
   // Determine color of the text. This may or may not be used
   // later, depending on whether the item is a text string or not.

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -63,6 +63,7 @@
 #include "m_argv.h"
 #include "m_snapshot.h"
 #include "i_sound.h"
+#include "r_bmaps.h"
 
 // [crispy] remove DOS reference from the game quit confirmation dialogs
 #include "SDL_platform.h"
@@ -7058,6 +7059,11 @@ void M_ResetSetupMenu(void)
   if (deh_set_blood_color)
   {
     enem_settings1[enem1_colored_blood].m_flags |= S_DISABLE;
+  }
+
+  if (!brightmaps_found || force_brightmaps)
+  {
+    gen_settings2[gen2_brightmaps].m_flags |= S_DISABLE;
   }
 
   DISABLE_ITEM(!comp[comp_vile], enem_settings1[enem1_ghost]);

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -2507,23 +2507,20 @@ void M_DrawScreenItems(setup_menu_t* src)
     int x_warn;
 
     if (warning_about_changes & S_BADVAL)
-      {
-	strcpy(menu_buffer, "Value out of Range");
-      }
+    {
+      strcpy(menu_buffer, "Value out of Range");
+    }
+    else if (warning_about_changes & S_PRGWARN)
+    {
+      strcpy(menu_buffer, "Warning: Program must be restarted to see changes");
+    }
     else
-      if (warning_about_changes & S_PRGWARN)
-	{
-	  strcpy(menu_buffer,
-		 "Warning: Program must be restarted to see changes");
-	}
-      else
-	{
-	  strcpy(menu_buffer,
-		 "Warning: Changes are pending until next game");
-	}
+    {
+      strcpy(menu_buffer, "Warning: Changes are pending until next game");
+    }
 
-      x_warn = ORIGWIDTH/2 - M_GetPixelWidth(menu_buffer)/2;
-      M_DrawMenuString(x_warn, y_warn, CR_RED);
+    x_warn = ORIGWIDTH/2 - M_GetPixelWidth(menu_buffer)/2;
+    M_DrawMenuString(x_warn, y_warn, CR_RED);
   }
 
   while (!(src->m_flags & S_END))

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -2192,28 +2192,28 @@ char gather_buffer[MAXGATHER+1];  // killough 10/98: make input character-based
 // displays the appropriate setting value: yes/no, a key binding, a number,
 // a paint chip, etc.
 
-static void M_DrawMiniThermo(int x, int y, int size, int dot, int color)
+static void M_DrawMiniThermo(int x, int y, int size, int dot, char *color)
 {
   int xx;
   int  i;
   const int step = M_THRM_STEP * M_THRM_SIZE / size;
 
   xx = x;
-  V_DrawPatch(xx, y, 0, W_CacheLumpName("M_MTHRML", PU_CACHE));
+  V_DrawPatchTranslated(xx, y, 0, W_CacheLumpName("M_MTHRML", PU_CACHE), color);
   xx += M_THRM_STEP;
   for (i = 0; i < M_THRM_SIZE; i++)
   {
-    V_DrawPatch(xx, y, 0, W_CacheLumpName("M_MTHRMM", PU_CACHE));
+    V_DrawPatchTranslated(xx, y, 0, W_CacheLumpName("M_MTHRMM", PU_CACHE), color);
     xx += M_THRM_STEP;
   }
-  V_DrawPatch(xx, y, 0, W_CacheLumpName("M_MTHRMR", PU_CACHE));
+  V_DrawPatchTranslated(xx, y, 0, W_CacheLumpName("M_MTHRMR", PU_CACHE), color);
 
   // [FG] do not crash anymore if value exceeds thermometer range
   if (dot > size)
       dot = size;
 
   V_DrawPatchTranslated(x + M_THRM_STEP / 2 + dot * step, y, 0,
-                        W_CacheLumpName("M_MTHRMO", PU_CACHE), colrngs[color]);
+                        W_CacheLumpName("M_MTHRMO", PU_CACHE), color);
 }
 
 void M_DrawSetting(setup_menu_t* s)
@@ -2472,7 +2472,8 @@ void M_DrawSetting(setup_menu_t* s)
       const int offsety = (M_SPC - SHORT(hu_font[0]->height)) / 2;
       const int size = (max == UL ? M_THRM_SIZE : max);
 
-      M_DrawMiniThermo(x - offsetx, y - offsety, size, value, color);
+      M_DrawMiniThermo(x - offsetx, y - offsety, size, value,
+                       M_MenuItemDisabled(flags) ? cr_dark : colrngs[color]);
 
       if (s->selectstrings && value >= 0 && s->selectstrings[value])
         strcpy(menu_buffer, s->selectstrings[value]);

--- a/src/m_menu.h
+++ b/src/m_menu.h
@@ -92,35 +92,38 @@ extern int warning_about_changes, print_warning_about_changes;
 // The following #defines are for the m_flags field of each item on every
 // Setup Screen. They can be OR'ed together where appropriate
 
-#define S_HILITE     0x1 // Cursor is sitting on this item
-#define S_SELECT     0x2 // We're changing this item
-#define S_TITLE      0x4 // Title item
-#define S_YESNO      0x8 // Yes or No item
-#define S_CRITEM    0x10 // Message color
-#define S_AM_COLOR  0x20 // Automap color
-#define S_CHAT_MACRO 0x40 // Chat String
-#define S_RESET     0x80 // Reset to Defaults Button
-#define S_PREV     0x100 // Previous menu exists
-#define S_NEXT     0x200 // Next menu exists
-#define S_INPUT    0x400 // Composite input
-#define S_WEAP     0x800 // Weapon #
-#define S_NUM     0x1000 // Numerical item
-#define S_SKIP    0x2000 // Cursor can't land here
-#define S_KEEP    0x4000 // Don't swap key out
-#define S_END     0x8000 // Last item in list (dummy)
-#define S_LEVWARN 0x10000// killough 8/30/98: Always warn about pending change
-#define S_PRGWARN 0x20000// killough 10/98: Warn about change until next run
-#define S_BADVAL  0x40000// killough 10/98: Warn about bad value
-// removed
-#define S_LEFTJUST 0x100000 // killough 10/98: items which are left-justified
-#define S_CREDIT  0x200000  // killough 10/98: credit
-#define S_BADVID  0x400000  // killough 12/98: video mode change error
-#define S_CHOICE  0x800000  // [FG] selection of choices
-#define S_DISABLE 0x1000000 // Disable item
-#define S_COSMETIC 0x2000000 // Don't warn about change
-#define S_THERMO  0x4000000 // Mini-thermo
-#define S_NAME    0x8000000 // Player name
-#define S_NEXT_LINE 0x10000000
+#define S_HILITE       0x00000001 // Cursor is sitting on this item
+#define S_SELECT       0x00000002 // We're changing this item
+#define S_TITLE        0x00000004 // Title item
+#define S_YESNO        0x00000008 // Yes or No item
+#define S_CRITEM       0x00000010 // Message color
+#define S_AM_COLOR     0x00000020 // Automap color
+#define S_CHAT_MACRO   0x00000040 // Chat String
+#define S_RESET        0x00000080 // Reset to Defaults Button
+#define S_PREV         0x00000100 // Previous menu exists
+#define S_NEXT         0x00000200 // Next menu exists
+#define S_INPUT        0x00000400 // Composite input
+#define S_WEAP         0x00000800 // Weapon #
+#define S_NUM          0x00001000 // Numerical item
+#define S_SKIP         0x00002000 // Cursor can't land here
+#define S_KEEP         0x00004000 // Don't swap key out
+#define S_END          0x00008000 // Last item in list (dummy)
+#define S_LEVWARN      0x00010000 // killough 8/30/98: Always warn about pending change
+#define S_PRGWARN      0x00020000 // killough 10/98: Warn about change until next run
+#define S_BADVAL       0x00040000 // killough 10/98: Warn about bad value
+#define S_LEFTJUST     0x00080000 // killough 10/98: items which are left-justified
+#define S_CREDIT       0x00100000 // killough 10/98: credit
+#define S_CHOICE       0x00200000 // [FG] selection of choices
+#define S_DISABLE      0x00400000 // Disable item
+#define S_COSMETIC     0x00800000 // Don't warn about change, always load from OPTIONS lump
+#define S_THERMO       0x01000000 // Mini-thermo
+#define S_NAME         0x02000000 // Player name
+#define S_NEXT_LINE    0x04000000 // Two lines menu items
+#define S_STRICT       0x08000000 // Disable in strict mode
+#define S_MBF          0x10000000 // Disable if complevel < mbf
+#define S_BOOM         0x20000000 // Disable if complevel < boom
+#define S_VANILLA      0x40000000 // Disable if complevel != vanilla
+#define S_CRITICAL     0x80000000 // Disable when recording/playing a demo and in netgame
 
 // S_SHOWDESC  = the set of items whose description should be displayed
 // S_SHOWSET   = the set of items whose setting should be displayed
@@ -170,7 +173,7 @@ typedef enum {
 typedef struct setup_menu_s
 {
   const char  *m_text;  // text to display
-  int         m_flags;  // phares 4/17/98: flag bits S_* (defined above)
+  uint32_t    m_flags;  // phares 4/17/98: flag bits S_* (defined above)
   setup_group m_group;  // Group
   short       m_x;      // screen x position (left is 0)
   short       m_y;      // screen y position (top is 0)

--- a/src/m_menu.h
+++ b/src/m_menu.h
@@ -95,8 +95,8 @@ extern int warning_about_changes, print_warning_about_changes;
 #define S_TITLE        0x00000004 // Title item
 #define S_YESNO        0x00000008 // Yes or No item
 #define S_CRITEM       0x00000010 // Message color
-#define S_AM_COLOR     0x00000020 // Automap color
-#define S_CHAT_MACRO   0x00000040 // Chat String
+#define S_COLOR        0x00000020 // Automap color
+#define S_STRING       0x00000040 // Chat/Player name String
 #define S_RESET        0x00000080 // Reset to Defaults Button
 #define S_PREV         0x00000100 // Previous menu exists
 #define S_NEXT         0x00000200 // Next menu exists
@@ -115,28 +115,21 @@ extern int warning_about_changes, print_warning_about_changes;
 #define S_DISABLE      0x00400000 // Disable item
 #define S_COSMETIC     0x00800000 // Don't warn about change, always load from OPTIONS lump
 #define S_THERMO       0x01000000 // Mini-thermo
-#define S_NAME         0x02000000 // Player name
-#define S_NEXT_LINE    0x04000000 // Two lines menu items
-#define S_STRICT       0x08000000 // Disable in strict mode
-#define S_MBF          0x10000000 // Disable if complevel < mbf
-#define S_BOOM         0x20000000 // Disable if complevel < boom
-#define S_VANILLA      0x40000000 // Disable if complevel != vanilla
-#define S_CRITICAL     0x80000000 // Disable when recording/playing a demo and in netgame
+#define S_NEXT_LINE    0x02000000 // Two lines menu items
+#define S_STRICT       0x04000000 // Disable in strict mode
+#define S_MBF          0x08000000 // Disable if complevel < mbf
+#define S_BOOM         0x10000000 // Disable if complevel < boom
+#define S_VANILLA      0x20000000 // Disable if complevel != vanilla
+#define S_CRITICAL     0x40000000 // Disable when recording/playing a demo and in netgame
 
 // S_SHOWDESC  = the set of items whose description should be displayed
 // S_SHOWSET   = the set of items whose setting should be displayed
 // S_STRING    = the set of items whose settings are strings -- killough 10/98:
 // S_HASDEFPTR = the set of items whose var field points to default array
 
-#define S_COLOR (S_AM_COLOR|S_COSMETIC)
+#define S_SHOWDESC (S_TITLE|S_YESNO|S_CRITEM|S_COLOR|S_STRING|S_RESET|S_PREV|S_NEXT|S_INPUT|S_WEAP|S_NUM|S_CREDIT|S_CHOICE|S_THERMO)
 
-#define S_CHAT (S_CHAT_MACRO|S_COSMETIC)
-
-#define S_SHOWDESC (S_TITLE|S_YESNO|S_CRITEM|S_COLOR|S_CHAT|S_RESET|S_PREV|S_NEXT|S_INPUT|S_WEAP|S_NUM|S_CREDIT|S_CHOICE|S_THERMO|S_NAME)
-
-#define S_SHOWSET  (S_YESNO|S_CRITEM|S_COLOR|S_CHAT|S_INPUT|S_WEAP|S_NUM|S_CHOICE|S_THERMO|S_NAME)
-
-#define S_STRING (S_CHAT_MACRO|S_NAME)
+#define S_SHOWSET  (S_YESNO|S_CRITEM|S_COLOR|S_STRING|S_INPUT|S_WEAP|S_NUM|S_CHOICE|S_THERMO)
 
 #define S_HASDEFPTR (S_STRING|S_YESNO|S_NUM|S_WEAP|S_COLOR|S_CRITEM|S_CHOICE|S_THERMO)
 
@@ -171,7 +164,7 @@ typedef enum {
 typedef struct setup_menu_s
 {
   const char  *m_text;  // text to display
-  uint32_t    m_flags;  // phares 4/17/98: flag bits S_* (defined above)
+  int         m_flags;  // phares 4/17/98: flag bits S_* (defined above)
   setup_group m_group;  // Group
   short       m_x;      // screen x position (left is 0)
   short       m_y;      // screen y position (top is 0)

--- a/src/m_menu.h
+++ b/src/m_menu.h
@@ -77,8 +77,6 @@ void M_ResetSetupMenuVideo(void);
 
 void M_ResetTimeScale(void);
 
-void M_UpdateCriticalItems(void);
-
 void M_DrawCredits(void);    // killough 11/98
 
 // killough 8/15/98: warn about changes not being committed until next game

--- a/src/r_bmaps.c
+++ b/src/r_bmaps.c
@@ -26,7 +26,9 @@
 #include "m_misc2.h"
 #include "u_scanner.h"
 
-int brightmaps;
+boolean brightmaps;
+boolean brightmaps_found;
+boolean force_brightmaps;
 
 #define COLORMASK_SIZE 256
 
@@ -214,7 +216,7 @@ const byte *R_BrightmapForTexName(const char *texname)
 
 const byte *R_BrightmapForSprite(const int type)
 {
-    if (STRICTMODE(brightmaps))
+    if (STRICTMODE(brightmaps) || force_brightmaps)
     {
         int i;
         for (i = sprites_bm.num_elems - 1; i >= 0 ; i--)
@@ -231,7 +233,7 @@ const byte *R_BrightmapForSprite(const int type)
 
 const byte *R_BrightmapForFlatNum(const int num)
 {
-    if (STRICTMODE(brightmaps))
+    if (STRICTMODE(brightmaps) || force_brightmaps)
     {
         int i;
         for (i = flats_bm.num_elems - 1; i >= 0; i--)
@@ -248,7 +250,7 @@ const byte *R_BrightmapForFlatNum(const int num)
 
 const byte *R_BrightmapForState(const int state)
 {
-    if (STRICTMODE(brightmaps))
+    if (STRICTMODE(brightmaps) || force_brightmaps)
     {
         int i;
         for (i = states_bm.num_elems - 1; i >= 0; i--)
@@ -268,6 +270,8 @@ void R_ParseBrightmaps(int lumpnum)
     u_scanner_t scanner, *s;
     const char *data = W_CacheLumpNum(lumpnum, PU_CACHE);
     int length = W_LumpLength(lumpnum);
+
+    force_brightmaps = W_IsWADLump(lumpnum);
 
     if (!num_brightmaps)
     {
@@ -350,4 +354,6 @@ void R_ParseBrightmaps(int lumpnum)
         }
     }
     U_ScanClose(s);
+
+    brightmaps_found = (num_brightmaps > 1);
 }

--- a/src/r_bmaps.h
+++ b/src/r_bmaps.h
@@ -22,7 +22,9 @@
 
 #include "doomtype.h"
 
-extern int brightmaps;
+extern boolean brightmaps;
+extern boolean brightmaps_found;
+extern boolean force_brightmaps;
 
 void R_ParseBrightmaps(int lumpnum);
 

--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -553,6 +553,7 @@ boolean W_IsIWADLump (const int lump)
 	       lumpinfo[lump].wad_file == wadfiles[0];
 }
 
+// check if lump is from WAD
 boolean W_IsWADLump (const int lump)
 {
 	return lump >= 0 && lump < numlumps && lumpinfo[lump].wad_file;

--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -104,6 +104,7 @@ static void W_AddFile(const char *name) // killough 1/31/98: static, const
   int         startlump;
   filelump_t  *fileinfo, *fileinfo2free=NULL; //killough
   filelump_t  singleinfo;
+  boolean     is_single = false;
   char        *filename = strcpy(malloc(strlen(name)+5), name);
 
   NormalizeSlashes(AddDefaultExtension(filename, ".wad"));  // killough 11/98
@@ -135,6 +136,7 @@ static void W_AddFile(const char *name) // killough 1/31/98: static, const
       singleinfo.size = LONG(W_FileLength(handle));
       ExtractFileBase(filename, singleinfo.name);
       numlumps++;
+      is_single = true;
     }
   else
     {
@@ -175,7 +177,7 @@ static void W_AddFile(const char *name) // killough 1/31/98: static, const
         lump_p->namespace = ns_global;              // killough 4/17/98
         strncpy (lump_p->name, fileinfo->name, 8);
         // [FG] WAD file that contains the lump
-        lump_p->wad_file = name;
+        lump_p->wad_file = (is_single ? NULL : name);
       }
 
     free(fileinfo2free);      // killough
@@ -549,6 +551,11 @@ boolean W_IsIWADLump (const int lump)
 {
 	return lump >= 0 && lump < numlumps &&
 	       lumpinfo[lump].wad_file == wadfiles[0];
+}
+
+boolean W_IsWADLump (const int lump)
+{
+	return lump >= 0 && lump < numlumps && lumpinfo[lump].wad_file;
 }
 
 // [FG] avoid demo lump name collisions

--- a/src/w_wad.h
+++ b/src/w_wad.h
@@ -123,6 +123,7 @@ extern void WritePredefinedLumpWad(const char *filename); // jff 5/6/98
 // [FG] name of the WAD file that contains the lump
 const char *W_WadNameForLump (const int lump);
 boolean W_IsIWADLump (const int lump);
+boolean W_IsWADLump (const int lump);
 void W_DemoLumpNameCollision(char **name);
 
 void W_CloseFileDescriptors(void);

--- a/src/w_wad.h
+++ b/src/w_wad.h
@@ -123,6 +123,7 @@ extern void WritePredefinedLumpWad(const char *filename); // jff 5/6/98
 // [FG] name of the WAD file that contains the lump
 const char *W_WadNameForLump (const int lump);
 boolean W_IsIWADLump (const int lump);
+// check if lump is from WAD
 boolean W_IsWADLump (const int lump);
 void W_DemoLumpNameCollision(char **name);
 


### PR DESCRIPTION
* Add menu flags for complevels, strict and critical modes.

* Consolidate all checks in `ItemDisabled()` function.

* Cosmetic fixes.

Fix #881 