### PR TITLE
switch to OpenAl for sound mixing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,9 +74,10 @@ option(CMAKE_FIND_PACKAGE_PREFER_CONFIG
 find_package(SDL2 2.0.7 REQUIRED)
 find_package(SDL2_mixer 2.0.2 REQUIRED)
 find_package(SDL2_net REQUIRED)
+find_package(OpenAL REQUIRED)
+find_package(SndFile 1.0.28 REQUIRED)
 
 find_package(FluidSynth 2.2.0)
-find_package(SndFile 1.0.28)
 
 # Python 3
 find_package(Python3 COMPONENTS Interpreter)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -190,13 +190,14 @@ if (FluidSynth_FOUND)
     target_compile_definitions(woof PRIVATE HAVE_FLUIDSYNTH)
 endif()
 
-if (SndFile_FOUND)
-    list(APPEND WOOF_LIBRARIES SndFile::sndfile)
-    target_compile_definitions(woof PRIVATE HAVE_SNDFILE)
-endif()
-
 target_link_libraries(woof PRIVATE ${WOOF_LIBRARIES}
-    SDL2::SDL2 SDL2_mixer::SDL2_mixer SDL2_net::SDL2_net opl textscreen)
+    SDL2::SDL2
+    SDL2_mixer::SDL2_mixer
+    SDL2_net::SDL2_net
+    OpenAL::OpenAL
+    SndFile::sndfile
+    opl
+    textscreen)
 
 # Optional features.
 #

--- a/src/i_sndfile.h
+++ b/src/i_sndfile.h
@@ -19,8 +19,9 @@
 #ifndef __I_SNDFILE__
 #define __I_SNDFILE__
 
-#include <SDL_audio.h>
+#include <AL/al.h>
+#include "doomtype.h"
 
-void *Load_SNDFile(void *data, SDL_AudioSpec *sample, Uint8 **wavdata, Uint32 *samplelen);
+boolean Load_SNDFile(void *data, ALenum *format, byte **wavdata, ALsizei *size, ALsizei *freq);
 
 #endif

--- a/src/sounds.c
+++ b/src/sounds.c
@@ -125,8 +125,7 @@ musicinfo_t S_music[] = {
    .volume = -1, \
    .data = NULL, \
    .usefulness = -1, \
-   .lumpnum = -1, \
-   .alen = 0}
+   .lumpnum = -1}
 
 #define SOUND(n, s, p) \
   SOUND_LINK(n, s, p, 0, -1)

--- a/src/sounds.h
+++ b/src/sounds.h
@@ -67,8 +67,6 @@ typedef struct sfxinfo_struct {
   // lump number of sfx
   int lumpnum;
 
-  // haleyjd 04/23/08: additional caching data
-  unsigned int alen;   // length of converted sound pointed to by data
 } sfxinfo_t;
 
 extern int parallel_sfx_limit;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -14,6 +14,7 @@
         "default-features": false,
         "features": [ "external-libs" ]
     },
-    "fluidsynth"
+    "fluidsynth",
+    "openal-soft"
   ]
 }


### PR DESCRIPTION
* Mix sfx with OpeanAL.

* Rewrote Load_SNDFile() to use float format. Made libsndfile mandatory.

Wow, OpenAl works so much better on my system. We can remove `parallel_sfx_limit` and audio pre-caching and everything will work fine. Music backends still use SDL_Mixer, streaming needs work. So far, in all my tests, the sound does not crack!