### PR TITLE
suppress puff interpolation for the first tic

### DIFF
--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -1318,6 +1318,9 @@ void P_SpawnPuff(fixed_t x,fixed_t y,fixed_t z)
 
   if (attackrange == MELEERANGE)
     P_SetMobjState (th, S_PUFF3);
+
+  // [crispy] suppress interpolation for the first tic
+  th->interp = -1;
 }
 
 


### PR DESCRIPTION
Now the snapping of the puff to the floor level isn't interpolated. Taken from Crispy Doom.

Test save: [woofsav0.zip](https://github.com/fabiangreffrath/woof/files/11190296/woofsav0.zip) (TNT.wad) Thanks to @JNechaevsky for bug report.
