### PR TITLE
umapinfo: fix intertext field for Doom 1

### DIFF
--- a/src/f_finale.c
+++ b/src/f_finale.c
@@ -842,10 +842,6 @@ void F_Drawer (void)
     if (!finalestage)
     {
       F_TextWrite();
-      if (!gamemapinfo->endpic[0])
-      {
-        using_FMI = false;
-      }
     }
     else if (strcmp(gamemapinfo->endpic, "$BUNNY") == 0)
     {


### PR DESCRIPTION
Fix #1102 

Originally this code was added to fix #245, but since then we adapted PrBoom+ approach, right? Anyway it works now with [Ultimate MIDI Pack](https://www.doomworld.com/forum/topic/120788-released-ultimate-midi-pack-a-community-music-replacement-for-the-original-doom/) and with just `intertext` field.