### PR TITLE
sound system clean up

### DIFF
--- a/src/d_deh.c
+++ b/src/d_deh.c
@@ -2229,7 +2229,7 @@ void deh_procSounds(DEHFILE *fpin, FILE* fpout, char *line)
                   S_sfx[indexnum].volume = value;
                 else
                   if (!strcasecmp(key,deh_sfxinfo[6]))  // Zero 4
-                    S_sfx[indexnum].data = (void *)(intptr_t) value; // killough 5/3/98: changed cast
+                    ; // ignored
                   else
                     if (!strcasecmp(key,deh_sfxinfo[7]))  // Neg. One 1
                       S_sfx[indexnum].usefulness = value;

--- a/src/sounds.c
+++ b/src/sounds.c
@@ -123,9 +123,10 @@ musicinfo_t S_music[] = {
    .link = l ? &original_S_sfx[l] : NULL, \
    .pitch = i, \
    .volume = -1, \
-   .data = NULL, \
+   .buffer = 0, \
    .usefulness = -1, \
-   .lumpnum = -1}
+   .lumpnum = -1, \
+   .cached = false}
 
 #define SOUND(n, s, p) \
   SOUND_LINK(n, s, p, 0, -1)

--- a/src/sounds.h
+++ b/src/sounds.h
@@ -56,8 +56,8 @@ typedef struct sfxinfo_struct {
   // volume if a link
   int volume;
 
-  // sound data
-  void *data;
+  // OpenAL buffer id
+  uint32_t buffer;
 
   // this is checked every second to see if sound
   // can be thrown out (if 0, then decrement, if -1,
@@ -66,6 +66,8 @@ typedef struct sfxinfo_struct {
 
   // lump number of sfx
   int lumpnum;
+
+  boolean cached;
 
 } sfxinfo_t;
 


### PR DESCRIPTION
* Explicitly use OpenAL buffer IDs instead of void pointers.

* Free the `openal_sources` array on shutdown.