### PR TITLE
use performance counters for FPS limiter

### DIFF
--- a/src/i_timer.h
+++ b/src/i_timer.h
@@ -30,7 +30,9 @@ int I_GetTime_RealTime(void);     // killough
 extern int (*I_GetFracTime)(void);
 
 // [FG] Same as I_GetTime, but returns time in milliseconds
-int I_GetTimeMS();
+int I_GetTimeMS(void);
+
+uint64_t I_GetTimeUS(void);
 
 void I_SetTimeScale(int scale);
 

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -970,21 +970,29 @@ void I_FinishUpdate(void)
 
    if (uncapped)
    {
-      if (fpslimit >= TICRATE)
-      {
-         static uint64_t last_frame;
-         uint64_t current_frame;
+        if (fpslimit >= TICRATE)
+        {
+            uint64_t target_time = 1000000ull / fpslimit;
+            static uint64_t start_time;
 
-         current_frame = (I_GetTimeMS() * fpslimit) / 1000;
+            while (1)
+            {
+                uint64_t current_time = I_GetTimeUS();
+                uint64_t elapsed_time = current_time - start_time;
+                uint64_t remaining_time = 0;
 
-         while (current_frame == last_frame)
-         {
-            I_Sleep(1);
-            current_frame = (I_GetTimeMS() * fpslimit) / 1000;
-         }
+                if (elapsed_time >= target_time)
+                {
+                    start_time = current_time;
+                    break;
+                }
 
-         last_frame = current_frame;
-      }
+                remaining_time = target_time - elapsed_time;
+
+                if (remaining_time > 1000)
+                    I_Sleep((remaining_time - 1000) / 1000);
+            }
+        }
 
         // [AM] Figure out how far into the current tic we're in as a fixed_t.
         fractionaltic = I_GetFracTime();


### PR DESCRIPTION
Adapted from DSDA-Doom. I have some stutters with the previous implementation. In 60hz mode, we need to advance frames every ~16.6666 ms, so I think the standard timer is not enough. We can also potentially use this for profiling.

On my Windows 10 system, VSync is actually disabled only in exclusive fullscreen mode. Maybe we should add an exclusive option to the fullscreen menu item?