### PR TITLE
sort config keys by setupscreen first and name second

### DIFF
--- a/src/doomdef.h
+++ b/src/doomdef.h
@@ -217,7 +217,8 @@ typedef enum {
 // Used when resetting the defaults for every item in a Setup group.
 
 typedef enum {
-  ss_none,
+  ss_gen,       // killough 10/98
+  ss_comp,      // killough 10/98
   ss_keys,
   ss_weap,
   ss_stat,
@@ -225,8 +226,7 @@ typedef enum {
   ss_enem,
   ss_mess,
   ss_chat,
-  ss_gen,       // killough 10/98
-  ss_comp,      // killough 10/98
+  ss_none,
   ss_max
 } ss_types;
 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -2566,6 +2566,16 @@ default_t *M_LookupDefault(const char *name)
 // M_SaveDefaults
 //
 
+static int M_CompareDefaults(const void *arg_a, const void *arg_b)
+{
+  const default_t *a = (const default_t *) arg_a;
+  const default_t *b = (const default_t *) arg_b;
+
+  const int ret = a->setupscreen - b->setupscreen;
+
+  return ret ? ret : strcmp(a->name, b->name);
+}
+
 void M_SaveDefaults (void)
 {
   char *tmpfile;
@@ -2589,6 +2599,8 @@ void M_SaveDefaults (void)
       maxlen = len;
     }
   }
+
+  qsort(defaults, NUMDEFAULTS, sizeof(default_t), M_CompareDefaults);
 
   tmpfile = M_StringJoin(D_DoomPrefDir(), DIR_SEPARATOR_S, "tmp", D_DoomExeName(), ".cfg", NULL);
   NormalizeSlashes(tmpfile);


### PR DESCRIPTION
Fixes #951 

TODO: Some config keys will need to get reassigned to a specific setupscreen, e.g. some video options currently fall into the `ss_none` category.