### PR TITLE
improve automap controls

### DIFF
--- a/src/am_map.c
+++ b/src/am_map.c
@@ -1015,14 +1015,14 @@ boolean AM_Responder
   if (!followplayer)
   {
     if (buttons_state[PAN_RIGHT])
-      m_paninc.x += FTOM(f_paninc);
+      m_paninc.x += FTOM(f_paninc << hires);
     if (buttons_state[PAN_LEFT])
-      m_paninc.x += -FTOM(f_paninc);
+      m_paninc.x += -FTOM(f_paninc << hires);
 
     if (buttons_state[PAN_UP])
-      m_paninc.y += FTOM(f_paninc);
+      m_paninc.y += FTOM(f_paninc << hires);
     if (buttons_state[PAN_DOWN])
-      m_paninc.y += -FTOM(f_paninc);
+      m_paninc.y += -FTOM(f_paninc << hires);
   }
 
   if (!mousewheelzoom)

--- a/src/am_map.c
+++ b/src/am_map.c
@@ -954,8 +954,11 @@ boolean AM_Responder
         case 1:  plr->message = s_AMSTR_OVERLAYON;  break;
         default: plr->message = s_AMSTR_OVERLAYOFF; break;
       }
-      AM_LevelInit();
-      AM_initVariables();
+
+      if (automapoverlay && scaledviewheight == SCREENHEIGHT)
+        f_h = (SCREENHEIGHT) << hires;
+      else
+        f_h = (SCREENHEIGHT-ST_HEIGHT) << hires;
     }
     else if (M_InputActivated(input_map_rotate))
     {


### PR DESCRIPTION
* Change the state of the automap buttons instantly, without waiting for the next tick.

* Opposite directions cancel each other.

Fix #991 and #992