### PR TITLE
don't run SDL_RenderPresent in I_UpdateRender

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -421,8 +421,6 @@ static inline void I_UpdateRender (void)
     {
         SDL_RenderCopy(renderer, texture, NULL, NULL);
     }
-
-    SDL_RenderPresent(renderer);
 }
 
 static void I_DrawDiskIcon(), I_RestoreDiskBackground();
@@ -507,6 +505,8 @@ void I_FinishUpdate(void)
     I_DrawDiskIcon();
 
     I_UpdateRender();
+
+    SDL_RenderPresent(renderer);
 
     if (uncapped)
     {


### PR DESCRIPTION
SDL's rendering functions operate on a backbuffer, the backbuffer should be considered invalidated after each present; do not assume that previous contents will exist between frames. Documentation:
https://wiki.libsdl.org/SDL2/SDL_RenderPresent

Fix #1076 