### PR TITLE
winmidi: Update volume after "reset all controllers" event

### DIFF
--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -909,6 +909,20 @@ static boolean AddToBuffer(unsigned int delta_time, midi_event_t *event,
                     SendNOPMsg(delta_time);
                     break;
 
+                case MIDI_CONTROLLER_RESET_ALL_CTRLS:
+                    SendShortMsg(delta_time, MIDI_EVENT_CONTROLLER,
+                                 event->data.channel.channel,
+                                 MIDI_CONTROLLER_RESET_ALL_CTRLS, 0);
+
+                    // MS GS Wavetable Synth resets the channel volume after a
+                    // "reset all controllers" event, so reapply the volume
+                    if (MidiDevice == ms_gs_synth)
+                    {
+                        i = event->data.channel.channel;
+                        SendVolumeMsg(0, i, channel_volume[i]);
+                    }
+                    break;
+
                 default:
                     SendShortMsg(delta_time, MIDI_EVENT_CONTROLLER,
                                  event->data.channel.channel,
@@ -1086,6 +1100,17 @@ static void FillBuffer(void)
                     {
                         SendShortMsg(0, MIDI_EVENT_CONTROLLER, i, MIDI_CONTROLLER_RESET_ALL_CTRLS, 0);
                     }
+
+                    // MS GS Wavetable Synth resets the channel volume after a
+                    // "reset all controllers" event, so reapply the volume
+                    if (MidiDevice == ms_gs_synth)
+                    {
+                        for (i = 0; i < MIDI_CHANNELS_PER_TRACK; ++i)
+                        {
+                            SendVolumeMsg(0, i, channel_volume[i]);
+                        }
+                    }
+
                     RestartTracks();
                     continue;
                 }


### PR DESCRIPTION
This is a workaround for a bug that appears when using Windows and the default Windows MIDI synth (Microsoft GS Wavetable Synth). When the MS GS Synth receives a "reset all controllers" event it also resets the channel volume, deviating from MIDI spec. As a result, in certain cases the channel can be audible even if the music volume slider is set to zero. The workaround is to always update the volume after a "reset all controllers" event.

Test wad: [reset_all_ctrls_test.zip](https://github.com/fabiangreffrath/woof/files/11107207/reset_all_ctrls_test.zip)
