### PR TITLE
fix pickup messages in multiplayer

### DIFF
--- a/src/am_map.c
+++ b/src/am_map.c
@@ -867,28 +867,28 @@ boolean AM_Responder
       followplayer = !followplayer;
       memset(buttons_state, 0, sizeof(buttons_state));
       // Ty 03/27/98 - externalized
-      doomprintf("%s", followplayer ? s_AMSTR_FOLLOWON : s_AMSTR_FOLLOWOFF);
+      displaymsg("%s", followplayer ? s_AMSTR_FOLLOWON : s_AMSTR_FOLLOWOFF);
     }
     else if (M_InputActivated(input_map_grid))
     {
       automap_grid = !automap_grid;      // killough 2/28/98
       // Ty 03/27/98 - *not* externalized
-      doomprintf("%s", automap_grid ? s_AMSTR_GRIDON : s_AMSTR_GRIDOFF);
+      displaymsg("%s", automap_grid ? s_AMSTR_GRIDON : s_AMSTR_GRIDOFF);
     }
     else if (M_InputActivated(input_map_mark))
     {
       // Ty 03/27/98 - *not* externalized     
-      doomprintf("%s %d", s_AMSTR_MARKEDSPOT, markpointnum);
+      displaymsg("%s %d", s_AMSTR_MARKEDSPOT, markpointnum);
       AM_addMark();
     }
     else if (M_InputActivated(input_map_clear))
     {
       // [Alaux] Clear just the last mark
       if (!markpointnum)
-        doomprintf("%s", s_AMSTR_MARKSCLEARED);
+        displaymsg("%s", s_AMSTR_MARKSCLEARED);
       else {
         AM_clearLastMark();
-        doomprintf("Cleared spot %d", markpointnum);
+        displaymsg("Cleared spot %d", markpointnum);
       }
     }
     else
@@ -899,9 +899,9 @@ boolean AM_Responder
 
       switch (automapoverlay)
       {
-        case 2:  doomprintf("Dark Overlay On");        break;
-        case 1:  doomprintf("%s", s_AMSTR_OVERLAYON);  break;
-        default: doomprintf("%s", s_AMSTR_OVERLAYOFF); break;
+        case 2:  displaymsg("Dark Overlay On");        break;
+        case 1:  displaymsg("%s", s_AMSTR_OVERLAYON);  break;
+        default: displaymsg("%s", s_AMSTR_OVERLAYOFF); break;
       }
 
       if (automapoverlay && scaledviewheight == SCREENHEIGHT)
@@ -915,9 +915,9 @@ boolean AM_Responder
     {
       automaprotate = !automaprotate;
       if (automaprotate)
-        doomprintf("%s", s_AMSTR_ROTATEON);
+        displaymsg("%s", s_AMSTR_ROTATEON);
       else
-        doomprintf("%s", s_AMSTR_ROTATEOFF);
+        displaymsg("%s", s_AMSTR_ROTATEOFF);
     }
     else
     {

--- a/src/am_map.c
+++ b/src/am_map.c
@@ -867,28 +867,28 @@ boolean AM_Responder
       followplayer = !followplayer;
       memset(buttons_state, 0, sizeof(buttons_state));
       // Ty 03/27/98 - externalized
-      doomprintf(MESSAGES_NONE, "%s", followplayer ? s_AMSTR_FOLLOWON : s_AMSTR_FOLLOWOFF);  
+      doomprintf("%s", followplayer ? s_AMSTR_FOLLOWON : s_AMSTR_FOLLOWOFF);  
     }
     else if (M_InputActivated(input_map_grid))
     {
       automap_grid = !automap_grid;      // killough 2/28/98
       // Ty 03/27/98 - *not* externalized
-      doomprintf(MESSAGES_NONE, "%s", automap_grid ? s_AMSTR_GRIDON : s_AMSTR_GRIDOFF);  
+      doomprintf("%s", automap_grid ? s_AMSTR_GRIDON : s_AMSTR_GRIDOFF);  
     }
     else if (M_InputActivated(input_map_mark))
     {
       // Ty 03/27/98 - *not* externalized     
-      doomprintf(MESSAGES_NONE, "%s %d", s_AMSTR_MARKEDSPOT, markpointnum);  
+      doomprintf("%s %d", s_AMSTR_MARKEDSPOT, markpointnum);  
       AM_addMark();
     }
     else if (M_InputActivated(input_map_clear))
     {
       // [Alaux] Clear just the last mark
       if (!markpointnum)
-        doomprintf(MESSAGES_NONE, "%s", s_AMSTR_MARKSCLEARED);
+        doomprintf("%s", s_AMSTR_MARKSCLEARED);
       else {
         AM_clearLastMark();
-        doomprintf(MESSAGES_NONE, "Cleared spot %d", markpointnum);
+        doomprintf("Cleared spot %d", markpointnum);
       }
     }
     else
@@ -899,9 +899,9 @@ boolean AM_Responder
 
       switch (automapoverlay)
       {
-        case 2:  doomprintf(MESSAGES_NONE, "Dark Overlay On");        break;
-        case 1:  doomprintf(MESSAGES_NONE, "%s", s_AMSTR_OVERLAYON);  break;
-        default: doomprintf(MESSAGES_NONE, "%s", s_AMSTR_OVERLAYOFF); break;
+        case 2:  doomprintf("Dark Overlay On");        break;
+        case 1:  doomprintf("%s", s_AMSTR_OVERLAYON);  break;
+        default: doomprintf("%s", s_AMSTR_OVERLAYOFF); break;
       }
 
       if (automapoverlay && scaledviewheight == SCREENHEIGHT)
@@ -915,9 +915,9 @@ boolean AM_Responder
     {
       automaprotate = !automaprotate;
       if (automaprotate)
-        doomprintf(MESSAGES_NONE, "%s", s_AMSTR_ROTATEON);
+        doomprintf("%s", s_AMSTR_ROTATEON);
       else
-        doomprintf(MESSAGES_NONE, "%s", s_AMSTR_ROTATEOFF);
+        doomprintf("%s", s_AMSTR_ROTATEOFF);
     }
     else
     {

--- a/src/am_map.c
+++ b/src/am_map.c
@@ -867,18 +867,18 @@ boolean AM_Responder
       followplayer = !followplayer;
       memset(buttons_state, 0, sizeof(buttons_state));
       // Ty 03/27/98 - externalized
-      doomprintf("%s", followplayer ? s_AMSTR_FOLLOWON : s_AMSTR_FOLLOWOFF);  
+      doomprintf("%s", followplayer ? s_AMSTR_FOLLOWON : s_AMSTR_FOLLOWOFF);
     }
     else if (M_InputActivated(input_map_grid))
     {
       automap_grid = !automap_grid;      // killough 2/28/98
       // Ty 03/27/98 - *not* externalized
-      doomprintf("%s", automap_grid ? s_AMSTR_GRIDON : s_AMSTR_GRIDOFF);  
+      doomprintf("%s", automap_grid ? s_AMSTR_GRIDON : s_AMSTR_GRIDOFF);
     }
     else if (M_InputActivated(input_map_mark))
     {
       // Ty 03/27/98 - *not* externalized     
-      doomprintf("%s %d", s_AMSTR_MARKEDSPOT, markpointnum);  
+      doomprintf("%s %d", s_AMSTR_MARKEDSPOT, markpointnum);
       AM_addMark();
     }
     else if (M_InputActivated(input_map_clear))

--- a/src/d_net.c
+++ b/src/d_net.c
@@ -55,7 +55,7 @@ static void PlayerQuitGame(player_t *player)
     exitmsg[7] += player_num;
 
     playeringame[player_num] = false;
-    doomprintf("%s", exitmsg);
+    displaymsg("%s", exitmsg);
     // [crispy] don't interpolate players who left the game
     player->mo->interp = false;
 

--- a/src/d_net.c
+++ b/src/d_net.c
@@ -55,7 +55,7 @@ static void PlayerQuitGame(player_t *player)
     exitmsg[7] += player_num;
 
     playeringame[player_num] = false;
-    doomprintf(MESSAGES_NONE, "%s", exitmsg);
+    doomprintf("%s", exitmsg);
     // [crispy] don't interpolate players who left the game
     player->mo->interp = false;
 

--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -442,6 +442,17 @@ extern int center_weapon;
 
 extern int cosmetic_bobbing;
 
+// Doom-style printf
+
+typedef enum {
+  MESSAGES_NONE,
+  MESSAGES_TOGGLE,
+  MESSAGES_PICKUP,
+} msg_category_t;
+
+void doomprintf(msg_category_t category, const char *, ...) PRINTF_ATTR(2, 3);
+void pickupmsg(player_t *player, const char *, ...) PRINTF_ATTR(2, 3);
+
 #endif
 
 //----------------------------------------------------------------------------

--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -450,8 +450,11 @@ typedef enum {
   MESSAGES_PICKUP,
 } msg_category_t;
 
-void doomprintf(msg_category_t category, const char *, ...) PRINTF_ATTR(2, 3);
-void pickupmsg(player_t *player, const char *, ...) PRINTF_ATTR(2, 3);
+void playermsg(player_t *player, msg_category_t category,
+              const char *, ...) PRINTF_ATTR(3, 4);
+#define doomprintf(...) playermsg(NULL, MESSAGES_NONE, __VA_ARGS__)
+#define pickupmsg(player, ...) playermsg(player, MESSAGES_PICKUP, __VA_ARGS__)
+#define togglemsg(...) playermsg(NULL, MESSAGES_TOGGLE, __VA_ARGS__)
 
 #endif
 

--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -450,11 +450,11 @@ typedef enum {
   MESSAGES_PICKUP,
 } msg_category_t;
 
-void playermsg(player_t *player, msg_category_t category,
+void doomprintf(player_t *player, msg_category_t category,
               const char *, ...) PRINTF_ATTR(3, 4);
-#define doomprintf(...) playermsg(NULL, MESSAGES_NONE, __VA_ARGS__)
-#define pickupmsg(player, ...) playermsg(player, MESSAGES_PICKUP, __VA_ARGS__)
-#define togglemsg(...) playermsg(NULL, MESSAGES_TOGGLE, __VA_ARGS__)
+#define displaymsg(...) doomprintf(NULL, MESSAGES_NONE, __VA_ARGS__)
+#define pickupmsg(player, ...) doomprintf(player, MESSAGES_PICKUP, __VA_ARGS__)
+#define togglemsg(...) doomprintf(NULL, MESSAGES_TOGGLE, __VA_ARGS__)
 
 #endif
 

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -1092,7 +1092,7 @@ static void G_JoinDemo(void)
   // clear progress demo bar
   ST_Start();
 
-  doomprintf(MESSAGES_NONE, "Demo recording: %s", demoname);
+  doomprintf("Demo recording: %s", demoname);
 }
 
 static void G_ReadDemoTiccmd(ticcmd_t *cmd)
@@ -1124,7 +1124,7 @@ static void G_ReadDemoTiccmd(ticcmd_t *cmd)
 	  cmd->buttons & BTS_SAVEGAME)
 	{
 	  cmd->buttons &= ~BT_SPECIALMASK;
-	  doomprintf(MESSAGES_NONE, "Game Saved (Suppressed)");
+	  doomprintf("Game Saved (Suppressed)");
 	}
     }
 }
@@ -2006,9 +2006,9 @@ static void G_DoSaveGame(void)
   length = save_p - savebuffer;
 
   if (!M_WriteFile(name, savebuffer, length))
-    doomprintf(MESSAGES_NONE, "%s", errno ? strerror(errno) : "Could not save game: Error unknown");
+    doomprintf("%s", errno ? strerror(errno) : "Could not save game: Error unknown");
   else
-    doomprintf(MESSAGES_NONE, "%s", s_GGSAVED);  // Ty 03/27/98 - externalized
+    doomprintf("%s", s_GGSAVED);  // Ty 03/27/98 - externalized
 
   Z_Free(savebuffer);  // killough
   savebuffer = save_p = NULL;
@@ -2364,7 +2364,7 @@ void G_Ticker(void)
 		  !(gametic&31) && ((gametic>>5)&3) == i )
 		{
 		  extern char **player_names[];
-		  doomprintf(MESSAGES_NONE, "%s is turbo!", *player_names[i]); // killough 9/29/98
+		  doomprintf("%s is turbo!", *player_names[i]); // killough 9/29/98
 		}
 
 	      if (netgame && !netdemo && !(gametic%ticdup) )
@@ -3793,7 +3793,7 @@ void G_BeginRecording(void)
       *demo_p++ = playeringame[i];
   }
 
-  doomprintf(MESSAGES_NONE, "Demo Recording: %s", M_BaseName(demoname));
+  doomprintf("Demo Recording: %s", M_BaseName(demoname));
 }
 
 //
@@ -3993,7 +3993,7 @@ boolean G_CheckDemoStatus(void)
           cmd->buttons |= BT_JOIN;
         }
 
-        doomprintf(MESSAGES_NONE, "Demo Recording: %s", M_BaseName(demoname));
+        doomprintf("Demo Recording: %s", M_BaseName(demoname));
 
         return true;
       }
@@ -4053,7 +4053,7 @@ boolean G_CheckDemoStatus(void)
 
 extern int show_toggle_messages, show_pickup_messages;
 
-void doomprintf(msg_category_t category, const char *s, ...)
+void playermsg(player_t *player, msg_category_t category, const char *s, ...)
 {
   static char msg[MAX_MESSAGE_SIZE];
   va_list v;
@@ -4065,21 +4065,11 @@ void doomprintf(msg_category_t category, const char *s, ...)
   va_start(v,s);
   vsprintf(msg,s,v);                  // print message in buffer
   va_end(v);
-  players[displayplayer].message = msg;  // set new message
-}
 
-void pickupmsg(player_t *player, const char *s, ...)
-{
-  static char msg[MAX_MESSAGE_SIZE];
-  va_list v;
-
-  if (player != &players[displayplayer] || !show_pickup_messages)
-    return;
-
-  va_start(v,s);
-  vsprintf(msg,s,v);
-  va_end(v);
-  player->message = msg;  // set new message
+  if (player)
+    player->message = msg;
+  else
+    players[displayplayer].message = msg;  // set new message
 }
 
 //----------------------------------------------------------------------------

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -1092,7 +1092,7 @@ static void G_JoinDemo(void)
   // clear progress demo bar
   ST_Start();
 
-  doomprintf("Demo recording: %s", demoname);
+  displaymsg("Demo recording: %s", demoname);
 }
 
 static void G_ReadDemoTiccmd(ticcmd_t *cmd)
@@ -1124,7 +1124,7 @@ static void G_ReadDemoTiccmd(ticcmd_t *cmd)
 	  cmd->buttons & BTS_SAVEGAME)
 	{
 	  cmd->buttons &= ~BT_SPECIALMASK;
-	  doomprintf("Game Saved (Suppressed)");
+	  displaymsg("Game Saved (Suppressed)");
 	}
     }
 }
@@ -2006,9 +2006,9 @@ static void G_DoSaveGame(void)
   length = save_p - savebuffer;
 
   if (!M_WriteFile(name, savebuffer, length))
-    doomprintf("%s", errno ? strerror(errno) : "Could not save game: Error unknown");
+    displaymsg("%s", errno ? strerror(errno) : "Could not save game: Error unknown");
   else
-    doomprintf("%s", s_GGSAVED);  // Ty 03/27/98 - externalized
+    displaymsg("%s", s_GGSAVED);  // Ty 03/27/98 - externalized
 
   Z_Free(savebuffer);  // killough
   savebuffer = save_p = NULL;
@@ -2364,7 +2364,7 @@ void G_Ticker(void)
 		  !(gametic&31) && ((gametic>>5)&3) == i )
 		{
 		  extern char **player_names[];
-		  doomprintf("%s is turbo!", *player_names[i]); // killough 9/29/98
+		  displaymsg("%s is turbo!", *player_names[i]); // killough 9/29/98
 		}
 
 	      if (netgame && !netdemo && !(gametic%ticdup) )
@@ -3793,7 +3793,7 @@ void G_BeginRecording(void)
       *demo_p++ = playeringame[i];
   }
 
-  doomprintf("Demo Recording: %s", M_BaseName(demoname));
+  displaymsg("Demo Recording: %s", M_BaseName(demoname));
 }
 
 //
@@ -3993,7 +3993,7 @@ boolean G_CheckDemoStatus(void)
           cmd->buttons |= BT_JOIN;
         }
 
-        doomprintf("Demo Recording: %s", M_BaseName(demoname));
+        displaymsg("Demo Recording: %s", M_BaseName(demoname));
 
         return true;
       }
@@ -4053,7 +4053,7 @@ boolean G_CheckDemoStatus(void)
 
 extern int show_toggle_messages, show_pickup_messages;
 
-void playermsg(player_t *player, msg_category_t category, const char *s, ...)
+void doomprintf(player_t *player, msg_category_t category, const char *s, ...)
 {
   static char msg[MAX_MESSAGE_SIZE];
   va_list v;

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -4051,11 +4051,12 @@ boolean G_CheckDemoStatus(void)
 
 #define MAX_MESSAGE_SIZE 1024
 
-void doomprintf(int category, const char *s, ...)
+extern int show_toggle_messages, show_pickup_messages;
+
+void doomprintf(msg_category_t category, const char *s, ...)
 {
   static char msg[MAX_MESSAGE_SIZE];
   va_list v;
-  extern int show_toggle_messages, show_pickup_messages;
 
   if ((category == MESSAGES_TOGGLE && !show_toggle_messages) ||
       (category == MESSAGES_PICKUP && !show_pickup_messages))
@@ -4065,6 +4066,20 @@ void doomprintf(int category, const char *s, ...)
   vsprintf(msg,s,v);                  // print message in buffer
   va_end(v);
   players[displayplayer].message = msg;  // set new message
+}
+
+void pickupmsg(player_t *player, const char *s, ...)
+{
+  static char msg[MAX_MESSAGE_SIZE];
+  va_list v;
+
+  if (player != &players[displayplayer] || !show_pickup_messages)
+    return;
+
+  va_start(v,s);
+  vsprintf(msg,s,v);
+  va_end(v);
+  player->message = msg;  // set new message
 }
 
 //----------------------------------------------------------------------------

--- a/src/hu_stuff.c
+++ b/src/hu_stuff.c
@@ -1675,7 +1675,7 @@ static int  tail = 0;
 void HU_queueChatChar(char c)
 {
   if (((head + 1) & (QUEUESIZE-1)) == tail)
-    doomprintf("%s", HUSTR_MSGU);
+    displaymsg("%s", HUSTR_MSGU);
   else
     {
       chatchars[head++] = c;
@@ -1796,7 +1796,7 @@ boolean HU_Responder(event_t *ev)
 		  if (M_InputActivated(input_chat_dest0 + i))
 		  {
 		    if (i == consoleplayer)
-		      doomprintf("%s", 
+		      displaymsg("%s", 
 			++num_nobrainers <  3 ? HUSTR_TALKTOSELF1 :
 	                  num_nobrainers <  6 ? HUSTR_TALKTOSELF2 :
 	                  num_nobrainers <  9 ? HUSTR_TALKTOSELF3 :
@@ -1840,7 +1840,7 @@ boolean HU_Responder(event_t *ev)
             // leave chat mode and notify that it was sent
             chat_on = false;
             strcpy(lastmessage, chat_macros[c]);
-            doomprintf("%s", lastmessage);
+            displaymsg("%s", lastmessage);
             eatkey = true;
           }
         else
@@ -1857,7 +1857,7 @@ boolean HU_Responder(event_t *ev)
                 if (w_chat.l.len)
                   {
                     strcpy(lastmessage, w_chat.l.l);
-                    doomprintf("%s", lastmessage);
+                    displaymsg("%s", lastmessage);
                   }
               }
             else

--- a/src/hu_stuff.c
+++ b/src/hu_stuff.c
@@ -1675,7 +1675,7 @@ static int  tail = 0;
 void HU_queueChatChar(char c)
 {
   if (((head + 1) & (QUEUESIZE-1)) == tail)
-    doomprintf(MESSAGES_NONE, "%s", HUSTR_MSGU);
+    doomprintf("%s", HUSTR_MSGU);
   else
     {
       chatchars[head++] = c;
@@ -1796,7 +1796,7 @@ boolean HU_Responder(event_t *ev)
 		  if (M_InputActivated(input_chat_dest0 + i))
 		  {
 		    if (i == consoleplayer)
-		      doomprintf(MESSAGES_NONE, "%s", 
+		      doomprintf("%s", 
 			++num_nobrainers <  3 ? HUSTR_TALKTOSELF1 :
 	                  num_nobrainers <  6 ? HUSTR_TALKTOSELF2 :
 	                  num_nobrainers <  9 ? HUSTR_TALKTOSELF3 :
@@ -1840,7 +1840,7 @@ boolean HU_Responder(event_t *ev)
             // leave chat mode and notify that it was sent
             chat_on = false;
             strcpy(lastmessage, chat_macros[c]);
-            doomprintf(MESSAGES_NONE, "%s", lastmessage);
+            doomprintf("%s", lastmessage);
             eatkey = true;
           }
         else
@@ -1857,7 +1857,7 @@ boolean HU_Responder(event_t *ev)
                 if (w_chat.l.len)
                   {
                     strcpy(lastmessage, w_chat.l.l);
-                    doomprintf(MESSAGES_NONE, "%s", lastmessage);
+                    doomprintf("%s", lastmessage);
                   }
               }
             else

--- a/src/m_cheat.c
+++ b/src/m_cheat.c
@@ -324,7 +324,7 @@ static void cheat_showfps()
 static void cheat_autoaim()
 {
   extern int autoaim;
-  doomprintf((autoaim=!autoaim) ?
+  displaymsg((autoaim=!autoaim) ?
     "Projectile autoaiming on" : 
     "Projectile autoaiming off");
 }
@@ -340,7 +340,7 @@ static void cheat_mus(char *buf)
   if (!isdigit(buf[0]) || !isdigit(buf[1]))
     return;
 
-  doomprintf("%s", s_STSTR_MUS); // Ty 03/27/98 - externalized
+  displaymsg("%s", s_STSTR_MUS); // Ty 03/27/98 - externalized
   
   // First check if we have a mapinfo entry for the requested level.
   if (gamemode == commercial)
@@ -353,7 +353,7 @@ static void cheat_mus(char *buf)
      musnum = W_CheckNumForName(entry->music);
 
      if (musnum == -1)
-        doomprintf("%s", s_STSTR_NOMUS);
+        displaymsg("%s", s_STSTR_NOMUS);
      else
      {
         S_ChangeMusInfoMusic(musnum, 1);
@@ -368,7 +368,7 @@ static void cheat_mus(char *buf)
           
       //jff 4/11/98 prevent IDMUS00 in DOOMII and IDMUS36 or greater
       if (musnum < mus_runnin || musnum >= NUMMUSIC)
-        doomprintf("%s", s_STSTR_NOMUS); // Ty 03/27/98 - externalized
+        displaymsg("%s", s_STSTR_NOMUS); // Ty 03/27/98 - externalized
       else
         {
           S_ChangeMusic(musnum, 1);
@@ -381,7 +381,7 @@ static void cheat_mus(char *buf)
           
       //jff 4/11/98 prevent IDMUS0x IDMUSx0 in DOOMI and greater than introa
       if (musnum < mus_e1m1 || musnum >= mus_runnin)
-        doomprintf("%s", s_STSTR_NOMUS); // Ty 03/27/98 - externalized
+        displaymsg("%s", s_STSTR_NOMUS); // Ty 03/27/98 - externalized
       else
         {
           S_ChangeMusic(musnum, 1);
@@ -395,7 +395,7 @@ static void cheat_choppers()
 {
   plyr->weaponowned[wp_chainsaw] = true;
   plyr->powers[pw_invulnerability] = true;
-  doomprintf("%s", s_STSTR_CHOPPERS); // Ty 03/27/98 - externalized
+  displaymsg("%s", s_STSTR_CHOPPERS); // Ty 03/27/98 - externalized
 }
 
 static void cheat_god()
@@ -428,28 +428,28 @@ static void cheat_god()
         plyr->mo->health = god_health;  // Ty 03/09/98 - deh
           
       plyr->health = god_health;
-      doomprintf("%s", s_STSTR_DQDON); // Ty 03/27/98 - externalized
+      displaymsg("%s", s_STSTR_DQDON); // Ty 03/27/98 - externalized
     }
   else 
-    doomprintf("%s", s_STSTR_DQDOFF); // Ty 03/27/98 - externalized
+    displaymsg("%s", s_STSTR_DQDOFF); // Ty 03/27/98 - externalized
 }
 
 static void cheat_buddha()
 {
   plyr->cheats ^= CF_BUDDHA;
   if (plyr->cheats & CF_BUDDHA)
-    doomprintf("Buddha Mode ON");
+    displaymsg("Buddha Mode ON");
   else
-    doomprintf("Buddha Mode OFF");
+    displaymsg("Buddha Mode OFF");
 }
 
 static void cheat_notarget()
 {
   plyr->cheats ^= CF_NOTARGET;
   if (plyr->cheats & CF_NOTARGET)
-    doomprintf("Notarget ON");
+    displaymsg("Notarget ON");
   else
-    doomprintf("Notarget OFF");
+    displaymsg("Notarget OFF");
 }
 
 boolean frozen_mode;
@@ -458,9 +458,9 @@ static void cheat_freeze()
 {
   frozen_mode = !frozen_mode;
   if (frozen_mode)
-    doomprintf("Freeze ON");
+    displaymsg("Freeze ON");
   else
-    doomprintf("Freeze OFF");
+    displaymsg("Freeze OFF");
 }
 
 static void cheat_avj()
@@ -479,7 +479,7 @@ static void cheat_health()
     if (plyr->mo)
       plyr->mo->health = mega_health;
     plyr->health = mega_health;
-    doomprintf("%s", s_STSTR_BEHOLDX); // Ty 03/27/98 - externalized
+    displaymsg("%s", s_STSTR_BEHOLDX); // Ty 03/27/98 - externalized
   }
 }
 
@@ -487,13 +487,13 @@ static void cheat_megaarmour()
 {
   plyr->armorpoints = idfa_armor;      // Ty 03/09/98 - deh
   plyr->armortype = idfa_armor_class;  // Ty 03/09/98 - deh
-  doomprintf("%s", s_STSTR_BEHOLDX); // Ty 03/27/98 - externalized
+  displaymsg("%s", s_STSTR_BEHOLDX); // Ty 03/27/98 - externalized
 }
 
 static void cheat_tst()
 { // killough 10/98: same as iddqd except for message
   cheat_god();
-  doomprintf(plyr->cheats & CF_GODMODE ? "God Mode On" : "God Mode Off");
+  displaymsg(plyr->cheats & CF_GODMODE ? "God Mode On" : "God Mode Off");
 }
 
 static void cheat_fa()
@@ -520,7 +520,7 @@ static void cheat_fa()
     if (i!=am_cell || gamemode!=shareware)
       plyr->ammo[i] = plyr->maxammo[i];
 
-  doomprintf("%s", s_STSTR_FAADDED);
+  displaymsg("%s", s_STSTR_FAADDED);
 }
 
 static void cheat_k()
@@ -530,7 +530,7 @@ static void cheat_k()
     if (!plyr->cards[i])     // only print message if at least one key added
       {                      // however, caller may overwrite message anyway
         plyr->cards[i] = true;
-        doomprintf("Keys Added");
+        displaymsg("Keys Added");
       }
 }
 
@@ -538,7 +538,7 @@ static void cheat_kfa()
 {
   cheat_k();
   cheat_fa();
-  doomprintf("%s", s_STSTR_KFAADDED);
+  displaymsg("%s", s_STSTR_KFAADDED);
 }
 
 static void cheat_noclip()
@@ -546,7 +546,7 @@ static void cheat_noclip()
   // Simplified, accepting both "noclip" and "idspispopd".
   // no clipping mode cheat
 
-  doomprintf("%s", (plyr->cheats ^= CF_NOCLIP) & CF_NOCLIP ? 
+  displaymsg("%s", (plyr->cheats ^= CF_NOCLIP) & CF_NOCLIP ? 
     s_STSTR_NCON : s_STSTR_NCOFF); // Ty 03/27/98 - externalized
 }
 
@@ -567,13 +567,13 @@ static void cheat_pw(int pw)
       if (pw != pw_strength && !comp[comp_infcheat])
         plyr->powers[pw] = -1;      // infinite duration -- killough
     }
-  doomprintf("%s", s_STSTR_BEHOLDX); // Ty 03/27/98 - externalized
+  displaymsg("%s", s_STSTR_BEHOLDX); // Ty 03/27/98 - externalized
 }
 
 // 'behold' power-up menu
 static void cheat_behold()
 {
-  doomprintf("%s", s_STSTR_BEHOLD); // Ty 03/27/98 - externalized
+  displaymsg("%s", s_STSTR_BEHOLD); // Ty 03/27/98 - externalized
 }
 
 // 'clev' change-level cheat
@@ -589,9 +589,9 @@ static void cheat_clev0()
   next = MAPNAME(epsd, map);
 
   if (W_CheckNumForName(next) != -1)
-    doomprintf("Current: %s, Next: %s", cur, next);
+    displaymsg("Current: %s, Next: %s", cur, next);
   else
-    doomprintf("Current: %s", cur);
+    displaymsg("Current: %s", cur);
 
   free(cur);
 }
@@ -641,7 +641,7 @@ static void cheat_clev(char *buf)
       }
       else
       {
-        doomprintf("IDCLEV target not found: %s", next);
+        displaymsg("IDCLEV target not found: %s", next);
         return;
       }
     }
@@ -651,7 +651,7 @@ static void cheat_clev(char *buf)
 
   idmusnum = -1; //jff 3/17/98 revert to normal level music on IDCLEV
 
-  doomprintf("%s", s_STSTR_CLEV); // Ty 03/27/98 - externalized
+  displaymsg("%s", s_STSTR_CLEV); // Ty 03/27/98 - externalized
 
   G_DeferedInitNew(gameskill, epsd, map);
 }
@@ -667,7 +667,7 @@ static void cheat_mypos()
 
 void cheat_mypos_print()
 {
-  doomprintf("X=%.10f Y=%.10f A=%-.0f",
+  displaymsg("X=%.10f Y=%.10f A=%-.0f",
           (double)players[consoleplayer].mo->x / FRACUNIT,
           (double)players[consoleplayer].mo->y / FRACUNIT,
           players[consoleplayer].mo->angle * (90.0/ANG90));
@@ -677,7 +677,7 @@ void cheat_mypos_print()
 
 static void cheat_comp0()
 {
-  doomprintf("Complevel: %s", G_GetCurrentComplevelName());
+  displaymsg("Complevel: %s", G_GetCurrentComplevelName());
 }
 
 static void cheat_comp(char *buf)
@@ -695,14 +695,14 @@ static void cheat_comp(char *buf)
   {
     demo_version = new_demover;
     G_ReloadDefaults(true);
-    doomprintf("New Complevel: %s", G_GetCurrentComplevelName());
+    displaymsg("New Complevel: %s", G_GetCurrentComplevelName());
   }
 }
 
 // variable friction cheat
 static void cheat_friction()
 {
-  doomprintf(            // Ty 03/27/98 - *not* externalized
+  displaymsg(            // Ty 03/27/98 - *not* externalized
     (variable_friction = !variable_friction) ? "Variable Friction enabled" : 
                                                "Variable Friction disabled");
 }
@@ -711,7 +711,7 @@ extern const char *default_skill_strings[];
 
 static void cheat_skill0()
 {
-  doomprintf("Skill: %s", default_skill_strings[gameskill + 1]);
+  displaymsg("Skill: %s", default_skill_strings[gameskill + 1]);
 }
 
 static void cheat_skill(char *buf)
@@ -721,7 +721,7 @@ static void cheat_skill(char *buf)
   if (skill >= 1 && skill <= 5)
   {
     gameskill = skill - 1;
-    doomprintf("Next Level Skill: %s", default_skill_strings[gameskill + 1]);
+    displaymsg("Next Level Skill: %s", default_skill_strings[gameskill + 1]);
 
     G_SetFastParms(fastparm || gameskill == sk_nightmare);
     respawnmonsters = gameskill == sk_nightmare || respawnparm;
@@ -732,14 +732,14 @@ static void cheat_skill(char *buf)
 // phares 3/10/98
 static void cheat_pushers()
 {
-  doomprintf(           // Ty 03/27/98 - *not* externalized
+  displaymsg(           // Ty 03/27/98 - *not* externalized
     (allow_pushers = !allow_pushers) ? "Pushers enabled" : "Pushers disabled");
 }
 
 // translucency cheat
 static void cheat_tran()
 {
-  doomprintf(            // Ty 03/27/98 - *not* externalized
+  displaymsg(            // Ty 03/27/98 - *not* externalized
     (translucency = !translucency) ? "Translucency enabled" : "Translucency disabled");
   D_SetPredefinedTranslucency();
 }
@@ -780,7 +780,7 @@ static void cheat_massacre()    // jff 2/01/98 kill all monsters
   P_MapEnd();
   // killough 3/22/98: make more intelligent about plural
   // Ty 03/27/98 - string(s) *not* externalized
-  doomprintf("%d Monster%s Killed", killcount, killcount==1 ? "" : "s");
+  displaymsg("%d Monster%s Killed", killcount, killcount==1 ? "" : "s");
 }
 
 static void cheat_spechits()
@@ -926,7 +926,7 @@ static void cheat_spechits()
     speciallines += EV_DoDoor(&dummy, doorOpen);
   }
 
-  doomprintf("%d Special Action%s Triggered", speciallines, speciallines == 1 ? "" : "s");
+  displaymsg("%d Special Action%s Triggered", speciallines, speciallines == 1 ? "" : "s");
 }
 
 // killough 2/7/98: move iddt cheat from am_map.c to here
@@ -1041,14 +1041,14 @@ static void cheat_reveal_item()
 static void cheat_hom()
 {
   extern int autodetect_hom;           // Ty 03/27/98 - *not* externalized
-  doomprintf((autodetect_hom = !autodetect_hom) ? "HOM Detection On" :
+  displaymsg((autodetect_hom = !autodetect_hom) ? "HOM Detection On" :
     "HOM Detection Off");
 }
 
 // killough 3/6/98: -fast parameter toggle
 static void cheat_fast()
 {
-  doomprintf((fastparm = !fastparm) ? "Fast Monsters On" : 
+  displaymsg((fastparm = !fastparm) ? "Fast Monsters On" : 
     "Fast Monsters Off");  // Ty 03/27/98 - *not* externalized
   G_SetFastParms(fastparm); // killough 4/10/98: set -fast parameter correctly
 }
@@ -1056,17 +1056,17 @@ static void cheat_fast()
 // killough 2/16/98: keycard/skullkey cheat functions
 static void cheat_key()
 {
-  doomprintf("Red, Yellow, Blue");  // Ty 03/27/98 - *not* externalized
+  displaymsg("Red, Yellow, Blue");  // Ty 03/27/98 - *not* externalized
 }
 
 static void cheat_keyx()
 {
-  doomprintf("Card, Skull");        // Ty 03/27/98 - *not* externalized
+  displaymsg("Card, Skull");        // Ty 03/27/98 - *not* externalized
 }
 
 static void cheat_keyxx(int key)
 {
-  doomprintf((plyr->cards[key] = !plyr->cards[key]) ? 
+  displaymsg((plyr->cards[key] = !plyr->cards[key]) ? 
     "Key Added" : "Key Removed");  // Ty 03/27/98 - *not* externalized
 }
 
@@ -1074,7 +1074,7 @@ static void cheat_keyxx(int key)
 
 static void cheat_weap()
 {                                   // Ty 03/27/98 - *not* externalized
-  doomprintf(have_ssg ? // killough 2/28/98
+  displaymsg(have_ssg ? // killough 2/28/98
     "Weapon number 1-9" : "Weapon number 1-8");
 }
 
@@ -1092,10 +1092,10 @@ static void cheat_weapx(char *buf)
     if (w >= 0 && w < NUMWEAPONS)
     {
       if ((plyr->weaponowned[w] = !plyr->weaponowned[w]))
-        doomprintf("Weapon Added");  // Ty 03/27/98 - *not* externalized
+        displaymsg("Weapon Added");  // Ty 03/27/98 - *not* externalized
       else 
         {
-          doomprintf("Weapon Removed"); // Ty 03/27/98 - *not* externalized
+          displaymsg("Weapon Removed"); // Ty 03/27/98 - *not* externalized
           if (w==plyr->readyweapon)         // maybe switch if weapon removed
             plyr->pendingweapon = P_SwitchWeapon(plyr);
         }
@@ -1105,7 +1105,7 @@ static void cheat_weapx(char *buf)
 // killough 2/16/98: generalized ammo cheats
 static void cheat_ammo()
 {
-  doomprintf("Ammo 1-4, Backpack");  // Ty 03/27/98 - *not* externalized
+  displaymsg("Ammo 1-4, Backpack");  // Ty 03/27/98 - *not* externalized
 }
 
 static void cheat_ammox(char *buf)
@@ -1113,10 +1113,10 @@ static void cheat_ammox(char *buf)
   int a = *buf - '1';
   if (*buf == 'b')  // Ty 03/27/98 - strings *not* externalized
     if ((plyr->backpack = !plyr->backpack))
-      for (doomprintf("Backpack Added"),   a=0 ; a<NUMAMMO ; a++)
+      for (displaymsg("Backpack Added"),   a=0 ; a<NUMAMMO ; a++)
         plyr->maxammo[a] <<= 1;
     else
-      for (doomprintf("Backpack Removed"), a=0 ; a<NUMAMMO ; a++)
+      for (displaymsg("Backpack Removed"), a=0 ; a<NUMAMMO ; a++)
         {
           if (plyr->ammo[a] > (plyr->maxammo[a] >>= 1))
             plyr->ammo[a] = plyr->maxammo[a];
@@ -1128,29 +1128,29 @@ static void cheat_ammox(char *buf)
         if ((plyr->ammo[a] = !plyr->ammo[a]))
         {
           plyr->ammo[a] = plyr->maxammo[a];
-          doomprintf("Ammo Added");
+          displaymsg("Ammo Added");
         }
         else
-          doomprintf("Ammo Removed");
+          displaymsg("Ammo Removed");
       }
 }
 
 static void cheat_smart()
 {
-  doomprintf((monsters_remember = !monsters_remember) ? 
+  displaymsg((monsters_remember = !monsters_remember) ? 
     "Smart Monsters Enabled" : "Smart Monsters Disabled");
 }
 
 static void cheat_pitch()
 {
-  doomprintf((pitched_sounds = !pitched_sounds) ? "Pitch Effects Enabled" :
+  displaymsg((pitched_sounds = !pitched_sounds) ? "Pitch Effects Enabled" :
     "Pitch Effects Disabled");
 }
 
 static void cheat_nuke()
 {
   extern int disable_nuke;
-  doomprintf((disable_nuke = !disable_nuke) ? "Nukage Disabled" :
+  displaymsg((disable_nuke = !disable_nuke) ? "Nukage Disabled" :
     "Nukage Enabled");
 }
 

--- a/src/m_cheat.c
+++ b/src/m_cheat.c
@@ -324,7 +324,7 @@ static void cheat_showfps()
 static void cheat_autoaim()
 {
   extern int autoaim;
-  doomprintf(MESSAGES_NONE, (autoaim=!autoaim) ?
+  doomprintf((autoaim=!autoaim) ?
     "Projectile autoaiming on" : 
     "Projectile autoaiming off");
 }
@@ -340,7 +340,7 @@ static void cheat_mus(char *buf)
   if (!isdigit(buf[0]) || !isdigit(buf[1]))
     return;
 
-  doomprintf(MESSAGES_NONE, "%s", s_STSTR_MUS); // Ty 03/27/98 - externalized
+  doomprintf("%s", s_STSTR_MUS); // Ty 03/27/98 - externalized
   
   // First check if we have a mapinfo entry for the requested level.
   if (gamemode == commercial)
@@ -353,7 +353,7 @@ static void cheat_mus(char *buf)
      musnum = W_CheckNumForName(entry->music);
 
      if (musnum == -1)
-        doomprintf(MESSAGES_NONE, "%s", s_STSTR_NOMUS);
+        doomprintf("%s", s_STSTR_NOMUS);
      else
      {
         S_ChangeMusInfoMusic(musnum, 1);
@@ -368,7 +368,7 @@ static void cheat_mus(char *buf)
           
       //jff 4/11/98 prevent IDMUS00 in DOOMII and IDMUS36 or greater
       if (musnum < mus_runnin || musnum >= NUMMUSIC)
-        doomprintf(MESSAGES_NONE, "%s", s_STSTR_NOMUS); // Ty 03/27/98 - externalized
+        doomprintf("%s", s_STSTR_NOMUS); // Ty 03/27/98 - externalized
       else
         {
           S_ChangeMusic(musnum, 1);
@@ -381,7 +381,7 @@ static void cheat_mus(char *buf)
           
       //jff 4/11/98 prevent IDMUS0x IDMUSx0 in DOOMI and greater than introa
       if (musnum < mus_e1m1 || musnum >= mus_runnin)
-        doomprintf(MESSAGES_NONE, "%s", s_STSTR_NOMUS); // Ty 03/27/98 - externalized
+        doomprintf("%s", s_STSTR_NOMUS); // Ty 03/27/98 - externalized
       else
         {
           S_ChangeMusic(musnum, 1);
@@ -395,7 +395,7 @@ static void cheat_choppers()
 {
   plyr->weaponowned[wp_chainsaw] = true;
   plyr->powers[pw_invulnerability] = true;
-  doomprintf(MESSAGES_NONE, "%s", s_STSTR_CHOPPERS); // Ty 03/27/98 - externalized
+  doomprintf("%s", s_STSTR_CHOPPERS); // Ty 03/27/98 - externalized
 }
 
 static void cheat_god()
@@ -428,28 +428,28 @@ static void cheat_god()
         plyr->mo->health = god_health;  // Ty 03/09/98 - deh
           
       plyr->health = god_health;
-      doomprintf(MESSAGES_NONE, "%s", s_STSTR_DQDON); // Ty 03/27/98 - externalized
+      doomprintf("%s", s_STSTR_DQDON); // Ty 03/27/98 - externalized
     }
   else 
-    doomprintf(MESSAGES_NONE, "%s", s_STSTR_DQDOFF); // Ty 03/27/98 - externalized
+    doomprintf("%s", s_STSTR_DQDOFF); // Ty 03/27/98 - externalized
 }
 
 static void cheat_buddha()
 {
   plyr->cheats ^= CF_BUDDHA;
   if (plyr->cheats & CF_BUDDHA)
-    doomprintf(MESSAGES_NONE, "Buddha Mode ON");
+    doomprintf("Buddha Mode ON");
   else
-    doomprintf(MESSAGES_NONE, "Buddha Mode OFF");
+    doomprintf("Buddha Mode OFF");
 }
 
 static void cheat_notarget()
 {
   plyr->cheats ^= CF_NOTARGET;
   if (plyr->cheats & CF_NOTARGET)
-    doomprintf(MESSAGES_NONE, "Notarget ON");
+    doomprintf("Notarget ON");
   else
-    doomprintf(MESSAGES_NONE, "Notarget OFF");
+    doomprintf("Notarget OFF");
 }
 
 boolean frozen_mode;
@@ -458,9 +458,9 @@ static void cheat_freeze()
 {
   frozen_mode = !frozen_mode;
   if (frozen_mode)
-    doomprintf(MESSAGES_NONE, "Freeze ON");
+    doomprintf("Freeze ON");
   else
-    doomprintf(MESSAGES_NONE, "Freeze OFF");
+    doomprintf("Freeze OFF");
 }
 
 static void cheat_avj()
@@ -479,7 +479,7 @@ static void cheat_health()
     if (plyr->mo)
       plyr->mo->health = mega_health;
     plyr->health = mega_health;
-    doomprintf(MESSAGES_NONE, "%s", s_STSTR_BEHOLDX); // Ty 03/27/98 - externalized
+    doomprintf("%s", s_STSTR_BEHOLDX); // Ty 03/27/98 - externalized
   }
 }
 
@@ -487,13 +487,13 @@ static void cheat_megaarmour()
 {
   plyr->armorpoints = idfa_armor;      // Ty 03/09/98 - deh
   plyr->armortype = idfa_armor_class;  // Ty 03/09/98 - deh
-  doomprintf(MESSAGES_NONE, "%s", s_STSTR_BEHOLDX); // Ty 03/27/98 - externalized
+  doomprintf("%s", s_STSTR_BEHOLDX); // Ty 03/27/98 - externalized
 }
 
 static void cheat_tst()
 { // killough 10/98: same as iddqd except for message
   cheat_god();
-  doomprintf(MESSAGES_NONE, plyr->cheats & CF_GODMODE ? "God Mode On" : "God Mode Off");
+  doomprintf(plyr->cheats & CF_GODMODE ? "God Mode On" : "God Mode Off");
 }
 
 static void cheat_fa()
@@ -520,7 +520,7 @@ static void cheat_fa()
     if (i!=am_cell || gamemode!=shareware)
       plyr->ammo[i] = plyr->maxammo[i];
 
-  doomprintf(MESSAGES_NONE, "%s", s_STSTR_FAADDED);
+  doomprintf("%s", s_STSTR_FAADDED);
 }
 
 static void cheat_k()
@@ -530,7 +530,7 @@ static void cheat_k()
     if (!plyr->cards[i])     // only print message if at least one key added
       {                      // however, caller may overwrite message anyway
         plyr->cards[i] = true;
-        doomprintf(MESSAGES_NONE, "Keys Added");
+        doomprintf("Keys Added");
       }
 }
 
@@ -538,7 +538,7 @@ static void cheat_kfa()
 {
   cheat_k();
   cheat_fa();
-  doomprintf(MESSAGES_NONE, "%s", s_STSTR_KFAADDED);
+  doomprintf("%s", s_STSTR_KFAADDED);
 }
 
 static void cheat_noclip()
@@ -546,7 +546,7 @@ static void cheat_noclip()
   // Simplified, accepting both "noclip" and "idspispopd".
   // no clipping mode cheat
 
-  doomprintf(MESSAGES_NONE, "%s", (plyr->cheats ^= CF_NOCLIP) & CF_NOCLIP ? 
+  doomprintf("%s", (plyr->cheats ^= CF_NOCLIP) & CF_NOCLIP ? 
     s_STSTR_NCON : s_STSTR_NCOFF); // Ty 03/27/98 - externalized
 }
 
@@ -567,13 +567,13 @@ static void cheat_pw(int pw)
       if (pw != pw_strength && !comp[comp_infcheat])
         plyr->powers[pw] = -1;      // infinite duration -- killough
     }
-  doomprintf(MESSAGES_NONE, "%s", s_STSTR_BEHOLDX); // Ty 03/27/98 - externalized
+  doomprintf("%s", s_STSTR_BEHOLDX); // Ty 03/27/98 - externalized
 }
 
 // 'behold' power-up menu
 static void cheat_behold()
 {
-  doomprintf(MESSAGES_NONE, "%s", s_STSTR_BEHOLD); // Ty 03/27/98 - externalized
+  doomprintf("%s", s_STSTR_BEHOLD); // Ty 03/27/98 - externalized
 }
 
 // 'clev' change-level cheat
@@ -589,9 +589,9 @@ static void cheat_clev0()
   next = MAPNAME(epsd, map);
 
   if (W_CheckNumForName(next) != -1)
-    doomprintf(MESSAGES_NONE, "Current: %s, Next: %s", cur, next);
+    doomprintf("Current: %s, Next: %s", cur, next);
   else
-    doomprintf(MESSAGES_NONE, "Current: %s", cur);
+    doomprintf("Current: %s", cur);
 
   free(cur);
 }
@@ -641,7 +641,7 @@ static void cheat_clev(char *buf)
       }
       else
       {
-        doomprintf(MESSAGES_NONE, "IDCLEV target not found: %s", next);
+        doomprintf("IDCLEV target not found: %s", next);
         return;
       }
     }
@@ -651,7 +651,7 @@ static void cheat_clev(char *buf)
 
   idmusnum = -1; //jff 3/17/98 revert to normal level music on IDCLEV
 
-  doomprintf(MESSAGES_NONE, "%s", s_STSTR_CLEV); // Ty 03/27/98 - externalized
+  doomprintf("%s", s_STSTR_CLEV); // Ty 03/27/98 - externalized
 
   G_DeferedInitNew(gameskill, epsd, map);
 }
@@ -667,7 +667,7 @@ static void cheat_mypos()
 
 void cheat_mypos_print()
 {
-  doomprintf(MESSAGES_NONE, "X=%.10f Y=%.10f A=%-.0f",
+  doomprintf("X=%.10f Y=%.10f A=%-.0f",
           (double)players[consoleplayer].mo->x / FRACUNIT,
           (double)players[consoleplayer].mo->y / FRACUNIT,
           players[consoleplayer].mo->angle * (90.0/ANG90));
@@ -677,7 +677,7 @@ void cheat_mypos_print()
 
 static void cheat_comp0()
 {
-  doomprintf(MESSAGES_NONE, "Complevel: %s", G_GetCurrentComplevelName());
+  doomprintf("Complevel: %s", G_GetCurrentComplevelName());
 }
 
 static void cheat_comp(char *buf)
@@ -695,14 +695,14 @@ static void cheat_comp(char *buf)
   {
     demo_version = new_demover;
     G_ReloadDefaults(true);
-    doomprintf(MESSAGES_NONE, "New Complevel: %s", G_GetCurrentComplevelName());
+    doomprintf("New Complevel: %s", G_GetCurrentComplevelName());
   }
 }
 
 // variable friction cheat
 static void cheat_friction()
 {
-  doomprintf(MESSAGES_NONE,             // Ty 03/27/98 - *not* externalized
+  doomprintf(            // Ty 03/27/98 - *not* externalized
     (variable_friction = !variable_friction) ? "Variable Friction enabled" : 
                                                "Variable Friction disabled");
 }
@@ -711,7 +711,7 @@ extern const char *default_skill_strings[];
 
 static void cheat_skill0()
 {
-  doomprintf(MESSAGES_NONE, "Skill: %s", default_skill_strings[gameskill + 1]);
+  doomprintf("Skill: %s", default_skill_strings[gameskill + 1]);
 }
 
 static void cheat_skill(char *buf)
@@ -721,7 +721,7 @@ static void cheat_skill(char *buf)
   if (skill >= 1 && skill <= 5)
   {
     gameskill = skill - 1;
-    doomprintf(MESSAGES_NONE, "Next Level Skill: %s", default_skill_strings[gameskill + 1]);
+    doomprintf("Next Level Skill: %s", default_skill_strings[gameskill + 1]);
 
     G_SetFastParms(fastparm || gameskill == sk_nightmare);
     respawnmonsters = gameskill == sk_nightmare || respawnparm;
@@ -732,14 +732,14 @@ static void cheat_skill(char *buf)
 // phares 3/10/98
 static void cheat_pushers()
 {
-  doomprintf(MESSAGES_NONE,            // Ty 03/27/98 - *not* externalized
+  doomprintf(           // Ty 03/27/98 - *not* externalized
     (allow_pushers = !allow_pushers) ? "Pushers enabled" : "Pushers disabled");
 }
 
 // translucency cheat
 static void cheat_tran()
 {
-  doomprintf(MESSAGES_NONE,             // Ty 03/27/98 - *not* externalized
+  doomprintf(            // Ty 03/27/98 - *not* externalized
     (translucency = !translucency) ? "Translucency enabled" : "Translucency disabled");
   D_SetPredefinedTranslucency();
 }
@@ -780,7 +780,7 @@ static void cheat_massacre()    // jff 2/01/98 kill all monsters
   P_MapEnd();
   // killough 3/22/98: make more intelligent about plural
   // Ty 03/27/98 - string(s) *not* externalized
-  doomprintf(MESSAGES_NONE, "%d Monster%s Killed", killcount, killcount==1 ? "" : "s");
+  doomprintf("%d Monster%s Killed", killcount, killcount==1 ? "" : "s");
 }
 
 static void cheat_spechits()
@@ -926,7 +926,7 @@ static void cheat_spechits()
     speciallines += EV_DoDoor(&dummy, doorOpen);
   }
 
-  doomprintf(MESSAGES_NONE, "%d Special Action%s Triggered", speciallines, speciallines == 1 ? "" : "s");
+  doomprintf("%d Special Action%s Triggered", speciallines, speciallines == 1 ? "" : "s");
 }
 
 // killough 2/7/98: move iddt cheat from am_map.c to here
@@ -1041,14 +1041,14 @@ static void cheat_reveal_item()
 static void cheat_hom()
 {
   extern int autodetect_hom;           // Ty 03/27/98 - *not* externalized
-  doomprintf(MESSAGES_NONE, (autodetect_hom = !autodetect_hom) ? "HOM Detection On" :
+  doomprintf((autodetect_hom = !autodetect_hom) ? "HOM Detection On" :
     "HOM Detection Off");
 }
 
 // killough 3/6/98: -fast parameter toggle
 static void cheat_fast()
 {
-  doomprintf(MESSAGES_NONE, (fastparm = !fastparm) ? "Fast Monsters On" : 
+  doomprintf((fastparm = !fastparm) ? "Fast Monsters On" : 
     "Fast Monsters Off");  // Ty 03/27/98 - *not* externalized
   G_SetFastParms(fastparm); // killough 4/10/98: set -fast parameter correctly
 }
@@ -1056,17 +1056,17 @@ static void cheat_fast()
 // killough 2/16/98: keycard/skullkey cheat functions
 static void cheat_key()
 {
-  doomprintf(MESSAGES_NONE, "Red, Yellow, Blue");  // Ty 03/27/98 - *not* externalized
+  doomprintf("Red, Yellow, Blue");  // Ty 03/27/98 - *not* externalized
 }
 
 static void cheat_keyx()
 {
-  doomprintf(MESSAGES_NONE, "Card, Skull");        // Ty 03/27/98 - *not* externalized
+  doomprintf("Card, Skull");        // Ty 03/27/98 - *not* externalized
 }
 
 static void cheat_keyxx(int key)
 {
-  doomprintf(MESSAGES_NONE, (plyr->cards[key] = !plyr->cards[key]) ? 
+  doomprintf((plyr->cards[key] = !plyr->cards[key]) ? 
     "Key Added" : "Key Removed");  // Ty 03/27/98 - *not* externalized
 }
 
@@ -1074,7 +1074,7 @@ static void cheat_keyxx(int key)
 
 static void cheat_weap()
 {                                   // Ty 03/27/98 - *not* externalized
-  doomprintf(MESSAGES_NONE, have_ssg ? // killough 2/28/98
+  doomprintf(have_ssg ? // killough 2/28/98
     "Weapon number 1-9" : "Weapon number 1-8");
 }
 
@@ -1092,10 +1092,10 @@ static void cheat_weapx(char *buf)
     if (w >= 0 && w < NUMWEAPONS)
     {
       if ((plyr->weaponowned[w] = !plyr->weaponowned[w]))
-        doomprintf(MESSAGES_NONE, "Weapon Added");  // Ty 03/27/98 - *not* externalized
+        doomprintf("Weapon Added");  // Ty 03/27/98 - *not* externalized
       else 
         {
-          doomprintf(MESSAGES_NONE, "Weapon Removed"); // Ty 03/27/98 - *not* externalized
+          doomprintf("Weapon Removed"); // Ty 03/27/98 - *not* externalized
           if (w==plyr->readyweapon)         // maybe switch if weapon removed
             plyr->pendingweapon = P_SwitchWeapon(plyr);
         }
@@ -1105,7 +1105,7 @@ static void cheat_weapx(char *buf)
 // killough 2/16/98: generalized ammo cheats
 static void cheat_ammo()
 {
-  doomprintf(MESSAGES_NONE, "Ammo 1-4, Backpack");  // Ty 03/27/98 - *not* externalized
+  doomprintf("Ammo 1-4, Backpack");  // Ty 03/27/98 - *not* externalized
 }
 
 static void cheat_ammox(char *buf)
@@ -1113,10 +1113,10 @@ static void cheat_ammox(char *buf)
   int a = *buf - '1';
   if (*buf == 'b')  // Ty 03/27/98 - strings *not* externalized
     if ((plyr->backpack = !plyr->backpack))
-      for (doomprintf(MESSAGES_NONE, "Backpack Added"),   a=0 ; a<NUMAMMO ; a++)
+      for (doomprintf("Backpack Added"),   a=0 ; a<NUMAMMO ; a++)
         plyr->maxammo[a] <<= 1;
     else
-      for (doomprintf(MESSAGES_NONE, "Backpack Removed"), a=0 ; a<NUMAMMO ; a++)
+      for (doomprintf("Backpack Removed"), a=0 ; a<NUMAMMO ; a++)
         {
           if (plyr->ammo[a] > (plyr->maxammo[a] >>= 1))
             plyr->ammo[a] = plyr->maxammo[a];
@@ -1128,29 +1128,29 @@ static void cheat_ammox(char *buf)
         if ((plyr->ammo[a] = !plyr->ammo[a]))
         {
           plyr->ammo[a] = plyr->maxammo[a];
-          doomprintf(MESSAGES_NONE, "Ammo Added");
+          doomprintf("Ammo Added");
         }
         else
-          doomprintf(MESSAGES_NONE, "Ammo Removed");
+          doomprintf("Ammo Removed");
       }
 }
 
 static void cheat_smart()
 {
-  doomprintf(MESSAGES_NONE, (monsters_remember = !monsters_remember) ? 
+  doomprintf((monsters_remember = !monsters_remember) ? 
     "Smart Monsters Enabled" : "Smart Monsters Disabled");
 }
 
 static void cheat_pitch()
 {
-  doomprintf(MESSAGES_NONE, (pitched_sounds = !pitched_sounds) ? "Pitch Effects Enabled" :
+  doomprintf((pitched_sounds = !pitched_sounds) ? "Pitch Effects Enabled" :
     "Pitch Effects Disabled");
 }
 
 static void cheat_nuke()
 {
   extern int disable_nuke;
-  doomprintf(MESSAGES_NONE, (disable_nuke = !disable_nuke) ? "Nukage Disabled" :
+  doomprintf((disable_nuke = !disable_nuke) ? "Nukage Disabled" :
     "Nukage Enabled");
 }
 

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -1685,9 +1685,9 @@ void M_ChangeMessages(int choice)
   showMessages = 1 - showMessages;
   
   if (!showMessages)
-    doomprintf(MESSAGES_NONE, "%s", s_MSGOFF); // Ty 03/27/98 - externalized
+    doomprintf("%s", s_MSGOFF); // Ty 03/27/98 - externalized
   else
-    doomprintf(MESSAGES_NONE, "%s", s_MSGON); // Ty 03/27/98 - externalized
+    doomprintf("%s", s_MSGON); // Ty 03/27/98 - externalized
 
   message_dontfuckwithme = true;
 }
@@ -2736,7 +2736,7 @@ int G_GotoNextLevel(int *pEpi, int *pMap)
     char *name = MAPNAME(epsd, map);
 
     if (W_CheckNumForName(name) == -1)
-      doomprintf(MESSAGES_NONE, "Next level not found: %s", name);
+      doomprintf("Next level not found: %s", name);
     else
     {
       G_DeferedInitNew(gameskill, epsd, map);
@@ -5521,21 +5521,21 @@ boolean M_Responder (event_t* ev)
       if (M_InputActivated(input_autorun)) // Autorun         //  V
 	{
 	  autorun = !autorun;
-	  doomprintf(MESSAGES_TOGGLE, "Always Run %s", autorun ? "On" : "Off");
+	  togglemsg("Always Run %s", autorun ? "On" : "Off");
 	  // return true; // [FG] don't let toggles eat keys
 	}
 
       if (M_InputActivated(input_novert))
 	{
 	  novert = !novert;
-	  doomprintf(MESSAGES_TOGGLE, "Vertical Mouse %s", !novert ? "On" : "Off");
+	  togglemsg("Vertical Mouse %s", !novert ? "On" : "Off");
 	  // return true; // [FG] don't let toggles eat keys
 	}
 
       if (M_InputActivated(input_mouselook))
 	{
 	  mouselook = !mouselook;
-	  doomprintf(MESSAGES_TOGGLE, "Mouselook %s", mouselook ? "On" : "Off");
+	  togglemsg("Mouselook %s", mouselook ? "On" : "Off");
 	  M_UpdateMouseLook();
 	  // return true; // [FG] don't let toggles eat keys
 	}
@@ -5543,7 +5543,7 @@ boolean M_Responder (event_t* ev)
       if (M_InputActivated(input_padlook))
 	{
 	  padlook = !padlook;
-	  doomprintf(MESSAGES_TOGGLE, "Padlook %s", padlook ? "On" : "Off");
+	  togglemsg("Padlook %s", padlook ? "On" : "Off");
 	  M_UpdateMouseLook();
 	  // return true; // [FG] don't let toggles eat keys
 	}
@@ -5624,7 +5624,7 @@ boolean M_Responder (event_t* ev)
 	  gamma2++;
 	  if (gamma2 > 17)
 	    gamma2 = 0;
-	  doomprintf(MESSAGES_TOGGLE, "Gamma correction level %s", gamma_strings[gamma2]);
+	  togglemsg("Gamma correction level %s", gamma_strings[gamma2]);
 	  M_ResetGamma();
 	  return true;                      
 	}
@@ -5703,7 +5703,7 @@ boolean M_Responder (event_t* ev)
         {
           realtic_clock_rate += 10;
           realtic_clock_rate = BETWEEN(10, 1000, realtic_clock_rate);
-          doomprintf(MESSAGES_NONE, "Game Speed: %d", realtic_clock_rate);
+          doomprintf("Game Speed: %d", realtic_clock_rate);
           I_SetTimeScale(realtic_clock_rate);
         }
 
@@ -5712,7 +5712,7 @@ boolean M_Responder (event_t* ev)
         {
           realtic_clock_rate -= 10;
           realtic_clock_rate = BETWEEN(10, 1000, realtic_clock_rate);
-          doomprintf(MESSAGES_NONE, "Game Speed: %d", realtic_clock_rate);
+          doomprintf("Game Speed: %d", realtic_clock_rate);
           I_SetTimeScale(realtic_clock_rate);
         }
 
@@ -5720,7 +5720,7 @@ boolean M_Responder (event_t* ev)
             && !strictmode)
         {
           realtic_clock_rate = 100;
-          doomprintf(MESSAGES_NONE, "Game Speed: %d", realtic_clock_rate);
+          doomprintf("Game Speed: %d", realtic_clock_rate);
           I_SetTimeScale(realtic_clock_rate);
         }
     }                               

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -1685,9 +1685,9 @@ void M_ChangeMessages(int choice)
   showMessages = 1 - showMessages;
   
   if (!showMessages)
-    doomprintf("%s", s_MSGOFF); // Ty 03/27/98 - externalized
+    displaymsg("%s", s_MSGOFF); // Ty 03/27/98 - externalized
   else
-    doomprintf("%s", s_MSGON); // Ty 03/27/98 - externalized
+    displaymsg("%s", s_MSGON); // Ty 03/27/98 - externalized
 
   message_dontfuckwithme = true;
 }
@@ -2736,7 +2736,7 @@ int G_GotoNextLevel(int *pEpi, int *pMap)
     char *name = MAPNAME(epsd, map);
 
     if (W_CheckNumForName(name) == -1)
-      doomprintf("Next level not found: %s", name);
+      displaymsg("Next level not found: %s", name);
     else
     {
       G_DeferedInitNew(gameskill, epsd, map);
@@ -5703,7 +5703,7 @@ boolean M_Responder (event_t* ev)
         {
           realtic_clock_rate += 10;
           realtic_clock_rate = BETWEEN(10, 1000, realtic_clock_rate);
-          doomprintf("Game Speed: %d", realtic_clock_rate);
+          displaymsg("Game Speed: %d", realtic_clock_rate);
           I_SetTimeScale(realtic_clock_rate);
         }
 
@@ -5712,7 +5712,7 @@ boolean M_Responder (event_t* ev)
         {
           realtic_clock_rate -= 10;
           realtic_clock_rate = BETWEEN(10, 1000, realtic_clock_rate);
-          doomprintf("Game Speed: %d", realtic_clock_rate);
+          displaymsg("Game Speed: %d", realtic_clock_rate);
           I_SetTimeScale(realtic_clock_rate);
         }
 
@@ -5720,7 +5720,7 @@ boolean M_Responder (event_t* ev)
             && !strictmode)
         {
           realtic_clock_rate = 100;
-          doomprintf("Game Speed: %d", realtic_clock_rate);
+          displaymsg("Game Speed: %d", realtic_clock_rate);
           I_SetTimeScale(realtic_clock_rate);
         }
     }                               

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -3321,7 +3321,7 @@ void M_ScreenShot (void)
   // players[consoleplayer].message = "screen shot"
 
   // killough 10/98: print error message and change sound effect if error
-  S_StartSound(NULL, !success ? doomprintf(MESSAGES_NONE, "%s", errno ? strerror(errno) :
+  S_StartSound(NULL, !success ? doomprintf("%s", errno ? strerror(errno) :
 					"Could not take screenshot"), sfx_oof :
                gamemode==commercial ? sfx_radio : sfx_tink);
 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -3321,7 +3321,7 @@ void M_ScreenShot (void)
   // players[consoleplayer].message = "screen shot"
 
   // killough 10/98: print error message and change sound effect if error
-  S_StartSound(NULL, !success ? doomprintf("%s", errno ? strerror(errno) :
+  S_StartSound(NULL, !success ? displaymsg("%s", errno ? strerror(errno) :
 					"Could not take screenshot"), sfx_oof :
                gamemode==commercial ? sfx_radio : sfx_tink);
 

--- a/src/p_doors.c
+++ b/src/p_doors.c
@@ -248,7 +248,7 @@ int EV_DoLockedDoor(line_t *line, vldoor_e type, mobj_t *thing)
     case 133:
       if (!p->cards[it_bluecard] && !p->cards[it_blueskull])
         {
-          doomprintf("%s", s_PD_BLUEO);  // Ty 03/27/98 - externalized
+          displaymsg("%s", s_PD_BLUEO);  // Ty 03/27/98 - externalized
           S_StartSound(p->mo,sfx_oof);                  // killough 3/20/98
           return 0;
         }
@@ -258,7 +258,7 @@ int EV_DoLockedDoor(line_t *line, vldoor_e type, mobj_t *thing)
     case 135:
       if (!p->cards[it_redcard] && !p->cards[it_redskull])
         {
-          doomprintf("%s", s_PD_REDO); // Ty 03/27/98 - externalized
+          displaymsg("%s", s_PD_REDO); // Ty 03/27/98 - externalized
           S_StartSound(p->mo,sfx_oof);                // killough 3/20/98
           return 0;
         }
@@ -268,7 +268,7 @@ int EV_DoLockedDoor(line_t *line, vldoor_e type, mobj_t *thing)
     case 137:
       if (!p->cards[it_yellowcard] && !p->cards[it_yellowskull])
         {
-          doomprintf("%s", s_PD_YELLOWO);  // Ty 03/27/98 - externalized
+          displaymsg("%s", s_PD_YELLOWO);  // Ty 03/27/98 - externalized
           S_StartSound(p->mo,sfx_oof);                    // killough 3/20/98
           return 0;
         }
@@ -395,7 +395,7 @@ int EV_VerticalDoor(line_t *line, mobj_t *thing)
         return 0;
       if (!player->cards[it_bluecard] && !player->cards[it_blueskull])
         {
-          doomprintf("%s", s_PD_BLUEK);  // Ty 03/27/98 - externalized
+          displaymsg("%s", s_PD_BLUEK);  // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
           return 0;
         }
@@ -407,7 +407,7 @@ int EV_VerticalDoor(line_t *line, mobj_t *thing)
         return 0;
       if (!player->cards[it_yellowcard] && !player->cards[it_yellowskull])
         {
-          doomprintf("%s", s_PD_YELLOWK);  // Ty 03/27/98 - externalized
+          displaymsg("%s", s_PD_YELLOWK);  // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);               // killough 3/20/98
           return 0;
         }
@@ -419,7 +419,7 @@ int EV_VerticalDoor(line_t *line, mobj_t *thing)
         return 0;
       if (!player->cards[it_redcard] && !player->cards[it_redskull])
         {
-          doomprintf("%s", s_PD_REDK); // Ty 03/27/98 - externalized
+          displaymsg("%s", s_PD_REDK); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);           // killough 3/20/98
           return 0;
         }

--- a/src/p_doors.c
+++ b/src/p_doors.c
@@ -248,7 +248,7 @@ int EV_DoLockedDoor(line_t *line, vldoor_e type, mobj_t *thing)
     case 133:
       if (!p->cards[it_bluecard] && !p->cards[it_blueskull])
         {
-          doomprintf(MESSAGES_NONE, "%s", s_PD_BLUEO);  // Ty 03/27/98 - externalized
+          doomprintf("%s", s_PD_BLUEO);  // Ty 03/27/98 - externalized
           S_StartSound(p->mo,sfx_oof);                  // killough 3/20/98
           return 0;
         }
@@ -258,7 +258,7 @@ int EV_DoLockedDoor(line_t *line, vldoor_e type, mobj_t *thing)
     case 135:
       if (!p->cards[it_redcard] && !p->cards[it_redskull])
         {
-          doomprintf(MESSAGES_NONE, "%s", s_PD_REDO); // Ty 03/27/98 - externalized
+          doomprintf("%s", s_PD_REDO); // Ty 03/27/98 - externalized
           S_StartSound(p->mo,sfx_oof);                // killough 3/20/98
           return 0;
         }
@@ -268,7 +268,7 @@ int EV_DoLockedDoor(line_t *line, vldoor_e type, mobj_t *thing)
     case 137:
       if (!p->cards[it_yellowcard] && !p->cards[it_yellowskull])
         {
-          doomprintf(MESSAGES_NONE, "%s", s_PD_YELLOWO);  // Ty 03/27/98 - externalized
+          doomprintf("%s", s_PD_YELLOWO);  // Ty 03/27/98 - externalized
           S_StartSound(p->mo,sfx_oof);                    // killough 3/20/98
           return 0;
         }
@@ -395,7 +395,7 @@ int EV_VerticalDoor(line_t *line, mobj_t *thing)
         return 0;
       if (!player->cards[it_bluecard] && !player->cards[it_blueskull])
         {
-          doomprintf(MESSAGES_NONE, "%s", s_PD_BLUEK);  // Ty 03/27/98 - externalized
+          doomprintf("%s", s_PD_BLUEK);  // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
           return 0;
         }
@@ -407,7 +407,7 @@ int EV_VerticalDoor(line_t *line, mobj_t *thing)
         return 0;
       if (!player->cards[it_yellowcard] && !player->cards[it_yellowskull])
         {
-          doomprintf(MESSAGES_NONE, "%s", s_PD_YELLOWK);  // Ty 03/27/98 - externalized
+          doomprintf("%s", s_PD_YELLOWK);  // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);               // killough 3/20/98
           return 0;
         }
@@ -419,7 +419,7 @@ int EV_VerticalDoor(line_t *line, mobj_t *thing)
         return 0;
       if (!player->cards[it_redcard] && !player->cards[it_redskull])
         {
-          doomprintf(MESSAGES_NONE, "%s", s_PD_REDK); // Ty 03/27/98 - externalized
+          doomprintf("%s", s_PD_REDK); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);           // killough 3/20/98
           return 0;
         }

--- a/src/p_inter.c
+++ b/src/p_inter.c
@@ -315,13 +315,13 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
     case SPR_ARM1:
       if (!P_GiveArmor (player, green_armor_class))
         return;
-      doomprintf(MESSAGES_PICKUP, "%s", s_GOTARMOR); // Ty 03/22/98 - externalized
+      pickupmsg(player, "%s", s_GOTARMOR); // Ty 03/22/98 - externalized
       break;
 
     case SPR_ARM2:
       if (!P_GiveArmor (player, blue_armor_class))
         return;
-      doomprintf(MESSAGES_PICKUP, "%s", s_GOTMEGA); // Ty 03/22/98 - externalized
+      pickupmsg(player, "%s", s_GOTMEGA); // Ty 03/22/98 - externalized
       break;
 
       // bonus items
@@ -329,7 +329,7 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
 
       if (beta_emulation)
 	{   // killough 7/11/98: beta version items did not have any effect
-	  doomprintf(MESSAGES_PICKUP, "You pick up a demonic dagger.");
+	  pickupmsg(player, "You pick up a demonic dagger.");
 	  break;
 	}
 
@@ -337,14 +337,14 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
       if (player->health > (maxhealth * 2))
         player->health = (maxhealth * 2);
       player->mo->health = player->health;
-      doomprintf(MESSAGES_PICKUP, "%s", s_GOTHTHBONUS); // Ty 03/22/98 - externalized
+      pickupmsg(player, "%s", s_GOTHTHBONUS); // Ty 03/22/98 - externalized
       break;
 
     case SPR_BON2:
 
       if (beta_emulation)
 	{ // killough 7/11/98: beta version items did not have any effect
-	  doomprintf(MESSAGES_PICKUP, "You pick up a skullchest.");
+	  pickupmsg(player, "You pick up a skullchest.");
 	  break;
 	}
 
@@ -353,15 +353,15 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
         player->armorpoints = max_armor;
       if (!player->armortype)
         player->armortype = green_armor_class;
-      doomprintf(MESSAGES_PICKUP, "%s", s_GOTARMBONUS); // Ty 03/22/98 - externalized
+      pickupmsg(player, "%s", s_GOTARMBONUS); // Ty 03/22/98 - externalized
       break;
 
     case SPR_BON3:      // killough 7/11/98: evil sceptre from beta version
-      doomprintf(MESSAGES_PICKUP, "Picked up an evil sceptre");
+      pickupmsg(player, "Picked up an evil sceptre");
       break;
 
     case SPR_BON4:      // killough 7/11/98: unholy bible from beta version
-      doomprintf(MESSAGES_PICKUP, "Picked up an unholy bible");
+      pickupmsg(player, "Picked up an unholy bible");
       break;
 
     case SPR_SOUL:
@@ -369,7 +369,7 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
       if (player->health > max_soul)
         player->health = max_soul;
       player->mo->health = player->health;
-      doomprintf(MESSAGES_PICKUP, "%s", s_GOTSUPER); // Ty 03/22/98 - externalized
+      pickupmsg(player, "%s", s_GOTSUPER); // Ty 03/22/98 - externalized
       sound = sfx_getpow;
       break;
 
@@ -379,7 +379,7 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
       player->health = mega_health;
       player->mo->health = player->health;
       P_GiveArmor (player,blue_armor_class);
-      doomprintf(MESSAGES_PICKUP, "%s", s_GOTMSPHERE); // Ty 03/22/98 - externalized
+      pickupmsg(player, "%s", s_GOTMSPHERE); // Ty 03/22/98 - externalized
       sound = sfx_getpow;
       break;
 
@@ -387,7 +387,7 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
         // leave cards for everyone
     case SPR_BKEY:
       if (!player->cards[it_bluecard])
-        doomprintf(MESSAGES_PICKUP, "%s", s_GOTBLUECARD); // Ty 03/22/98 - externalized
+        pickupmsg(player, "%s", s_GOTBLUECARD); // Ty 03/22/98 - externalized
       P_GiveCard (player, it_bluecard);
       if (!netgame)
         break;
@@ -395,7 +395,7 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
 
     case SPR_YKEY:
       if (!player->cards[it_yellowcard])
-        doomprintf(MESSAGES_PICKUP, "%s", s_GOTYELWCARD); // Ty 03/22/98 - externalized
+        pickupmsg(player, "%s", s_GOTYELWCARD); // Ty 03/22/98 - externalized
       P_GiveCard (player, it_yellowcard);
       if (!netgame)
         break;
@@ -403,7 +403,7 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
 
     case SPR_RKEY:
       if (!player->cards[it_redcard])
-        doomprintf(MESSAGES_PICKUP, "%s", s_GOTREDCARD); // Ty 03/22/98 - externalized
+        pickupmsg(player, "%s", s_GOTREDCARD); // Ty 03/22/98 - externalized
       P_GiveCard (player, it_redcard);
       if (!netgame)
         break;
@@ -411,7 +411,7 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
 
     case SPR_BSKU:
       if (!player->cards[it_blueskull])
-        doomprintf(MESSAGES_PICKUP, "%s", s_GOTBLUESKUL); // Ty 03/22/98 - externalized
+        pickupmsg(player, "%s", s_GOTBLUESKUL); // Ty 03/22/98 - externalized
       P_GiveCard (player, it_blueskull);
       if (!netgame)
         break;
@@ -419,7 +419,7 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
 
     case SPR_YSKU:
       if (!player->cards[it_yellowskull])
-        doomprintf(MESSAGES_PICKUP, "%s", s_GOTYELWSKUL); // Ty 03/22/98 - externalized
+        pickupmsg(player, "%s", s_GOTYELWSKUL); // Ty 03/22/98 - externalized
       P_GiveCard (player, it_yellowskull);
       if (!netgame)
         break;
@@ -427,7 +427,7 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
 
     case SPR_RSKU:
       if (!player->cards[it_redskull])
-        doomprintf(MESSAGES_PICKUP, "%s", s_GOTREDSKULL); // Ty 03/22/98 - externalized
+        pickupmsg(player, "%s", s_GOTREDSKULL); // Ty 03/22/98 - externalized
       P_GiveCard (player, it_redskull);
       if (!netgame)
         break;
@@ -437,7 +437,7 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
     case SPR_STIM:
       if (!P_GiveBody (player, 10))
         return;
-      doomprintf(MESSAGES_PICKUP, "%s", s_GOTSTIM); // Ty 03/22/98 - externalized
+      pickupmsg(player, "%s", s_GOTSTIM); // Ty 03/22/98 - externalized
       break;
 
     case SPR_MEDI:
@@ -446,9 +446,9 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
 
       // [FG] show "Picked up a Medikit that you really need" message as intended
       if (player->health < 50)
-        doomprintf(MESSAGES_PICKUP, "%s", s_GOTMEDINEED); // Ty 03/22/98 - externalized
+        pickupmsg(player, "%s", s_GOTMEDINEED); // Ty 03/22/98 - externalized
       else
-        doomprintf(MESSAGES_PICKUP, "%s", s_GOTMEDIKIT); // Ty 03/22/98 - externalized
+        pickupmsg(player, "%s", s_GOTMEDIKIT); // Ty 03/22/98 - externalized
       break;
 
 
@@ -456,14 +456,14 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
     case SPR_PINV:
       if (!P_GivePower (player, pw_invulnerability))
         return;
-      doomprintf(MESSAGES_PICKUP, "%s", s_GOTINVUL); // Ty 03/22/98 - externalized
+      pickupmsg(player, "%s", s_GOTINVUL); // Ty 03/22/98 - externalized
       sound = sfx_getpow;
       break;
 
     case SPR_PSTR:
       if (!P_GivePower (player, pw_strength))
         return;
-      doomprintf(MESSAGES_PICKUP, "%s", s_GOTBERSERK); // Ty 03/22/98 - externalized
+      pickupmsg(player, "%s", s_GOTBERSERK); // Ty 03/22/98 - externalized
       if (player->readyweapon != wp_fist)
 	if (!beta_emulation // killough 10/98: don't switch as much in -beta
 	    || player->readyweapon == wp_pistol)
@@ -474,7 +474,7 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
     case SPR_PINS:
       if (!P_GivePower (player, pw_invisibility))
         return;
-      doomprintf(MESSAGES_PICKUP, "%s", s_GOTINVIS); // Ty 03/22/98 - externalized
+      pickupmsg(player, "%s", s_GOTINVIS); // Ty 03/22/98 - externalized
       sound = sfx_getpow;
       break;
 
@@ -485,14 +485,14 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
       if (beta_emulation)  // killough 7/19/98: beta rad suit did not wear off
 	player->powers[pw_ironfeet] = -1;
 
-      doomprintf(MESSAGES_PICKUP, "%s", s_GOTSUIT); // Ty 03/22/98 - externalized
+      pickupmsg(player, "%s", s_GOTSUIT); // Ty 03/22/98 - externalized
       sound = sfx_getpow;
       break;
 
     case SPR_PMAP:
       if (!P_GivePower (player, pw_allmap))
         return;
-      doomprintf(MESSAGES_PICKUP, "%s", s_GOTMAP); // Ty 03/22/98 - externalized
+      pickupmsg(player, "%s", s_GOTMAP); // Ty 03/22/98 - externalized
       sound = sfx_getpow;
       break;
 
@@ -506,7 +506,7 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
 	player->powers[pw_infrared] = -1;
 
       sound = sfx_getpow;
-      doomprintf(MESSAGES_PICKUP, "%s", s_GOTVISOR); // Ty 03/22/98 - externalized
+      pickupmsg(player, "%s", s_GOTVISOR); // Ty 03/22/98 - externalized
       break;
 
       // ammo
@@ -521,49 +521,49 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
           if (!P_GiveAmmo (player,am_clip,1))
             return;
         }
-      doomprintf(MESSAGES_PICKUP, "%s", s_GOTCLIP); // Ty 03/22/98 - externalized
+      pickupmsg(player, "%s", s_GOTCLIP); // Ty 03/22/98 - externalized
       break;
 
     case SPR_AMMO:
       if (!P_GiveAmmo (player, am_clip,5))
         return;
-      doomprintf(MESSAGES_PICKUP, "%s", s_GOTCLIPBOX); // Ty 03/22/98 - externalized
+      pickupmsg(player, "%s", s_GOTCLIPBOX); // Ty 03/22/98 - externalized
       break;
 
     case SPR_ROCK:
       if (!P_GiveAmmo (player, am_misl,1))
         return;
-      doomprintf(MESSAGES_PICKUP, "%s", s_GOTROCKET); // Ty 03/22/98 - externalized
+      pickupmsg(player, "%s", s_GOTROCKET); // Ty 03/22/98 - externalized
       break;
 
     case SPR_BROK:
       if (!P_GiveAmmo (player, am_misl,5))
         return;
-      doomprintf(MESSAGES_PICKUP, "%s", s_GOTROCKBOX); // Ty 03/22/98 - externalized
+      pickupmsg(player, "%s", s_GOTROCKBOX); // Ty 03/22/98 - externalized
       break;
 
     case SPR_CELL:
       if (!P_GiveAmmo (player, am_cell,1))
         return;
-      doomprintf(MESSAGES_PICKUP, "%s", s_GOTCELL); // Ty 03/22/98 - externalized
+      pickupmsg(player, "%s", s_GOTCELL); // Ty 03/22/98 - externalized
       break;
 
     case SPR_CELP:
       if (!P_GiveAmmo (player, am_cell,5))
         return;
-      doomprintf(MESSAGES_PICKUP, "%s", s_GOTCELLBOX); // Ty 03/22/98 - externalized
+      pickupmsg(player, "%s", s_GOTCELLBOX); // Ty 03/22/98 - externalized
       break;
 
     case SPR_SHEL:
       if (!P_GiveAmmo (player, am_shell,1))
         return;
-      doomprintf(MESSAGES_PICKUP, "%s", s_GOTSHELLS); // Ty 03/22/98 - externalized
+      pickupmsg(player, "%s", s_GOTSHELLS); // Ty 03/22/98 - externalized
       break;
 
     case SPR_SBOX:
       if (!P_GiveAmmo (player, am_shell,5))
         return;
-      doomprintf(MESSAGES_PICKUP, "%s", s_GOTSHELLBOX); // Ty 03/22/98 - externalized
+      pickupmsg(player, "%s", s_GOTSHELLBOX); // Ty 03/22/98 - externalized
       break;
 
     case SPR_BPAK:
@@ -575,7 +575,7 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
         }
       for (i=0 ; i<NUMAMMO ; i++)
         P_GiveAmmo (player, i, 1);
-      doomprintf(MESSAGES_PICKUP, "%s", s_GOTBACKPACK); // Ty 03/22/98 - externalized
+      pickupmsg(player, "%s", s_GOTBACKPACK); // Ty 03/22/98 - externalized
       break;
 
         // weapons
@@ -583,51 +583,51 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
       if (!P_GiveWeapon (player, wp_bfg, false) )
         return;
       if (classic_bfg || beta_emulation)
-        doomprintf(MESSAGES_PICKUP, "You got the BFG2704!  Oh, yes."); // killough 8/9/98: beta BFG
+        pickupmsg(player, "You got the BFG2704!  Oh, yes."); // killough 8/9/98: beta BFG
       else
-        doomprintf(MESSAGES_PICKUP, "%s", s_GOTBFG9000); // Ty 03/22/98 - externalized
+        pickupmsg(player, "%s", s_GOTBFG9000); // Ty 03/22/98 - externalized
       sound = sfx_wpnup;
       break;
 
     case SPR_MGUN:
       if (!P_GiveWeapon (player, wp_chaingun, special->flags & MF_DROPPED))
         return;
-      doomprintf(MESSAGES_PICKUP, "%s", s_GOTCHAINGUN); // Ty 03/22/98 - externalized
+      pickupmsg(player, "%s", s_GOTCHAINGUN); // Ty 03/22/98 - externalized
       sound = sfx_wpnup;
       break;
 
     case SPR_CSAW:
       if (!P_GiveWeapon(player, wp_chainsaw, false))
         return;
-      doomprintf(MESSAGES_PICKUP, "%s", s_GOTCHAINSAW); // Ty 03/22/98 - externalized
+      pickupmsg(player, "%s", s_GOTCHAINSAW); // Ty 03/22/98 - externalized
       sound = sfx_wpnup;
       break;
 
     case SPR_LAUN:
       if (!P_GiveWeapon (player, wp_missile, false) )
         return;
-      doomprintf(MESSAGES_PICKUP, "%s", s_GOTLAUNCHER); // Ty 03/22/98 - externalized
+      pickupmsg(player, "%s", s_GOTLAUNCHER); // Ty 03/22/98 - externalized
       sound = sfx_wpnup;
       break;
 
     case SPR_PLAS:
       if (!P_GiveWeapon(player, wp_plasma, false))
         return;
-      doomprintf(MESSAGES_PICKUP, "%s", s_GOTPLASMA); // Ty 03/22/98 - externalized
+      pickupmsg(player, "%s", s_GOTPLASMA); // Ty 03/22/98 - externalized
       sound = sfx_wpnup;
       break;
 
     case SPR_SHOT:
       if (!P_GiveWeapon(player, wp_shotgun, special->flags & MF_DROPPED))
         return;
-      doomprintf(MESSAGES_PICKUP, "%s", s_GOTSHOTGUN); // Ty 03/22/98 - externalized
+      pickupmsg(player, "%s", s_GOTSHOTGUN); // Ty 03/22/98 - externalized
       sound = sfx_wpnup;
       break;
 
     case SPR_SGN2:
       if (!P_GiveWeapon(player, wp_supershotgun, special->flags & MF_DROPPED))
         return;
-      doomprintf(MESSAGES_PICKUP, "%s", s_GOTSHOTGUN2); // Ty 03/22/98 - externalized
+      pickupmsg(player, "%s", s_GOTSHOTGUN2); // Ty 03/22/98 - externalized
       sound = sfx_wpnup;
       break;
 

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -89,7 +89,7 @@ boolean P_SetMobjState(mobj_t* mobj,statenum_t state)
   while (!mobj->tics && !seenstate[state]);   // killough 4/9/98
 
   if (ret && !mobj->tics)  // killough 4/9/98: detect state cycles
-    doomprintf("Warning: State Cycle Detected");
+    displaymsg("Warning: State Cycle Detected");
 
   if (!--recursion)
     for (;(state=seenstate[i]);i=state-1)

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -89,7 +89,7 @@ boolean P_SetMobjState(mobj_t* mobj,statenum_t state)
   while (!mobj->tics && !seenstate[state]);   // killough 4/9/98
 
   if (ret && !mobj->tics)  // killough 4/9/98: detect state cycles
-    doomprintf(MESSAGES_NONE, "Warning: State Cycle Detected");
+    doomprintf("Warning: State Cycle Detected");
 
   if (!--recursion)
     for (;(state=seenstate[i]);i=state-1)

--- a/src/p_spec.c
+++ b/src/p_spec.c
@@ -800,7 +800,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
           !player->cards[it_yellowcard] &&
           !player->cards[it_yellowskull])
         {
-          doomprintf(MESSAGES_NONE, "%s", s_PD_ANY); // Ty 03/27/98 - externalized
+          doomprintf("%s", s_PD_ANY); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
           return false;
         }
@@ -809,7 +809,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
       if (!player->cards[it_redcard] &&
           (!skulliscard || !player->cards[it_redskull]))
         {
-          doomprintf(MESSAGES_NONE, "%s", skulliscard? s_PD_REDK : s_PD_REDC); // Ty 03/27/98 - externalized
+          doomprintf("%s", skulliscard? s_PD_REDK : s_PD_REDC); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
           return false;
         }
@@ -818,7 +818,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
       if (!player->cards[it_bluecard] &&
           (!skulliscard || !player->cards[it_blueskull]))
         {
-          doomprintf(MESSAGES_NONE, "%s", skulliscard? s_PD_BLUEK : s_PD_BLUEC); // Ty 03/27/98 - externalized
+          doomprintf("%s", skulliscard? s_PD_BLUEK : s_PD_BLUEC); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
           return false;
         }
@@ -827,7 +827,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
       if (!player->cards[it_yellowcard] &&
           (!skulliscard || !player->cards[it_yellowskull]))
         {
-          doomprintf(MESSAGES_NONE, "%s", skulliscard? s_PD_YELLOWK : s_PD_YELLOWC); // Ty 03/27/98 - externalized
+          doomprintf("%s", skulliscard? s_PD_YELLOWK : s_PD_YELLOWC); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
           return false;
         }
@@ -836,7 +836,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
       if (!player->cards[it_redskull] &&
           (!skulliscard || !player->cards[it_redcard]))
         {
-          doomprintf(MESSAGES_NONE, "%s", skulliscard? s_PD_REDK : s_PD_REDS); // Ty 03/27/98 - externalized
+          doomprintf("%s", skulliscard? s_PD_REDK : s_PD_REDS); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
           return false;
         }
@@ -845,7 +845,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
       if (!player->cards[it_blueskull] &&
           (!skulliscard || !player->cards[it_bluecard]))
         {
-          doomprintf(MESSAGES_NONE, "%s", skulliscard? s_PD_BLUEK : s_PD_BLUES); // Ty 03/27/98 - externalized
+          doomprintf("%s", skulliscard? s_PD_BLUEK : s_PD_BLUES); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
           return false;
         }
@@ -854,7 +854,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
       if (!player->cards[it_yellowskull] &&
           (!skulliscard || !player->cards[it_yellowcard]))
         {
-          doomprintf(MESSAGES_NONE, "%s", skulliscard? s_PD_YELLOWK : s_PD_YELLOWS); // Ty 03/27/98 - externalized
+          doomprintf("%s", skulliscard? s_PD_YELLOWK : s_PD_YELLOWS); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
           return false;
         }
@@ -868,7 +868,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
            !player->cards[it_yellowcard] ||
            !player->cards[it_yellowskull]))
         {
-          doomprintf(MESSAGES_NONE, "%s", s_PD_ALL6); // Ty 03/27/98 - externalized
+          doomprintf("%s", s_PD_ALL6); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
           return false;
         }
@@ -879,7 +879,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
            // http://prboom.sourceforge.net/mbf-bugs.html
            !(player->cards[it_yellowcard] | (demo_version == 203 ? !player->cards[it_yellowskull] : player->cards[it_yellowskull]))))
         {
-          doomprintf(MESSAGES_NONE, "%s", s_PD_ALL3); // Ty 03/27/98 - externalized
+          doomprintf("%s", s_PD_ALL3); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
           return false;
         }

--- a/src/p_spec.c
+++ b/src/p_spec.c
@@ -800,7 +800,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
           !player->cards[it_yellowcard] &&
           !player->cards[it_yellowskull])
         {
-          doomprintf("%s", s_PD_ANY); // Ty 03/27/98 - externalized
+          displaymsg("%s", s_PD_ANY); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
           return false;
         }
@@ -809,7 +809,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
       if (!player->cards[it_redcard] &&
           (!skulliscard || !player->cards[it_redskull]))
         {
-          doomprintf("%s", skulliscard? s_PD_REDK : s_PD_REDC); // Ty 03/27/98 - externalized
+          displaymsg("%s", skulliscard? s_PD_REDK : s_PD_REDC); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
           return false;
         }
@@ -818,7 +818,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
       if (!player->cards[it_bluecard] &&
           (!skulliscard || !player->cards[it_blueskull]))
         {
-          doomprintf("%s", skulliscard? s_PD_BLUEK : s_PD_BLUEC); // Ty 03/27/98 - externalized
+          displaymsg("%s", skulliscard? s_PD_BLUEK : s_PD_BLUEC); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
           return false;
         }
@@ -827,7 +827,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
       if (!player->cards[it_yellowcard] &&
           (!skulliscard || !player->cards[it_yellowskull]))
         {
-          doomprintf("%s", skulliscard? s_PD_YELLOWK : s_PD_YELLOWC); // Ty 03/27/98 - externalized
+          displaymsg("%s", skulliscard? s_PD_YELLOWK : s_PD_YELLOWC); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
           return false;
         }
@@ -836,7 +836,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
       if (!player->cards[it_redskull] &&
           (!skulliscard || !player->cards[it_redcard]))
         {
-          doomprintf("%s", skulliscard? s_PD_REDK : s_PD_REDS); // Ty 03/27/98 - externalized
+          displaymsg("%s", skulliscard? s_PD_REDK : s_PD_REDS); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
           return false;
         }
@@ -845,7 +845,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
       if (!player->cards[it_blueskull] &&
           (!skulliscard || !player->cards[it_bluecard]))
         {
-          doomprintf("%s", skulliscard? s_PD_BLUEK : s_PD_BLUES); // Ty 03/27/98 - externalized
+          displaymsg("%s", skulliscard? s_PD_BLUEK : s_PD_BLUES); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
           return false;
         }
@@ -854,7 +854,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
       if (!player->cards[it_yellowskull] &&
           (!skulliscard || !player->cards[it_yellowcard]))
         {
-          doomprintf("%s", skulliscard? s_PD_YELLOWK : s_PD_YELLOWS); // Ty 03/27/98 - externalized
+          displaymsg("%s", skulliscard? s_PD_YELLOWK : s_PD_YELLOWS); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
           return false;
         }
@@ -868,7 +868,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
            !player->cards[it_yellowcard] ||
            !player->cards[it_yellowskull]))
         {
-          doomprintf("%s", s_PD_ALL6); // Ty 03/27/98 - externalized
+          displaymsg("%s", s_PD_ALL6); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
           return false;
         }
@@ -879,7 +879,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
            // http://prboom.sourceforge.net/mbf-bugs.html
            !(player->cards[it_yellowcard] | (demo_version == 203 ? !player->cards[it_yellowskull] : player->cards[it_yellowskull]))))
         {
-          doomprintf("%s", s_PD_ALL3); // Ty 03/27/98 - externalized
+          displaymsg("%s", s_PD_ALL3); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
           return false;
         }

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -709,7 +709,7 @@ int rendered_visplanes, rendered_segs, rendered_vissprites;
 void R_ShowRenderingStats(void)
 {
   extern int fps;
-  doomprintf("Segs %d, Visplanes %d, Sprites %d, FPS %d",
+  displaymsg("Segs %d, Visplanes %d, Sprites %d, FPS %d",
           rendered_segs, rendered_visplanes, rendered_vissprites, fps);
 }
 

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -709,7 +709,7 @@ int rendered_visplanes, rendered_segs, rendered_vissprites;
 void R_ShowRenderingStats(void)
 {
   extern int fps;
-  doomprintf(MESSAGES_NONE, "Segs %d, Visplanes %d, Sprites %d, FPS %d",
+  doomprintf("Segs %d, Visplanes %d, Sprites %d, FPS %d",
           rendered_segs, rendered_visplanes, rendered_vissprites, fps);
 }
 

--- a/src/z_zone.h
+++ b/src/z_zone.h
@@ -55,16 +55,6 @@ void Z_ChangeTag(void *ptr, pu_tag tag);
 void *Z_Calloc(size_t n, size_t n2, pu_tag tag, void **user);
 void *Z_Realloc(void *p, size_t n, pu_tag tag, void **user);
 
-// Doom-style printf
-
-enum {
-  MESSAGES_NONE,
-  MESSAGES_TOGGLE,
-  MESSAGES_PICKUP,
-};
-
-void doomprintf(int category, const char *, ...) PRINTF_ATTR(2, 3);
-
 #endif
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
At this point maybe we should remove category parameter from `doomprintf()`? E.g. add another `printtoggle()` function.

Tested with
```
woof -privateserver
woof -autojoin
```