### PR TITLE
Remove unused/useless code

### DIFF
--- a/src/am_map.c
+++ b/src/am_map.c
@@ -251,7 +251,6 @@ static int  f_h;
 
 static int  lightlev;        // used for funky strobing effect
 static byte*  fb;            // pseudo-frame buffer
-static int  amclock;
 
 static mpoint_t m_paninc;    // how far the window pans each tic (map coords)
 static fixed_t mtof_zoommul; // how far the window zooms each tic (map coords)
@@ -571,7 +570,6 @@ void AM_initVariables(void)
   automapactive = true;
   fb = screens[0];
 
-  amclock = 0;
   lightlev = 0;
 
   m_paninc.x = m_paninc.y = 0;
@@ -1120,8 +1118,6 @@ void AM_Ticker (void)
 {
   if (!automapactive)
     return;
-
-  amclock++;
 
   // Change the zoom if necessary.
   if (ftom_zoommul != FRACUNIT)

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -399,21 +399,6 @@ static int TranslateKey(SDL_Keysym *sym)
     }
 }
 
-int I_ScanCode2DoomCode (int a)
-{
-   // haleyjd
-   return a;
-}
-
-// Automatic caching inverter, so you don't need to maintain two tables.
-// By Lee Killough
-
-int I_DoomCode2ScanCode (int a)
-{
-   // haleyjd
-   return a;
-}
-
 // [FG] mouse button and movement handling from Chocolate Doom 3.0
 
 static void UpdateMouseButtonState(unsigned int button, boolean on, unsigned int dclick)

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -58,9 +58,6 @@ void I_FinishUpdate (void);
 
 void I_ReadScreen (byte* scr);
 
-int I_DoomCode2ScanCode(int);   // killough
-int I_ScanCode2DoomCode(int);   // killough
-
 void I_ResetScreen(void);   // killough 10/98
 void I_ToggleToggleFullScreen(void); // [FG] fullscreen mode menu toggle
 void I_ToggleVsync(void); // [JN] Calls native SDL vsync toggle

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -1086,14 +1086,6 @@ default_t defaults[] = {
   // Controls
   //
 
-  // For key bindings, the values stored in the key_* variables       // phares
-  // are the internal Doom Codes. The values stored in the default.cfg
-  // file are the keyboard codes. I_ScanCode2DoomCode converts from
-  // keyboard codes to Doom Codes. I_DoomCode2ScanCode converts from
-  // Doom Codes to keyboard codes, and is only used when writing back
-  // to default.cfg. For the printable keys (i.e. alphas, numbers)
-  // the Doom Code is the ascii code.
-
   {
     "input_turnright",
     NULL, NULL,
@@ -2801,11 +2793,10 @@ void M_SaveDefaults (void)
 
       if (dp->type != input)
       {
-      if (dp->type == number ? fprintf(f, "%-*s %i\n", maxlen, dp->name,
-			       strncmp(dp->name, "key_", 4) ? value.i :
-			       I_DoomCode2ScanCode(value.i)) == EOF :
-	  fprintf(f,"%-*s \"%s\"\n", maxlen, dp->name, (char *) value.s) == EOF)
-	goto error;
+      if (dp->type == number ?
+          fprintf(f, "%-*s %i\n", maxlen, dp->name, value.i) == EOF :
+          fprintf(f,"%-*s \"%s\"\n", maxlen, dp->name, (char *) value.s) == EOF)
+        goto error;
       }
 
       if (dp->type == input)
@@ -2940,9 +2931,6 @@ boolean M_ParseOption(const char *p, boolean wad)
     {
       if (sscanf(strparm, "%i", &parm) != 1)
 	return 1;                       // Not A Number
-
-      if (!strncmp(name, "key_", 4))    // killough
-	parm = I_ScanCode2DoomCode(parm);
 
       //jff 3/4/98 range check numeric parameters
       if ((dp->limit.min == UL || dp->limit.min <= parm) &&


### PR DESCRIPTION
Namely the following:

`I_ScanCode2DoomCode()`
`I_DoomCode2ScanCode()`
`amclock`