### PR TITLE
win midi: increase BUFFER_INITIAL_SIZE, wait no more than 3 seconds

### DIFF
--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -133,7 +133,7 @@ static win_midi_song_t song;
 
 #define BUFFER_INITIAL_SIZE 8192
 
-#define WAIT_TIME 3000
+#define PLAYER_THREAD_WAIT_TIME 3000
 
 typedef struct
 {
@@ -209,7 +209,7 @@ static void AllocateBuffer(const unsigned int size)
         MIDIHDR *hdr = &MidiStreamHdr;
         MMRESULT mmr;
 
-        MidiStreamHdr.dwFlags &= ~MHDR_INQUEUE;
+        hdr->dwFlags &= ~MHDR_INQUEUE;
         mmr = midiOutUnprepareHeader((HMIDIOUT)hMidiStream, hdr, sizeof(MIDIHDR));
         if (mmr != MMSYSERR_NOERROR)
         {
@@ -1483,7 +1483,7 @@ static void I_WIN_StopSong(void *handle)
     }
 
     SetEvent(hExitEvent);
-    WaitForSingleObject(hPlayerThread, WAIT_TIME);
+    WaitForSingleObject(hPlayerThread, PLAYER_THREAD_WAIT_TIME);
     CloseHandle(hPlayerThread);
     hPlayerThread = NULL;
 
@@ -1678,7 +1678,7 @@ static void I_WIN_ShutdownMusic(void)
     {
         MidiError("midiStreamRestart", mmr);
     }
-    WaitForSingleObject(hBufferReturnEvent, WAIT_TIME);
+    WaitForSingleObject(hBufferReturnEvent, PLAYER_THREAD_WAIT_TIME);
     mmr = midiStreamStop(hMidiStream);
     if (mmr != MMSYSERR_NOERROR)
     {

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -1427,7 +1427,10 @@ static boolean I_WIN_InitMusic(int device)
         return false;
     }
 
-    AllocateBuffer(BUFFER_INITIAL_SIZE);
+    if (buffer.data == NULL)
+    {
+        AllocateBuffer(BUFFER_INITIAL_SIZE);
+    }
 
     hBufferReturnEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
     hExitEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
@@ -1670,6 +1673,8 @@ static void I_WIN_ShutdownMusic(void)
         MidiError("midiStreamStop", mmr);
     }
 
+    buffer.position = 0;
+
     mmr = midiStreamClose(hMidiStream);
     if (mmr != MMSYSERR_NOERROR)
     {
@@ -1679,14 +1684,6 @@ static void I_WIN_ShutdownMusic(void)
 
     CloseHandle(hBufferReturnEvent);
     CloseHandle(hExitEvent);
-
-    if (buffer.data)
-    {
-        free(buffer.data);
-        buffer.data = NULL;
-        buffer.size = 0;
-        buffer.position = 0;
-    }
 }
 
 static int I_WIN_DeviceList(const char *devices[], int size, int *current_device)

--- a/src/i_winmusic.c
+++ b/src/i_winmusic.c
@@ -194,6 +194,7 @@ static void AllocateBuffer(const unsigned int size)
 
     if (buffer.data)
     {
+        MidiStreamHdr.dwFlags &= ~MHDR_INQUEUE;
         mmr = midiOutUnprepareHeader((HMIDIOUT)hMidiStream, hdr, sizeof(MIDIHDR));
         if (mmr != MMSYSERR_NOERROR)
         {


### PR DESCRIPTION
Avoid `midiOutUnprepareHeader()` which contains use after free (tested with ASan).

@ceski-1 Do you think the buffer size `8192` is enough?

I once had a crash with a resent build of Woof but can't replicate it. I guess there is a problem with the `midiOutUnprepareHeader()` function.