### PR TITLE
implement bilinear sharpening from Crispy Doom

### DIFF
--- a/src/i_video.h
+++ b/src/i_video.h
@@ -79,6 +79,7 @@ extern int widescreen; // widescreen mode
 extern int video_display; // display index
 extern boolean screenvisible;
 extern boolean reset_screen;
+extern boolean bilinear_sharpening;
 
 extern int gamma2;
 byte I_GetPaletteIndex(byte *palette, int r, int g, int b);

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -4033,6 +4033,7 @@ enum {
   gen2_trans,
   gen2_transpct,
   gen2_stub1,
+  gen2_bilinear_sharpening,
   gen2_sky1,
   gen2_sky2,
   gen2_swirl,
@@ -4157,6 +4158,9 @@ setup_menu_t gen_settings2[] = { // General Settings screen2
    M_Y+ gen2_transpct*M_SPC, {"tran_filter_pct"}, 0, M_Trans},
 
   {"", S_SKIP, m_null, M_X, M_Y + gen2_stub1*M_SPC},
+
+  {"Enable bilinear sharpening", S_YESNO, m_null, M_X,
+   M_Y+ gen2_bilinear_sharpening*M_SPC, {"bilinear_sharpening"}, 0, M_ResetScreen},
 
   {"Stretch Short Skies", S_YESNO, m_null, M_X,
    M_Y + gen2_sky1*M_SPC, {"stretchsky"}, 0, R_InitSkyMap},

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -4030,10 +4030,10 @@ setup_menu_t gen_settings1[] = { // General Settings screen1
 
 enum {
   gen2_title1,
+  gen2_bilinear_sharpening,
   gen2_trans,
   gen2_transpct,
   gen2_stub1,
-  gen2_bilinear_sharpening,
   gen2_sky1,
   gen2_sky2,
   gen2_swirl,
@@ -4151,6 +4151,9 @@ setup_menu_t gen_settings2[] = { // General Settings screen2
   {"Display Options"  ,S_SKIP|S_TITLE, m_null, M_X,
    M_Y + gen2_title1*M_SPC},
 
+  {"Enable bilinear sharpening", S_YESNO, m_null, M_X,
+   M_Y+ gen2_bilinear_sharpening*M_SPC, {"bilinear_sharpening"}, 0, M_ResetScreen},
+
   {"Enable predefined translucency", S_YESNO|S_STRICT, m_null, M_X,
    M_Y+ gen2_trans*M_SPC, {"translucency"}, 0, M_Trans},
 
@@ -4158,9 +4161,6 @@ setup_menu_t gen_settings2[] = { // General Settings screen2
    M_Y+ gen2_transpct*M_SPC, {"tran_filter_pct"}, 0, M_Trans},
 
   {"", S_SKIP, m_null, M_X, M_Y + gen2_stub1*M_SPC},
-
-  {"Enable bilinear sharpening", S_YESNO, m_null, M_X,
-   M_Y+ gen2_bilinear_sharpening*M_SPC, {"bilinear_sharpening"}, 0, M_ResetScreen},
 
   {"Stretch Short Skies", S_YESNO, m_null, M_X,
    M_Y + gen2_sky1*M_SPC, {"stretchsky"}, 0, R_InitSkyMap},

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -249,6 +249,13 @@ default_t defaults[] = {
   },
 
   {
+    "bilinear_sharpening",
+    (config_t *) &bilinear_sharpening, NULL,
+    {0}, {0,1}, number, ss_gen, wad_no,
+    "enable bilinear sharpening"
+  },
+
+  {
     "vga_porch_flash",
     (config_t *) &vga_porch_flash, NULL,
     {0}, {0, 1}, number, ss_none, wad_no,


### PR DESCRIPTION
Seems to be a popular feature request. I think the difference is worth it:
on
![image](https://user-images.githubusercontent.com/5077629/234648863-73017d40-86c3-41a1-b554-d8eb9b129d56.png)
off
![image](https://user-images.githubusercontent.com/5077629/234648909-6e957b61-80a7-413c-9985-754599526e99.png)

I wanted to do it with shaders, but it's tricky if we need direct3d and opengl support, maybe in the next release. To be honest, the difference with the SDL implementation is not that big, from my experiments. Also zero performance difference on my system.