### PR TITLE
change `snd_samplerate` variable to constant

### DIFF
--- a/src/i_flmusic.c
+++ b/src/i_flmusic.c
@@ -203,7 +203,7 @@ static boolean I_FL_InitMusic(int device)
 
     settings = new_fluid_settings();
 
-    fluid_settings_setnum(settings, "synth.sample-rate", snd_samplerate);
+    fluid_settings_setnum(settings, "synth.sample-rate", SND_SAMPLERATE);
 
     fluid_settings_setint(settings, "synth.chorus.active", mus_chorus);
     fluid_settings_setint(settings, "synth.reverb.active", mus_reverb);

--- a/src/i_oalmusic.c
+++ b/src/i_oalmusic.c
@@ -293,7 +293,7 @@ void I_OAL_HookMusic(callback_func_t callback_func)
         callback = callback_func;
 
         player.format = AL_FORMAT_STEREO16;
-        player.freq = snd_samplerate;
+        player.freq = SND_SAMPLERATE;
 
         I_OAL_SetGain(1.0f);
         StartPlayer();

--- a/src/i_oplmusic.c
+++ b/src/i_oplmusic.c
@@ -1721,7 +1721,7 @@ static boolean OPL_InitMusic(void)
     char *dmxoption;
     opl_init_result_t chip_type;
 
-    OPL_SetSampleRate(snd_samplerate);
+    OPL_SetSampleRate(SND_SAMPLERATE);
 
     chip_type = OPL_Init(opl_io_port);
     if (chip_type == OPL_INIT_NONE)

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -59,9 +59,6 @@ static music_module_t *active_module = NULL;
 // these routines think that sound has been initialized when it hasn't
 static boolean snd_init = false;
 
-// haleyjd 10/28/05: updated for Julian's music code, need full quality now
-int snd_samplerate;
-
 static ALuint *openal_sources;
 
 typedef struct {

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -35,7 +35,7 @@
 #define NORM_SEP 128
 #define S_STEREO_SWING (96<<FRACBITS)
 
-extern int snd_samplerate;
+#define SND_SAMPLERATE 44100
 
 // [FG] variable pitch bend range
 extern int pitch_bend_range;

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -384,13 +384,6 @@ default_t defaults[] = {
     "variable pitch bend range (100 none, 120 default)"
   },
 
-  {
-    "snd_samplerate",
-    (config_t *) &snd_samplerate, NULL,
-    {44100}, {11025, 96000}, number, ss_none, wad_no,
-    "audio device frequency in Hz"
-  },
-
   // [FG] play sounds in full length
   {
     "full_sounds",


### PR DESCRIPTION
It's not possible to "force" a samplerate when creating an OpenAL audio device, see https://github.com/kcat/openal-soft/issues/350

We use the `SND_SAMPLERATE` macro only when generating synth music.