### PR TITLE
more robust fallback logic for music modules (fix crash on Linux+FluidSynth w/no soundfonts)

### DIFF
--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -702,11 +702,21 @@ int midi_player; // current music module
 
 static void MidiPlayerFallback(void)
 {
-    // Fall back to module 0 device 0.
-    midi_player = 0;
-    midi_player_module = music_modules[0].module;
-    midi_player_module->I_InitMusic(0);
-    active_module = midi_player_module;
+    // Fall back the the first module that initializes, device 0.
+    int i;
+
+    for (i = 0; i < arrlen(music_modules); i++)
+    {
+        if (music_modules[i].module->I_InitMusic(0))
+        {
+            midi_player = i;
+            midi_player_module = music_modules[midi_player].module;
+            active_module = midi_player_module;
+            return;
+        }
+    }
+
+    I_Error("MidiPlayerFallback: No music module could be initialized");
 }
 
 void I_SetMidiPlayer(int device)


### PR DESCRIPTION
The MIDI player fallback logic was to initialize *module 0 device 0*. However, it is possible that this fallback also fails.

A scenario where this happens is when running on Linux with FluidSynth but no soundfonts. In this case, FluidSynth will fail to initialize, the fallback will try to use FluidSynth again, which will fail again, and since the return code of `module->I_InitMusic` is not checked, the module will stay uninitialized and will cause a crash a bit later.

To fix this, implement a more robust fallback logic which tries to initialize each music module. This logic will always succeed since in the worst case it will fallback to OPL, which currently never fails.
