### PR TITLE
fix restart MUSINFO music from save

### DIFF
--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -1536,8 +1536,14 @@ void P_SetupLevel(int episode, int map, int playermask, skill_t skill)
     playback_nextlevel = false;
   }
 
+  // [crispy] don't load map's default music if loaded from a savegame with
+  // MUSINFO data
+  if (!musinfo.from_savegame)
+  {
   // Make sure all sounds are stopped before Z_FreeTags.
   S_Start();
+  }
+  musinfo.from_savegame = false;
 
   Z_FreeTag(PU_LEVEL);
   Z_FreeTag(PU_CACHE);


### PR DESCRIPTION
Tested on MAP01 aaliens.wad. @MrAlaux mentioned this bug it on DSDA Discord.