### PR TITLE
reset musinfo.from_savegame on G_DoWorldDone and G_DeferedInitNew

### DIFF
--- a/src/g_game.c
+++ b/src/g_game.c
@@ -2161,7 +2161,7 @@ static void G_DoLoadGame(void)
     char lump[9] = {0};
     int i;
 
-    M_CopyLumpName(lump, save_p);
+    memcpy(lump, save_p, 8);
 
     i = W_CheckNumForName(lump);
 

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -1495,6 +1495,7 @@ frommapinfo:
 static void G_DoWorldDone(void)
 {
   idmusnum = -1;             //jff 3/17/98 allow new level's music to be loaded
+  musinfo.from_savegame = false;
   gamestate = GS_LEVEL;
   gameepisode = wminfo.nextep + 1;
   gamemap = wminfo.next+1;
@@ -2160,7 +2161,7 @@ static void G_DoLoadGame(void)
     char lump[9] = {0};
     int i;
 
-    memcpy(lump, save_p, 8);
+    M_CopyLumpName(lump, save_p);
 
     i = W_CheckNumForName(lump);
 
@@ -2773,6 +2774,7 @@ void G_DeferedInitNew(skill_t skill, int episode, int map)
   d_episode = episode;
   d_map = map;
   gameaction = ga_newgame;
+  musinfo.from_savegame = false;
 
   if (demorecording)
   {


### PR DESCRIPTION
Fix this issue: [[doomworld]](https://www.doomworld.com/forum/topic/112333-this-is-woof-1100-may-4-2023-updated-winmbf/?do=findComment&comment=2641269)

Not sure about this fix, it got convoluted. How about refactoring MUSINFO? For example, we don't need a parser from Hexen there.