### PR TITLE
set display resolution when toggle exclusive fullscreen

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -283,6 +283,13 @@ void I_ToggleExclusiveFullScreen(void)
 
     if (exclusive_fullscreen)
     {
+        SDL_DisplayMode mode;
+        if (SDL_GetCurrentDisplayMode(video_display, &mode) != 0)
+        {
+            I_Error("Could not get display mode for video display #%d: %s",
+                    video_display, SDL_GetError());
+        }
+        SDL_SetWindowSize(screen, mode.w, mode.h);
         SDL_SetWindowFullscreen(screen, SDL_WINDOW_FULLSCREEN);
     }
     else


### PR DESCRIPTION
If the game is started in windowed mode, when switching to exclusive fullscreen mode, the the size of the window is applied to renderer instead of the size of fullscreen. Tested on Win10.