### PR TITLE
add weaponinfo checks to weapon centering code

### DIFF
--- a/src/p_pspr.c
+++ b/src/p_pspr.c
@@ -437,6 +437,19 @@ void P_DropWeapon(player_t *player)
 }
 
 //
+// P_ApplyBobbing
+// Bob the weapon based on movement speed.
+//
+
+static void P_ApplyBobbing(int *sx, int *sy, fixed_t bob)
+{
+  int angle = (128*leveltime) & FINEMASK;
+  *sx = FRACUNIT + FixedMul(bob, finecosine[angle]);
+  angle &= FINEANGLES/2-1;
+  *sy = WEAPONTOP + FixedMul(bob, finesine[angle]);
+}
+
+//
 // A_WeaponReady
 // The player can fire the weapon
 // or change to another weapon at this time.
@@ -480,13 +493,7 @@ void A_WeaponReady(player_t *player, pspdef_t *psp)
   else
     player->attackdown = false;
 
-  // bob the weapon based on movement speed
-  {
-    int angle = (128*leveltime) & FINEMASK;
-    psp->sx = FRACUNIT + FixedMul(player->bob, finecosine[angle]);
-    angle &= FINEANGLES/2-1;
-    psp->sy = WEAPONTOP + FixedMul(player->bob, finesine[angle]);
-  }
+  P_ApplyBobbing(&psp->sx, &psp->sy, player->bob);
 }
 
 //
@@ -1113,10 +1120,7 @@ void P_MovePsprites(player_t *player)
     // [FG] not attacking means idle
     else if (!player->attackdown || center_weapon == WEAPON_BOBBING)
     {
-      int angle = (128*leveltime) & FINEMASK;
-      psp->sx2 = FRACUNIT + FixedMul(player->bob2, finecosine[angle]);
-      angle &= FINEANGLES/2-1;
-      psp->sy2 = WEAPONTOP + FixedMul(player->bob2, finesine[angle]);
+      P_ApplyBobbing(&psp->sx2, &psp->sy2, player->bob2);
     }
     // [FG] center the weapon sprite horizontally and push up vertically
     else if (center_weapon == WEAPON_CENTERED)

--- a/src/p_pspr.c
+++ b/src/p_pspr.c
@@ -1081,7 +1081,7 @@ void P_MovePsprites(player_t *player)
 
   if (!cosmetic_bobbing)
   {
-    static fixed_t last_sy = 32 * FRACUNIT;
+    static fixed_t last_sy = WEAPONTOP;
 
     psp->sx2 = FRACUNIT;
 
@@ -1091,13 +1091,13 @@ void P_MovePsprites(player_t *player)
         state != winfo->downstate && state != winfo->upstate)
     {
       last_sy = psp->sy2;
-      psp->sy2 = 32 * FRACUNIT;
+      psp->sy2 = WEAPONTOP;
     }
     else if (psp->state->action.p2 == (actionf_p2)A_Lower ||
              state == winfo->downstate)
     {
       // We want to move smoothly from where we were
-      psp->sy2 -= (last_sy - 32 * FRACUNIT);
+      psp->sy2 -= (last_sy - WEAPONTOP);
     }
   }
   else if (cosmetic_bobbing == BOBBING_75 || center_weapon || uncapped)
@@ -1112,9 +1112,9 @@ void P_MovePsprites(player_t *player)
     // [FG] not attacking means idle
     else if (!player->attackdown || center_weapon == WEAPON_BOBBING)
     {
-      int angle = (128*leveltime) & FINEMASK;
+      angle_t angle = (128 * leveltime) & FINEMASK;
       psp->sx2 = FRACUNIT + FixedMul(player->bob2, finecosine[angle]);
-      angle &= FINEANGLES/2-1;
+      angle &= (FINEANGLES / 2 - 1);
       psp->sy2 = WEAPONTOP + FixedMul(player->bob2, finesine[angle]);
     }
     // [FG] center the weapon sprite horizontally and push up vertically

--- a/src/p_pspr.c
+++ b/src/p_pspr.c
@@ -1058,7 +1058,7 @@ void P_SetupPsprites(player_t *player)
 void P_MovePsprites(player_t *player)
 {
   pspdef_t *psp = player->psprites;
-  weaponinfo_t *winfo = &weaponinfo[player->readyweapon];
+  weaponinfo_t *winfo;
   int i, state;
 
   // a null state means not active
@@ -1077,6 +1077,7 @@ void P_MovePsprites(player_t *player)
   psp->sx2 = psp->sx;
   psp->sy2 = psp->sy;
 
+  winfo = &weaponinfo[player->readyweapon];
   state = psp->state - states;
 
   if (!cosmetic_bobbing)

--- a/src/p_pspr.c
+++ b/src/p_pspr.c
@@ -1080,7 +1080,7 @@ void P_MovePsprites(player_t *player)
   winfo = &weaponinfo[player->readyweapon];
   state = psp->state - states;
 
-  if (!cosmetic_bobbing)
+  if (psp->state && !cosmetic_bobbing)
   {
     static fixed_t last_sy = WEAPONTOP;
 
@@ -1101,7 +1101,7 @@ void P_MovePsprites(player_t *player)
       psp->sy2 -= (last_sy - WEAPONTOP);
     }
   }
-  else if (cosmetic_bobbing == BOBBING_75 || center_weapon || uncapped)
+  else if (psp->state && (cosmetic_bobbing == BOBBING_75 || center_weapon || uncapped))
   {
     // [FG] don't center during lowering and raising states
     if (psp->state->misc1 ||

--- a/src/p_pspr.c
+++ b/src/p_pspr.c
@@ -1058,7 +1058,8 @@ void P_SetupPsprites(player_t *player)
 void P_MovePsprites(player_t *player)
 {
   pspdef_t *psp = player->psprites;
-  int i;
+  weaponinfo_t *winfo = &weaponinfo[player->readyweapon];
+  int i, state;
 
   // a null state means not active
   // drop tic count and possibly change state
@@ -1076,31 +1077,36 @@ void P_MovePsprites(player_t *player)
   psp->sx2 = psp->sx;
   psp->sy2 = psp->sy;
 
-  if (psp->state && !cosmetic_bobbing)
+  state = psp->state - states;
+
+  if (!cosmetic_bobbing)
   {
     static fixed_t last_sy = 32 * FRACUNIT;
 
     psp->sx2 = FRACUNIT;
 
-    if (psp->state->action.p2 != (actionf_p2)A_Lower &&
+    if (!psp->state->misc1 &&
+        psp->state->action.p2 != (actionf_p2)A_Lower &&
         psp->state->action.p2 != (actionf_p2)A_Raise &&
-        !psp->state->misc1)
+        state != winfo->downstate && state != winfo->upstate)
     {
       last_sy = psp->sy2;
       psp->sy2 = 32 * FRACUNIT;
     }
-    else if (psp->state->action.p2 == (actionf_p2)A_Lower)
+    else if (psp->state->action.p2 == (actionf_p2)A_Lower ||
+             state == winfo->downstate)
     {
       // We want to move smoothly from where we were
       psp->sy2 -= (last_sy - 32 * FRACUNIT);
     }
   }
-  else if (psp->state && (cosmetic_bobbing == BOBBING_75 || center_weapon || uncapped))
+  else if (cosmetic_bobbing == BOBBING_75 || center_weapon || uncapped)
   {
     // [FG] don't center during lowering and raising states
     if (psp->state->misc1 ||
         psp->state->action.p2 == (actionf_p2)A_Lower ||
-        psp->state->action.p2 == (actionf_p2)A_Raise)
+        psp->state->action.p2 == (actionf_p2)A_Raise ||
+        state == winfo->downstate || state == winfo->upstate)
     {
     }
     // [FG] not attacking means idle

--- a/src/p_pspr.c
+++ b/src/p_pspr.c
@@ -1113,9 +1113,9 @@ void P_MovePsprites(player_t *player)
     // [FG] not attacking means idle
     else if (!player->attackdown || center_weapon == WEAPON_BOBBING)
     {
-      angle_t angle = (128 * leveltime) & FINEMASK;
+      int angle = (128*leveltime) & FINEMASK;
       psp->sx2 = FRACUNIT + FixedMul(player->bob2, finecosine[angle]);
-      angle &= (FINEANGLES / 2 - 1);
+      angle &= FINEANGLES/2-1;
       psp->sy2 = WEAPONTOP + FixedMul(player->bob2, finesine[angle]);
     }
     // [FG] center the weapon sprite horizontally and push up vertically


### PR DESCRIPTION
Fix #1027 

This fixes both D4V.wad and armas29.wad for me. Not sure if this is the correct approach.