### PR TITLE
fix initialization with invalid video_display setting

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -834,19 +834,23 @@ static void CenterWindow(int *x, int *y, int w, int h)
     }
 }
 
-static void I_GetWindowPosition(int *x, int *y, int w, int h)
+static void I_ResetInvalidDisplayIndex(void)
 {
     // Check that video_display corresponds to a display that really exists,
     // and if it doesn't, reset it.
     if (video_display < 0 || video_display >= SDL_GetNumVideoDisplays())
     {
         fprintf(stderr,
-                "I_GetWindowPosition: We were configured to run on display #%d, "
-                "but it no longer exists (max %d). Moving to display 0.\n",
+                "I_ResetInvalidDisplayIndex: We were configured to run on "
+                "display #%d, but it no longer exists (max %d). "
+                "Moving to display 0.\n",
                 video_display, SDL_GetNumVideoDisplays() - 1);
         video_display = 0;
     }
+}
 
+static void I_GetWindowPosition(int *x, int *y, int w, int h)
+{
     // in fullscreen mode, the window "position" still matters, because
     // we use it to control which display we run fullscreen on.
 
@@ -1165,6 +1169,7 @@ static void I_InitGraphicsMode(void)
 
     int p, tmp_scalefactor;
 
+    I_ResetInvalidDisplayIndex();
     hires = default_hires;
 
     //!


### PR DESCRIPTION
If the `video_display` setting is invalid (for example, due to a disconnected monitor), it was reset on `I_GetWindowPosition`, which is called during video initialization.

However, commit dc4182d6d81f ("add exclusive fullscreen to the menu") reordered the initialization logic. As a result, an invalid `video_display` can be passed to `SDL_GetCurrentDisplayMode`, causing Woof to exit before the `video_display` reset logic is run.

Commit cab179594848 ("i_video.c refactor, resize upscaled texture on window resize") somewhat mitigates the problem, but an exit still happens when `fullscreen = 1` and `exclusive_fullscreen = 1`.

Fix this by moving the `video_display` reset logic to a separate function which is called at the very start of video initialization.