### PR TITLE
add initialization checks to music modules

### DIFF
--- a/opl/opl_sdl.c
+++ b/opl/opl_sdl.c
@@ -251,7 +251,14 @@ static int OPL_SDL_Init(unsigned int port_base)
     callback_mutex = SDL_CreateMutex();
     callback_queue_mutex = SDL_CreateMutex();
 
-    I_OAL_HookMusic(OPL_Callback);
+    if (!I_OAL_HookMusic(OPL_Callback))
+    {
+        OPL_Queue_Destroy(callback_queue);
+        SDL_DestroyMutex(callback_mutex);
+        SDL_DestroyMutex(callback_queue_mutex);
+        return 0;
+    }
+
     I_OAL_SetGain((float)opl_gain / 100.0f);
 
     return 1;

--- a/src/i_flmusic.c
+++ b/src/i_flmusic.c
@@ -290,25 +290,37 @@ static boolean I_FL_InitMusic(int device)
 
 static void I_FL_SetMusicVolume(int volume)
 {
-    // FluidSynth's default is 0.2. Make 1.0 the maximum.
-    // 0 -- 0.2 -- 10.0
-    fluid_synth_set_gain(synth, ((float)volume / 15) * ((float)mus_gain / 100));
+    if (synth)
+    {
+        // FluidSynth's default is 0.2. Make 1.0 the maximum.
+        // 0 -- 0.2 -- 10.0
+        fluid_synth_set_gain(synth, ((float)volume / 15) * ((float)mus_gain / 100));
+    }
 }
 
 static void I_FL_PauseSong(void *handle)
 {
-    fluid_player_stop(player);
+    if (player)
+    {
+        fluid_player_stop(player);
+    }
 }
 
 static void I_FL_ResumeSong(void *handle)
 {
-    fluid_player_play(player);
+    if (player)
+    {
+        fluid_player_play(player);
+    }
 }
 
 static void I_FL_PlaySong(void *handle, boolean looping)
 {
-    fluid_player_set_loop(player, looping ? -1 : 1);
-    fluid_player_play(player);
+    if (player)
+    {
+        fluid_player_set_loop(player, looping ? -1 : 1);
+        fluid_player_play(player);
+    }
 }
 
 static void I_FL_StopSong(void *handle)
@@ -352,11 +364,18 @@ static void *I_FL_RegisterSong(void *data, int len)
 
     if (result != FLUID_OK)
     {
-        fprintf(stderr, "FluidSynth failed to load in-memory song\n");
+        delete_fluid_player(player);
+        player = NULL;
+        fprintf(stderr, "I_FL_RegisterSong: Failed to load in-memory song.\n");
         return NULL;
     }
 
-    I_OAL_HookMusic(FL_Callback);
+    if (!I_OAL_HookMusic(FL_Callback))
+    {
+        delete_fluid_player(player);
+        player = NULL;
+        return NULL;
+    }
 
     return (void *)1;
 }

--- a/src/i_oalmusic.h
+++ b/src/i_oalmusic.h
@@ -17,11 +17,11 @@
 #ifndef __I_OALMUSIC__
 #define __I_OALMUSIC__
 
-#include <stdint.h>
+#include "doomtype.h"
 
 typedef uint32_t (*callback_func_t)(uint8_t *buffer, uint32_t buffer_samples);
 
-void I_OAL_HookMusic(callback_func_t callback_func);
+boolean I_OAL_HookMusic(callback_func_t callback_func);
 void I_OAL_SetGain(float gain);
 
 #endif

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -759,9 +759,8 @@ void I_SetMidiPlayer(int device)
 
 boolean I_InitMusic(void)
 {
-    if (nomusicparm || !snd_init)
+    if (nomusicparm)
     {
-        nomusicparm = true;
         return false;
     }
 

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -1319,7 +1319,7 @@ static void I_WIN_StopSong(void *handle)
 {
     MMRESULT mmr;
 
-    if (!hPlayerThread)
+    if (!hMidiStream)
     {
         return;
     }
@@ -1339,6 +1339,11 @@ static void I_WIN_StopSong(void *handle)
 static void I_WIN_PlaySong(void *handle, boolean looping)
 {
     MMRESULT mmr;
+
+    if (!hMidiStream)
+    {
+        return;
+    }
 
     song.looping = looping;
 
@@ -1361,6 +1366,11 @@ static void I_WIN_PauseSong(void *handle)
 {
     MMRESULT mmr;
 
+    if (!hMidiStream)
+    {
+        return;
+    }
+
     mmr = midiStreamPause(hMidiStream);
     if (mmr != MMSYSERR_NOERROR)
     {
@@ -1371,6 +1381,11 @@ static void I_WIN_PauseSong(void *handle)
 static void I_WIN_ResumeSong(void *handle)
 {
     MMRESULT mmr;
+
+    if (!hMidiStream)
+    {
+        return;
+    }
 
     mmr = midiStreamRestart(hMidiStream);
     if (mmr != MMSYSERR_NOERROR)
@@ -1386,6 +1401,11 @@ static void *I_WIN_RegisterSong(void *data, int len)
     MIDIPROPTIMEDIV prop_timediv;
     MIDIPROPTEMPO prop_tempo;
     MMRESULT mmr;
+
+    if (!hMidiStream)
+    {
+        return NULL;
+    }
 
     if (IsMid(data, len))
     {
@@ -1460,6 +1480,11 @@ static void *I_WIN_RegisterSong(void *data, int len)
 
 static void I_WIN_UnRegisterSong(void *handle)
 {
+    if (!hMidiStream)
+    {
+        return;
+    }
+
     if (song.tracks)
     {
         unsigned int i;


### PR DESCRIPTION
Now, for example, if OpenAL fails to initialize, Win Native MIDI can still work.