### PR TITLE
do not show full wad paths in savegame header

### DIFF
--- a/src/g_game.c
+++ b/src/g_game.c
@@ -1947,8 +1947,9 @@ static void G_DoSaveGame(void)
     char **w = wadfiles;
     for (*save_p = 0; *w; w++)
       {
-        CheckSaveGame(strlen(*w)+2);
-        strcat(strcat((char *) save_p, *w), "\n");
+        const char *basename = M_BaseName(*w);
+        CheckSaveGame(strlen(basename)+2);
+        strcat(strcat((char *) save_p, basename), "\n");
       }
     save_p += strlen((char *) save_p)+1;
   }


### PR DESCRIPTION
Perhaps we shouldn't store full paths, especially with %TEMP% folders on Windows:
before:
![image](https://user-images.githubusercontent.com/5077629/234869718-dbe68200-2d71-4905-91cc-982c78bb973f.png)
after:
![image](https://user-images.githubusercontent.com/5077629/234869508-a1222777-b37a-47aa-ae31-dfaa78e21f57.png)
