### PR TITLE
check for negative value in ptr_lstrip()

### DIFF
--- a/.github/workflows/win_msvc.yml
+++ b/.github/workflows/win_msvc.yml
@@ -29,7 +29,6 @@ jobs:
         run: |
           set -euo pipefail
           cd ${{ env.VCPKG_ROOT }}
-          git pull
           ./bootstrap-vcpkg.sh -disableMetrics
           nuget=$(./vcpkg.exe fetch nuget | tail -n 1)
           owner="${GITHUB_REPOSITORY%/*}"

--- a/src/d_deh.c
+++ b/src/d_deh.c
@@ -3137,7 +3137,7 @@ void rstrip(char *s)  // strip trailing whitespace
 //
 char *ptr_lstrip(char *p)  // point past leading whitespace
 {
-  while (isspace(*p))
+  while (*p >= 0 && isspace(*p))
     p++;
   return p;
 }


### PR DESCRIPTION
This fixes parsing of DEHACKED in [D2ISOv2.wad](https://www.doomworld.com/idgames/levels/doom2/megawads/d2isov2) with debug version of CRT. If the value < 0 the behavior of `isspace()` is undefined according to the documentation. [MSDN](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/isspace-iswspace-isspace-l-iswspace-l?view=msvc-170#return-value), [cppreference.com](https://en.cppreference.com/w/c/string/byte/isspace)

`QUITMSG1...QUITMSG14` does not seem to work in the `[STRINGS]` block. This works in ZDoom: https://zdoom.org/wiki/Strings. Should we fix it?