### PR TITLE
fix door interpolation in Doom2 MAP19

### DIFF
--- a/src/p_floor.c
+++ b/src/p_floor.c
@@ -62,15 +62,17 @@ result_e T_MovePlane
   fixed_t       destheight; //jff 02/04/98 used to keep floors/ceilings
                             // from moving thru each other
 
-  sector->oldgametic = gametic;
-
   switch(floorOrCeiling)
   {
     case 0:
       // Moving a floor
 
       // [AM] Store old sector heights for interpolation.
-      sector->oldfloorheight = sector->floorheight;
+      if (sector->oldgametic != gametic)
+      {
+        sector->oldfloorheight = sector->floorheight;
+        sector->oldgametic = gametic;
+      }
 
       switch(direction)
       {
@@ -150,7 +152,11 @@ result_e T_MovePlane
       // moving a ceiling
 
       // [AM] Store old sector heights for interpolation.
-      sector->oldceilingheight = sector->ceilingheight;
+      if (sector->oldgametic != gametic)
+      {
+        sector->oldceilingheight = sector->ceilingheight;
+        sector->oldgametic = gametic;
+      }
 
       switch(direction)
       {

--- a/src/p_floor.c
+++ b/src/p_floor.c
@@ -61,6 +61,13 @@ result_e T_MovePlane
   fixed_t       lastpos;     
   fixed_t       destheight; //jff 02/04/98 used to keep floors/ceilings
                             // from moving thru each other
+  static boolean moved_ceil, moved_floor;
+
+  if (sector->oldgametic != gametic)
+  {
+    sector->oldgametic = gametic;
+    moved_ceil = moved_floor = false;
+  }
 
   switch(floorOrCeiling)
   {
@@ -68,10 +75,10 @@ result_e T_MovePlane
       // Moving a floor
 
       // [AM] Store old sector heights for interpolation.
-      if (sector->oldgametic != gametic)
+      if (!moved_floor)
       {
         sector->oldfloorheight = sector->floorheight;
-        sector->oldgametic = gametic;
+        moved_floor = true;
       }
 
       switch(direction)
@@ -152,10 +159,10 @@ result_e T_MovePlane
       // moving a ceiling
 
       // [AM] Store old sector heights for interpolation.
-      if (sector->oldgametic != gametic)
+      if (!moved_ceil)
       {
         sector->oldceilingheight = sector->ceilingheight;
-        sector->oldgametic = gametic;
+        moved_ceil = true;
       }
 
       switch(direction)


### PR DESCRIPTION
https://github.com/fabiangreffrath/woof/assets/5077629/1459159d-ce8f-4999-82c0-6af57c05023c

save: [woofsav0.zip](https://github.com/fabiangreffrath/woof/files/11717885/woofsav0.zip)
 
The same issue is present in Crispy Doom. Thanks to @JNechaevsky for bug report.