### PR TITLE
remove one pixel trimming for each font character in setup menu

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -2430,6 +2430,7 @@ void D_DoomMain(void)
 
   puts("HU_Init: Setting up heads up display.");
   HU_Init();
+  M_SetMenuFontSpacing();
 
   puts("ST_Init: Init status bar.");
   ST_Init();

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -5044,9 +5044,7 @@ void M_DrawStringCR(int cx, int cy, char *color, const char *ch)
     
       V_DrawPatchTranslated(cx,cy,0,hu_font[c],color);
 
-      // The screen is cramped, so trim one unit from each
-      // character so they butt up against each other.
-      cx += w - 1; 
+      cx += w;
     }
 }
 
@@ -5088,9 +5086,7 @@ int M_GetPixelWidth(const char *ch)
 	  continue;
 	}
       len += SHORT (hu_font[c]->width);
-      len--; // adjust so everything fits
     }
-  len++; // replace what you took away on the last char only
   return len;
 }
 

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -5019,6 +5019,8 @@ setup_menu_t helpstrings[] =  // HELP screen strings
 
 #define SPACEWIDTH 4
 
+static int menu_font_spacing = 0;
+
 // M_DrawMenuString() draws the string in menu_buffer[]
 
 void M_DrawStringCR(int cx, int cy, char *color, const char *ch)
@@ -5044,7 +5046,9 @@ void M_DrawStringCR(int cx, int cy, char *color, const char *ch)
     
       V_DrawPatchTranslated(cx,cy,0,hu_font[c],color);
 
-      cx += w;
+      // The screen is cramped, so trim one unit from each
+      // character so they butt up against each other.
+      cx += w + menu_font_spacing;
     }
 }
 
@@ -5086,7 +5090,9 @@ int M_GetPixelWidth(const char *ch)
 	  continue;
 	}
       len += SHORT (hu_font[c]->width);
+      len += menu_font_spacing; // adjust so everything fits
     }
+  len -= menu_font_spacing; // replace what you took away on the last char only
   return len;
 }
 
@@ -7024,6 +7030,12 @@ void M_Init(void)
     free(replace);
     endmsg[9] = string;
   }
+}
+
+void M_SetMenuFontSpacing(void)
+{
+  if (M_StringWidth("abcdefghijklmnopqrstuvwxyz01234") > 230)
+    menu_font_spacing = -1;
 }
 
 // killough 10/98: allow runtime changing of menu order

--- a/src/m_menu.h
+++ b/src/m_menu.h
@@ -79,6 +79,8 @@ void M_ResetTimeScale(void);
 
 void M_DrawCredits(void);    // killough 11/98
 
+void M_SetMenuFontSpacing(void);
+
 // killough 8/15/98: warn about changes not being committed until next game
 #define warn_about_changes(x) (warning_about_changes=(x), \
 			       print_warning_about_changes = 2)


### PR DESCRIPTION
This fixes some PWADs fonts.
Dimension of the Boomed
before:
![woof0000](https://user-images.githubusercontent.com/5077629/222981051-a83c29e5-bef7-4ee9-95b7-9898f8eec665.png)
after:
![woof0001](https://user-images.githubusercontent.com/5077629/222981064-a29fade8-ed73-433e-ae6a-e3e949531f9c.png)
[Atmospheric Extinction](https://doomwiki.org/wiki/Atmospheric_Extinction)
before:
![woof0002](https://user-images.githubusercontent.com/5077629/222981147-7e2799c8-a2df-422b-b0c0-ec00fdcb7a17.png)
after:
![woof0003](https://user-images.githubusercontent.com/5077629/222981158-15b77a73-bfd1-431d-b6b8-7da5db5b72af.png)

We will need some menu adjustments if we accept this.