### PR TITLE
fix hang on OPL3 emulation with no sound card

### DIFF
--- a/opl/opl_sdl.c
+++ b/opl/opl_sdl.c
@@ -251,7 +251,8 @@ static int OPL_SDL_Init(unsigned int port_base)
     callback_mutex = SDL_CreateMutex();
     callback_queue_mutex = SDL_CreateMutex();
 
-    I_OAL_HookMusic(OPL_Callback);
+    if (!I_OAL_HookMusic(OPL_Callback))
+        return 0;
     I_OAL_SetGain((float)opl_gain / 100.0f);
 
     return 1;

--- a/src/i_oalmusic.c
+++ b/src/i_oalmusic.c
@@ -321,7 +321,7 @@ void I_OAL_SetGain(float gain)
     alSourcef(player.source, AL_GAIN, (ALfloat)gain);
 }
 
-void I_OAL_HookMusic(callback_func_t callback_func)
+boolean I_OAL_HookMusic(callback_func_t callback_func)
 {
     if (callback_func)
     {
@@ -333,12 +333,14 @@ void I_OAL_HookMusic(callback_func_t callback_func)
 
         I_OAL_SetGain(1.0f);
         I_OAL_PlaySong(NULL, false);
+        return player_thread_running;
     }
     else
     {
         I_OAL_UnRegisterSong(NULL);
 
         callback = NULL;
+        return true;
     }
 }
 

--- a/src/i_oalmusic.h
+++ b/src/i_oalmusic.h
@@ -18,10 +18,11 @@
 #define __I_OALMUSIC__
 
 #include <stdint.h>
+#include "doomdef.h"
 
 typedef uint32_t (*callback_func_t)(uint8_t *buffer, uint32_t buffer_samples);
 
-void I_OAL_HookMusic(callback_func_t callback_func);
+boolean I_OAL_HookMusic(callback_func_t callback_func);
 void I_OAL_SetGain(float gain);
 
 #endif


### PR DESCRIPTION
Since Woof! 11.0.0, if the MIDI player is set to OPL3 emulation but sound initialization fails (such as when there is no sound card available), Woof hangs. The hang occurs within `OPL_Delay` due to a deadlock: since the player thread is not running, the delay's callback never runs.

In previous versions, `OPL_SDL_Init` would fail when sound initialization failed, and it prevented the rest of the OPL initialization logic, including the call to `OPL_Delay`. However, this broke when switching from SDL_Mixer to OpenAL.

This commit re-adds the checks so `OPL_SDL_Init` fails when sound initialization fails.