### PR TITLE
fix memory issues found with AddressSanitizer

### DIFF
--- a/.github/workflows/win_msvc.yml
+++ b/.github/workflows/win_msvc.yml
@@ -5,9 +5,9 @@ on:
     branches: [ master ]
     tags: ['*']
     paths-ignore: ['**.md']
-  pull_request:
-    branches: [ master ]
-    paths-ignore: ['**.md']
+  # pull_request:
+  #   branches: [ master ]
+  #   paths-ignore: ['**.md']
   workflow_dispatch:
 
 env:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -185,6 +185,12 @@ endif()
 target_woof_settings(woof)
 target_include_directories(woof PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../")
 
+option(ENABLE_ASAN "Enable ASan" FALSE)
+if(ENABLE_ASAN)
+    target_compile_options(woof PRIVATE -fsanitize=address)
+    target_link_options(woof PRIVATE -fsanitize=address)
+endif()
+
 list(APPEND SDL2_LIBRARIES
     $<IF:$<TARGET_EXISTS:SDL2_net::SDL2_net>,SDL2_net::SDL2_net,SDL2_net::SDL2_net-static>)
 

--- a/src/hu_lib.c
+++ b/src/hu_lib.c
@@ -130,6 +130,9 @@ void HUlib_addStringToTextLine(hu_textline_t *l, char *s)
   unsigned char c;
   patch_t *const *const f = *l->f;
 
+  if (!*s)
+    return;
+
   while (*s)
   {
     c = toupper(*s++);

--- a/src/hu_stuff.c
+++ b/src/hu_stuff.c
@@ -646,7 +646,7 @@ void HU_Start(void)
     else
       s = gamemapinfo->mapname;
 
-    if (s == gamemapinfo->mapname || strcmp(s, "-") != 0)
+    if (s == gamemapinfo->mapname || U_CheckField(s))
     {
       while (*s)
         HUlib_addCharToTextLine(&w_title, *(s++));

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -62,6 +62,7 @@ int window_position_x, window_position_y;
 static int window_x, window_y;
 int video_display = 0;
 static int fullscreen_width, fullscreen_height; // [FG] exclusive fullscreen
+boolean reset_screen;
 
 void *I_GetSDLWindow(void)
 {
@@ -887,6 +888,12 @@ void I_FinishUpdate(void)
 
    UpdateGrab();
 
+   if (reset_screen)
+   {
+      I_ResetScreen();
+      reset_screen = false;
+   }
+
    // draws little dots on the bottom of the screen
    if (devparm)
    {
@@ -1669,6 +1676,8 @@ static void I_InitGraphicsMode(void)
    SDL_RenderClear(renderer);
    SDL_RenderPresent(renderer);
 
+   V_Init();
+
    // [FG] create paletted frame buffer
 
    if (sdlscreen != NULL)
@@ -1724,8 +1733,6 @@ static void I_InitGraphicsMode(void)
                                SDL_TEXTUREACCESS_STREAMING,
                                v_w, v_h);
 
-   V_Init();
-
    UpdateGrab();
 
    in_graphics_mode = 1;
@@ -1737,13 +1744,6 @@ static void I_InitGraphicsMode(void)
 
 void I_ResetScreen(void)
 {
-   if (!in_graphics_mode)
-   {
-      setsizeneeded = true;
-      V_Init();
-      return;
-   }
-
    I_ShutdownGraphics();     // Switch out of old graphics mode
 
    I_InitGraphicsMode();     // Switch to new graphics mode

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -78,6 +78,7 @@ extern int vga_porch_flash; // emulate VGA "porch" behaviour
 extern int widescreen; // widescreen mode
 extern int video_display; // display index
 extern boolean screenvisible;
+extern boolean reset_screen;
 
 extern int gamma2;
 byte I_GetPaletteIndex(byte *palette, int r, int g, int b);

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -3962,19 +3962,24 @@ static void M_CoerceFPSLimit(void)
     fpslimit = 0;
 }
 
+static void M_ResetScreen(void)
+{
+  reset_screen = true;
+}
+
 setup_menu_t gen_settings1[] = { // General Settings screen1
 
   {"Video"       ,S_SKIP|S_TITLE, m_null, M_X, M_Y},
 
   {"High Resolution", S_YESNO, m_null, M_X, M_Y+ gen1_hires*M_SPC,
-   {"hires"}, 0, I_ResetScreen},
+   {"hires"}, 0, M_ResetScreen},
 
   // [FG] fullscreen mode menu toggle
   {"Fullscreen Mode", S_YESNO, m_null, M_X, M_Y+ gen1_fullscreen*M_SPC,
    {"fullscreen"}, 0, M_ToggleFullScreen},
 
   {"Widescreen Rendering", S_YESNO, m_null, M_X, M_Y+ gen1_widescreen*M_SPC,
-   {"widescreen"}, 0, I_ResetScreen},
+   {"widescreen"}, 0, M_ResetScreen},
 
   // [FG] uncapped frame rate
   {"Uncapped Frame Rate", S_YESNO, m_null, M_X, M_Y+ gen1_uncapped*M_SPC,

--- a/src/m_misc2.c
+++ b/src/m_misc2.c
@@ -455,6 +455,22 @@ int M_snprintf(char *buf, size_t buf_len, const char *s, ...)
     return result;
 }
 
+// Copy lump name (up to 8 chars) to dest buffer.
+
+void M_CopyLumpName(char *dest, const char *src)
+{
+    size_t len;
+
+    len = strnlen(src, 8);
+
+    if (len < 8)
+    {
+        len++;
+    }
+
+    memcpy(dest, src, len);
+}
+
 //
 // 1/18/98 killough: adds a default extension to a path
 // Note: Backslashes are treated specially, for MS-DOS.

--- a/src/m_misc2.h
+++ b/src/m_misc2.h
@@ -42,6 +42,7 @@ boolean M_StringCaseEndsWith(const char *s, const char *suffix);
 int M_vsnprintf(char *buf, size_t buf_len, const char *s, va_list args) PRINTF_ATTR(3, 0);
 int M_snprintf(char *buf, size_t buf_len, const char *s, ...) PRINTF_ATTR(3, 4);
 
+void M_CopyLumpName(char *dest, const char *src);
 char *AddDefaultExtension(char *path, const char *ext);
 void NormalizeSlashes(char *str);
 

--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -242,7 +242,7 @@ static void W_CoalesceMarkedResource(const char *start_marker,
     {
       lumpinfo[numlumps].size = 0;  // killough 3/20/98: force size to be 0
       lumpinfo[numlumps].namespace = ns_global;   // killough 4/17/98
-      memcpy(lumpinfo[numlumps++].name, end_marker, 8);
+      strncpy(lumpinfo[numlumps++].name, end_marker, 8);
     }
 }
 

--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -242,7 +242,7 @@ static void W_CoalesceMarkedResource(const char *start_marker,
     {
       lumpinfo[numlumps].size = 0;  // killough 3/20/98: force size to be 0
       lumpinfo[numlumps].namespace = ns_global;   // killough 4/17/98
-      strncpy(lumpinfo[numlumps++].name, end_marker, 8);
+      M_StringCopy(lumpinfo[numlumps++].name, end_marker, 8);
     }
 }
 

--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -242,7 +242,7 @@ static void W_CoalesceMarkedResource(const char *start_marker,
     {
       lumpinfo[numlumps].size = 0;  // killough 3/20/98: force size to be 0
       lumpinfo[numlumps].namespace = ns_global;   // killough 4/17/98
-      M_StringCopy(lumpinfo[numlumps++].name, end_marker, 8);
+      memcpy(lumpinfo[numlumps++].name, end_marker, 8);
     }
 }
 

--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -511,7 +511,7 @@ void WritePredefinedLumpWad(const char *filename)
          
          fileinfo.filepos = LONG(filepos);
          fileinfo.size    = LONG(predefined_lumps[i].size);         
-         memcpy(fileinfo.name, predefined_lumps[i].name, 8);
+         M_CopyLumpName(fileinfo.name, predefined_lumps[i].name);
          
          fwrite(&fileinfo, 1, sizeof(fileinfo), file);
 

--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -240,9 +240,10 @@ static void W_CoalesceMarkedResource(const char *start_marker,
 
   if (mark_end)                                   // add end marker
     {
+      size_t len = strnlen(end_marker, 8);
       lumpinfo[numlumps].size = 0;  // killough 3/20/98: force size to be 0
       lumpinfo[numlumps].namespace = ns_global;   // killough 4/17/98
-      memcpy(lumpinfo[numlumps++].name, end_marker, 8);
+      memcpy(lumpinfo[numlumps++].name, end_marker, len < 8 ? len + 1 : len);
     }
 }
 

--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -166,7 +166,7 @@ static void W_AddFile(const char *name) // killough 1/31/98: static, const
         lump_p->size = LONG(fileinfo->size);
         lump_p->data = NULL;                        // killough 1/31/98
         lump_p->namespace = ns_global;              // killough 4/17/98
-        strncpy (lump_p->name, fileinfo->name, 8);
+        M_CopyLumpName(lump_p->name, fileinfo->name);
         // [FG] WAD file that contains the lump
         lump_p->wad_file = (is_single ? NULL : name);
       }
@@ -202,7 +202,7 @@ static void W_CoalesceMarkedResource(const char *start_marker,
       { // If this is the first start marker, add start marker to marked lumps
         if (!num_marked)
           {
-            memcpy(marked->name, start_marker, 8);
+            M_CopyLumpName(marked->name, start_marker);
             marked->size = 0;  // killough 3/20/98: force size to be 0
             marked->namespace = ns_global;        // killough 4/17/98
             num_marked = 1;
@@ -240,10 +240,9 @@ static void W_CoalesceMarkedResource(const char *start_marker,
 
   if (mark_end)                                   // add end marker
     {
-      size_t len = strnlen(end_marker, 8);
       lumpinfo[numlumps].size = 0;  // killough 3/20/98: force size to be 0
       lumpinfo[numlumps].namespace = ns_global;   // killough 4/17/98
-      memcpy(lumpinfo[numlumps++].name, end_marker, len < 8 ? len + 1 : len);
+      M_CopyLumpName(lumpinfo[numlumps++].name, end_marker);
     }
 }
 


### PR DESCRIPTION
I discovered a rare crash that occurs due to heap corruption and decided to give AddressSanitizer a try. Great tool, highly recommend.

@fabiangreffrath There is heap use after free in `r_draw.c` related to brightmaps code. Hold enter on the "widescreen" menu item, maybe toggle fullscreen/windowed a few times first and it will crash. This bug also occurs with the previous release of Woof. Asan report:
<details>
<summary>report</summary>

```
=================================================================
==9056==ERROR: AddressSanitizer: heap-use-after-free on address 0x11d37a388ddf at pc 0x7fff70866df5 bp 0x00099f95e850 sp 0x00099f95e850
WRITE of size 1 at 0x11d37a388ddf thread T0
    #0 0x7fff70866df4 in R_DrawSpan C:\develop\woof\src\r_draw.c:787
    #1 0x7fff7086fd58 in R_MapPlane C:\develop\woof\src\r_plane.c:169
    #2 0x7fff7087003d in R_MakeSpans C:\develop\woof\src\r_plane.c:311
    #3 0x7fff70870eb1 in do_draw_plane C:\develop\woof\src\r_plane.c:453
    #4 0x7fff7086e2c1 in R_DrawPlanes C:\develop\woof\src\r_plane.c:472
    #5 0x7fff7086b1ee in R_RenderPlayerView C:\develop\woof\src\r_main.c:827
    #6 0x7fff7072d9cb in D_Display C:\develop\woof\src\d_main.c:280
    #7 0x7fff70735316 in D_DoomMain C:\develop\woof\src\d_main.c:2723
    #8 0x7fff707603d6 in Woof_Main C:\develop\woof\src\i_main.c:58
    #9 0x7ff6859914db in SDL_main C:\develop\woof\win32\win_launcher.c:21
    #10 0x7ff68599532b in main_getcmdline C:\develop\vcpkg\buildtrees\sdl2\src\ase-2.26.5-fdc15bb8fb.clean\src\main\windows\SDL_windows_main.c:82
    #11 0x7ff6859953d2 in main C:\develop\vcpkg\buildtrees\sdl2\src\ase-2.26.5-fdc15bb8fb.clean\src\main\windows\SDL_windows_main.c:97
    #12 0x7ff685991958 in invoke_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:78
    #13 0x7ff6859917fd in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #14 0x7ff6859916bd in __scrt_common_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:330
    #15 0x7ff6859919ed in mainCRTStartup D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_main.cpp:16
    #16 0x7fff9c4b7603 in BaseThreadInitThunk+0x13 (C:\Windows\System32\KERNEL32.DLL+0x180017603)
    #17 0x7fff9d5226a0 in RtlUserThreadStart+0x20 (C:\Windows\SYSTEM32\ntdll.dll+0x1800526a0)

0x11d37a388ddf is located 226783 bytes inside of 340824-byte region [0x11d37a351800,0x11d37a3a4b58)
freed by thread T0 here:
    #0 0x7fff6ee833b4 in _asan_wrap_GlobalSize+0x5036b (c:\develop\woof\build\src\clang_rt.asan_dbg_dynamic-x86_64.dll+0x1800533b4)
    #1 0x7fff70215ac4 in real_free C:\develop\vcpkg\buildtrees\sdl2\src\ase-2.26.5-fdc15bb8fb.clean\src\stdlib\SDL_malloc.c:5321
    #2 0x7fff7021580e in SDL_free_REAL C:\develop\vcpkg\buildtrees\sdl2\src\ase-2.26.5-fdc15bb8fb.clean\src\stdlib\SDL_malloc.c:5461
    #3 0x7fff7012af8f in SDL_SIMDFree_REAL C:\develop\vcpkg\buildtrees\sdl2\src\ase-2.26.5-fdc15bb8fb.clean\src\cpuinfo\SDL_cpuinfo.c:1194
    #4 0x7fff702c6037 in SDL_FreeSurface_REAL C:\develop\vcpkg\buildtrees\sdl2\src\ase-2.26.5-fdc15bb8fb.clean\src\video\SDL_surface.c:1619
    #5 0x7fff701301c4 in SDL_FreeSurface C:\develop\vcpkg\buildtrees\sdl2\src\ase-2.26.5-fdc15bb8fb.clean\src\dynapi\SDL_dynapi_procs.h:478
    #6 0x7fff7077534c in I_InitGraphicsMode C:\develop\woof\src\i_video.c:1681
    #7 0x7fff70770c37 in I_ResetScreen C:\develop\woof\src\i_video.c:1766
    #8 0x7fff70783968 in M_Responder C:\develop\woof\src\m_menu.c:5799
    #9 0x7fff7072d4d3 in D_ProcessEvents C:\develop\woof\src\d_main.c:196
    #10 0x7fff7072b658 in BuildNewTic C:\develop\woof\src\d_loop.c:143
    #11 0x7fff7072a720 in NetUpdate C:\develop\woof\src\d_loop.c:237
    #12 0x7fff7086b1e9 in R_RenderPlayerView C:\develop\woof\src\r_main.c:825
    #13 0x7fff7072d9cb in D_Display C:\develop\woof\src\d_main.c:280
    #14 0x7fff70735316 in D_DoomMain C:\develop\woof\src\d_main.c:2723
    #15 0x7fff707603d6 in Woof_Main C:\develop\woof\src\i_main.c:58
    #16 0x7ff6859914db in SDL_main C:\develop\woof\win32\win_launcher.c:21
    #17 0x7ff68599532b in main_getcmdline C:\develop\vcpkg\buildtrees\sdl2\src\ase-2.26.5-fdc15bb8fb.clean\src\main\windows\SDL_windows_main.c:82
    #18 0x7ff6859953d2 in main C:\develop\vcpkg\buildtrees\sdl2\src\ase-2.26.5-fdc15bb8fb.clean\src\main\windows\SDL_windows_main.c:97
    #19 0x7ff685991958 in invoke_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:78
    #20 0x7ff6859917fd in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #21 0x7ff6859916bd in __scrt_common_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:330
    #22 0x7ff6859919ed in mainCRTStartup D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_main.cpp:16
    #23 0x7fff9c4b7603 in BaseThreadInitThunk+0x13 (C:\Windows\System32\KERNEL32.DLL+0x180017603)
    #24 0x7fff9d5226a0 in RtlUserThreadStart+0x20 (C:\Windows\SYSTEM32\ntdll.dll+0x1800526a0)

previously allocated by thread T0 here:
    #0 0x7fff6ee83554 in _asan_wrap_GlobalSize+0x5050b (c:\develop\woof\build\src\clang_rt.asan_dbg_dynamic-x86_64.dll+0x180053554)
    #1 0x7fff70215a34 in real_malloc C:\develop\vcpkg\buildtrees\sdl2\src\ase-2.26.5-fdc15bb8fb.clean\src\stdlib\SDL_malloc.c:5318
    #2 0x7fff702156d5 in SDL_malloc_REAL C:\develop\vcpkg\buildtrees\sdl2\src\ase-2.26.5-fdc15bb8fb.clean\src\stdlib\SDL_malloc.c:5417
    #3 0x7fff7012ad0e in SDL_SIMDAlloc_REAL C:\develop\vcpkg\buildtrees\sdl2\src\ase-2.26.5-fdc15bb8fb.clean\src\cpuinfo\SDL_cpuinfo.c:1127
    #4 0x7fff702c5ba8 in SDL_CreateRGBSurfaceWithFormat_REAL C:\develop\vcpkg\buildtrees\sdl2\src\ase-2.26.5-fdc15bb8fb.clean\src\video\SDL_surface.c:152
    #5 0x7fff702c5895 in SDL_CreateRGBSurface_REAL C:\develop\vcpkg\buildtrees\sdl2\src\ase-2.26.5-fdc15bb8fb.clean\src\video\SDL_surface.c:198
    #6 0x7fff70130074 in SDL_CreateRGBSurface C:\develop\vcpkg\buildtrees\sdl2\src\ase-2.26.5-fdc15bb8fb.clean\src\dynapi\SDL_dynapi_procs.h:476
    #7 0x7fff707753a1 in I_InitGraphicsMode C:\develop\woof\src\i_video.c:1687
    #8 0x7fff70770c37 in I_ResetScreen C:\develop\woof\src\i_video.c:1766
    #9 0x7fff70783968 in M_Responder C:\develop\woof\src\m_menu.c:5799
    #10 0x7fff7072d4d3 in D_ProcessEvents C:\develop\woof\src\d_main.c:196
    #11 0x7fff7072b658 in BuildNewTic C:\develop\woof\src\d_loop.c:143
    #12 0x7fff7072a720 in NetUpdate C:\develop\woof\src\d_loop.c:237
    #13 0x7fff7072a8e4 in TryRunTics C:\develop\woof\src\d_loop.c:805
    #14 0x7fff707352c8 in D_DoomMain C:\develop\woof\src\d_main.c:2716
    #15 0x7fff707603d6 in Woof_Main C:\develop\woof\src\i_main.c:58
    #16 0x7ff6859914db in SDL_main C:\develop\woof\win32\win_launcher.c:21
    #17 0x7ff68599532b in main_getcmdline C:\develop\vcpkg\buildtrees\sdl2\src\ase-2.26.5-fdc15bb8fb.clean\src\main\windows\SDL_windows_main.c:82
    #18 0x7ff6859953d2 in main C:\develop\vcpkg\buildtrees\sdl2\src\ase-2.26.5-fdc15bb8fb.clean\src\main\windows\SDL_windows_main.c:97
    #19 0x7ff685991958 in invoke_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:78
    #20 0x7ff6859917fd in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #21 0x7ff6859916bd in __scrt_common_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:330
    #22 0x7ff6859919ed in mainCRTStartup D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_main.cpp:16
    #23 0x7fff9c4b7603 in BaseThreadInitThunk+0x13 (C:\Windows\System32\KERNEL32.DLL+0x180017603)
    #24 0x7fff9d5226a0 in RtlUserThreadStart+0x20 (C:\Windows\SYSTEM32\ntdll.dll+0x1800526a0)

SUMMARY: AddressSanitizer: heap-use-after-free C:\develop\woof\src\r_draw.c:787 in R_DrawSpan
Shadow bytes around the buggy address:
  0x038ddcdf1160: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x038ddcdf1170: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x038ddcdf1180: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x038ddcdf1190: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x038ddcdf11a0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
=>0x038ddcdf11b0: fd fd fd fd fd fd fd fd fd fd fd[fd]fd fd fd fd
  0x038ddcdf11c0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x038ddcdf11d0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x038ddcdf11e0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x038ddcdf11f0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x038ddcdf1200: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==9056==ABORTING
```
</details>


@ceski-1 Apparently `midiOutUnprepareHeader()` is just broken: [[doomworld]](https://www.doomworld.com/forum/topic/131924-address-sanitizer-and-midioutunprepareheader/) Thus, we must select a non-Native MIDI backend if we want to use the AddressSanitizer on Windows.

 