### PR TITLE
disable ALC_HRTF_SOFT

### DIFF
--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -607,8 +607,6 @@ struct {
 // I_InitSound
 //
 
-int snd_hrtf;
-
 void I_InitSound(void)
 {
     const ALCchar *name;
@@ -617,7 +615,7 @@ void I_InitSound(void)
     ALCint srate = -1;
 
     ALCint attribs[] = { // zero terminated list of integer pairs
-        ALC_HRTF_SOFT, ALC_DONT_CARE_SOFT,
+        ALC_HRTF_SOFT, ALC_FALSE,
         0
     };
 
@@ -642,14 +640,7 @@ void I_InitSound(void)
         return;
     }
 
-    if (alcIsExtensionPresent(device, "ALC_SOFT_HRTF") != AL_FALSE)
-    {
-        if (snd_hrtf == 0)
-            attribs[1] = ALC_FALSE;
-        else if (snd_hrtf > 0)
-            attribs[1] = ALC_TRUE;
-    }
-    else
+    if (alcIsExtensionPresent(device, "ALC_SOFT_HRTF") == AL_FALSE)
     {
         attribs[0] = 0;
     }

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -607,12 +607,19 @@ struct {
 // I_InitSound
 //
 
+int snd_hrtf;
+
 void I_InitSound(void)
 {
     const ALCchar *name;
     ALCdevice *device;
     ALCcontext *context;
     ALCint srate = -1;
+
+    ALCint attribs[] = {
+        ALC_HRTF_SOFT, ALC_DONT_CARE_SOFT,
+        0 // end of list
+    };
 
     if (nosfxparm && nomusicparm)
     {
@@ -635,7 +642,19 @@ void I_InitSound(void)
         return;
     }
 
-    context = alcCreateContext(device, NULL);
+    if (alcIsExtensionPresent(device, "ALC_SOFT_HRTF") != AL_FALSE)
+    {
+        if (snd_hrtf == 0)
+            attribs[1] = ALC_FALSE;
+        else if (snd_hrtf > 0)
+            attribs[1] = ALC_TRUE;
+    }
+    else
+    {
+        attribs[0] = 0;
+    }
+
+    context = alcCreateContext(device, &attribs[0]);
     if (!context || alcMakeContextCurrent(context) == ALC_FALSE)
     {
         fprintf(stderr, "I_InitSound: Error making context.\n");

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -616,9 +616,9 @@ void I_InitSound(void)
     ALCcontext *context;
     ALCint srate = -1;
 
-    ALCint attribs[] = {
+    ALCint attribs[] = { // zero terminated list of integer pairs
         ALC_HRTF_SOFT, ALC_DONT_CARE_SOFT,
-        0 // end of list
+        0
     };
 
     if (nosfxparm && nomusicparm)

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -98,7 +98,6 @@ extern int winmm_chorus_level;
 extern int opl_gain;
 extern int midi_player_menu;
 extern char *snd_resampler;
-extern int snd_hrtf;
 extern boolean demobar;
 extern boolean smoothlight;
 extern boolean brightmaps;
@@ -413,13 +412,6 @@ default_t defaults[] = {
     (config_t *) &snd_resampler, NULL,
     {.s = "linear"}, {0}, string, ss_gen, wad_no,
     "OpenAL resampler (\"nearest\", \"linear\" (default), \"cubic\")"
-  },
-
-  {
-    "snd_hrtf",
-    (config_t *) &snd_hrtf, NULL,
-    {-1}, {-1, 1}, 0, ss_gen, wad_no,
-    "OpenAL HRTF mode (-1 = Auto, 0 = Disable, 1 = Enable)"
   },
 
   // [FG] music backend

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -98,6 +98,7 @@ extern int winmm_chorus_level;
 extern int opl_gain;
 extern int midi_player_menu;
 extern char *snd_resampler;
+extern int snd_hrtf;
 extern boolean demobar;
 extern boolean smoothlight;
 extern boolean brightmaps;
@@ -412,6 +413,13 @@ default_t defaults[] = {
     (config_t *) &snd_resampler, NULL,
     {.s = "linear"}, {0}, string, ss_gen, wad_no,
     "OpenAL resampler (\"nearest\", \"linear\" (default), \"cubic\")"
+  },
+
+  {
+    "snd_hrtf",
+    (config_t *) &snd_hrtf, NULL,
+    {-1}, {-1, 1}, 0, ss_gen, wad_no,
+    "OpenAL HRTF mode (-1 = Auto, 0 = Disable, 1 = Enable)"
   },
 
   // [FG] music backend


### PR DESCRIPTION
These options are taken from GZDoom: https://github.com/ZDoom/gzdoom/blob/86bc9cafd49307a9367ba59b54c88d6525f73e69/src/common/audio/sound/oalsound.cpp#L627-L636

Apparently some users are having issues with the default HRTF settings. Thanks to @liPillON for testing.