### PR TITLE
winmidi: Compatibility update

### DIFF
--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -36,8 +36,6 @@
 
 int winmm_reset_type = -1;
 int winmm_reset_delay = 0;
-int winmm_reverb_level = -1;
-int winmm_chorus_level = -1;
 
 char *winmm_device = "";
 
@@ -321,46 +319,6 @@ static void ResetVolume(void)
     }
 }
 
-static void ResetReverb(int reset_type)
-{
-    int i;
-    int reverb = winmm_reverb_level;
-
-    if (reverb == -1 && reset_type == RESET_TYPE_NONE)
-    {
-        // No reverb specified and no SysEx reset selected. Use GM default.
-        reverb = 40;
-    }
-
-    if (reverb > -1)
-    {
-        for (i = 0; i < MIDI_CHANNELS_PER_TRACK; ++i)
-        {
-            SendShortMsg(0, MIDI_EVENT_CONTROLLER, i, MIDI_CONTROLLER_REVERB, reverb);
-        }
-    }
-}
-
-static void ResetChorus(int reset_type)
-{
-    int i;
-    int chorus = winmm_chorus_level;
-
-    if (chorus == -1 && reset_type == RESET_TYPE_NONE)
-    {
-        // No chorus specified and no SysEx reset selected. Use GM default.
-        chorus = 0;
-    }
-
-    if (chorus > -1)
-    {
-        for (i = 0; i < MIDI_CHANNELS_PER_TRACK; ++i)
-        {
-            SendShortMsg(0, MIDI_EVENT_CONTROLLER, i, MIDI_CONTROLLER_CHORUS, chorus);
-        }
-    }
-}
-
 static void ResetControllers(void)
 {
     int i;
@@ -373,6 +331,8 @@ static void ResetControllers(void)
         SendShortMsg(0, MIDI_EVENT_CONTROLLER, i, MIDI_CONTROLLER_BANK_SELECT_MSB, 0);
         SendShortMsg(0, MIDI_EVENT_CONTROLLER, i, MIDI_CONTROLLER_BANK_SELECT_LSB, 0);
         SendShortMsg(0, MIDI_EVENT_PROGRAM_CHANGE, i, 0, 0);
+        SendShortMsg(0, MIDI_EVENT_CONTROLLER, i, MIDI_CONTROLLER_REVERB, 40);
+        SendShortMsg(0, MIDI_EVENT_CONTROLLER, i, MIDI_CONTROLLER_CHORUS, 0);
     }
 }
 
@@ -480,9 +440,6 @@ static void ResetDevice(void)
         // when sending a GM/GS reset, so do it manually.
         ResetPitchBendSensitivity();
     }
-
-    ResetReverb(reset_type);
-    ResetChorus(reset_type);
 
     // Reset volume (initial playback or on shutdown if no SysEx reset).
     if (initial_playback || reset_type == RESET_TYPE_NONE)

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -272,7 +272,7 @@ static void SendDelayMsg(int time_ms)
     SendNOPMsg(time_ticks);
 }
 
-static void UpdateTempo(int time, midi_event_t *event)
+static void UpdateTempo(int time, const midi_event_t *event)
 {
     native_event_t native_event;
 
@@ -571,7 +571,7 @@ static void SendSysExMsg(int time, const byte *data, int length)
 }
 
 static void SendProgramMsg(int time, int channel, int program,
-                           midi_fallback_t *fallback)
+                           const midi_fallback_t *fallback)
 {
     switch ((int)fallback->type)
     {
@@ -605,7 +605,7 @@ static void SetLoopPoint(void)
     song.saved_elapsed_time = song.elapsed_time;
 }
 
-static void CheckFFLoop(midi_event_t *event)
+static void CheckFFLoop(const midi_event_t *event)
 {
     if (event->data.meta.length == sizeof(ff_loopStart) &&
         !memcmp(event->data.meta.data, ff_loopStart, sizeof(ff_loopStart)))
@@ -620,7 +620,7 @@ static void CheckFFLoop(midi_event_t *event)
     }
 }
 
-static boolean AddToBuffer(unsigned int delta_time, midi_event_t *event,
+static boolean AddToBuffer(unsigned int delta_time, const midi_event_t *event,
                            win_midi_track_t *track)
 {
     unsigned int i;

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -89,9 +89,6 @@ static HANDLE hPlayerThread;
 // MS GS Wavetable Synth Device ID.
 static int ms_gs_synth = MIDI_MAPPER;
 
-// EMIDI device for track designation.
-static int emidi_device;
-
 static char **winmm_devices;
 static int winmm_devices_num;
 
@@ -454,9 +451,6 @@ static void ResetDevice(void)
     MIDI_ResetFallback();
     use_fallback = (reset_type == RESET_TYPE_GS);
 
-    // Assign EMIDI device for track designation.
-    emidi_device = (reset_type == RESET_TYPE_GS);
-
     switch (reset_type)
     {
         case RESET_TYPE_NONE:
@@ -668,9 +662,6 @@ static void SendSysExMsg(int time, const byte *data, int length)
         // GS (SC-88 or higher). Preserve the composer's intent.
         MIDI_ResetFallback();
         use_fallback = false;
-
-        // Use default device for EMIDI.
-        emidi_device = EMIDI_DEVICE_GENERAL_MIDI;
     }
 }
 
@@ -793,7 +784,8 @@ static boolean AddToBuffer(unsigned int delta_time, midi_event_t *event,
             return true;
     }
 
-    if (track->emidi_designated && (emidi_device & ~track->emidi_device_flags))
+    if (track->emidi_designated &&
+        (EMIDI_DEVICE_GENERAL_MIDI & ~track->emidi_device_flags))
     {
         // Send NOP if this device has been excluded from this track.
         SendNOPMsg(delta_time);

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -800,6 +800,31 @@ static void SendEMIDI(unsigned int delta_time, const midi_event_t *event,
     }
 }
 
+static void SendMetaMsg(unsigned int delta_time, const midi_event_t *event,
+                        win_midi_track_t *track)
+{
+    switch (event->data.meta.type)
+    {
+        case MIDI_META_END_OF_TRACK:
+            track->end_of_track = true;
+            SendNOPMsg(delta_time);
+            break;
+
+        case MIDI_META_SET_TEMPO:
+            UpdateTempo(delta_time, event);
+            break;
+
+        case MIDI_META_MARKER:
+            CheckFFLoop(event);
+            SendNOPMsg(delta_time);
+            break;
+
+        default:
+            SendNOPMsg(delta_time);
+            break;
+    }
+}
+
 static boolean AddToBuffer(unsigned int delta_time, const midi_event_t *event,
                            win_midi_track_t *track)
 {
@@ -817,26 +842,7 @@ static boolean AddToBuffer(unsigned int delta_time, const midi_event_t *event,
             return false;
 
         case MIDI_EVENT_META:
-            switch (event->data.meta.type)
-            {
-                case MIDI_META_END_OF_TRACK:
-                    track->end_of_track = true;
-                    SendNOPMsg(delta_time);
-                    break;
-
-                case MIDI_META_SET_TEMPO:
-                    UpdateTempo(delta_time, event);
-                    break;
-
-                case MIDI_META_MARKER:
-                    CheckFFLoop(event);
-                    SendNOPMsg(delta_time);
-                    break;
-
-                default:
-                    SendNOPMsg(delta_time);
-                    break;
-            }
+            SendMetaMsg(delta_time, event, track);
             return true;
     }
 

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -633,12 +633,151 @@ static void CheckFFLoop(const midi_event_t *event)
     }
 }
 
-static boolean AddToBuffer(unsigned int delta_time, const midi_event_t *event,
-                           win_midi_track_t *track)
+static void SendEMIDI(unsigned int delta_time, const midi_event_t *event,
+                      win_midi_track_t *track, const midi_fallback_t *fallback)
 {
     unsigned int i;
     unsigned int flag;
     int count;
+
+    switch ((int)event->event_type)
+    {
+        case EMIDI_CONTROLLER_TRACK_DESIGNATION:
+            if (track->elapsed_time < timediv)
+            {
+                flag = event->data.channel.param2;
+
+                if (flag == EMIDI_DEVICE_ALL)
+                {
+                    track->emidi_device_flags = UINT_MAX;
+                    track->emidi_designated = true;
+                }
+                else if (flag <= EMIDI_DEVICE_ULTRASOUND)
+                {
+                    track->emidi_device_flags |= 1 << flag;
+                    track->emidi_designated = true;
+                }
+            }
+            SendNOPMsg(delta_time);
+            break;
+
+        case EMIDI_CONTROLLER_TRACK_EXCLUSION:
+            if (song.rpg_loop)
+            {
+                SetLoopPoint();
+            }
+            else if (track->elapsed_time < timediv)
+            {
+                flag = event->data.channel.param2;
+
+                if (!track->emidi_designated)
+                {
+                    track->emidi_device_flags = UINT_MAX;
+                    track->emidi_designated = true;
+                }
+
+                if (flag <= EMIDI_DEVICE_ULTRASOUND)
+                {
+                    track->emidi_device_flags &= ~(1 << flag);
+                }
+            }
+            SendNOPMsg(delta_time);
+            break;
+
+        case EMIDI_CONTROLLER_PROGRAM_CHANGE:
+            if (track->emidi_program || track->elapsed_time < timediv)
+            {
+                track->emidi_program = true;
+                SendProgramMsg(delta_time, event->data.channel.channel,
+                               event->data.channel.param2, fallback);
+            }
+            else
+            {
+                SendNOPMsg(delta_time);
+            }
+            break;
+
+        case EMIDI_CONTROLLER_VOLUME:
+            if (track->emidi_volume || track->elapsed_time < timediv)
+            {
+                track->emidi_volume = true;
+                SendVolumeMsg(delta_time, event);
+            }
+            else
+            {
+                SendNOPMsg(delta_time);
+            }
+            break;
+
+        case EMIDI_CONTROLLER_LOOP_BEGIN:
+            count = event->data.channel.param2;
+            count = (count == 0) ? (-1) : count;
+            track->emidi_loop_count = count;
+            MIDI_SetLoopPoint(track->iter);
+            SendNOPMsg(delta_time);
+            break;
+
+        case EMIDI_CONTROLLER_LOOP_END:
+            if (event->data.channel.param2 == EMIDI_LOOP_FLAG)
+            {
+                if (track->emidi_loop_count != 0)
+                {
+                    MIDI_RestartAtLoopPoint(track->iter);
+                }
+
+                if (track->emidi_loop_count > 0)
+                {
+                    track->emidi_loop_count--;
+                }
+            }
+            SendNOPMsg(delta_time);
+            break;
+
+        case EMIDI_CONTROLLER_GLOBAL_LOOP_BEGIN:
+            count = event->data.channel.param2;
+            count = (count == 0) ? (-1) : count;
+            for (i = 0; i < song.num_tracks; ++i)
+            {
+                song.tracks[i].emidi_loop_count = count;
+                MIDI_SetLoopPoint(song.tracks[i].iter);
+                song.tracks[i].saved_end_of_track = song.tracks[i].end_of_track;
+                song.tracks[i].saved_elapsed_time = song.tracks[i].elapsed_time;
+            }
+            song.saved_elapsed_time = song.elapsed_time;
+            SendNOPMsg(delta_time);
+            break;
+
+        case EMIDI_CONTROLLER_GLOBAL_LOOP_END:
+            if (event->data.channel.param2 == EMIDI_LOOP_FLAG)
+            {
+                for (i = 0; i < song.num_tracks; ++i)
+                {
+                    if (song.tracks[i].emidi_loop_count != 0)
+                    {
+                        MIDI_RestartAtLoopPoint(song.tracks[i].iter);
+                        song.tracks[i].end_of_track = song.tracks[i].saved_end_of_track;
+                        song.tracks[i].elapsed_time = song.tracks[i].saved_elapsed_time;
+                        song.elapsed_time = song.saved_elapsed_time;
+                    }
+
+                    if (song.tracks[i].emidi_loop_count > 0)
+                    {
+                        song.tracks[i].emidi_loop_count--;
+                    }
+                }
+            }
+            SendNOPMsg(delta_time);
+            break;
+
+        default:
+            SendNOPMsg(delta_time);
+            break;
+    }
+}
+
+static boolean AddToBuffer(unsigned int delta_time, const midi_event_t *event,
+                           win_midi_track_t *track)
+{
     midi_fallback_t fallback = {FALLBACK_NONE, 0};
 
     if (use_fallback)
@@ -736,130 +875,14 @@ static boolean AddToBuffer(unsigned int delta_time, const midi_event_t *event,
                     break;
 
                 case EMIDI_CONTROLLER_TRACK_DESIGNATION:
-                    if (track->elapsed_time < timediv)
-                    {
-                        flag = event->data.channel.param2;
-
-                        if (flag == EMIDI_DEVICE_ALL)
-                        {
-                            track->emidi_device_flags = UINT_MAX;
-                            track->emidi_designated = true;
-                        }
-                        else if (flag <= EMIDI_DEVICE_ULTRASOUND)
-                        {
-                            track->emidi_device_flags |= 1 << flag;
-                            track->emidi_designated = true;
-                        }
-                    }
-                    SendNOPMsg(delta_time);
-                    break;
-
                 case EMIDI_CONTROLLER_TRACK_EXCLUSION:
-                    if (song.rpg_loop)
-                    {
-                        SetLoopPoint();
-                    }
-                    else if (track->elapsed_time < timediv)
-                    {
-                        flag = event->data.channel.param2;
-
-                        if (!track->emidi_designated)
-                        {
-                            track->emidi_device_flags = UINT_MAX;
-                            track->emidi_designated = true;
-                        }
-
-                        if (flag <= EMIDI_DEVICE_ULTRASOUND)
-                        {
-                            track->emidi_device_flags &= ~(1 << flag);
-                        }
-                    }
-                    SendNOPMsg(delta_time);
-                    break;
-
                 case EMIDI_CONTROLLER_PROGRAM_CHANGE:
-                    if (track->emidi_program || track->elapsed_time < timediv)
-                    {
-                        track->emidi_program = true;
-                        SendProgramMsg(delta_time, event->data.channel.channel,
-                                       event->data.channel.param2, &fallback);
-                    }
-                    else
-                    {
-                        SendNOPMsg(delta_time);
-                    }
-                    break;
-
                 case EMIDI_CONTROLLER_VOLUME:
-                    if (track->emidi_volume || track->elapsed_time < timediv)
-                    {
-                        track->emidi_volume = true;
-                        SendVolumeMsg(delta_time, event);
-                    }
-                    else
-                    {
-                        SendNOPMsg(delta_time);
-                    }
-                    break;
-
                 case EMIDI_CONTROLLER_LOOP_BEGIN:
-                    count = event->data.channel.param2;
-                    count = (count == 0) ? (-1) : count;
-                    track->emidi_loop_count = count;
-                    MIDI_SetLoopPoint(track->iter);
-                    SendNOPMsg(delta_time);
-                    break;
-
                 case EMIDI_CONTROLLER_LOOP_END:
-                    if (event->data.channel.param2 == EMIDI_LOOP_FLAG)
-                    {
-                        if (track->emidi_loop_count != 0)
-                        {
-                            MIDI_RestartAtLoopPoint(track->iter);
-                        }
-
-                        if (track->emidi_loop_count > 0)
-                        {
-                            track->emidi_loop_count--;
-                        }
-                    }
-                    SendNOPMsg(delta_time);
-                    break;
-
                 case EMIDI_CONTROLLER_GLOBAL_LOOP_BEGIN:
-                    count = event->data.channel.param2;
-                    count = (count == 0) ? (-1) : count;
-                    for (i = 0; i < song.num_tracks; ++i)
-                    {
-                        song.tracks[i].emidi_loop_count = count;
-                        MIDI_SetLoopPoint(song.tracks[i].iter);
-                        song.tracks[i].saved_end_of_track = song.tracks[i].end_of_track;
-                        song.tracks[i].saved_elapsed_time = song.tracks[i].elapsed_time;
-                    }
-                    song.saved_elapsed_time = song.elapsed_time;
-                    SendNOPMsg(delta_time);
-                    break;
-
                 case EMIDI_CONTROLLER_GLOBAL_LOOP_END:
-                    if (event->data.channel.param2 == EMIDI_LOOP_FLAG)
-                    {
-                        for (i = 0; i < song.num_tracks; ++i)
-                        {
-                            if (song.tracks[i].emidi_loop_count != 0)
-                            {
-                                MIDI_RestartAtLoopPoint(song.tracks[i].iter);
-                                song.tracks[i].end_of_track = song.tracks[i].saved_end_of_track;
-                                song.tracks[i].elapsed_time = song.tracks[i].saved_elapsed_time;
-                                song.elapsed_time = song.saved_elapsed_time;
-                            }
-
-                            if (song.tracks[i].emidi_loop_count > 0)
-                            {
-                                song.tracks[i].emidi_loop_count--;
-                            }
-                        }
-                    }
-                    SendNOPMsg(delta_time);
+                    SendEMIDI(delta_time, event, track, &fallback);
                     break;
 
                 case MIDI_CONTROLLER_RESET_ALL_CTRLS:

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -937,7 +937,10 @@ static boolean AddToBuffer(unsigned int delta_time, midi_event_t *event,
                     {
                         song.tracks[i].emidi_loop_count = count;
                         MIDI_SetLoopPoint(song.tracks[i].iter);
+                        song.tracks[i].saved_end_of_track = song.tracks[i].end_of_track;
+                        song.tracks[i].saved_elapsed_time = song.tracks[i].elapsed_time;
                     }
+                    song.saved_elapsed_time = song.elapsed_time;
                     SendNOPMsg(delta_time);
                     break;
 
@@ -949,6 +952,9 @@ static boolean AddToBuffer(unsigned int delta_time, midi_event_t *event,
                             if (song.tracks[i].emidi_loop_count != 0)
                             {
                                 MIDI_RestartAtLoopPoint(song.tracks[i].iter);
+                                song.tracks[i].end_of_track = song.tracks[i].saved_end_of_track;
+                                song.tracks[i].elapsed_time = song.tracks[i].saved_elapsed_time;
+                                song.elapsed_time = song.saved_elapsed_time;
                             }
 
                             if (song.tracks[i].emidi_loop_count > 0)

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -64,7 +64,7 @@ static const byte ff_loopEnd[] = {'l', 'o', 'o', 'p', 'E', 'n', 'd'};
 static boolean use_fallback;
 
 #define DEFAULT_VOLUME 100
-static int channel_volume[MIDI_CHANNELS_PER_TRACK];
+static byte channel_volume[MIDI_CHANNELS_PER_TRACK];
 static float volume_factor = 0.0f;
 static boolean update_volume = false;
 
@@ -236,26 +236,29 @@ static void StreamOut(void)
     }
 }
 
-static void SendShortMsg(int time, int status, int channel, int param1, int param2)
+static void SendShortMsg(unsigned int delta_time, byte status, byte channel,
+                         byte param1, byte param2)
 {
     native_event_t native_event;
-    native_event.dwDeltaTime = time;
+    native_event.dwDeltaTime = delta_time;
     native_event.dwStreamID = 0;
     native_event.dwEvent = MAKE_EVT(status | channel, param1, param2, MEVT_SHORTMSG);
     WriteBuffer((byte *)&native_event, sizeof(native_event_t));
 }
 
-static void SendChannelMsg(int time, const midi_event_t *event, boolean use_param2)
+static void SendChannelMsg(unsigned int delta_time, const midi_event_t *event,
+                           boolean use_param2)
 {
-    SendShortMsg(time, event->event_type, event->data.channel.channel,
+    SendShortMsg(delta_time, event->event_type, event->data.channel.channel,
                  event->data.channel.param1,
                  use_param2 ? event->data.channel.param2 : 0);
 }
 
-static void SendLongMsg(int time, const byte *ptr, int length)
+static void SendLongMsg(unsigned int delta_time, const byte *ptr,
+                        unsigned int length)
 {
     native_event_t native_event;
-    native_event.dwDeltaTime = time;
+    native_event.dwDeltaTime = delta_time;
     native_event.dwStreamID = 0;
     native_event.dwEvent = MAKE_EVT(length, 0, 0, MEVT_LONGMSG);
     WriteBuffer((byte *)&native_event, sizeof(native_event_t));
@@ -263,46 +266,47 @@ static void SendLongMsg(int time, const byte *ptr, int length)
     WriteBufferPad();
 }
 
-static void SendNOPMsg(int time)
+static void SendNOPMsg(unsigned int delta_time)
 {
     native_event_t native_event;
-    native_event.dwDeltaTime = time;
+    native_event.dwDeltaTime = delta_time;
     native_event.dwStreamID = 0;
     native_event.dwEvent = MAKE_EVT(0, 0, 0, MEVT_NOP);
     WriteBuffer((byte *)&native_event, sizeof(native_event_t));
 }
 
-static void SendDelayMsg(int time_ms)
+static void SendDelayMsg(unsigned int time_ms)
 {
     // Convert ms to ticks (see "Standard MIDI Files 1.0" page 14).
-    int time_ticks = (float)time_ms * 1000 * timediv / tempo + 0.5f;
-    SendNOPMsg(time_ticks);
+    const unsigned int ticks = (float)time_ms * 1000 * timediv / tempo + 0.5f;
+    SendNOPMsg(ticks);
 }
 
-static void UpdateTempo(int time, const midi_event_t *event)
+static void UpdateTempo(unsigned int delta_time, const midi_event_t *event)
 {
     native_event_t native_event;
 
     tempo = MAKE_EVT(event->data.meta.data[2], event->data.meta.data[1],
                      event->data.meta.data[0], 0);
 
-    native_event.dwDeltaTime = time;
+    native_event.dwDeltaTime = delta_time;
     native_event.dwStreamID = 0;
     native_event.dwEvent = MAKE_EVT(tempo, 0, 0, MEVT_TEMPO);
     WriteBuffer((byte *)&native_event, sizeof(native_event_t));
 }
 
-static void SendManualVolumeMsg(int time, int channel, int volume)
+static void SendManualVolumeMsg(unsigned int delta_time, byte channel,
+                                byte volume)
 {
-    int scaled_volume = volume * volume_factor + 0.5f;
-    SendShortMsg(time, MIDI_EVENT_CONTROLLER, channel,
+    const byte scaled_volume = (byte)(volume * volume_factor + 0.5f) & 0x7F;
+    SendShortMsg(delta_time, MIDI_EVENT_CONTROLLER, channel,
                  MIDI_CONTROLLER_VOLUME_MSB, scaled_volume);
     channel_volume[channel] = volume;
 }
 
-static void SendVolumeMsg(int time, const midi_event_t *event)
+static void SendVolumeMsg(unsigned int delta_time, const midi_event_t *event)
 {
-    SendManualVolumeMsg(time, event->data.channel.channel,
+    SendManualVolumeMsg(delta_time, event->data.channel.channel,
                         event->data.channel.param2);
 }
 
@@ -417,7 +421,7 @@ static void ResetDevice(void)
     }
 }
 
-static boolean IsPartLevel(const byte *msg, int length)
+static boolean IsPartLevel(const byte *msg, unsigned int length)
 {
     if (length == 10 &&
         msg[0] == 0x41 && // Roland
@@ -442,7 +446,7 @@ static boolean IsPartLevel(const byte *msg, int length)
     return false;
 }
 
-static boolean IsSysExReset(const byte *msg, int length)
+static boolean IsSysExReset(const byte *msg, unsigned int length)
 {
     if (length < 5)
     {
@@ -551,7 +555,7 @@ static void SendSysExMsg(unsigned int delta_time, const midi_event_t *event)
     boolean is_sysex_reset;
     const byte event_type = MIDI_EVENT_SYSEX;
     const byte *data = event->data.sysex.data;
-    const int length = event->data.sysex.length;
+    const unsigned int length = event->data.sysex.length;
 
     if (IsPartLevel(data, length))
     {
@@ -608,24 +612,25 @@ static void SendSysExMsg(unsigned int delta_time, const midi_event_t *event)
     }
 }
 
-static void SendProgramMsg(int time, int channel, int program,
+static void SendProgramMsg(unsigned int delta_time, byte channel, byte program,
                            const midi_fallback_t *fallback)
 {
     switch ((int)fallback->type)
     {
         case FALLBACK_BANK_MSB:
-            SendShortMsg(time, MIDI_EVENT_CONTROLLER, channel,
+            SendShortMsg(delta_time, MIDI_EVENT_CONTROLLER, channel,
                          MIDI_CONTROLLER_BANK_SELECT_MSB, fallback->value);
             SendShortMsg(0, MIDI_EVENT_PROGRAM_CHANGE, channel, program, 0);
             break;
 
         case FALLBACK_DRUMS:
-            SendShortMsg(time, MIDI_EVENT_PROGRAM_CHANGE, channel,
+            SendShortMsg(delta_time, MIDI_EVENT_PROGRAM_CHANGE, channel,
                          fallback->value, 0);
             break;
 
         default:
-            SendShortMsg(time, MIDI_EVENT_PROGRAM_CHANGE, channel, program, 0);
+            SendShortMsg(delta_time, MIDI_EVENT_PROGRAM_CHANGE, channel,
+                         program, 0);
             break;
     }
 }

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -823,7 +823,7 @@ static boolean AddToBuffer(unsigned int delta_time, const midi_event_t *event,
 
     if (use_fallback)
     {
-        MIDI_CheckFallback(event, &fallback);
+        MIDI_CheckFallback(event, &fallback, true);
     }
 
     switch ((int)event->event_type)

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -95,8 +95,6 @@ extern int     mus_gain;
 extern char *winmm_device;
 extern int winmm_reset_type;
 extern int winmm_reset_delay;
-extern int winmm_reverb_level;
-extern int winmm_chorus_level;
 #endif
 extern int opl_gain;
 extern int midi_player_menu;
@@ -519,20 +517,6 @@ default_t defaults[] = {
     (config_t *) &winmm_reset_delay, NULL,
     {0}, {0, 2000}, number, ss_none, wad_no,
     "Delay after reset for native MIDI (milliseconds)"
-  },
-
-  {
-    "winmm_reverb_level",
-    (config_t *) &winmm_reverb_level, NULL,
-    {-1}, {-1, 127}, number, ss_none, wad_no,
-    "Reverb send level for native MIDI (-1 = Default, 0 = Off, 127 = Max)"
-  },
-
-  {
-    "winmm_chorus_level",
-    (config_t *) &winmm_chorus_level, NULL,
-    {-1}, {-1, 127}, number, ss_none, wad_no,
-    "Chorus send level for native MIDI (-1 = Default, 0 = Off, 127 = Max)"
   },
 #endif
 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -508,8 +508,8 @@ default_t defaults[] = {
   {
     "winmm_reset_type",
     (config_t *) &winmm_reset_type, NULL,
-    {-1}, {-1, 4}, number, ss_none, wad_no,
-    "SysEx reset for native MIDI (-1 = Default, 0 = None, 1 = GS, 2 = GM, 3 = GM2, 4 = XG)"
+    {1}, {0, 3}, number, ss_none, wad_no,
+    "SysEx reset for native MIDI (0 = None, 1 = GM, 2 = GS, 3 = XG)"
   },
 
   {

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -93,6 +93,7 @@ extern int     mus_gain;
 #endif
 #if defined(_WIN32)
 extern char *winmm_device;
+extern int winmm_complevel;
 extern int winmm_reset_type;
 extern int winmm_reset_delay;
 #endif
@@ -503,6 +504,13 @@ default_t defaults[] = {
     (config_t *) &winmm_device, NULL,
     {.s = ""}, {0}, string, ss_none, wad_no,
     "Native MIDI device"
+  },
+
+  {
+    "winmm_complevel",
+    (config_t *) &winmm_complevel, NULL,
+    {1}, {0, 2}, number, ss_none, wad_no,
+    "Native MIDI compatibility level (0 = Vanilla, 1 = Standard, 2 = Full)"
   },
 
   {

--- a/src/midifallback.c
+++ b/src/midifallback.c
@@ -144,7 +144,8 @@ static boolean GetProgramFallback(byte idx, byte program,
     return false;
 }
 
-void MIDI_CheckFallback(const midi_event_t *event, midi_fallback_t *fallback)
+void MIDI_CheckFallback(const midi_event_t *event, midi_fallback_t *fallback,
+                        boolean allow_sysex)
 {
     byte idx;
     byte program;
@@ -152,7 +153,10 @@ void MIDI_CheckFallback(const midi_event_t *event, midi_fallback_t *fallback)
     switch ((int)event->event_type)
     {
         case MIDI_EVENT_SYSEX:
-            UpdateDrumMap(event->data.sysex.data, event->data.sysex.length);
+            if (allow_sysex)
+            {
+                UpdateDrumMap(event->data.sysex.data, event->data.sysex.length);
+            }
             break;
 
         case MIDI_EVENT_CONTROLLER:

--- a/src/midifallback.c
+++ b/src/midifallback.c
@@ -17,6 +17,7 @@
 
 
 #include "doomtype.h"
+#include "m_io.h"
 #include "midifile.h"
 #include "midifallback.h"
 
@@ -110,6 +111,11 @@ static boolean GetProgramFallback(byte idx, byte program,
             // Fall to capital when no instrument has (successfully)
             // selected this variation or if the variation is above 63.
             fallback->value = 0;
+
+            fprintf(stderr,
+                    "midifallback: warning: ch=%d [bank_msb=%d prog=%d] "
+                    "falling back to [bank_msb=%d prog=%d]\n",
+                    idx, bank_msb[idx], program, fallback->value, program);
             return true;
         }
 
@@ -125,6 +131,11 @@ static boolean GetProgramFallback(byte idx, byte program,
             }
             fallback->value -= 8;
         }
+
+        fprintf(stderr,
+                "midifallback: warning: ch=%d [bank_msb=%d prog=%d] "
+                "falling back to [bank_msb=%d prog=%d]\n",
+                idx, bank_msb[idx], program, fallback->value, program);
         return true;
     }
     else // Drums channel
@@ -137,6 +148,11 @@ static boolean GetProgramFallback(byte idx, byte program,
             fallback->type = FALLBACK_DRUMS;
             fallback->value = drums_table[program];
             selected[idx] = true;
+
+            fprintf(stderr,
+                    "midifallback: warning: ch=%d [prog=%d] "
+                    "falling back to [prog=%d] (drums)\n",
+                    idx, program, fallback->value);
             return true;
         }
     }
@@ -176,6 +192,11 @@ void MIDI_CheckFallback(const midi_event_t *event, midi_fallback_t *fallback,
                         // preserves user's current SC-XX map.
                         fallback->type = FALLBACK_BANK_LSB;
                         fallback->value = 0;
+
+                        fprintf(stderr,
+                                "midifallback: warning: ch=%d [bank_lsb=%d] "
+                                "replaced by [bank_lsb=%d]\n",
+                                idx, event->data.channel.param2, fallback->value);
                         return;
                     }
                     break;

--- a/src/midifallback.c
+++ b/src/midifallback.c
@@ -17,7 +17,7 @@
 
 
 #include "doomtype.h"
-#include "m_io.h"
+#include <stdio.h>
 #include "midifile.h"
 #include "midifallback.h"
 

--- a/src/midifallback.h
+++ b/src/midifallback.h
@@ -35,7 +35,8 @@ typedef struct midi_fallback_t
     byte value;
 } midi_fallback_t;
 
-void MIDI_CheckFallback(const midi_event_t *event, midi_fallback_t *fallback);
+void MIDI_CheckFallback(const midi_event_t *event, midi_fallback_t *fallback,
+                        boolean allow_sysex);
 void MIDI_ResetFallback(void);
 void MIDI_InitFallback(void);
 

--- a/src/midifile.h
+++ b/src/midifile.h
@@ -23,6 +23,12 @@ typedef struct midi_track_iter_s midi_track_iter_t;
 
 #define MIDI_CHANNELS_PER_TRACK 16
 
+#define MIDI_RPN_MSB                 0x00
+#define MIDI_RPN_PITCH_BEND_SENS_LSB 0x00
+#define MIDI_RPN_FINE_TUNING_LSB     0x01
+#define MIDI_RPN_COARSE_TUNING_LSB   0x02
+#define MIDI_RPN_NULL                0x7F
+
 typedef enum
 {
     MIDI_EVENT_NOTE_OFF        = 0x80,
@@ -48,20 +54,29 @@ typedef enum
     MIDI_CONTROLLER_DATA_ENTRY_MSB  = 0x06,
     MIDI_CONTROLLER_VOLUME_MSB      = 0x07,
     MIDI_CONTROLLER_PAN             = 0x0A,
+    MIDI_CONTROLLER_EXPRESSION      = 0x0B,
 
     MIDI_CONTROLLER_BANK_SELECT_LSB = 0x20,
     MIDI_CONTROLLER_DATA_ENTRY_LSB  = 0x26,
     MIDI_CONTROLLER_VOLUME_LSB      = 0X27,
 
+    MIDI_CONTROLLER_HOLD1_PEDAL     = 0x40,
+    MIDI_CONTROLLER_SOFT_PEDAL      = 0x43,
+
     MIDI_CONTROLLER_REVERB          = 0x5B,
     MIDI_CONTROLLER_CHORUS          = 0x5D,
 
+    MIDI_CONTROLLER_NRPN_LSB        = 0x62,
+    MIDI_CONTROLLER_NRPN_MSB        = 0x63,
     MIDI_CONTROLLER_RPN_LSB         = 0x64,
     MIDI_CONTROLLER_RPN_MSB         = 0x65,
 
     MIDI_CONTROLLER_ALL_SOUND_OFF   = 0x78,
     MIDI_CONTROLLER_RESET_ALL_CTRLS = 0x79,
     MIDI_CONTROLLER_ALL_NOTES_OFF   = 0x7B,
+
+    MIDI_CONTROLLER_POLY_MODE_OFF   = 0x7E,
+    MIDI_CONTROLLER_POLY_MODE_ON    = 0x7F,
 } midi_controller_t;
 
 typedef enum


### PR DESCRIPTION
This is a large update that provides a more conservative default experience for users when using native Windows MIDI. It can now emulate Vanilla Doom's DMX MPU-401 mode, Microsoft GS Wavetable Synth, or send all messages to the MIDI device. Documentation is here: https://gist.github.com/ceski-1/86b7405a66ff67c42a788000edc3b625

There are also some bug fixes and clean ups.