### PR TITLE
Allow direct toggle between windowed and exclusive fullscreen modes

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1395,12 +1395,7 @@ void I_ResetScreen(void)
 
 void I_ShutdownGraphics(void)
 {
-    if (fullscreen && exclusive_fullscreen)
-    {
-        window_position_x = 0;
-        window_position_y = 0;
-    }
-    else
+    if (!(fullscreen && exclusive_fullscreen))
     {
         SDL_GetWindowPosition(screen, &window_position_x, &window_position_y);
     }

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1367,6 +1367,9 @@ static void I_ReinitGraphicsMode(void)
         screen = NULL;
     }
 
+    window_position_x = 0;
+    window_position_y = 0;
+
     I_InitGraphicsMode();
 }
 
@@ -1392,7 +1395,15 @@ void I_ResetScreen(void)
 
 void I_ShutdownGraphics(void)
 {
-    SDL_GetWindowPosition(screen, &window_position_x, &window_position_y);
+    if (fullscreen && exclusive_fullscreen)
+    {
+        window_position_x = 0;
+        window_position_y = 0;
+    }
+    else
+    {
+        SDL_GetWindowPosition(screen, &window_position_x, &window_position_y);
+    }
 
     UpdateGrab();
 }

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1353,30 +1353,6 @@ static void I_InitGraphicsMode(void)
 
 static void I_ReinitGraphicsMode(void)
 {
-    if (texture_upscaled != NULL)
-    {
-        SDL_DestroyTexture(texture_upscaled);
-        texture_upscaled = NULL;
-    }
-
-    if (texture != NULL)
-    {
-        SDL_DestroyTexture(texture);
-        texture = NULL;
-    }
-
-    if (argbbuffer != NULL)
-    {
-        SDL_FreeSurface(argbbuffer);
-        argbbuffer = NULL;
-    }
-
-    if (sdlscreen != NULL)
-    {
-        SDL_FreeSurface(sdlscreen);
-        sdlscreen = NULL;
-    }
-
     if (renderer != NULL)
     {
         SDL_DestroyRenderer(renderer);

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -59,8 +59,6 @@ void I_FinishUpdate (void);
 void I_ReadScreen (byte* scr);
 
 void I_ResetScreen(void);   // killough 10/98
-void I_ToggleFullScreen(void); // [FG] fullscreen mode menu toggle
-void I_ToggleExclusiveFullScreen(void);
 void I_ToggleVsync(void); // [JN] Calls native SDL vsync toggle
 
 extern boolean use_vsync;  // killough 2/8/98: controls whether vsync is called
@@ -80,6 +78,8 @@ extern int video_display; // display index
 extern boolean screenvisible;
 extern boolean need_reset;
 extern boolean smooth_scaling;
+extern boolean toggle_fullscreen;
+extern boolean toggle_exclusive_fullscreen;
 
 extern int gamma2;
 byte I_GetPaletteIndex(byte *palette, int r, int g, int b);

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -3942,18 +3942,14 @@ static void M_EnableDisableFPSLimit(void)
   }
 }
 
-void M_ToggleFullScreen(void)
+static void M_ToggleFullScreen(void)
 {
-  DISABLE_ITEM(!fullscreen, gen_settings1[gen1_exclusive_fullscreen]);
-
-  I_ToggleFullScreen();
+  toggle_fullscreen = true;
 }
 
 static void M_ToggleExclusiveFullScreen(void)
 {
-  DISABLE_ITEM(exclusive_fullscreen, gen_settings1[gen1_fullscreen]);
-
-  I_ToggleExclusiveFullScreen();
+  toggle_exclusive_fullscreen = true;
 }
 
 static void M_CoerceFPSLimit(void)
@@ -7209,16 +7205,6 @@ void M_ResetMenu(void)
 void M_ResetSetupMenu(void)
 {
   extern boolean deh_set_blood_color;
-
-  // [FG] exclusive fullscreen
-  if (!fullscreen)
-  {
-    gen_settings1[gen1_exclusive_fullscreen].m_flags |= S_DISABLE;
-  }
-  if (fullscreen && exclusive_fullscreen)
-  {
-    gen_settings1[gen1_fullscreen].m_flags |= S_DISABLE;
-  }
 
   if (M_ParmExists("-strict"))
   {

--- a/src/m_menu.h
+++ b/src/m_menu.h
@@ -72,8 +72,6 @@ void M_DrawCredits(void);    // killough 11/98
 
 void M_SetMenuFontSpacing(void);
 
-void M_ToggleFullScreen(void);
-
 // killough 8/15/98: warn about changes not being committed until next game
 #define warn_about_changes(x) (warning_about_changes=(x), \
 			       print_warning_about_changes = 2)


### PR DESCRIPTION
Second attempt. Tested with Windows 10 and Arch Linux.
1. This approach destroys the window when toggling exclusive fullscreen. 
2. The correct monitor is now used in a multi-monitor configuration when toggling exclusive fullscreen. Previously, with Woof master, toggling exclusive fullscreen resulted in the game only showing on the monitor used at launch.