### PR TITLE
mouse settings like in Crispy, smooth scaling is on by default

### DIFF
--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -368,8 +368,8 @@ extern  gamestate_t     wipegamestate;
 
 extern  int             mouseSensitivity_horiz; // killough
 extern  int             mouseSensitivity_vert;
-extern  int             mouseSensitivity_horiz2; // [FG] strafe
-extern  int             mouseSensitivity_vert2; // [FG] look
+extern  int             mouseSensitivity_horiz_strafe; // [FG] strafe
+extern  int             mouseSensitivity_vert_look; // [FG] look
 
 // debug flag to cancel adaptiveness
 extern  boolean         singletics;

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -1008,12 +1008,12 @@ boolean G_Responder(event_t* ev)
     case ev_mouse:
       if (mouseSensitivity_horiz) // [FG] turn
         mousex = ev->data2*(mouseSensitivity_horiz+5)/10;
-      if (mouseSensitivity_horiz2) // [FG] strafe
-        mousex2 = ev->data2*(mouseSensitivity_horiz2+5)/10;
+      if (mouseSensitivity_horiz_strafe) // [FG] strafe
+        mousex2 = ev->data2*(mouseSensitivity_horiz_strafe+5)/10;
       if (mouseSensitivity_vert) // [FG] move
         mousey = ev->data3*(mouseSensitivity_vert+5)/10;
-      if (mouseSensitivity_vert2) // [FG] look
-        mousey2 = ev->data3*(mouseSensitivity_vert2+5)/10;
+      if (mouseSensitivity_vert_look) // [FG] look
+        mousey2 = ev->data3*(mouseSensitivity_vert_look+5)/10;
       return true;    // eat events
 
     case ev_joyb_down:

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -64,7 +64,7 @@ static int window_x, window_y;
 int video_display = 0;
 static int fullscreen_width, fullscreen_height; // [FG] exclusive fullscreen
 boolean reset_screen;
-boolean bilinear_sharpening;
+boolean smooth_scaling;
 boolean cfg_hires;
 
 void *I_GetSDLWindow(void)
@@ -883,7 +883,7 @@ static inline void I_UpdateRender (void)
     SDL_UpdateTexture(texture, NULL, argbbuffer->pixels, argbbuffer->pitch);
     SDL_RenderClear(renderer);
 
-    if (bilinear_sharpening)
+    if (smooth_scaling)
     {
         // Render this intermediate texture into the upscaled texture
         // using "nearest" integer scaling.
@@ -1817,7 +1817,7 @@ static void I_InitGraphicsMode(void)
                                SDL_TEXTUREACCESS_STREAMING,
                                v_w, v_h);
 
-   if (bilinear_sharpening)
+   if (smooth_scaling)
    {
       CreateUpscaledTexture(v_w, v_h);
    }

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -79,7 +79,7 @@ extern int widescreen; // widescreen mode
 extern int video_display; // display index
 extern boolean screenvisible;
 extern boolean reset_screen;
-extern boolean bilinear_sharpening;
+extern boolean smooth_scaling;
 
 extern int gamma2;
 byte I_GetPaletteIndex(byte *palette, int r, int g, int b);

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -4030,7 +4030,7 @@ setup_menu_t gen_settings1[] = { // General Settings screen1
 
 enum {
   gen2_title1,
-  gen2_bilinear_sharpening,
+  gen2_smooth_scaling,
   gen2_trans,
   gen2_transpct,
   gen2_stub1,
@@ -4172,8 +4172,8 @@ setup_menu_t gen_settings2[] = { // General Settings screen2
   {"Display Options"  ,S_SKIP|S_TITLE, m_null, M_X,
    M_Y + gen2_title1*M_SPC},
 
-  {"Enable bilinear sharpening", S_YESNO, m_null, M_X,
-   M_Y+ gen2_bilinear_sharpening*M_SPC, {"bilinear_sharpening"}, 0, M_ResetScreen},
+  {"Smooth Pixel Scaling", S_YESNO, m_null, M_X,
+   M_Y+ gen2_smooth_scaling*M_SPC, {"smooth_scaling"}, 0, M_ResetScreen},
 
   {"Enable predefined translucency", S_YESNO|S_STRICT, m_null, M_X,
    M_Y+ gen2_trans*M_SPC, {"translucency"}, 0, M_Trans},

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -72,8 +72,8 @@ extern boolean chat_on;          // in heads-up code
 
 int mouseSensitivity_horiz; // has default   //  killough
 int mouseSensitivity_vert;  // has default
-int mouseSensitivity_horiz2; // [FG] strafe
-int mouseSensitivity_vert2; // [FG] look
+int mouseSensitivity_horiz_strafe; // [FG] strafe
+int mouseSensitivity_vert_look; // [FG] look
 
 int showMessages;    // Show messages has default, 0 = off, 1 = on
 int show_toggle_messages;
@@ -1508,12 +1508,12 @@ void M_DrawMouse(void)
   //jff 4/3/98 clamp horizontal sensitivity display
   mhmx = mouseSensitivity_horiz; // >23? 23 : mouseSensitivity_horiz;
   M_DrawThermo(MouseDef.x,MouseDef.y+LINEHEIGHT*(mouse_horiz+1),24,mhmx);
-  mhmx2 = mouseSensitivity_horiz2; // >23? 23 : mouseSensitivity_horiz;
+  mhmx2 = mouseSensitivity_horiz_strafe; // >23? 23 : mouseSensitivity_horiz;
   M_DrawThermo(MouseDef.x,MouseDef.y+LINEHEIGHT*(mouse_horiz2+1),24,mhmx2);
   //jff 4/3/98 clamp vertical sensitivity display
   mvmx = mouseSensitivity_vert; // >23? 23 : mouseSensitivity_vert;
   M_DrawThermo(MouseDef.x,MouseDef.y+LINEHEIGHT*(mouse_vert+1),24,mvmx);
-  mvmx2 = mouseSensitivity_vert2; // >23? 23 : mouseSensitivity_vert;
+  mvmx2 = mouseSensitivity_vert_look; // >23? 23 : mouseSensitivity_vert;
   M_DrawThermo(MouseDef.x,MouseDef.y+LINEHEIGHT*(mouse_vert2+1),24,mvmx2);
 }
 
@@ -1541,7 +1541,7 @@ void M_MouseHoriz(int choice)
 
 void M_MouseHoriz2(int choice)
 {
-  M_Mouse(choice, &mouseSensitivity_horiz2);
+  M_Mouse(choice, &mouseSensitivity_horiz_strafe);
 }
 
 void M_MouseVert(int choice)
@@ -1551,7 +1551,7 @@ void M_MouseVert(int choice)
 
 void M_MouseVert2(int choice)
 {
-  M_Mouse(choice, &mouseSensitivity_vert2);
+  M_Mouse(choice, &mouseSensitivity_vert_look);
 }
 
 void M_Mouse(int choice, int *sens)

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -252,7 +252,7 @@ default_t defaults[] = {
   {
     "bilinear_sharpening",
     (config_t *) &bilinear_sharpening, NULL,
-    {0}, {0,1}, number, ss_gen, wad_no,
+    {1}, {0,1}, number, ss_gen, wad_no,
     "enable bilinear sharpening"
   },
 
@@ -1992,6 +1992,56 @@ default_t defaults[] = {
     "1 to invert gamepad look axis"
   },
 
+  { //jff 4/3/98 allow unlimited sensitivity
+    "mouse_sensitivity",
+    (config_t *) &mouseSensitivity_horiz, NULL,
+    {5}, {0,UL}, number, ss_none, wad_no,
+    "adjust horizontal (x) mouse sensitivity for turning"
+  },
+
+  { //jff 4/3/98 allow unlimited sensitivity
+    "mouse_sensitivity_y",
+    (config_t *) &mouseSensitivity_vert, NULL,
+    {5}, {0,UL}, number, ss_none, wad_no,
+    "adjust vertical (y) mouse sensitivity for moving"
+  },
+
+  {
+    "mouse_sensitivity_strafe",
+    (config_t *) &mouseSensitivity_horiz_strafe, NULL,
+    {5}, {0,UL}, number, ss_none, wad_no,
+    "adjust horizontal (x) mouse sensitivity for strafing"
+  },
+
+  {
+    "mouse_sensitivity_y_look",
+    (config_t *) &mouseSensitivity_vert_look, NULL,
+    {5}, {0,UL}, number, ss_none, wad_no,
+    "adjust vertical (y) mouse sensitivity for looking"
+  },
+
+  {
+    "mouse_acceleration",
+    (config_t *) &mouse_acceleration, NULL,
+    {10}, {0,40}, number, ss_none, wad_no,
+    "adjust mouse acceleration (0 = 1.0, 40 = 5.0)"
+  },
+
+  {
+    "mouse_acceleration_threshold",
+    (config_t *) &mouse_acceleration_threshold, NULL,
+    {10}, {0,32}, number, ss_none, wad_no,
+    "adjust mouse acceleration threshold"
+  },
+
+  // [FG] invert vertical axis
+  {
+    "mouse_y_invert",
+    (config_t *) &mouse_y_invert, NULL,
+    {0}, {0,1}, number, ss_gen, wad_no,
+    "invert vertical axis"
+  },
+
   {
     "novert",
     (config_t *) &novert, NULL,
@@ -2019,56 +2069,6 @@ default_t defaults[] = {
     (config_t *) &grabmouse, NULL,
     {1}, {0, 1}, number, ss_none, wad_no,
     "1 to grab mouse during play"
-  },
-
-  // [FG] invert vertical axis
-  {
-    "mouse_y_invert",
-    (config_t *) &mouse_y_invert, NULL,
-    {0}, {0,1}, number, ss_gen, wad_no,
-    "invert vertical axis"
-  },
-
-  { //jff 4/3/98 allow unlimited sensitivity
-    "mouse_sensitivity_horiz",
-    (config_t *) &mouseSensitivity_horiz, NULL,
-    {10}, {0,UL}, number, ss_none, wad_no,
-    "adjust horizontal (x) mouse sensitivity for turning"
-  },
-
-  { //jff 4/3/98 allow unlimited sensitivity
-    "mouse_sensitivity_vert",
-    (config_t *) &mouseSensitivity_vert, NULL,
-    {5}, {0,UL}, number, ss_none, wad_no,
-    "adjust vertical (y) mouse sensitivity for moving"
-  },
-
-  {
-    "mouse_sensitivity_horiz_strafe",
-    (config_t *) &mouseSensitivity_horiz2, NULL,
-    {5}, {0,UL}, number, ss_none, wad_no,
-    "adjust horizontal (x) mouse sensitivity for strafing"
-  },
-
-  {
-    "mouse_sensitivity_vert_look",
-    (config_t *) &mouseSensitivity_vert2, NULL,
-    {10}, {0,UL}, number, ss_none, wad_no,
-    "adjust vertical (y) mouse sensitivity for looking"
-  },
-
-  {
-    "mouse_acceleration",
-    (config_t *) &mouse_acceleration, NULL,
-    {10}, {0,40}, number, ss_none, wad_no,
-    "adjust mouse acceleration (0 = 1.0, 40 = 5.0)"
-  },
-
-  {
-    "mouse_acceleration_threshold",
-    (config_t *) &mouse_acceleration_threshold, NULL,
-    {10}, {0,32}, number, ss_none, wad_no,
-    "adjust mouse acceleration threshold"
   },
 
   //

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -250,10 +250,10 @@ default_t defaults[] = {
   },
 
   {
-    "bilinear_sharpening",
-    (config_t *) &bilinear_sharpening, NULL,
+    "smooth_scaling",
+    (config_t *) &smooth_scaling, NULL,
     {1}, {0,1}, number, ss_gen, wad_no,
-    "enable bilinear sharpening"
+    "enable smooth pixel scaling"
   },
 
   {


### PR DESCRIPTION
Since we enable mouse acceleration by default, we need to change the mouse sensitivity. I have changed the config entries so it will reset the users settings, not sure if we should do this. The alternative is to disable mouse acceleration by default.

Also turn on bilinear sharpening for that "Crispy" look. Maybe rename it to "smooth pixel scaling"? Or "downsampling"?