### PR TITLE
don't destroy render on graphics re init

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1637,9 +1637,11 @@ static void I_InitGraphicsMode(void)
       flags |= SDL_RENDERER_PRESENTVSYNC;
    }
 
+   // [FG] create renderer
+
    if (renderer == NULL)
    {
-       renderer = SDL_CreateRenderer(screen, -1, flags);
+      renderer = SDL_CreateRenderer(screen, -1, flags);
    }
 
    // [FG] try again without hardware acceleration

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1637,15 +1637,10 @@ static void I_InitGraphicsMode(void)
       flags |= SDL_RENDERER_PRESENTVSYNC;
    }
 
-   // [FG] create renderer
-
-   if (renderer != NULL)
+   if (renderer == NULL)
    {
-      SDL_DestroyRenderer(renderer);
-      texture = NULL;
+       renderer = SDL_CreateRenderer(screen, -1, flags);
    }
-
-   renderer = SDL_CreateRenderer(screen, -1, flags);
 
    // [FG] try again without hardware acceleration
    if (renderer == NULL)


### PR DESCRIPTION
With `SDL_RenderSetVSync()` we don't need to re create render. Fix freezes on Windows 11.