### PR TITLE
Make IDCLEV00 restart the current map

### DIFF
--- a/src/m_cheat.c
+++ b/src/m_cheat.c
@@ -633,8 +633,16 @@ static void cheat_clev(char *buf)
 
     if (W_CheckNumForName(next) == -1)
     {
-      doomprintf(MESSAGES_NONE, "IDCLEV target not found: %s", next);
-      return;
+      // [Alaux] Restart map with IDCLEV00
+      if ((epsd == 0 && map == 0) || (gamemode == commercial && map == 0))
+      {
+        epsd = gameepisode;
+        map = gamemap;
+      }
+      else {
+        doomprintf(MESSAGES_NONE, "IDCLEV target not found: %s", next);
+        return;
+      }
     }
   }
 

--- a/src/m_cheat.c
+++ b/src/m_cheat.c
@@ -639,7 +639,8 @@ static void cheat_clev(char *buf)
         epsd = gameepisode;
         map = gamemap;
       }
-      else {
+      else
+      {
         doomprintf(MESSAGES_NONE, "IDCLEV target not found: %s", next);
         return;
       }


### PR DESCRIPTION
Exactly as implemented in Nugget Doom for a while now. Haven't had any issues with it so far.

Maybe the Cheats guide should be updated to make mention of this? If you don't mind, I'd rather you take care of it, I'm not sure how you'd like to redact it.