### PR TITLE
keep ceilings mapping with ceilings, and floors mapping with floors

### DIFF
--- a/src/r_plane.c
+++ b/src/r_plane.c
@@ -244,7 +244,17 @@ visplane_t *R_FindPlane(fixed_t height, int picnum, int lightlevel,
   unsigned hash;                      // killough
 
   if (picnum == skyflatnum || picnum & PL_SKYFLAT)  // killough 10/98
-    lightlevel = height = 0;   // killough 7/19/98: most skies map together
+  {
+    lightlevel = 0;   // killough 7/19/98: most skies map together
+
+    // haleyjd 05/06/08: but not all. If height > viewpoint.z, set height to 1
+    // instead of 0, to keep ceilings mapping with ceilings, and floors mapping
+    // with floors.
+    if (height > viewz)
+      height = 1;
+    else
+      height = 0;
+  }
 
   // New visplane algorithm uses hash table -- killough
   hash = visplane_hash(picnum,lightlevel,height);


### PR DESCRIPTION
Taken from Eternity Engine, https://github.com/team-eternity/eternity/blob/cdac0335080c09e3eb38ed560de0de0f542cc3c7/source/r_plane.cpp#L638-L643

This increases the FPS in pln.wad just like removing the `lightlevel = 0` line. Related issue #1107 