### PR TITLE
add exclusive fullscreen to the menu

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -657,8 +657,6 @@ void I_ToggleFullScreen(void)
 
 void I_ToggleExclusiveFullScreen(void)
 {
-    unsigned int flags = 0;
-
     if (!fullscreen)
     {
         return;

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -667,8 +667,7 @@ void I_ToggleExclusiveFullScreen(void)
         SDL_SetWindowSize(screen, fullscreen_width, fullscreen_height);
         SDL_SetWindowFullscreen(screen, SDL_WINDOW_FULLSCREEN);
     }
-
-    if (!exclusive_fullscreen)
+    else
     {
         SDL_SetWindowFullscreen(screen, SDL_WINDOW_FULLSCREEN_DESKTOP);
     }

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -58,8 +58,8 @@ static SDL_Texture *texture;
 static SDL_Rect blit_rect = {0};
 
 int window_width, window_height;
+int window_position_x, window_position_y;
 static int window_x, window_y;
-char *window_position;
 int video_display = 0;
 static int fullscreen_width, fullscreen_height; // [FG] exclusive fullscreen
 
@@ -1163,19 +1163,10 @@ void I_ShutdownGraphics(void)
 {
    if (in_graphics_mode)  // killough 10/98
    {
-      char buf[16];
-      int buflen;
-
-      // Store the (x, y) coordinates of the window
-      // in the "window_position" config parameter
-      SDL_GetWindowPosition(screen, &window_x, &window_y);
-      M_snprintf(buf, sizeof(buf), "%i,%i", window_x, window_y);
-      buflen = strlen(buf) + 1;
-      if (strlen(window_position) < buflen)
+      if (!fullscreen)
       {
-          window_position = I_Realloc(window_position, buflen);
+          SDL_GetWindowPosition(screen, &window_position_x, &window_position_y);
       }
-      M_StringCopy(window_position, buf, buflen);
 
       UpdateGrab();
       in_graphics_mode = false;
@@ -1315,34 +1306,14 @@ static void I_GetWindowPosition(int *x, int *y, int w, int h)
         video_display = 0;
     }
 
-    // in fullscreen mode, the window "position" still matters, because
-    // we use it to control which display we run fullscreen on.
-
-    if (fullscreen)
+    if (window_position_x == 0 && window_position_y == 0)
     {
         CenterWindow(x, y, w, h);
-        return;
     }
-
-    // in windowed mode, the desired window position can be specified
-    // in the configuration file.
-
-    if (window_position == NULL || !strcmp(window_position, ""))
+    else
     {
-        *x = *y = SDL_WINDOWPOS_UNDEFINED;
-    }
-    else if (!strcmp(window_position, "center"))
-    {
-        // Note: SDL has a SDL_WINDOWPOS_CENTER, but this is useless for our
-        // purposes, since we also want to control which display we appear on.
-        // So we have to do this ourselves.
-        CenterWindow(x, y, w, h);
-    }
-    else if (sscanf(window_position, "%i,%i", x, y) != 2)
-    {
-        // invalid format: revert to default
-        fprintf(stderr, "I_GetWindowPosition: invalid window_position setting\n");
-        *x = *y = SDL_WINDOWPOS_UNDEFINED;
+        *x = window_position_x;
+        *y = window_position_y;
     }
 }
 

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1538,6 +1538,12 @@ static void I_InitGraphicsMode(void)
       }
    }
 
+   // Exclusive fullscreen only works in fullscreen mode.
+   if (exclusive_fullscreen && !fullscreen)
+   {
+      exclusive_fullscreen = false;
+   }
+
    if (M_CheckParm("-borderless"))
    {
       flags |= SDL_WINDOW_BORDERLESS;

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1724,18 +1724,6 @@ static void I_InitGraphicsMode(void)
                                SDL_TEXTUREACCESS_STREAMING,
                                v_w, v_h);
 
-   // Workaround for SDL 2.0.14 (and 2.0.16) alt-tab bug (taken from Doom Retro)
-#if defined(_WIN32)
-   {
-      SDL_version ver;
-      SDL_GetVersion(&ver);
-      if (ver.major == 2 && ver.minor == 0 && (ver.patch == 14 || ver.patch == 16))
-      {
-         SDL_SetHintWithPriority(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "1", SDL_HINT_OVERRIDE);
-      }
-   }
-#endif
-
    V_Init();
 
    UpdateGrab();

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1163,10 +1163,7 @@ void I_ShutdownGraphics(void)
 {
    if (in_graphics_mode)  // killough 10/98
    {
-      if (!fullscreen)
-      {
-          SDL_GetWindowPosition(screen, &window_position_x, &window_position_y);
-      }
+      SDL_GetWindowPosition(screen, &window_position_x, &window_position_y);
 
       UpdateGrab();
       in_graphics_mode = false;
@@ -1291,6 +1288,13 @@ static void CenterWindow(int *x, int *y, int w, int h)
 
     *x = bounds.x + SDL_max((bounds.w - w) / 2, 0);
     *y = bounds.y + SDL_max((bounds.h - h) / 2, 0);
+
+    // Fix exclusive fullscreen mode.
+    if (*x == 0 && *y == 0)
+    {
+        *x = SDL_WINDOWPOS_CENTERED;
+        *y = SDL_WINDOWPOS_CENTERED;
+    }
 }
 
 static void I_GetWindowPosition(int *x, int *y, int w, int h)
@@ -1306,8 +1310,21 @@ static void I_GetWindowPosition(int *x, int *y, int w, int h)
         video_display = 0;
     }
 
+    // in fullscreen mode, the window "position" still matters, because
+    // we use it to control which display we run fullscreen on.
+
+    if (fullscreen)
+    {
+        CenterWindow(x, y, w, h);
+        return;
+    }
+
+    // center
     if (window_position_x == 0 && window_position_y == 0)
     {
+        // Note: SDL has a SDL_WINDOWPOS_CENTERED, but this is useless for our
+        // purposes, since we also want to control which display we appear on.
+        // So we have to do this ourselves.
         CenterWindow(x, y, w, h);
     }
     else

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -697,7 +697,7 @@ void I_GetEvent(void)
                     if (!exclusive_fullscreen)
                     {
                         fullscreen = !fullscreen;
-                        I_ToggleFullScreen();
+                        M_ToggleFullScreen();
                         break;
                     }
                 }

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -59,7 +59,8 @@ void I_FinishUpdate (void);
 void I_ReadScreen (byte* scr);
 
 void I_ResetScreen(void);   // killough 10/98
-void I_ToggleToggleFullScreen(void); // [FG] fullscreen mode menu toggle
+void I_ToggleFullScreen(void); // [FG] fullscreen mode menu toggle
+void I_ToggleExclusiveFullScreen(void);
 void I_ToggleVsync(void); // [JN] Calls native SDL vsync toggle
 
 extern int use_vsync;  // killough 2/8/98: controls whether vsync is called
@@ -69,6 +70,8 @@ extern int hires;      // killough 11/98
 extern int useaspect;
 extern int uncapped; // [FG] uncapped rendering frame rate
 
+extern boolean fullscreen;
+extern boolean exclusive_fullscreen;
 extern int fpslimit; // when uncapped, limit framerate to this value
 extern int integer_scaling; // [FG] force integer scales
 extern int vga_porch_flash; // emulate VGA "porch" behaviour
@@ -76,7 +79,6 @@ extern int widescreen; // widescreen mode
 extern int video_display; // display index
 extern int window_width, window_height;
 extern char *window_position;
-extern int fullscreen_width, fullscreen_height; // [FG] exclusive fullscreen
 extern boolean screenvisible;
 
 extern int gamma2;

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -77,8 +77,6 @@ extern int integer_scaling; // [FG] force integer scales
 extern int vga_porch_flash; // emulate VGA "porch" behaviour
 extern int widescreen; // widescreen mode
 extern int video_display; // display index
-extern int window_width, window_height;
-extern char *window_position;
 extern boolean screenvisible;
 
 extern int gamma2;

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -3942,7 +3942,7 @@ static void M_EnableDisableFPSLimit(void)
   }
 }
 
-static void M_ToggleFullScreen(void)
+void M_ToggleFullScreen(void)
 {
   DISABLE_ITEM(!fullscreen, gen_settings1[gen1_exclusive_fullscreen]);
 

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -3876,6 +3876,7 @@ enum {
   gen1_uncapped,
   gen1_fpslimit,
   gen1_vsync,
+  gen1_exclusive_fullscreen,
   gen1_gamma,
   gen1_end1,
 
@@ -3941,6 +3942,20 @@ static void M_EnableDisableFPSLimit(void)
   }
 }
 
+static void M_ToggleFullScreen(void)
+{
+  DISABLE_ITEM(!fullscreen, gen_settings1[gen1_exclusive_fullscreen]);
+
+  I_ToggleFullScreen();
+}
+
+static void M_ToggleExclusiveFullScreen(void)
+{
+  DISABLE_ITEM(exclusive_fullscreen, gen_settings1[gen1_fullscreen]);
+
+  I_ToggleExclusiveFullScreen();
+}
+
 static void M_CoerceFPSLimit(void)
 {
   if (fpslimit < TICRATE)
@@ -3956,7 +3971,7 @@ setup_menu_t gen_settings1[] = { // General Settings screen1
 
   // [FG] fullscreen mode menu toggle
   {"Fullscreen Mode", S_YESNO, m_null, M_X, M_Y+ gen1_fullscreen*M_SPC,
-   {"fullscreen"}, 0, I_ToggleToggleFullScreen},
+   {"fullscreen"}, 0, M_ToggleFullScreen},
 
   {"Widescreen Rendering", S_YESNO, m_null, M_X, M_Y+ gen1_widescreen*M_SPC,
    {"widescreen"}, 0, I_ResetScreen},
@@ -3970,6 +3985,9 @@ setup_menu_t gen_settings1[] = { // General Settings screen1
 
   {"Vertical Sync", S_YESNO, m_null, M_X,
    M_Y+ gen1_vsync*M_SPC, {"use_vsync"}, 0, I_ToggleVsync},
+
+  {"Exclusive Fullscreen", S_YESNO, m_null, M_X, M_Y+ gen1_exclusive_fullscreen*M_SPC,
+   {"exclusive_fullscreen"}, 0, M_ToggleExclusiveFullScreen},
 
   {"Gamma Correction", S_THERMO, m_null, M_X_THRM,
    M_Y+ gen1_gamma*M_SPC, {"gamma2"}, 0, M_ResetGamma, gamma_strings},
@@ -7121,7 +7139,11 @@ void M_ResetSetupMenu(void)
   extern boolean deh_set_blood_color;
 
   // [FG] exclusive fullscreen
-  if (fullscreen_width != 0 || fullscreen_height != 0)
+  if (!fullscreen)
+  {
+    gen_settings1[gen1_exclusive_fullscreen].m_flags |= S_DISABLE;
+  }
+  if (fullscreen && exclusive_fullscreen)
   {
     gen_settings1[gen1_fullscreen].m_flags |= S_DISABLE;
   }

--- a/src/m_menu.h
+++ b/src/m_menu.h
@@ -72,6 +72,8 @@ void M_DrawCredits(void);    // killough 11/98
 
 void M_SetMenuFontSpacing(void);
 
+void M_ToggleFullScreen(void);
+
 // killough 8/15/98: warn about changes not being committed until next game
 #define warn_about_changes(x) (warning_about_changes=(x), \
 			       print_warning_about_changes = 2)

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -212,14 +212,14 @@ default_t defaults[] = {
   {
     "window_position_x",
     (config_t *) &window_position_x, NULL,
-    {0}, {0, UL}, number, ss_none, wad_no,
+    {0}, {UL, UL}, number, ss_none, wad_no,
     "window position x"
   },
 
   {
     "window_position_y",
     (config_t *) &window_position_y, NULL,
-    {0}, {0, UL}, number, ss_none, wad_no,
+    {0}, {UL, UL}, number, ss_none, wad_no,
     "window position y"
   },
 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -158,7 +158,7 @@ default_t defaults[] = {
     "exclusive_fullscreen",
     (config_t *) &exclusive_fullscreen, NULL,
     {1}, {0, 1}, number, ss_none, wad_no,
-    "1 to enable exclusive_fullscreen mode"
+    "1 to enable exclusive fullscreen mode"
   },
 
   {

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -74,6 +74,8 @@ extern int tran_filter_pct;            // killough 2/21/98
 extern int showMessages;
 
 extern int forceFlipPan;
+extern int window_width, window_height;
+extern int window_position_x, window_position_y;
 extern int grabmouse;
 extern boolean flipcorpses; // [crispy] randomly flip corpse, blood and death animation sprites
 extern boolean ghost_monsters; // [crispy] resurrected pools of gore ("ghost monsters") are translucent
@@ -208,10 +210,17 @@ default_t defaults[] = {
 
   // window position
   {
-    "window_position",
-    (config_t *) &window_position, NULL,
-    {.s = "center"}, {0}, string, ss_none, wad_no,
-    "window position \"x,y\""
+    "window_position_x",
+    (config_t *) &window_position_x, NULL,
+    {0}, {0, UL}, number, ss_none, wad_no,
+    "window position x"
+  },
+
+  {
+    "window_position_y",
+    (config_t *) &window_position_y, NULL,
+    {0}, {0, UL}, number, ss_none, wad_no,
+    "window position y"
   },
 
   // window width

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -75,7 +75,6 @@ extern int showMessages;
 
 extern int forceFlipPan;
 extern int grabmouse;
-extern int fullscreen; // [FG] save fullscren mode
 extern boolean flipcorpses; // [crispy] randomly flip corpse, blood and death animation sprites
 extern boolean ghost_monsters; // [crispy] resurrected pools of gore ("ghost monsters") are translucent
 extern int mouse_acceleration;
@@ -154,6 +153,13 @@ default_t defaults[] = {
   },
 
   {
+    "exclusive_fullscreen",
+    (config_t *) &exclusive_fullscreen, NULL,
+    {1}, {0, 1}, number, ss_none, wad_no,
+    "1 to enable exclusive_fullscreen mode"
+  },
+
+  {
     "use_vsync",
     (config_t *) &use_vsync, NULL,
     {1}, {0,1}, number, ss_none, wad_no,
@@ -222,22 +228,6 @@ default_t defaults[] = {
     (config_t *) &window_height, NULL,
     {600}, {0, UL}, number, ss_none, wad_no,
     "window height"
-  },
-
-  // [FG] exclusive fullscreen width
-  {
-    "fullscreen_width",
-    (config_t *) &fullscreen_width, NULL,
-    {0}, {0, UL}, number, ss_none, wad_no,
-    "exclusive fullscreen width"
-  },
-
-  // [FG] exclusive fullscreen height
-  {
-    "fullscreen_height",
-    (config_t *) &fullscreen_height, NULL,
-    {0}, {0, UL}, number, ss_none, wad_no,
-    "exclusive fullscreen height"
   },
 
   {


### PR DESCRIPTION
Enable exclusive fullscreen only in fullscreen mode, because switch between exclusive fullscreen and windowed mode is glitchy on my Windows 10 system.