### PR TITLE
Fix P_RadiusAttack dist depending on damage

### DIFF
--- a/src/p_map.c
+++ b/src/p_map.c
@@ -1839,7 +1839,7 @@ boolean PIT_RadiusAttack(mobj_t *thing)
 
 void P_RadiusAttack(mobj_t *spot, mobj_t *source, int damage, int distance)
 {
-  fixed_t dist = (damage+MAXRADIUS)<<FRACBITS;
+  fixed_t dist = (distance+MAXRADIUS)<<FRACBITS;
   int yh = (spot->y + dist - bmaporgy)>>MAPBLOCKSHIFT;
   int yl = (spot->y - dist - bmaporgy)>>MAPBLOCKSHIFT;
   int xh = (spot->x + dist - bmaporgx)>>MAPBLOCKSHIFT;


### PR DESCRIPTION
Fix variable "dist" in P_RadiusAttack depending on damage (like vanilla Doom), which causes attack radius to actually depend on damage. Now depends on distance arg (like dsda-doom).