### PR TITLE
3D Audio Support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,7 @@ set(WOOF_SOURCES
     g_game.c               g_game.h
     hu_lib.c               hu_lib.h
     hu_stuff.c             hu_stuff.h
+    i_3dsound.c
     i_endoom.c             i_endoom.h
     i_glob.c               i_glob.h
     i_input.c              i_input.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,7 +34,9 @@ set(WOOF_SOURCES
     i_glob.c               i_glob.h
     i_input.c              i_input.h
     i_main.c
+    i_mbfsound.c
     i_oalmusic.c           i_oalmusic.h
+    i_oalsound.c           i_oalsound.h
                            i_oalstream.h
     i_oplmusic.c
     i_sndfile.c            i_sndfile.h

--- a/src/d_loop.c
+++ b/src/d_loop.c
@@ -713,7 +713,7 @@ static void SinglePlayerClear(ticcmd_set_t *set)
 
 void RunTic(ticcmd_t *cmds, boolean *ingame);
 
-void TryRunTics (void)
+boolean TryRunTics (void)
 {
     int	i;
     int	lowtic;
@@ -770,7 +770,7 @@ void TryRunTics (void)
         // [AM] If we've uncapped the framerate and there are no tics
         //      to run, return early instead of waiting around.
         if (return_early)
-            return;
+            return false;
     }
     else
     {
@@ -785,7 +785,7 @@ void TryRunTics (void)
         // [AM] If we've uncapped the framerate and there are no tics
         //      to run, return early instead of waiting around.
         if (return_early)
-            return;
+            return false;
 
         if (counts < 1)
             counts = 1;
@@ -817,7 +817,7 @@ void TryRunTics (void)
             // forever - give the menu a chance to work.
             if (I_GetTime() / ticdup - entertic >= MAX_NETGAME_STALL_TICS)
             {
-                return;
+                return true;
             }
 
             I_Sleep(1);
@@ -831,7 +831,7 @@ void TryRunTics (void)
 
         if (!PlayersInGame())
         {
-            return;
+            return true;
         }
 
         set = &ticdata[(gametic / ticdup) % BACKUPTICS];
@@ -858,4 +858,6 @@ void TryRunTics (void)
 
 	NetUpdate ();	// check for new console commands
     }
+
+    return true;
 }

--- a/src/d_loop.c
+++ b/src/d_loop.c
@@ -713,7 +713,7 @@ static void SinglePlayerClear(ticcmd_set_t *set)
 
 void RunTic(ticcmd_t *cmds, boolean *ingame);
 
-boolean TryRunTics (void)
+void TryRunTics (void)
 {
     int	i;
     int	lowtic;
@@ -770,7 +770,7 @@ boolean TryRunTics (void)
         // [AM] If we've uncapped the framerate and there are no tics
         //      to run, return early instead of waiting around.
         if (return_early)
-            return false;
+            return;
     }
     else
     {
@@ -785,7 +785,7 @@ boolean TryRunTics (void)
         // [AM] If we've uncapped the framerate and there are no tics
         //      to run, return early instead of waiting around.
         if (return_early)
-            return false;
+            return;
 
         if (counts < 1)
             counts = 1;
@@ -817,7 +817,7 @@ boolean TryRunTics (void)
             // forever - give the menu a chance to work.
             if (I_GetTime() / ticdup - entertic >= MAX_NETGAME_STALL_TICS)
             {
-                return true;
+                return;
             }
 
             I_Sleep(1);
@@ -831,7 +831,7 @@ boolean TryRunTics (void)
 
         if (!PlayersInGame())
         {
-            return true;
+            return;
         }
 
         set = &ticdata[(gametic / ticdup) % BACKUPTICS];
@@ -858,6 +858,4 @@ boolean TryRunTics (void)
 
 	NetUpdate ();	// check for new console commands
     }
-
-    return true;
 }

--- a/src/d_loop.c
+++ b/src/d_loop.c
@@ -38,6 +38,8 @@
 #include "net_sdl.h"
 #include "net_loop.h"
 
+#include "s_sound.h"
+
 // The complete set of data for a particular tic.
 
 typedef struct
@@ -817,7 +819,7 @@ void TryRunTics (void)
             // forever - give the menu a chance to work.
             if (I_GetTime() / ticdup - entertic >= MAX_NETGAME_STALL_TICS)
             {
-                return;
+                goto end;
             }
 
             I_Sleep(1);
@@ -831,7 +833,7 @@ void TryRunTics (void)
 
         if (!PlayersInGame())
         {
-            return;
+            goto end;
         }
 
         set = &ticdata[(gametic / ticdup) % BACKUPTICS];
@@ -858,4 +860,8 @@ void TryRunTics (void)
 
 	NetUpdate ();	// check for new console commands
     }
+
+end:
+    // killough 3/16/98: change consoleplayer to displayplayer
+    S_UpdateSounds(players[displayplayer].mo); // move positional sounds
 }

--- a/src/d_loop.c
+++ b/src/d_loop.c
@@ -819,7 +819,7 @@ void TryRunTics (void)
             // forever - give the menu a chance to work.
             if (I_GetTime() / ticdup - entertic >= MAX_NETGAME_STALL_TICS)
             {
-                goto end;
+                return;
             }
 
             I_Sleep(1);
@@ -833,7 +833,7 @@ void TryRunTics (void)
 
         if (!PlayersInGame())
         {
-            goto end;
+            return;
         }
 
         set = &ticdata[(gametic / ticdup) % BACKUPTICS];
@@ -861,7 +861,6 @@ void TryRunTics (void)
 	NetUpdate ();	// check for new console commands
     }
 
-end:
     // killough 3/16/98: change consoleplayer to displayplayer
     S_UpdateSounds(players[displayplayer].mo); // move positional sounds
 }

--- a/src/d_loop.h
+++ b/src/d_loop.h
@@ -36,7 +36,7 @@ void NetUpdate (void);
 void D_QuitNetGame (void);
 
 //? how many ticks to run?
-void TryRunTics (void);
+boolean TryRunTics (void);
 
 // Called at start of game loop to initialize timers
 void D_StartGameLoop(void);

--- a/src/d_loop.h
+++ b/src/d_loop.h
@@ -36,7 +36,7 @@ void NetUpdate (void);
 void D_QuitNetGame (void);
 
 //? how many ticks to run?
-boolean TryRunTics (void);
+void TryRunTics (void);
 
 // Called at start of game loop to initialize timers
 void D_StartGameLoop(void);

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -2743,17 +2743,18 @@ void D_DoomMain(void)
       // frame syncronous IO operations
       I_StartFrame ();
 
-      TryRunTics (); // will run at least one tic
+      if (TryRunTics()) // will run at least one tic
+      {
+        // killough 3/16/98: change consoleplayer to displayplayer
+        S_UpdateSounds(players[displayplayer].mo);// move positional sounds
 
-      // killough 3/16/98: change consoleplayer to displayplayer
-      S_UpdateSounds(players[displayplayer].mo);// move positional sounds
+        // Sound mixing for the buffer is snychronous.
+        I_UpdateSound();
+      }
 
       // Update display, next frame, with current state.
       if (screenvisible)
         D_Display();
-
-      // Sound mixing for the buffer is snychronous.
-      I_UpdateSound();
     }
 }
 

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -2751,9 +2751,6 @@ void D_DoomMain(void)
       // Update display, next frame, with current state.
       if (screenvisible)
         D_Display();
-
-      // Sound mixing for the buffer is snychronous.
-      I_UpdateSound();
     }
 }
 

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -2743,18 +2743,17 @@ void D_DoomMain(void)
       // frame syncronous IO operations
       I_StartFrame ();
 
-      if (TryRunTics()) // will run at least one tic
-      {
-        // killough 3/16/98: change consoleplayer to displayplayer
-        S_UpdateSounds(players[displayplayer].mo);// move positional sounds
+      TryRunTics (); // will run at least one tic
 
-        // Sound mixing for the buffer is snychronous.
-        I_UpdateSound();
-      }
+      // killough 3/16/98: change consoleplayer to displayplayer
+      S_UpdateSounds(players[displayplayer].mo);// move positional sounds
 
       // Update display, next frame, with current state.
       if (screenvisible)
         D_Display();
+
+      // Sound mixing for the buffer is snychronous.
+      I_UpdateSound();
     }
 }
 

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -2745,9 +2745,6 @@ void D_DoomMain(void)
 
       TryRunTics (); // will run at least one tic
 
-      // killough 3/16/98: change consoleplayer to displayplayer
-      S_UpdateSounds(players[displayplayer].mo);// move positional sounds
-
       // Update display, next frame, with current state.
       if (screenvisible)
         D_Display();

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -775,6 +775,9 @@ static void G_DoLoadLevel(void)
   st_armor  = players[displayplayer].armorpoints;
   gameaction = ga_nothing;
 
+  // Set the initial listener parameters using the player's initial state.
+  S_InitListener(players[displayplayer].mo);
+
   // clear cmd building stuff
   memset (gamekeydown, 0, sizeof(gamekeydown));
   mousex = mousex2 = mousey = mousey2 = 0;

--- a/src/i_3dsound.c
+++ b/src/i_3dsound.c
@@ -1,0 +1,314 @@
+//
+// Copyright(C) 2023 ceski
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//      System interface for 3D sound.
+//
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "doomstat.h"
+#include "i_oalsound.h"
+#include "r_data.h"
+#include "r_main.h"
+
+#define VIEWDIST (ORIGWIDTH / 2) // Distance from projection plane to POV.
+#define FIXED_TO_ALFLOAT(x) ((ALfloat)(((double)x) / FRACUNIT))
+
+typedef struct oal_listener_params_s
+{
+    ALfloat position[3];
+    ALfloat velocity[3];
+    ALfloat orientation[6];
+} oal_listener_params_t;
+
+typedef struct oal_source_params_s
+{
+    ALfloat position[3];
+    ALfloat velocity[3];
+    ALfloat direction[3];
+    boolean point_source;
+} oal_source_params_t;
+
+static boolean I_3D_InitSound(void)
+{
+    return I_OAL_InitSound(true);
+}
+
+static boolean I_3D_ReinitSound(void)
+{
+    return I_OAL_ReinitSound(true);
+}
+
+static void CalcPitchAngle(const player_t *player, angle_t *pitch)
+{
+    fixed_t lookdir, slope;
+
+    // Same as R_SetupFrame() in r_main.c.
+    lookdir = player->lookdir / MLOOKUNIT + player->recoilpitch;
+
+    if (lookdir == 0)
+    {
+        *pitch = 0;
+        return;
+    }
+
+    if (lookdir > LOOKDIRMAX)
+        lookdir = LOOKDIRMAX;
+    else if (lookdir < -LOOKDIRMAX)
+        lookdir = -LOOKDIRMAX;
+
+    slope = (lookdir << FRACBITS) / VIEWDIST;
+    if (slope < 0)
+    {
+        *pitch = (ANGLE_MAX - tantoangle[-slope >> DBITS]) >> ANGLETOFINESHIFT;
+    }
+    else
+    {
+        *pitch = tantoangle[slope >> DBITS] >> ANGLETOFINESHIFT;
+    }
+}
+
+static void CalcListenerParams(const mobj_t *listener, oal_listener_params_t *lis)
+{
+    const player_t *player = listener->player;
+    const angle_t yaw = listener->angle >> ANGLETOFINESHIFT;
+    angle_t pitch;
+
+    lis->position[0] = FIXED_TO_ALFLOAT(listener->x);
+    lis->position[1] = FIXED_TO_ALFLOAT(player->viewz);
+    lis->position[2] = FIXED_TO_ALFLOAT(-listener->y);
+
+    lis->velocity[0] = FIXED_TO_ALFLOAT(listener->momx) * TICRATE;
+    //lis->velocity[1] = FIXED_TO_ALFLOAT(listener->momz) * TICRATE;
+    lis->velocity[1] = 0.0f;
+    lis->velocity[2] = FIXED_TO_ALFLOAT(-listener->momy) * TICRATE;
+
+    CalcPitchAngle(player, &pitch);
+    if (pitch == 0)
+    {
+        // "At" vector after yaw rotation.
+        lis->orientation[0] = FIXED_TO_ALFLOAT(finecosine[yaw]);
+        lis->orientation[1] = 0.0f;
+        lis->orientation[2] = FIXED_TO_ALFLOAT(-finesine[yaw]);
+
+        // "Up" vector doesn't change.
+        lis->orientation[3] = 0.0f;
+        lis->orientation[4] = 1.0f;
+        lis->orientation[5] = 0.0f;
+    }
+    else
+    {
+        // "At" vector after yaw and pitch rotations.
+        lis->orientation[0] = FIXED_TO_ALFLOAT(finecosine[yaw] * finesine[pitch]);
+        lis->orientation[1] = FIXED_TO_ALFLOAT(finecosine[pitch]);
+        lis->orientation[2] = FIXED_TO_ALFLOAT(-finesine[yaw] * finesine[pitch]);
+
+        // "Up" vector after yaw and pitch rotations.
+        lis->orientation[3] = FIXED_TO_ALFLOAT(-finecosine[yaw] * finecosine[pitch]);
+        lis->orientation[4] = FIXED_TO_ALFLOAT(finesine[pitch]);
+        lis->orientation[5] = FIXED_TO_ALFLOAT(finesine[yaw] * finecosine[pitch]);
+    }
+}
+
+static void CalcSourceParams(const mobj_t *listener, const mobj_t *source,
+                             oal_source_params_t *src)
+{
+    src->position[0] = FIXED_TO_ALFLOAT(source->x);
+    src->position[2] = FIXED_TO_ALFLOAT(-source->y);
+
+    // Treat monsters and projectiles as point sources.
+    src->point_source = source->info && source->info->actualheight;
+
+    if (src->point_source)
+    {
+        const int yaw = source->angle >> ANGLETOFINESHIFT;
+
+        // Set vertical position to middle of sprite.
+        src->position[1] = FIXED_TO_ALFLOAT(source->z + (source->info->actualheight >> 1));
+
+        src->direction[0] = FIXED_TO_ALFLOAT(finecosine[yaw]);
+        src->direction[1] = 0.0f;
+        src->direction[2] = FIXED_TO_ALFLOAT(-finesine[yaw]);
+
+        src->velocity[0] = FIXED_TO_ALFLOAT(source->momx) * TICRATE;
+        //src->velocity[1] = FIXED_TO_ALFLOAT(source->momz) * TICRATE;
+        src->velocity[1] = 0.0f;
+        src->velocity[2] = FIXED_TO_ALFLOAT(-source->momy) * TICRATE;
+    }
+    else
+    {
+        // This is a door, switch, lift, etc. and doesn't have a proper vertical
+        // position. Similar to vanilla Doom, make sure the player can hear this
+        // at any vertical position (e.g. tall lifts).
+        
+        // Set the source's vertical position to the listener's vertical position.
+        src->position[1] = FIXED_TO_ALFLOAT(listener->player->viewz);
+
+        src->direction[0] = 0.0f;
+        src->direction[1] = 0.0f;
+        src->direction[2] = 0.0f;
+
+        src->velocity[0] = 0.0f;
+        src->velocity[1] = 0.0f;
+        src->velocity[2] = 0.0f;
+    }
+}
+
+static void CalcHypotenuse(fixed_t adx, fixed_t ady, fixed_t *dist)
+{
+    if (ady > adx)
+    {
+        const fixed_t temp = adx;
+        adx = ady;
+        ady = temp;
+    }
+
+    if (adx)
+    {
+        const int slope = FixedDiv(ady, adx) >> DBITS;
+        const int angle = tantoangle[slope] >> ANGLETOFINESHIFT;
+        *dist = FixedDiv(adx, finecosine[angle]);
+    }
+    else
+    {
+        *dist = 0;
+    }
+}
+
+static void CalcDistance(const mobj_t *listener, const mobj_t *source,
+                         fixed_t *dist)
+{
+    const fixed_t adx = abs((listener->x >> FRACBITS) - (source->x >> FRACBITS));
+    const fixed_t ady = abs((listener->y >> FRACBITS) - (source->y >> FRACBITS));
+    const fixed_t adz = abs((listener->z >> FRACBITS) - (source->z >> FRACBITS));
+    fixed_t distxy;
+
+    CalcHypotenuse(adx, ady, &distxy);
+    CalcHypotenuse(distxy, adz, dist);
+}
+
+static boolean CalcVolumePriority(const mobj_t *listener, const mobj_t *source,
+                                  int *vol, int *pri)
+{
+    fixed_t dist;
+    int pri_volume;
+
+    CalcDistance(listener, source, &dist);
+
+    if (dist == 0)
+    {
+        return true;
+    }
+    else if (dist >= OAL_CULL_DISTANCE)
+    {
+        return false;
+    }
+    else if (dist <= OAL_REF_DISTANCE)
+    {
+        pri_volume = *vol;
+    }
+    else if (dist > OAL_MAX_DISTANCE)
+    {
+        // OpenAL inverse distance model never reaches zero volume. Gradually
+        // ramp down the volume as the distance approaches the limit.
+        pri_volume = *vol * (OAL_CULL_DISTANCE - dist) /
+                            (OAL_CULL_DISTANCE - OAL_MAX_DISTANCE);
+        *vol = pri_volume;
+    }
+    else
+    {
+        // Range where OpenAL inverse distance model applies. Calculate volume
+        // for priority bookkeeping but let OpenAL handle the real volume.
+        // Simplify formula for OAL_ROLLOFF_FACTOR = 1:
+        pri_volume = *vol * OAL_REF_DISTANCE / dist;
+    }
+
+    // Decrease priority with volume attenuation.
+    *pri += (127 - pri_volume);
+
+    if (*pri > 255)
+        *pri = 255;
+
+    return pri_volume > 0;
+}
+
+static boolean ScaleVolume(int chanvol, int *vol)
+{
+    *vol = (snd_SfxVolume * chanvol) / 15;
+
+    if (*vol < 1)
+        return false;
+    else if (*vol > 127)
+        *vol = 127;
+
+    return true;
+}
+
+static boolean I_3D_AdjustSoundParams(const mobj_t *listener, const mobj_t *source,
+                                      int chanvol, int *vol, int *sep, int *pri,
+                                      int channel)
+{
+    oal_listener_params_t lis;
+    oal_source_params_t src;
+
+    if (!ScaleVolume(chanvol, vol))
+    {
+        return false;
+    }
+
+    if (!source || source == players[displayplayer].mo || !listener ||
+        !listener->player)
+    {
+        I_OAL_DeferUpdates();
+        I_OAL_ResetSource2D(channel);
+        return true;
+    }
+
+    if (!CalcVolumePriority(listener, source, vol, pri))
+    {
+        return false;
+    }
+
+    CalcSourceParams(listener, source, &src);
+    CalcListenerParams(listener, &lis);
+
+    I_OAL_DeferUpdates();
+    I_OAL_ResetSource3D(channel, src.point_source);
+    I_OAL_AdjustSource3D(channel, src.position, src.velocity, src.direction);
+    I_OAL_AdjustListener3D(lis.position, lis.velocity, lis.orientation);
+
+    return true;
+}
+
+static void I_3D_UpdateSoundParams(int channel, int volume, int separation)
+{
+    I_OAL_SetVolume(channel, volume);
+    I_OAL_ProcessUpdates();
+}
+
+const sound_module_t sound_3d_module =
+{
+    I_3D_InitSound,
+    I_3D_ReinitSound,
+    I_OAL_AllowReinitSound,
+    I_OAL_UpdateUserSoundSettings,
+    I_OAL_CacheSound,
+    I_3D_AdjustSoundParams,
+    I_3D_UpdateSoundParams,
+    I_OAL_StartSound,
+    I_OAL_StopSound,
+    I_OAL_SoundIsPlaying,
+    I_OAL_ShutdownSound,
+};

--- a/src/i_3dsound.c
+++ b/src/i_3dsound.c
@@ -40,16 +40,6 @@ typedef struct oal_source_params_s
     boolean point_source;
 } oal_source_params_t;
 
-static boolean I_3D_InitSound(void)
-{
-    return I_OAL_InitSound(true);
-}
-
-static boolean I_3D_ReinitSound(void)
-{
-    return I_OAL_ReinitSound(true);
-}
-
 static void CalcPitchAngle(const player_t *player, angle_t *pitch)
 {
     fixed_t lookdir, slope;
@@ -305,8 +295,8 @@ static void I_3D_UpdateSoundParams(int channel, int volume, int separation)
 
 const sound_module_t sound_3d_module =
 {
-    I_3D_InitSound,
-    I_3D_ReinitSound,
+    I_OAL_InitSound,
+    I_OAL_ReinitSound,
     I_OAL_AllowReinitSound,
     I_OAL_UpdateUserSoundSettings,
     I_OAL_CacheSound,

--- a/src/i_3dsound.c
+++ b/src/i_3dsound.c
@@ -91,8 +91,7 @@ static void CalcListenerParams(const mobj_t *listener, oal_listener_params_t *li
     lis->position[2] = FIXED_TO_ALFLOAT(-listener->y);
 
     lis->velocity[0] = FIXED_TO_ALFLOAT(listener->momx) * TICRATE;
-    //lis->velocity[1] = FIXED_TO_ALFLOAT(listener->momz) * TICRATE;
-    lis->velocity[1] = 0.0f;
+    lis->velocity[1] = FIXED_TO_ALFLOAT(listener->momz) * TICRATE;
     lis->velocity[2] = FIXED_TO_ALFLOAT(-listener->momy) * TICRATE;
 
     CalcPitchAngle(player, &pitch);
@@ -143,8 +142,7 @@ static void CalcSourceParams(const mobj_t *listener, const mobj_t *source,
         src->direction[2] = FIXED_TO_ALFLOAT(-finesine[yaw]);
 
         src->velocity[0] = FIXED_TO_ALFLOAT(source->momx) * TICRATE;
-        //src->velocity[1] = FIXED_TO_ALFLOAT(source->momz) * TICRATE;
-        src->velocity[1] = 0.0f;
+        src->velocity[1] = FIXED_TO_ALFLOAT(source->momz) * TICRATE;
         src->velocity[2] = FIXED_TO_ALFLOAT(-source->momy) * TICRATE;
     }
     else

--- a/src/i_3dsound.c
+++ b/src/i_3dsound.c
@@ -41,7 +41,6 @@ typedef struct oal_source_params_s
     fixed_t z;
 } oal_source_params_t;
 
-static oal_listener_params_t lis;
 static oal_source_params_t src;
 
 static void CalcPitchAngle(const player_t *player, angle_t *pitch)
@@ -270,7 +269,6 @@ static boolean I_3D_AdjustSoundParams(const mobj_t *listener, const mobj_t *sour
 
     src.use_3d = true;
     CalcSourceParams(source, &src);
-    CalcListenerParams(listener, &lis);
 
     return true;
 }
@@ -279,11 +277,23 @@ static void I_3D_UpdateSoundParams(int channel, int volume, int separation)
 {
     if (src.use_3d)
     {
-        I_OAL_AdjustSource3D(channel, src.position, src.velocity);
-        I_OAL_AdjustListener3D(lis.position, lis.velocity, lis.orientation);
+        I_OAL_UpdateSourceParams(channel, src.position, src.velocity);
     }
 
     I_OAL_SetVolume(channel, volume);
+}
+
+static void I_3D_UpdateListenerParams(const mobj_t *listener)
+{
+    oal_listener_params_t lis;
+
+    if (!listener || !listener->player)
+    {
+        return;
+    }
+
+    CalcListenerParams(listener, &lis);
+    I_OAL_UpdateListenerParams(lis.position, lis.velocity, lis.orientation);
 }
 
 static boolean I_3D_StartSound(int channel, ALuint buffer, int pitch)
@@ -309,6 +319,7 @@ const sound_module_t sound_3d_module =
     I_OAL_CacheSound,
     I_3D_AdjustSoundParams,
     I_3D_UpdateSoundParams,
+    I_3D_UpdateListenerParams,
     I_3D_StartSound,
     I_OAL_StopSound,
     I_OAL_SoundIsPlaying,

--- a/src/i_3dsound.c
+++ b/src/i_3dsound.c
@@ -256,7 +256,6 @@ static boolean I_3D_AdjustSoundParams(const mobj_t *listener, const mobj_t *sour
     if (!source || source == players[displayplayer].mo || !listener ||
         !listener->player)
     {
-        I_OAL_DeferUpdates();
         I_OAL_ResetSource2D(channel);
         return true;
     }
@@ -271,7 +270,6 @@ static boolean I_3D_AdjustSoundParams(const mobj_t *listener, const mobj_t *sour
     CalcSourceParams(source, &src);
     CalcListenerParams(listener, &lis);
 
-    I_OAL_DeferUpdates();
     I_OAL_ResetSource3D(channel, src.point_source);
     I_OAL_AdjustSource3D(channel, src.position, src.velocity);
     I_OAL_AdjustListener3D(lis.position, lis.velocity, lis.orientation);
@@ -282,7 +280,6 @@ static boolean I_3D_AdjustSoundParams(const mobj_t *listener, const mobj_t *sour
 static void I_3D_UpdateSoundParams(int channel, int volume, int separation)
 {
     I_OAL_SetVolume(channel, volume);
-    I_OAL_ProcessUpdates();
 }
 
 const sound_module_t sound_3d_module =
@@ -298,4 +295,6 @@ const sound_module_t sound_3d_module =
     I_OAL_StopSound,
     I_OAL_SoundIsPlaying,
     I_OAL_ShutdownSound,
+    I_OAL_DeferUpdates,
+    I_OAL_ProcessUpdates,
 };

--- a/src/i_3dsound.c
+++ b/src/i_3dsound.c
@@ -43,24 +43,16 @@ typedef struct oal_source_params_s
 
 static void CalcPitchAngle(const player_t *player, angle_t *pitch)
 {
-    fixed_t lookdir, slope;
+    fixed_t slope;
 
-    // Same as R_SetupFrame() in r_main.c.
-    lookdir = player->lookdir / MLOOKUNIT + player->recoilpitch;
-
-    if (lookdir == 0)
+    if (player->slope == 0)
     {
         *pitch = 0;
         return;
     }
 
-    if (lookdir > LOOKDIRMAX)
-        lookdir = LOOKDIRMAX;
-    else if (lookdir < -LOOKDIRMAX)
-        lookdir = -LOOKDIRMAX;
-
     // Flip sign due to right-hand rule.
-    slope = (-lookdir << FRACBITS) / VIEWDIST;
+    slope = -player->slope;
     if (slope < 0)
     {
         *pitch = (ANGLE_MAX - tantoangle[-slope >> DBITS]) >> ANGLETOFINESHIFT;

--- a/src/i_3dsound.c
+++ b/src/i_3dsound.c
@@ -37,7 +37,6 @@ typedef struct oal_source_params_s
 {
     ALfloat position[3];
     ALfloat velocity[3];
-    ALfloat direction[3];
     boolean point_source;
 } oal_source_params_t;
 
@@ -141,14 +140,8 @@ static void CalcSourceParams(const mobj_t *listener, const mobj_t *source,
 
     if (src->point_source)
     {
-        const int yaw = source->angle >> ANGLETOFINESHIFT;
-
         // Set vertical position to middle of sprite.
         src->position[1] = FIXED_TO_ALFLOAT(source->z + (source->info->actualheight >> 1));
-
-        src->direction[0] = FIXED_TO_ALFLOAT(finecosine[yaw]);
-        src->direction[1] = 0.0f;
-        src->direction[2] = FIXED_TO_ALFLOAT(-finesine[yaw]);
 
         if (oal_use_doppler)
         {
@@ -171,10 +164,6 @@ static void CalcSourceParams(const mobj_t *listener, const mobj_t *source,
         
         // Set the source's vertical position to the listener's vertical position.
         src->position[1] = FIXED_TO_ALFLOAT(listener->player->viewz);
-
-        src->direction[0] = 0.0f;
-        src->direction[1] = 0.0f;
-        src->direction[2] = 0.0f;
 
         src->velocity[0] = 0.0f;
         src->velocity[1] = 0.0f;
@@ -302,7 +291,7 @@ static boolean I_3D_AdjustSoundParams(const mobj_t *listener, const mobj_t *sour
 
     I_OAL_DeferUpdates();
     I_OAL_ResetSource3D(channel, src.point_source);
-    I_OAL_AdjustSource3D(channel, src.position, src.velocity, src.direction);
+    I_OAL_AdjustSource3D(channel, src.position, src.velocity);
     I_OAL_AdjustListener3D(lis.position, lis.velocity, lis.orientation);
 
     return true;

--- a/src/i_3dsound.c
+++ b/src/i_3dsound.c
@@ -24,7 +24,7 @@
 #include "r_main.h"
 
 #define VIEWDIST (ORIGWIDTH / 2) // Distance from projection plane to POV.
-#define FIXED_TO_ALFLOAT(x) ((ALfloat)(((double)x) / FRACUNIT))
+#define FIXED_TO_ALFLOAT(x) ((ALfloat)((double)(x) / FRACUNIT))
 
 typedef struct oal_listener_params_s
 {
@@ -59,7 +59,8 @@ static void CalcPitchAngle(const player_t *player, angle_t *pitch)
     else if (lookdir < -LOOKDIRMAX)
         lookdir = -LOOKDIRMAX;
 
-    slope = (lookdir << FRACBITS) / VIEWDIST;
+    // Flip sign due to right-hand rule.
+    slope = (-lookdir << FRACBITS) / VIEWDIST;
     if (slope < 0)
     {
         *pitch = (ANGLE_MAX - tantoangle[-slope >> DBITS]) >> ANGLETOFINESHIFT;
@@ -109,14 +110,14 @@ static void CalcListenerParams(const mobj_t *listener, oal_listener_params_t *li
     else
     {
         // "At" vector after yaw and pitch rotations.
-        lis->orientation[0] = FIXED_TO_ALFLOAT(finecosine[yaw] * finesine[pitch]);
-        lis->orientation[1] = FIXED_TO_ALFLOAT(finecosine[pitch]);
-        lis->orientation[2] = FIXED_TO_ALFLOAT(-finesine[yaw] * finesine[pitch]);
+        lis->orientation[0] = FIXED_TO_ALFLOAT(FixedMul(finecosine[yaw], finecosine[pitch]));
+        lis->orientation[1] = FIXED_TO_ALFLOAT(-finesine[pitch]);
+        lis->orientation[2] = FIXED_TO_ALFLOAT(-FixedMul(finesine[yaw], finecosine[pitch]));
 
         // "Up" vector after yaw and pitch rotations.
-        lis->orientation[3] = FIXED_TO_ALFLOAT(-finecosine[yaw] * finecosine[pitch]);
-        lis->orientation[4] = FIXED_TO_ALFLOAT(finesine[pitch]);
-        lis->orientation[5] = FIXED_TO_ALFLOAT(finesine[yaw] * finecosine[pitch]);
+        lis->orientation[3] = FIXED_TO_ALFLOAT(FixedMul(finecosine[yaw], finesine[pitch]));
+        lis->orientation[4] = FIXED_TO_ALFLOAT(finecosine[pitch]);
+        lis->orientation[5] = FIXED_TO_ALFLOAT(-FixedMul(finesine[yaw], finesine[pitch]));
     }
 }
 

--- a/src/i_3dsound.c
+++ b/src/i_3dsound.c
@@ -209,20 +209,20 @@ static boolean CalcVolumePriority(const mobj_t *listener, const mobj_t *source,
     {
         return true;
     }
-    else if (dist >= OAL_CULL_DISTANCE)
+    else if (dist >= (S_CLIPPING_DIST >> FRACBITS))
     {
         return false;
     }
-    else if (dist <= OAL_REF_DISTANCE)
+    else if (dist <= (S_CLOSE_DIST >> FRACBITS))
     {
         pri_volume = *vol;
     }
-    else if (dist > OAL_MAX_DISTANCE)
+    else if (dist > S_ATTENUATOR)
     {
         // OpenAL inverse distance model never reaches zero volume. Gradually
         // ramp down the volume as the distance approaches the limit.
-        pri_volume = *vol * (OAL_CULL_DISTANCE - dist) /
-                            (OAL_CULL_DISTANCE - OAL_MAX_DISTANCE);
+        pri_volume = *vol * ((S_CLIPPING_DIST >> FRACBITS) - dist) /
+                            (S_CLOSE_DIST >> FRACBITS);
         *vol = pri_volume;
     }
     else
@@ -230,7 +230,7 @@ static boolean CalcVolumePriority(const mobj_t *listener, const mobj_t *source,
         // Range where OpenAL inverse distance model applies. Calculate volume
         // for priority bookkeeping but let OpenAL handle the real volume.
         // Simplify formula for OAL_ROLLOFF_FACTOR = 1:
-        pri_volume = *vol * OAL_REF_DISTANCE / dist;
+        pri_volume = *vol * (S_CLOSE_DIST >> FRACBITS) / dist;
     }
 
     // Decrease priority with volume attenuation.

--- a/src/i_3dsound.c
+++ b/src/i_3dsound.c
@@ -128,7 +128,7 @@ static void CalcSourceParams(const mobj_t *listener, const mobj_t *source,
     src->position[2] = FIXED_TO_ALFLOAT(-source->y);
 
     // Treat monsters and projectiles as point sources.
-    src->point_source = source->info && source->info->actualheight;
+    src->point_source = (source->info && source->info->actualheight);
 
     if (src->point_source)
     {
@@ -239,7 +239,7 @@ static boolean CalcVolumePriority(const mobj_t *listener, const mobj_t *source,
     if (*pri > 255)
         *pri = 255;
 
-    return pri_volume > 0;
+    return (pri_volume > 0);
 }
 
 static boolean ScaleVolume(int chanvol, int *vol)

--- a/src/i_3dsound.c
+++ b/src/i_3dsound.c
@@ -90,9 +90,18 @@ static void CalcListenerParams(const mobj_t *listener, oal_listener_params_t *li
     lis->position[1] = FIXED_TO_ALFLOAT(player->viewz);
     lis->position[2] = FIXED_TO_ALFLOAT(-listener->y);
 
-    lis->velocity[0] = FIXED_TO_ALFLOAT(listener->momx) * TICRATE;
-    lis->velocity[1] = FIXED_TO_ALFLOAT(listener->momz) * TICRATE;
-    lis->velocity[2] = FIXED_TO_ALFLOAT(-listener->momy) * TICRATE;
+    if (oal_use_doppler)
+    {
+        lis->velocity[0] = FIXED_TO_ALFLOAT(listener->momx) * TICRATE;
+        lis->velocity[1] = FIXED_TO_ALFLOAT(listener->momz) * TICRATE;
+        lis->velocity[2] = FIXED_TO_ALFLOAT(-listener->momy) * TICRATE;
+    }
+    else
+    {
+        lis->velocity[0] = 0.0f;
+        lis->velocity[1] = 0.0f;
+        lis->velocity[2] = 0.0f;
+    }
 
     CalcPitchAngle(player, &pitch);
     if (pitch == 0)
@@ -141,9 +150,18 @@ static void CalcSourceParams(const mobj_t *listener, const mobj_t *source,
         src->direction[1] = 0.0f;
         src->direction[2] = FIXED_TO_ALFLOAT(-finesine[yaw]);
 
-        src->velocity[0] = FIXED_TO_ALFLOAT(source->momx) * TICRATE;
-        src->velocity[1] = FIXED_TO_ALFLOAT(source->momz) * TICRATE;
-        src->velocity[2] = FIXED_TO_ALFLOAT(-source->momy) * TICRATE;
+        if (oal_use_doppler)
+        {
+            src->velocity[0] = FIXED_TO_ALFLOAT(source->momx) * TICRATE;
+            src->velocity[1] = FIXED_TO_ALFLOAT(source->momz) * TICRATE;
+            src->velocity[2] = FIXED_TO_ALFLOAT(-source->momy) * TICRATE;
+        }
+        else
+        {
+            src->velocity[0] = 0.0f;
+            src->velocity[1] = 0.0f;
+            src->velocity[2] = 0.0f;
+        }
     }
     else
     {

--- a/src/i_3dsound.c
+++ b/src/i_3dsound.c
@@ -77,6 +77,8 @@ static void CalcListenerParams(const mobj_t *listener, oal_listener_params_t *li
     const angle_t yaw = listener->angle >> ANGLETOFINESHIFT;
     angle_t pitch;
 
+    // Doom to OpenAL space: {x, y, z} to {x, z, -y}
+
     lis->position[0] = FIXED_TO_ALFLOAT(listener->x);
     lis->position[1] = FIXED_TO_ALFLOAT(player->viewz);
     lis->position[2] = FIXED_TO_ALFLOAT(-listener->y);
@@ -123,6 +125,8 @@ static void CalcListenerParams(const mobj_t *listener, oal_listener_params_t *li
 
 static void CalcSourceParams(const mobj_t *source, oal_source_params_t *src)
 {
+    // Doom to OpenAL space: {x, y, z} to {x, z, -y}
+
     src->position[0] = FIXED_TO_ALFLOAT(source->x);
     src->position[1] = FIXED_TO_ALFLOAT(src->z);
     src->position[2] = FIXED_TO_ALFLOAT(-source->y);

--- a/src/i_3dsound.c
+++ b/src/i_3dsound.c
@@ -23,7 +23,6 @@
 #include "r_data.h"
 #include "r_main.h"
 
-#define VIEWDIST (ORIGWIDTH / 2) // Distance from projection plane to POV.
 #define FIXED_TO_ALFLOAT(x) ((ALfloat)((double)(x) / FRACUNIT))
 
 typedef struct oal_listener_params_s

--- a/src/i_mbfsound.c
+++ b/src/i_mbfsound.c
@@ -23,22 +23,6 @@
 #include "i_sound.h"
 #include "r_main.h"
 
-// when to clip out sounds
-// Does not fit the large outdoor areas.
-#define S_CLIPPING_DIST (1200 << FRACBITS)
-
-// Distance to origin when sounds should be maxed out.
-// This should relate to movement clipping resolution
-// (see BLOCKMAP handling).
-// Originally: (200*0x10000).
-//
-// killough 12/98: restore original
-// #define S_CLOSE_DIST (160<<FRACBITS)
-
-#define S_CLOSE_DIST (200 << FRACBITS)
-
-#define S_ATTENUATOR ((S_CLIPPING_DIST - S_CLOSE_DIST) >> FRACBITS)
-
 static boolean I_MBF_InitSound(void)
 {
     return I_OAL_InitSound(false);

--- a/src/i_mbfsound.c
+++ b/src/i_mbfsound.c
@@ -106,10 +106,8 @@ void I_MBF_UpdateSoundParams(int channel, int volume, int separation)
         separation = 254 - separation;
     }
 
-    I_OAL_DeferUpdates();
     I_OAL_SetVolume(channel, volume);
     I_OAL_SetPan(channel, separation);
-    I_OAL_ProcessUpdates();
 }
 
 const sound_module_t sound_mbf_module =
@@ -125,4 +123,6 @@ const sound_module_t sound_mbf_module =
     I_OAL_StopSound,
     I_OAL_SoundIsPlaying,
     I_OAL_ShutdownSound,
+    I_OAL_DeferUpdates,
+    I_OAL_ProcessUpdates,
 };

--- a/src/i_mbfsound.c
+++ b/src/i_mbfsound.c
@@ -23,6 +23,8 @@
 #include "i_sound.h"
 #include "r_main.h"
 
+int forceFlipPan;
+
 static boolean I_MBF_AdjustSoundParams(const mobj_t *listener, const mobj_t *source,
                                        int chanvol, int *vol, int *sep, int *pri,
                                        int channel)
@@ -98,6 +100,12 @@ static boolean I_MBF_AdjustSoundParams(const mobj_t *listener, const mobj_t *sou
 
 void I_MBF_UpdateSoundParams(int channel, int volume, int separation)
 {
+    // SoM 7/1/02: forceFlipPan accounted for here
+    if (forceFlipPan)
+    {
+        separation = 254 - separation;
+    }
+
     I_OAL_DeferUpdates();
     I_OAL_SetVolume(channel, volume);
     I_OAL_SetPan(channel, separation);

--- a/src/i_mbfsound.c
+++ b/src/i_mbfsound.c
@@ -118,7 +118,7 @@ static boolean I_MBF_AdjustSoundParams(const mobj_t *listener, const mobj_t *sou
     if (*pri > 255) // cap to 255
         *pri = 255;
 
-    return *vol > 0;
+    return (*vol > 0);
 }
 
 void I_MBF_UpdateSoundParams(int channel, int volume, int separation)

--- a/src/i_mbfsound.c
+++ b/src/i_mbfsound.c
@@ -1,0 +1,107 @@
+//
+// Copyright (C) 1999 by
+// id Software, Chi Hoang, Lee Killough, Jim Flynn, Rand Phares, Ty Halderman
+// Copyright(C) 2023 ceski
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//      System interface for WinMBF sound.
+//
+
+#include "i_oalsound.h"
+#include "i_sound.h"
+#include "r_main.h"
+
+// when to clip out sounds
+// Does not fit the large outdoor areas.
+#define S_CLIPPING_DIST (1200 << FRACBITS)
+
+// Distance to origin when sounds should be maxed out.
+// This should relate to movement clipping resolution
+// (see BLOCKMAP handling).
+// Originally: (200*0x10000).
+//
+// killough 12/98: restore original
+// #define S_CLOSE_DIST (160<<FRACBITS)
+
+#define S_CLOSE_DIST (200 << FRACBITS)
+
+#define S_ATTENUATOR ((S_CLIPPING_DIST - S_CLOSE_DIST) >> FRACBITS)
+
+static boolean I_MBF_AdjustSoundParams(const mobj_t *listener, const mobj_t *source,
+                                       int basevolume, int *vol, int *sep, int *pri,
+                                       int channel)
+{
+    fixed_t adx, ady, dist;
+    angle_t angle;
+
+    // calculate the distance to sound origin
+    //  and clip it if necessary
+    //
+    // killough 11/98: scale coordinates down before calculations start
+    // killough 12/98: use exact distance formula instead of approximation
+
+    adx = abs((listener->x >> FRACBITS) - (source->x >> FRACBITS));
+    ady = abs((listener->y >> FRACBITS) - (source->y >> FRACBITS));
+
+    if (ady > adx)
+        dist = adx, adx = ady, ady = dist;
+
+    dist = adx ? FixedDiv(adx, finesine[(tantoangle[FixedDiv(ady, adx) >> DBITS]
+                                         + ANG90) >> ANGLETOFINESHIFT]) : 0;
+
+    if (!dist)  // killough 11/98: handle zero-distance as special case
+    {
+        *sep = NORM_SEP;
+        *vol = basevolume;
+        return *vol > 0;
+    }
+
+    if (dist > S_CLIPPING_DIST >> FRACBITS)
+        return false;
+
+    // angle of source to listener
+    angle = R_PointToAngle2(listener->x, listener->y, source->x, source->y);
+
+    if (angle <= listener->angle)
+        angle += 0xffffffff;
+    angle -= listener->angle;
+    angle >>= ANGLETOFINESHIFT;
+
+    // stereo separation
+    *sep = NORM_SEP - FixedMul(S_STEREO_SWING >> FRACBITS, finesine[angle]);
+
+    // volume calculation
+    *vol = dist < S_CLOSE_DIST >> FRACBITS ? basevolume :
+        basevolume * ((S_CLIPPING_DIST >> FRACBITS) - dist) /
+        S_ATTENUATOR;
+
+    // haleyjd 09/27/06: decrease priority with volume attenuation
+    *pri = *pri + (127 - *vol);
+
+    if (*pri > 255) // cap to 255
+        *pri = 255;
+
+    return *vol > 0;
+}
+
+const sound_module_t sound_mbf_module =
+{
+    I_OAL_InitSound,
+    I_OAL_CacheSound,
+    I_MBF_AdjustSoundParams,
+    I_OAL_UpdateSoundParams2D,
+    I_OAL_StartSound,
+    I_OAL_StopSound,
+    I_OAL_SoundIsPlaying,
+    I_OAL_ShutdownSound,
+};

--- a/src/i_mbfsound.c
+++ b/src/i_mbfsound.c
@@ -1,6 +1,7 @@
 //
 // Copyright (C) 1999 by
 // id Software, Chi Hoang, Lee Killough, Jim Flynn, Rand Phares, Ty Halderman
+// Copyright(C) 2020-2023 Fabian Greffrath
 // Copyright(C) 2023 ceski
 //
 // This program is free software; you can redistribute it and/or

--- a/src/i_mbfsound.c
+++ b/src/i_mbfsound.c
@@ -26,8 +26,7 @@
 int forceFlipPan;
 
 static boolean I_MBF_AdjustSoundParams(const mobj_t *listener, const mobj_t *source,
-                                       int chanvol, int *vol, int *sep, int *pri,
-                                       int channel)
+                                       int chanvol, int *vol, int *sep, int *pri)
 {
     fixed_t adx, ady, dist;
     angle_t angle;

--- a/src/i_mbfsound.c
+++ b/src/i_mbfsound.c
@@ -23,16 +23,6 @@
 #include "i_sound.h"
 #include "r_main.h"
 
-static boolean I_MBF_InitSound(void)
-{
-    return I_OAL_InitSound(false);
-}
-
-static boolean I_MBF_ReinitSound(void)
-{
-    return I_OAL_ReinitSound(false);
-}
-
 static boolean I_MBF_AdjustSoundParams(const mobj_t *listener, const mobj_t *source,
                                        int chanvol, int *vol, int *sep, int *pri,
                                        int channel)
@@ -116,8 +106,8 @@ void I_MBF_UpdateSoundParams(int channel, int volume, int separation)
 
 const sound_module_t sound_mbf_module =
 {
-    I_MBF_InitSound,
-    I_MBF_ReinitSound,
+    I_OAL_InitSound,
+    I_OAL_ReinitSound,
     I_OAL_AllowReinitSound,
     I_OAL_UpdateUserSoundSettings,
     I_OAL_CacheSound,

--- a/src/i_mbfsound.c
+++ b/src/i_mbfsound.c
@@ -118,6 +118,7 @@ const sound_module_t sound_mbf_module =
     I_OAL_CacheSound,
     I_MBF_AdjustSoundParams,
     I_MBF_UpdateSoundParams,
+    NULL,
     I_OAL_StartSound,
     I_OAL_StopSound,
     I_OAL_SoundIsPlaying,

--- a/src/i_oalmusic.c
+++ b/src/i_oalmusic.c
@@ -21,8 +21,7 @@
 #include <string.h>
 
 #include "SDL.h"
-#include "al.h"
-#include "alc.h"
+#include "alext.h"
 
 #include "doomtype.h"
 #include "i_sndfile.h"
@@ -222,6 +221,18 @@ static boolean I_OAL_InitMusic(int device)
     alSource3i(player.source, AL_POSITION, 0, 0, -1);
     alSourcei(player.source, AL_SOURCE_RELATIVE, AL_TRUE);
     alSourcei(player.source, AL_ROLLOFF_FACTOR, 0);
+
+    // Bypass speaker virtualization for music.
+    if (alIsExtensionPresent("AL_SOFT_direct_channels"))
+    {
+        alSourcei(player.source, AL_DIRECT_CHANNELS_SOFT, AL_TRUE);
+    }
+
+    // Bypass speaker virtualization for music.
+    if (alIsExtensionPresent("AL_SOFT_source_spatialize"))
+    {
+        alSourcei(player.source, AL_SOURCE_SPATIALIZE_SOFT, AL_FALSE);
+    }
 
     music_initialized = true;
 

--- a/src/i_oalsound.c
+++ b/src/i_oalsound.c
@@ -522,7 +522,6 @@ boolean I_OAL_CacheSound(ALuint *buffer, ALenum format, const byte *data,
         return false;
     }
 
-    alGetError();
     alBufferData(*buffer, format, data, size, freq);
     if (alGetError() != AL_NO_ERROR)
     {
@@ -558,22 +557,10 @@ boolean I_OAL_StartSound(int channel, ALuint buffer, int pitch)
 
     alDeferUpdatesSOFT();
 
-    alGetError();
     alSourcef(oal->sources[channel], AL_PITCH,
               pitch == NORM_PITCH ? OAL_DEFAULT_PITCH : steptable[pitch]);
-    if (alGetError() != AL_NO_ERROR)
-    {
-        fprintf(stderr, "I_OAL_StartSound: Error setting pitch.\n");
-        return false;
-    }
 
-    alGetError();
     alSourcei(oal->sources[channel], AL_BUFFER, buffer);
-    if (alGetError() != AL_NO_ERROR)
-    {
-        fprintf(stderr, "I_OAL_StartSound: Error selecting buffer.\n");
-        return false;
-    }
 
     alGetError();
     alSourcePlay(oal->sources[channel]);
@@ -597,12 +584,7 @@ void I_OAL_StopSound(int channel)
         return;
     }
 
-    alGetError();
     alSourceStop(oal->sources[channel]);
-    if (alGetError() != AL_NO_ERROR)
-    {
-        fprintf(stderr, "I_OAL_StopSound: Error stopping source.\n");
-    }
 
     oal->active[channel] = false;
 }
@@ -616,13 +598,7 @@ boolean I_OAL_SoundIsPlaying(int channel)
         return false;
     }
 
-    alGetError();
     alGetSourcei(oal->sources[channel], AL_SOURCE_STATE, &state);
-    if (alGetError() != AL_NO_ERROR)
-    {
-        fprintf(stderr, "I_OAL_SoundIsPlaying: Error reading state.\n");
-        return false;
-    }
 
     return (state == AL_PLAYING);
 }
@@ -634,12 +610,7 @@ void I_OAL_SetVolume(int channel, int volume)
         return;
     }
 
-    alGetError();
     alSourcef(oal->sources[channel], AL_GAIN, VOL_TO_GAIN(volume));
-    if (alGetError() != AL_NO_ERROR)
-    {
-        fprintf(stderr, "I_OAL_SetVolume: Error setting gain.\n");
-    }
 }
 
 void I_OAL_SetPan(int channel, int separation)
@@ -653,10 +624,5 @@ void I_OAL_SetPan(int channel, int separation)
 
     // Emulate 2D panning (https://github.com/kcat/openal-soft/issues/194).
     pan = (ALfloat)separation / 255.0f - 0.5f;
-    alGetError();
     alSource3f(oal->sources[channel], AL_POSITION, pan, 0.0f, -sqrtf(1.0f - pan * pan));
-    if (alGetError() != AL_NO_ERROR)
-    {
-        fprintf(stderr, "I_OAL_SetPan: Error setting pan.\n");
-    }
 }

--- a/src/i_oalsound.c
+++ b/src/i_oalsound.c
@@ -381,7 +381,7 @@ static boolean OpenDevice(ALCdevice **device)
         return false;
     }
 
-    if (alcIsExtensionPresent(*device, "ALC_ENUMERATE_ALL_EXT") == AL_TRUE)
+    if (alcIsExtensionPresent(*device, "ALC_ENUMERATE_ALL_EXT") == ALC_TRUE)
         name = alcGetString(*device, ALC_ALL_DEVICES_SPECIFIER);
     else
         name = alcGetString(*device, ALC_DEVICE_SPECIFIER);
@@ -399,14 +399,14 @@ static void GetAttribs(ALCint *attribs)
 
     memset(attribs, 0, sizeof(*attribs) * OAL_NUM_ATTRIBS);
 
-    if (alcIsExtensionPresent(oal->device, "ALC_SOFT_HRTF") == AL_TRUE)
+    if (alcIsExtensionPresent(oal->device, "ALC_SOFT_HRTF") == ALC_TRUE)
     {
         attribs[i++] = ALC_HRTF_SOFT;
         attribs[i++] = use_3d ? (snd_hrtf ? ALC_TRUE : ALC_FALSE) : ALC_FALSE;
     }
 
 #ifdef ALC_OUTPUT_MODE_SOFT
-    if (alcIsExtensionPresent(oal->device, "ALC_SOFT_output_mode") == AL_TRUE)
+    if (alcIsExtensionPresent(oal->device, "ALC_SOFT_output_mode") == ALC_TRUE)
     {
         attribs[i++] = ALC_OUTPUT_MODE_SOFT;
         attribs[i++] = use_3d ? (snd_hrtf ? ALC_STEREO_HRTF_SOFT : ALC_ANY_SOFT) :
@@ -454,7 +454,7 @@ boolean I_OAL_InitSound(void)
     }
 
     oal->SOFT_source_spatialize = (alIsExtensionPresent("AL_SOFT_source_spatialize") == AL_TRUE);
-    oal->EXT_EFX = (alcIsExtensionPresent(oal->device, "ALC_EXT_EFX") == AL_TRUE);
+    oal->EXT_EFX = (alcIsExtensionPresent(oal->device, "ALC_EXT_EFX") == ALC_TRUE);
     oal->EXT_SOURCE_RADIUS = (alIsExtensionPresent("AL_EXT_SOURCE_RADIUS") == AL_TRUE);
     oal->active = malloc(sizeof(*oal->active) * MAX_CHANNELS);
     InitDeferred();
@@ -474,7 +474,7 @@ boolean I_OAL_ReinitSound(void)
         return false;
     }
 
-    if (alcIsExtensionPresent(oal->device, "ALC_SOFT_HRTF") != AL_TRUE)
+    if (alcIsExtensionPresent(oal->device, "ALC_SOFT_HRTF") != ALC_TRUE)
     {
         fprintf(stderr, "I_OAL_ReinitSound: Extension not present.\n");
         return false;
@@ -491,7 +491,7 @@ boolean I_OAL_ReinitSound(void)
 
     GetAttribs(attribs);
 
-    if (alcResetDeviceSOFT(oal->device, attribs) != AL_TRUE)
+    if (alcResetDeviceSOFT(oal->device, attribs) != ALC_TRUE)
     {
         fprintf(stderr, "I_OAL_ReinitSound: Error resetting device.\n");
         I_OAL_ShutdownSound();
@@ -511,7 +511,7 @@ boolean I_OAL_AllowReinitSound(void)
     }
 
     // alcResetDeviceSOFT() is part of the ALC_SOFT_HRTF extension.
-    return (alcIsExtensionPresent(oal->device, "ALC_SOFT_HRTF") == AL_TRUE);
+    return (alcIsExtensionPresent(oal->device, "ALC_SOFT_HRTF") == ALC_TRUE);
 }
 
 boolean I_OAL_CacheSound(ALuint *buffer, ALenum format, const byte *data,

--- a/src/i_oalsound.c
+++ b/src/i_oalsound.c
@@ -48,6 +48,8 @@ boolean snd_hrtf;
 int snd_absorption;
 int snd_doppler;
 
+int oal_use_doppler;
+
 static const char *oal_resamplers[] = {
     "Nearest", "Linear", "Cubic"
 };
@@ -327,6 +329,7 @@ void I_OAL_UpdateUserSoundSettings(void)
 
     // Context state parameters.
     alDopplerFactor((ALfloat)snd_doppler * snd_doppler / 100.0f);
+    oal_use_doppler = (alGetFloat(AL_DOPPLER_FACTOR) > 0.0001f);
 }
 
 static void ResetParams(void)

--- a/src/i_oalsound.c
+++ b/src/i_oalsound.c
@@ -396,12 +396,14 @@ static void GetAttribs(boolean use_3d, ALCint *attribs)
         attribs[i++] = use_3d ? (snd_hrtf ? ALC_TRUE : ALC_FALSE) : ALC_FALSE;
     }
 
+#ifdef _WIN32
     if (alcIsExtensionPresent(oal->device, "ALC_SOFT_output_mode") == AL_TRUE)
     {
         attribs[i++] = ALC_OUTPUT_MODE_SOFT;
         attribs[i++] = use_3d ? (snd_hrtf ? ALC_STEREO_HRTF_SOFT : ALC_ANY_SOFT) :
                                 ALC_STEREO_BASIC_SOFT;
     }
+#endif
 }
 
 boolean I_OAL_InitSound(boolean use_3d)

--- a/src/i_oalsound.c
+++ b/src/i_oalsound.c
@@ -25,7 +25,8 @@
 
 #define OAL_ROLLOFF_FACTOR 1
 #define OAL_SPEED_OF_SOUND 343.3f
-#define OAL_MAP_UNITS_PER_METER (128.0f / 3.0f) // 128 map units per 3 meters.
+// 128 map units per 3 meters (https://doomwiki.org/wiki/Map_unit).
+#define OAL_MAP_UNITS_PER_METER (128.0f / 3.0f)
 #define OAL_SOURCE_RADIUS 32.0f
 #define OAL_DEFAULT_PITCH 1.0f
 #define OAL_NUM_ATTRIBS 5

--- a/src/i_oalsound.c
+++ b/src/i_oalsound.c
@@ -444,9 +444,9 @@ boolean I_OAL_InitSound(boolean use_3d)
         return false;
     }
 
-    oal->SOFT_source_spatialize = alIsExtensionPresent("AL_SOFT_source_spatialize") == AL_TRUE;
-    oal->EXT_EFX = alcIsExtensionPresent(oal->device, "ALC_EXT_EFX") == AL_TRUE;
-    oal->EXT_SOURCE_RADIUS = alIsExtensionPresent("AL_EXT_SOURCE_RADIUS") == AL_TRUE;
+    oal->SOFT_source_spatialize = (alIsExtensionPresent("AL_SOFT_source_spatialize") == AL_TRUE);
+    oal->EXT_EFX = (alcIsExtensionPresent(oal->device, "ALC_EXT_EFX") == AL_TRUE);
+    oal->EXT_SOURCE_RADIUS = (alIsExtensionPresent("AL_EXT_SOURCE_RADIUS") == AL_TRUE);
     oal->active = malloc(sizeof(*oal->active) * MAX_CHANNELS);
     InitDeferred();
     ResetParams();
@@ -501,7 +501,7 @@ boolean I_OAL_AllowReinitSound(void)
         return false;
     }
 
-    return alcIsExtensionPresent(oal->device, "ALC_SOFT_HRTF") == AL_TRUE;
+    return (alcIsExtensionPresent(oal->device, "ALC_SOFT_HRTF") == AL_TRUE);
 }
 
 boolean I_OAL_CacheSound(ALuint *buffer, ALenum format, const byte *data,

--- a/src/i_oalsound.c
+++ b/src/i_oalsound.c
@@ -490,8 +490,6 @@ boolean I_OAL_ReinitSound(boolean use_3d)
         return false;
     }
 
-    ResetParams();
-
     return true;
 }
 

--- a/src/i_oalsound.c
+++ b/src/i_oalsound.c
@@ -396,7 +396,7 @@ static void GetAttribs(boolean use_3d, ALCint *attribs)
         attribs[i++] = use_3d ? (snd_hrtf ? ALC_TRUE : ALC_FALSE) : ALC_FALSE;
     }
 
-#ifdef _WIN32
+#ifdef ALC_OUTPUT_MODE_SOFT
     if (alcIsExtensionPresent(oal->device, "ALC_SOFT_output_mode") == AL_TRUE)
     {
         attribs[i++] = ALC_OUTPUT_MODE_SOFT;

--- a/src/i_oalsound.c
+++ b/src/i_oalsound.c
@@ -261,8 +261,8 @@ void I_OAL_ResetSource3D(int channel, boolean point_source)
     alSourcei(oal->sources[channel], AL_SOURCE_RELATIVE, AL_FALSE);
 }
 
-void I_OAL_AdjustSource3D(int channel, const ALfloat *position,
-                          const ALfloat *velocity)
+void I_OAL_UpdateSourceParams(int channel, const ALfloat *position,
+                              const ALfloat *velocity)
 {
     if (!oal)
     {
@@ -273,8 +273,8 @@ void I_OAL_AdjustSource3D(int channel, const ALfloat *position,
     alSourcefv(oal->sources[channel], AL_VELOCITY, velocity);
 }
 
-void I_OAL_AdjustListener3D(const ALfloat *position, const ALfloat *velocity,
-                            const ALfloat *orientation)
+void I_OAL_UpdateListenerParams(const ALfloat *position, const ALfloat *velocity,
+                                const ALfloat *orientation)
 {
     if (!oal)
     {

--- a/src/i_oalsound.c
+++ b/src/i_oalsound.c
@@ -332,7 +332,7 @@ static void ResetParams(void)
     const ALint default_orientation[] = {0, 0, -1, 0, 1, 0};
     int i;
 
-    // Source paramters.
+    // Source parameters.
     for (i = 0; i < MAX_CHANNELS; i++)
     {
         oal->active[i] = false;

--- a/src/i_oalsound.c
+++ b/src/i_oalsound.c
@@ -246,7 +246,6 @@ void I_OAL_ResetSource2D(int channel)
 
     alSource3f(oal->sources[channel], AL_POSITION, 0.0f, 0.0f, 0.0f);
     alSource3f(oal->sources[channel], AL_VELOCITY, 0.0f, 0.0f, 0.0f);
-    alSource3i(oal->sources[channel], AL_DIRECTION, 0, 0, 0);
 
     alSourcei(oal->sources[channel], AL_ROLLOFF_FACTOR, 0);
     alSourcei(oal->sources[channel], AL_SOURCE_RELATIVE, AL_TRUE);
@@ -281,7 +280,7 @@ void I_OAL_ResetSource3D(int channel, boolean point_source)
 }
 
 void I_OAL_AdjustSource3D(int channel, const ALfloat *position,
-                          const ALfloat *velocity, const ALfloat *direction)
+                          const ALfloat *velocity)
 {
     if (!oal)
     {
@@ -290,7 +289,6 @@ void I_OAL_AdjustSource3D(int channel, const ALfloat *position,
 
     alSourcefv(oal->sources[channel], AL_POSITION, position);
     alSourcefv(oal->sources[channel], AL_VELOCITY, velocity);
-    alSourcefv(oal->sources[channel], AL_DIRECTION, direction);
 }
 
 void I_OAL_AdjustListener3D(const ALfloat *position, const ALfloat *velocity,
@@ -334,6 +332,7 @@ static void ResetParams(void)
     {
         oal->active[i] = false;
         I_OAL_ResetSource2D(i);
+        alSource3i(oal->sources[i], AL_DIRECTION, 0, 0, 0);
         alSourcei(oal->sources[i], AL_MAX_DISTANCE, S_ATTENUATOR);
         alSourcei(oal->sources[i], AL_REFERENCE_DISTANCE, S_CLOSE_DIST >> FRACBITS);
     }

--- a/src/i_oalsound.c
+++ b/src/i_oalsound.c
@@ -341,8 +341,8 @@ static void ResetParams(void)
     {
         oal->active[i] = false;
         I_OAL_ResetSource2D(i);
-        alSourcei(oal->sources[i], AL_MAX_DISTANCE, OAL_MAX_DISTANCE);
-        alSourcei(oal->sources[i], AL_REFERENCE_DISTANCE, OAL_REF_DISTANCE);
+        alSourcei(oal->sources[i], AL_MAX_DISTANCE, S_ATTENUATOR);
+        alSourcei(oal->sources[i], AL_REFERENCE_DISTANCE, S_CLOSE_DIST >> FRACBITS);
     }
 
     // Listener parameters.

--- a/src/i_oalsound.c
+++ b/src/i_oalsound.c
@@ -332,8 +332,6 @@ static void ResetParams(void)
     const ALint default_orientation[] = {0, 0, -1, 0, 1, 0};
     int i;
 
-    alDeferUpdatesSOFT();
-
     // Source paramters.
     for (i = 0; i < MAX_CHANNELS; i++)
     {
@@ -366,8 +364,6 @@ static void ResetParams(void)
     alSpeedOfSound(OAL_SPEED_OF_SOUND * OAL_MAP_UNITS_PER_METER);
 
     I_OAL_UpdateUserSoundSettings();
-
-    alProcessUpdatesSOFT();
 }
 
 static boolean OpenDevice(ALCdevice **device)
@@ -563,8 +559,6 @@ boolean I_OAL_StartSound(int channel, ALuint buffer, int pitch)
         return false;
     }
 
-    alDeferUpdatesSOFT();
-
     alSourcef(oal->sources[channel], AL_PITCH,
               pitch == NORM_PITCH ? OAL_DEFAULT_PITCH : steptable[pitch]);
 
@@ -577,8 +571,6 @@ boolean I_OAL_StartSound(int channel, ALuint buffer, int pitch)
         fprintf(stderr, "I_OAL_StartSound: Error playing source.\n");
         return false;
     }
-
-    alProcessUpdatesSOFT();
 
     oal->active[channel] = true;
 

--- a/src/i_oalsound.c
+++ b/src/i_oalsound.c
@@ -48,7 +48,7 @@ boolean snd_hrtf;
 int snd_absorption;
 int snd_doppler;
 
-int oal_use_doppler;
+boolean oal_use_doppler;
 
 static const char *oal_resamplers[] = {
     "Nearest", "Linear", "Cubic"

--- a/src/i_oalsound.c
+++ b/src/i_oalsound.c
@@ -1,0 +1,511 @@
+//
+// Copyright(C) 2023 Roman Fomin
+// Copyright(C) 2023 ceski
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//      System interface for OpenAL sound.
+//
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "alext.h"
+
+#include "i_oalsound.h"
+
+char *snd_resampler;
+
+typedef struct oal_system_s
+{
+    ALCdevice *device;
+    ALCint *attribs;
+    ALCcontext *context;
+    ALuint *sources;
+    ALuint *buffers;
+    int num_buffers;
+    int num_buffers_mem;
+    boolean initialized;
+} oal_system_t;
+
+static oal_system_t oal;
+
+static boolean OpenDevice(void)
+{
+    const ALCchar *name;
+    ALCint srate = -1;
+
+    oal.device = alcOpenDevice(NULL);
+    if (oal.device)
+    {
+        if (alcIsExtensionPresent(oal.device, "ALC_ENUMERATE_ALL_EXT") != AL_FALSE)
+            name = alcGetString(oal.device, ALC_ALL_DEVICES_SPECIFIER);
+        else
+            name = alcGetString(oal.device, ALC_DEVICE_SPECIFIER);
+    }
+    else
+    {
+        printf("Could not open a device.\n");
+        return false;
+    }
+
+    alcGetIntegerv(oal.device, ALC_FREQUENCY, 1, &srate);
+    printf("Using '%s' @ %d Hz.\n", name, srate);
+
+    return true;
+}
+
+static void CloseDevice(void)
+{
+    if (oal.device)
+    {
+        alcCloseDevice(oal.device);
+        oal.device = NULL;
+    }
+}
+
+static void FreeAttributes(void)
+{
+    if (oal.attribs)
+    {
+        free(oal.attribs);
+        oal.attribs = NULL;
+    }
+}
+
+static boolean CreateContext(void)
+{
+    oal.context = alcCreateContext(oal.device, oal.attribs);
+    if (!oal.context || alcMakeContextCurrent(oal.context) == ALC_FALSE)
+    {
+        fprintf(stderr, "CreateContext: Error making context.\n");
+        return false;
+    }
+
+    FreeAttributes();
+
+    return true;
+}
+
+static void DestroyContext(void)
+{
+    alcMakeContextCurrent(NULL);
+    if (oal.context)
+    {
+        alcDestroyContext(oal.context);
+        oal.context = NULL;
+    }
+}
+
+static boolean GenerateSources(void)
+{
+    oal.sources = malloc(sizeof(*oal.sources) * MAX_CHANNELS);
+    if (oal.sources == NULL)
+    {
+        fprintf(stderr, "GenerateSources: Error allocating sources.\n");
+        return false;
+    }
+
+    alGetError();
+    alGenSources(MAX_CHANNELS, oal.sources);
+    if (alGetError() != AL_NO_ERROR)
+    {
+        fprintf(stderr, "GenerateSources: Error making sources.\n");
+        return false;
+    }
+
+    return true;
+}
+
+static void DeleteSources(void)
+{
+    if (oal.sources)
+    {
+        alDeleteSources(MAX_CHANNELS, oal.sources);
+        oal.sources = NULL;
+    }
+}
+
+static void SetSourceParams2D(void)
+{
+    int i;
+
+    // Emulate 2D panning (https://github.com/kcat/openal-soft/issues/194).
+    for (i = 0; i < MAX_CHANNELS; i++)
+    {
+        alSourcef(oal.sources[i], AL_ROLLOFF_FACTOR, 0.0f);
+        alSourcei(oal.sources[i], AL_SOURCE_RELATIVE, AL_TRUE);
+    }
+}
+
+// C doesn't allow casting between function and non-function pointer types, so
+// with C99 we need to use a union to reinterpret the pointer type. Pre-C99
+// still needs to use a normal cast and live with the warning (C++ is fine with
+// a regular reinterpret_cast).
+#if __STDC_VERSION__ >= 199901L
+#define FUNCTION_CAST(T, ptr) (union{void *p; T f;}){ptr}.f
+#else
+#define FUNCTION_CAST(T, ptr) (T)(ptr)
+#endif
+
+static void SetResampler(void)
+{
+    LPALGETSTRINGISOFT alGetStringiSOFT = NULL;
+    ALint i, num_resamplers, def_resampler;
+
+    if (!alIsExtensionPresent("AL_SOFT_source_resampler"))
+    {
+        printf(" Resampler info not available!\n");
+        return;
+    }
+
+    alGetStringiSOFT = FUNCTION_CAST(LPALGETSTRINGISOFT, alGetProcAddress("alGetStringiSOFT"));
+
+    if (!alGetStringiSOFT)
+    {
+        fprintf(stderr, "SetResampler: alGetStringiSOFT() is not available.\n");
+        return;
+    }
+
+    num_resamplers = alGetInteger(AL_NUM_RESAMPLERS_SOFT);
+    def_resampler = alGetInteger(AL_DEFAULT_RESAMPLER_SOFT);
+
+    if (!num_resamplers)
+    {
+        printf(" No resamplers found!\n");
+        return;
+    }
+
+    for (i = 0; i < num_resamplers; i++)
+    {
+        if (!strcasecmp(snd_resampler, alGetStringiSOFT(AL_RESAMPLER_NAME_SOFT, i)))
+        {
+            def_resampler = i;
+            break;
+        }
+    }
+    if (i == num_resamplers)
+    {
+        printf(" Failed to find resampler: '%s'.\n", snd_resampler);
+        return;
+    }
+
+    for (i = 0; i < MAX_CHANNELS; i++)
+    {
+        alSourcei(oal.sources[i], AL_SOURCE_RESAMPLER_SOFT, def_resampler);
+    }
+
+    printf(" Using '%s' resampler.\n",
+           alGetStringiSOFT(AL_RESAMPLER_NAME_SOFT, def_resampler));
+}
+
+static void SetAttributes(ALCint hrtf_flag, ALCint output_mode)
+{
+    int i = 0;
+
+    FreeAttributes();
+
+    // Zero-terminated list of integer pairs.
+    oal.attribs = calloc(5, sizeof(*oal.attribs));
+    if (oal.attribs == NULL)
+    {
+        fprintf(stderr, "SetAttributes: Error allocating attributes.\n");
+        return;
+    }
+
+    if (alcIsExtensionPresent(oal.device, "ALC_SOFT_HRTF") == ALC_TRUE)
+    {
+        oal.attribs[i++] = ALC_HRTF_SOFT;
+        oal.attribs[i++] = hrtf_flag;
+    }
+
+    if (alcIsExtensionPresent(oal.device, "ALC_SOFT_output_mode") == ALC_TRUE)
+    {
+        oal.attribs[i++] = ALC_OUTPUT_MODE_SOFT;
+        oal.attribs[i++] = output_mode;
+    }
+}
+
+boolean I_OAL_InitSound(void)
+{
+    if (OpenDevice())
+    {
+        SetAttributes(ALC_FALSE, ALC_STEREO_BASIC_SOFT);
+        if (CreateContext())
+        {
+            if (GenerateSources())
+            {
+                SetSourceParams2D();
+                SetResampler();
+                return true;
+            }
+            DeleteSources();
+        }
+        FreeAttributes();
+        DestroyContext();
+    }
+    CloseDevice();
+
+    return false;
+}
+
+static boolean UpdateBufferArray(ALuint buffer)
+{
+    if (oal.num_buffers == oal.num_buffers_mem)
+    {
+        ALuint *new_buffers;
+
+        oal.num_buffers_mem += NUMSFX;
+
+        new_buffers = realloc(oal.buffers,
+                              sizeof(ALuint) * (oal.num_buffers_mem));
+        if (new_buffers == NULL)
+        {
+            fprintf(stderr, "UpdateBufferArray: Error reallocating buffers.\n");
+            return false;
+        }
+
+        oal.buffers = new_buffers;
+    }
+
+    oal.buffers[oal.num_buffers] = buffer;
+    oal.num_buffers++;
+
+    return true;
+}
+
+static boolean CreateBuffer(ALuint *buffer)
+{
+    alGetError();
+    alGenBuffers(1, buffer);
+    if (alGetError() != AL_NO_ERROR)
+    {
+        fprintf(stderr, "CreateBuffer: Error creating buffer.\n");
+        return false;
+    }
+    return true;
+}
+
+static void DeleteBuffers(void)
+{
+    if (oal.buffers)
+    {
+        if (oal.num_buffers > 0)
+        {
+            alDeleteBuffers(oal.num_buffers, oal.buffers);
+        }
+        free(oal.buffers);
+        oal.buffers = NULL;
+    }
+    oal.num_buffers = 0;
+    oal.num_buffers_mem = 0;
+}
+
+static boolean BufferData(ALuint buffer, ALenum format, const byte *data,
+                          ALsizei size, ALsizei freq)
+{
+    alGetError();
+    alBufferData(buffer, format, data, size, freq);
+    if (alGetError() != AL_NO_ERROR)
+    {
+        fprintf(stderr, "BufferData: Error buffering data.\n");
+        return false;
+    }
+    return true;
+}
+
+boolean I_OAL_CacheSound(ALuint *buffer, ALenum format, const byte *data,
+                         ALsizei size, ALsizei freq)
+{
+    if (!oal.device)
+    {
+        return false;
+    }
+
+    if (!CreateBuffer(buffer))
+    {
+        return false;
+    }
+
+    if (!BufferData(*buffer, format, data, size, freq))
+    {
+        return false;
+    }
+
+    if (!UpdateBufferArray(*buffer))
+    {
+        return false;
+    }
+
+    return true;
+}
+
+static boolean SetSourceGain(int channel, ALfloat volume)
+{
+    alGetError();
+    alSourcef(oal.sources[channel], AL_GAIN, volume);
+    if (alGetError() != AL_NO_ERROR)
+    {
+        fprintf(stderr, "SetSourceGain: Error setting gain.\n");
+        return false;
+    }
+    return true;
+}
+
+static boolean SetSourcePosition(int channel, ALfloat x, ALfloat y, ALfloat z)
+{
+    alGetError();
+    alSource3f(oal.sources[channel], AL_POSITION, x, y, z);
+    if (alGetError() != AL_NO_ERROR)
+    {
+        fprintf(stderr, "SetSourcePosition: Error setting position.\n");
+        return false;
+    }
+    return true;
+}
+
+static boolean AssignBufferToSource(int channel, ALuint buffer)
+{
+    alGetError();
+    alSourcei(oal.sources[channel], AL_BUFFER, buffer);
+    if (alGetError() != AL_NO_ERROR)
+    {
+        fprintf(stderr, "AssignBufferToSource: Error selecting buffer.\n");
+        return false;
+    }
+    return true;
+}
+
+static boolean SetSourcePitch(int channel, int pitch)
+{
+    alGetError();
+    alSourcef(oal.sources[channel], AL_PITCH, steptable[pitch]);
+    if (alGetError() != AL_NO_ERROR)
+    {
+        fprintf(stderr, "SetSourcePitch: Error setting pitch.\n");
+        return false;
+    }
+    return true;
+}
+
+static boolean SourcePlay(int channel)
+{
+    alGetError();
+    alSourcePlay(oal.sources[channel]);
+    if (alGetError() != AL_NO_ERROR)
+    {
+        fprintf(stderr, "SourcePlay: Error playing source.\n");
+        return false;
+    }
+    return true;
+}
+
+void I_OAL_UpdateSoundParams2D(int channel, int volume, int separation)
+{
+    ALfloat pan;
+
+    if (!oal.device)
+    {
+        return;
+    }
+
+    SetSourceGain(channel, (ALfloat)volume / 127.0f);
+
+    pan = (ALfloat)separation / 255.0f - 0.5f;
+
+    // Emulate 2D panning (https://github.com/kcat/openal-soft/issues/194).
+    SetSourcePosition(channel, pan, 0.0f, -sqrtf(1.0f - pan * pan));
+}
+
+boolean I_OAL_StartSound(int channel, ALuint buffer, int pitch)
+{
+    if (!oal.device)
+    {
+        return false;
+    }
+
+    if (!AssignBufferToSource(channel, buffer))
+    {
+        return false;
+    }
+
+    if (pitch != NORM_PITCH)
+    {
+        if (!SetSourcePitch(channel, pitch))
+        {
+            return false;
+        }
+    }
+
+    if (!SourcePlay(channel))
+    {
+        return false;
+    }
+
+    return true;
+}
+
+void I_OAL_StopSound(int channel)
+{
+    if (!oal.device)
+    {
+        return;
+    }
+
+    alGetError();
+    alSourceStop(oal.sources[channel]);
+    if (alGetError() != AL_NO_ERROR)
+    {
+        fprintf(stderr, "I_OAL_StopSound: Error stopping source.\n");
+    }
+}
+
+boolean I_OAL_SoundIsPlaying(int channel)
+{
+    ALint state;
+
+    if (!oal.device)
+    {
+        return false;
+    }
+
+    alGetError();
+    alGetSourcei(oal.sources[channel], AL_SOURCE_STATE, &state);
+    if (alGetError() != AL_NO_ERROR)
+    {
+        fprintf(stderr, "I_OAL_SoundIsPlaying: Error reading state.\n");
+        return false;
+    }
+
+    return state == AL_PLAYING;
+}
+
+void I_OAL_ShutdownSound(void)
+{
+    DeleteSources();
+    DeleteBuffers();
+    FreeAttributes();
+    DestroyContext();
+    CloseDevice();
+}
+
+const sound_module_t sound_oal_module =
+{
+    I_OAL_InitSound,
+    I_OAL_CacheSound,
+    NULL, // [ceski] Placeholder.
+    NULL, // [ceski] Placeholder.
+    I_OAL_StartSound,
+    I_OAL_StopSound,
+    I_OAL_SoundIsPlaying,
+    I_OAL_ShutdownSound,
+};

--- a/src/i_oalsound.c
+++ b/src/i_oalsound.c
@@ -392,8 +392,9 @@ static boolean OpenDevice(ALCdevice **device)
     return true;
 }
 
-static void GetAttribs(boolean use_3d, ALCint *attribs)
+static void GetAttribs(ALCint *attribs)
 {
+    const boolean use_3d = (snd_module == SND_MODULE_3D);
     int i = 0;
 
     memset(attribs, 0, sizeof(*attribs) * OAL_NUM_ATTRIBS);
@@ -414,7 +415,7 @@ static void GetAttribs(boolean use_3d, ALCint *attribs)
 #endif
 }
 
-boolean I_OAL_InitSound(boolean use_3d)
+boolean I_OAL_InitSound(void)
 {
     ALCdevice *device;
     ALCint attribs[OAL_NUM_ATTRIBS];
@@ -432,7 +433,7 @@ boolean I_OAL_InitSound(boolean use_3d)
 
     oal = calloc(1, sizeof(*oal));
     oal->device = device;
-    GetAttribs(use_3d, attribs);
+    GetAttribs(attribs);
 
     oal->context = alcCreateContext(oal->device, attribs);
     if (!oal->context || !alcMakeContextCurrent(oal->context))
@@ -462,7 +463,7 @@ boolean I_OAL_InitSound(boolean use_3d)
     return true;
 }
 
-boolean I_OAL_ReinitSound(boolean use_3d)
+boolean I_OAL_ReinitSound(void)
 {
     LPALCRESETDEVICESOFT alcResetDeviceSOFT = NULL;
     ALCint attribs[OAL_NUM_ATTRIBS];
@@ -488,7 +489,7 @@ boolean I_OAL_ReinitSound(boolean use_3d)
         return false;
     }
 
-    GetAttribs(use_3d, attribs);
+    GetAttribs(attribs);
 
     if (alcResetDeviceSOFT(oal->device, attribs) != AL_TRUE)
     {

--- a/src/i_oalsound.c
+++ b/src/i_oalsound.c
@@ -311,13 +311,20 @@ void I_OAL_UpdateUserSoundSettings(void)
         return;
     }
 
-    // Source parameters.
     SetResampler(oal->sources);
-    oal->absorption = (ALfloat)snd_absorption / 2.0f;
 
-    // Context state parameters.
-    alDopplerFactor((ALfloat)snd_doppler * snd_doppler / 100.0f);
-    oal_use_doppler = (alGetFloat(AL_DOPPLER_FACTOR) > 0.0001f);
+    if (snd_module == SND_MODULE_3D)
+    {
+        oal->absorption = (ALfloat)snd_absorption / 2.0f;
+        alDopplerFactor((ALfloat)snd_doppler * snd_doppler / 100.0f);
+        oal_use_doppler = (snd_doppler > 0);
+    }
+    else
+    {
+        oal->absorption = 0.0f;
+        alDopplerFactor(0.0f);
+        oal_use_doppler = false;
+    }
 }
 
 static void ResetParams(void)

--- a/src/i_oalsound.c
+++ b/src/i_oalsound.c
@@ -501,6 +501,7 @@ boolean I_OAL_AllowReinitSound(void)
         return false;
     }
 
+    // alcResetDeviceSOFT() is part of the ALC_SOFT_HRTF extension.
     return (alcIsExtensionPresent(oal->device, "ALC_SOFT_HRTF") == AL_TRUE);
 }
 

--- a/src/i_oalsound.c
+++ b/src/i_oalsound.c
@@ -493,6 +493,8 @@ boolean I_OAL_ReinitSound(boolean use_3d)
         return false;
     }
 
+    ResetParams();
+
     return true;
 }
 

--- a/src/i_oalsound.h
+++ b/src/i_oalsound.h
@@ -19,16 +19,50 @@
 #ifndef __I_OALSOUND__
 #define __I_OALSOUND__
 
+#include "alext.h"
+
 #include "doomtype.h"
 #include "i_sound.h"
 
-boolean I_OAL_InitSound(void);
+#define OAL_CULL_DISTANCE 1200 // Distance where sound is culled.
+#define OAL_MAX_DISTANCE 1000 // Distance where volume no longer attenuates.
+#define OAL_REF_DISTANCE 200 // Distance where volume is no longer clamped.
+
+void I_OAL_DeferUpdates(void);
+
+void I_OAL_ProcessUpdates(void);
+
+void I_OAL_ShutdownSound(void);
+
+void I_OAL_ResetSource2D(int channel);
+
+void I_OAL_ResetSource3D(int channel, boolean point_source);
+
+void I_OAL_AdjustSource3D(int channel, const ALfloat *position,
+                          const ALfloat *velocity, const ALfloat *direction);
+
+void I_OAL_AdjustListener3D(const ALfloat *position, const ALfloat *velocity,
+                            const ALfloat *orientation);
+
+void I_OAL_UpdateUserSoundSettings(void);
+
+boolean I_OAL_InitSound(boolean use_3d);
+
+boolean I_OAL_ReinitSound(boolean use_3d);
+
+boolean I_OAL_AllowReinitSound(void);
+
 boolean I_OAL_CacheSound(ALuint *buffer, ALenum format, const byte *data,
                          ALsizei size, ALsizei freq);
-void I_OAL_UpdateSoundParams2D(int channel, int volume, int separation);
+
 boolean I_OAL_StartSound(int channel, ALuint buffer, int pitch);
+
 void I_OAL_StopSound(int channel);
+
 boolean I_OAL_SoundIsPlaying(int channel);
-void I_OAL_ShutdownSound(void);
+
+void I_OAL_SetVolume(int channel, int volume);
+
+void I_OAL_SetPan(int channel, int separation);
 
 #endif

--- a/src/i_oalsound.h
+++ b/src/i_oalsound.h
@@ -37,7 +37,7 @@ void I_OAL_ResetSource2D(int channel);
 void I_OAL_ResetSource3D(int channel, boolean point_source);
 
 void I_OAL_AdjustSource3D(int channel, const ALfloat *position,
-                          const ALfloat *velocity, const ALfloat *direction);
+                          const ALfloat *velocity);
 
 void I_OAL_AdjustListener3D(const ALfloat *position, const ALfloat *velocity,
                             const ALfloat *orientation);

--- a/src/i_oalsound.h
+++ b/src/i_oalsound.h
@@ -36,11 +36,11 @@ void I_OAL_ResetSource2D(int channel);
 
 void I_OAL_ResetSource3D(int channel, boolean point_source);
 
-void I_OAL_AdjustSource3D(int channel, const ALfloat *position,
-                          const ALfloat *velocity);
+void I_OAL_UpdateSourceParams(int channel, const ALfloat *position,
+                              const ALfloat *velocity);
 
-void I_OAL_AdjustListener3D(const ALfloat *position, const ALfloat *velocity,
-                            const ALfloat *orientation);
+void I_OAL_UpdateListenerParams(const ALfloat *position, const ALfloat *velocity,
+                                const ALfloat *orientation);
 
 void I_OAL_UpdateUserSoundSettings(void);
 

--- a/src/i_oalsound.h
+++ b/src/i_oalsound.h
@@ -24,10 +24,6 @@
 #include "doomtype.h"
 #include "i_sound.h"
 
-#define OAL_CULL_DISTANCE 1200 // Distance where sound is culled.
-#define OAL_MAX_DISTANCE 1000 // Distance where volume no longer attenuates.
-#define OAL_REF_DISTANCE 200 // Distance where volume is no longer clamped.
-
 void I_OAL_DeferUpdates(void);
 
 void I_OAL_ProcessUpdates(void);

--- a/src/i_oalsound.h
+++ b/src/i_oalsound.h
@@ -24,6 +24,8 @@
 #include "doomtype.h"
 #include "i_sound.h"
 
+extern boolean oal_use_doppler;
+
 void I_OAL_DeferUpdates(void);
 
 void I_OAL_ProcessUpdates(void);

--- a/src/i_oalsound.h
+++ b/src/i_oalsound.h
@@ -1,0 +1,34 @@
+//
+// Copyright(C) 2023 Roman Fomin
+// Copyright(C) 2023 ceski
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//      System interface for OpenAL sound.
+//
+
+#ifndef __I_OALSOUND__
+#define __I_OALSOUND__
+
+#include "doomtype.h"
+#include "i_sound.h"
+
+boolean I_OAL_InitSound(void);
+boolean I_OAL_CacheSound(ALuint *buffer, ALenum format, const byte *data,
+                         ALsizei size, ALsizei freq);
+void I_OAL_UpdateSoundParams2D(int channel, int volume, int separation);
+boolean I_OAL_StartSound(int channel, ALuint buffer, int pitch);
+void I_OAL_StopSound(int channel);
+boolean I_OAL_SoundIsPlaying(int channel);
+void I_OAL_ShutdownSound(void);
+
+#endif

--- a/src/i_oalsound.h
+++ b/src/i_oalsound.h
@@ -44,9 +44,9 @@ void I_OAL_AdjustListener3D(const ALfloat *position, const ALfloat *velocity,
 
 void I_OAL_UpdateUserSoundSettings(void);
 
-boolean I_OAL_InitSound(boolean use_3d);
+boolean I_OAL_InitSound(void);
 
-boolean I_OAL_ReinitSound(boolean use_3d);
+boolean I_OAL_ReinitSound(void);
 
 boolean I_OAL_AllowReinitSound(void);
 

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -308,6 +308,22 @@ void I_UpdateSoundParams(int channel, int volume, int separation)
   sound_module->UpdateSoundParams(channel, volume, separation);
 }
 
+void I_DeferSoundUpdates(void)
+{
+    if (!snd_init)
+        return;
+
+    sound_module->DeferUpdates();
+}
+
+void I_ProcessSoundUpdates(void)
+{
+    if (!snd_init)
+        return;
+
+    sound_module->ProcessUpdates();
+}
+
 // [FG] variable pitch bend range
 int pitch_bend_range;
 

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -301,6 +301,14 @@ void I_UpdateSoundParams(int channel, int volume, int separation)
   sound_module->UpdateSoundParams(channel, volume, separation);
 }
 
+void I_UpdateListenerParams(const mobj_t *listener)
+{
+    if (!snd_init || !sound_module->UpdateListenerParams)
+        return;
+
+    sound_module->UpdateListenerParams(listener);
+}
+
 void I_DeferSoundUpdates(void)
 {
     if (!snd_init)

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -274,19 +274,12 @@ static boolean CacheSound(sfxinfo_t *sfx, int channel)
 // Returns false if no sound should be played.
 //
 boolean I_AdjustSoundParams(const mobj_t *listener, const mobj_t *source,
-                            int chanvol, int *vol, int *sep, int *pri,
-                            int channel)
+                            int chanvol, int *vol, int *sep, int *pri)
 {
   if (!snd_init)
     return false;
 
-#ifdef RANGECHECK
-  if (channel < 0 || channel >= MAX_CHANNELS)
-    I_Error("I_AdjustSoundParams: channel out of range");
-#endif
-
-  return sound_module->AdjustSoundParams(listener, source, chanvol, vol, sep,
-                                         pri, channel);
+  return sound_module->AdjustSoundParams(listener, source, chanvol, vol, sep, pri);
 }
 
 //

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -501,36 +501,6 @@ int I_SoundID(int channel)
   return channelinfo[channel].idnum;
 }
 
-// This function loops all active (internal) sound
-//  channels, retrieves a given number of samples
-//  from the raw sound data, modifies it according
-//  to the current (internal) channel parameters,
-//  mixes the per channel samples into the global
-//  mixbuffer, clamping it to the allowed range,
-//  and sets up everything for transferring the
-//  contents of the mixbuffer to the (two)
-//  hardware channels (left and right, that is).
-//
-//  allegro does this now
-
-void I_UpdateSound(void)
-{
-  int i;
-
-  // Check all channels to see if a sound has finished
-
-  for (i = 0; i < MAX_CHANNELS; i++)
-  {
-    if (channelinfo[i].enabled && !I_SoundIsPlaying(i))
-    {
-      // Sound has finished playing on this channel,
-      // but sound data has not been released to cache
-
-      StopChannel(i);
-    }
-  }
-}
-
 //
 // I_ShutdownSound
 //
@@ -674,10 +644,7 @@ void I_SetSoundModule(int device)
 
     for (i = 0; i < MAX_CHANNELS; i++)
     {
-        if (channelinfo[i].enabled && I_SoundIsPlaying(i))
-        {
-            StopChannel(i);
-        }
+        StopChannel(i);
     }
 
     sound_module = sound_modules[device];

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -676,7 +676,7 @@ void I_SetSoundModule(int device)
         return;
     }
 
-    if (device < 0 && device >= arrlen(sound_modules))
+    if (device < 0 || device >= arrlen(sound_modules))
     {
         fprintf(stderr, "I_SetSoundModule: Invalid choice.\n");
         return;

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -104,7 +104,7 @@ static void StopChannel(int channel)
 
   if (channelinfo[channel].enabled)
   {
-    sound_module->I_StopSound(channel);
+    sound_module->StopSound(channel);
 
     channelinfo[channel].enabled = false;
   }
@@ -234,7 +234,7 @@ static boolean CacheSound(sfxinfo_t *sfx, int channel)
       sampledata = wavdata;
     }
 
-    if (!sound_module->I_CacheSound(&buffer, format, sampledata, size, freq))
+    if (!sound_module->CacheSound(&buffer, format, sampledata, size, freq))
     {
         fprintf(stderr, "CacheSound: Error buffering data.\n");
         break;
@@ -285,8 +285,8 @@ boolean I_AdjustSoundParams(const mobj_t *listener, const mobj_t *source,
     I_Error("I_AdjustSoundParams: channel out of range");
 #endif
 
-  return sound_module->I_AdjustSoundParams(listener, source, chanvol, vol, sep,
-                                           pri, channel);
+  return sound_module->AdjustSoundParams(listener, source, chanvol, vol, sep,
+                                         pri, channel);
 }
 
 int forceFlipPan;
@@ -311,7 +311,7 @@ void I_UpdateSoundParams(int channel, int volume, int separation)
   if (forceFlipPan)
     separation = 254 - separation;
 
-  sound_module->I_UpdateSoundParams(channel, volume, separation);
+  sound_module->UpdateSoundParams(channel, volume, separation);
 }
 
 // [FG] variable pitch bend range
@@ -441,7 +441,7 @@ boolean I_StartSound(sfxinfo_t *sound, int vol, int sep, int pitch, int channel)
     channelinfo[channel].idnum = id++; // give the sound a unique id
     I_UpdateSoundParams(channel, vol, sep);
 
-    if (!sound_module->I_StartSound(channel, buffer, pitch))
+    if (!sound_module->StartSound(channel, buffer, pitch))
     {
       fprintf(stderr, "I_StartSound: Error playing sfx.\n");
       return false;
@@ -487,7 +487,7 @@ boolean I_SoundIsPlaying(int channel)
     I_Error("I_SoundIsPlaying: channel out of range");
 #endif
 
-  return sound_module->I_SoundIsPlaying(channel);
+  return sound_module->SoundIsPlaying(channel);
 }
 
 //
@@ -555,7 +555,7 @@ void I_ShutdownSound(void)
         return;
     }
 
-    sound_module->I_ShutdownSound();
+    sound_module->ShutdownSound();
 
     for (i = 0; i < num_sfx; ++i)
     {
@@ -602,7 +602,7 @@ void I_InitSound(void)
 
     sound_module = sound_modules[snd_module];
 
-    if (!sound_module->I_InitSound())
+    if (!sound_module->InitSound())
     {
         fprintf(stderr, "I_InitSound: Failed to initialize sound.\n");
         return;
@@ -652,7 +652,7 @@ void I_UpdateUserSoundSettings(void)
         return;
     }
 
-    sound_module->I_UpdateUserSoundSettings();
+    sound_module->UpdateUserSoundSettings();
 }
 
 boolean I_AllowReinitSound(void)
@@ -663,7 +663,7 @@ boolean I_AllowReinitSound(void)
         return false;
     }
 
-    return sound_module->I_AllowReinitSound();
+    return sound_module->AllowReinitSound();
 }
 
 void I_SetSoundModule(int device)
@@ -692,7 +692,7 @@ void I_SetSoundModule(int device)
 
     sound_module = sound_modules[device];
 
-    if (!sound_module->I_ReinitSound())
+    if (!sound_module->ReinitSound())
     {
         fprintf(stderr, "I_SetSoundModule: Failed to reinitialize sound.\n");
     }

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -289,8 +289,6 @@ boolean I_AdjustSoundParams(const mobj_t *listener, const mobj_t *source,
                                          pri, channel);
 }
 
-int forceFlipPan;
-
 //
 // I_UpdateSoundParams
 //
@@ -306,10 +304,6 @@ void I_UpdateSoundParams(int channel, int volume, int separation)
   if (channel < 0 || channel >= MAX_CHANNELS)
     I_Error("I_UpdateSoundParams: channel out of range");
 #endif
-
-  // SoM 7/1/02: forceFlipPan accounted for here
-  if (forceFlipPan)
-    separation = 254 - separation;
 
   sound_module->UpdateSoundParams(channel, volume, separation);
 }

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -101,6 +101,15 @@ extern const sound_module_t sound_mbf_module;
 extern const sound_module_t sound_3d_module;
 //extern const sound_module_t sound_pcsound_module;
 
+typedef enum snd_module_e
+{
+    SND_MODULE_MBF,
+    SND_MODULE_3D,
+    //SND_MODULE_PCSOUND,
+
+    NUM_SND_MODULES
+} snd_module_t;
+
 void I_UpdateUserSoundSettings(void);
 boolean I_AllowReinitSound(void);
 void I_SetSoundModule(int device);

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -122,11 +122,8 @@ void I_SetChannels(void);
 // Get raw data lump index for sound descriptor.
 int I_GetSfxLumpNum(sfxinfo_t *sfxinfo);
 
-// Get a handle to a sound channel. Returns -1 if all channels are used.
-int I_GetChannel(void);
-
 // Starts a sound in a particular sound channel.
-boolean I_StartSound(sfxinfo_t *sound, int vol, int sep, int pitch, int handle);
+int I_StartSound(sfxinfo_t *sound, int vol, int sep, int pitch);
 
 // Stops a sound channel.
 void I_StopSound(int handle);

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -65,20 +65,20 @@ extern int snd_doppler;
 
 typedef struct sound_module_s
 {
-    boolean (*I_InitSound)(void);
-    boolean (*I_ReinitSound)(void);
-    boolean (*I_AllowReinitSound)(void);
-    void (*I_UpdateUserSoundSettings)(void);
-    boolean (*I_CacheSound)(ALuint *buffer, ALenum format, const byte *data,
-                            ALsizei size, ALsizei freq);
-    boolean (*I_AdjustSoundParams)(const mobj_t *listener, const mobj_t *source,
-                                   int chanvol, int *vol, int *sep, int *pri,
-                                   int channel);
-    void (*I_UpdateSoundParams)(int channel, int vol, int sep);
-    boolean (*I_StartSound)(int channel, ALuint buffer, int pitch);
-    void (*I_StopSound)(int channel);
-    boolean (*I_SoundIsPlaying)(int channel);
-    void (*I_ShutdownSound)(void);
+    boolean (*InitSound)(void);
+    boolean (*ReinitSound)(void);
+    boolean (*AllowReinitSound)(void);
+    void (*UpdateUserSoundSettings)(void);
+    boolean (*CacheSound)(ALuint *buffer, ALenum format, const byte *data,
+                          ALsizei size, ALsizei freq);
+    boolean (*AdjustSoundParams)(const mobj_t *listener, const mobj_t *source,
+                                 int chanvol, int *vol, int *sep, int *pri,
+                                 int channel);
+    void (*UpdateSoundParams)(int channel, int vol, int sep);
+    boolean (*StartSound)(int channel, ALuint buffer, int pitch);
+    void (*StopSound)(int channel);
+    boolean (*SoundIsPlaying)(int channel);
+    void (*ShutdownSound)(void);
 } sound_module_t;
 
 extern const sound_module_t sound_mbf_module;

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -57,13 +57,22 @@ void I_ShutdownSound(void);
 //  SFX I/O
 //
 
+extern int snd_resampler;
+extern int snd_module;
+extern boolean snd_hrtf;
+extern int snd_absorption;
+extern int snd_doppler;
+
 typedef struct sound_module_s
 {
     boolean (*I_InitSound)(void);
+    boolean (*I_ReinitSound)(void);
+    boolean (*I_AllowReinitSound)(void);
+    void (*I_UpdateUserSoundSettings)(void);
     boolean (*I_CacheSound)(ALuint *buffer, ALenum format, const byte *data,
                             ALsizei size, ALsizei freq);
     boolean (*I_AdjustSoundParams)(const mobj_t *listener, const mobj_t *source,
-                                   int basevolume, int *vol, int *sep, int *pri,
+                                   int chanvol, int *vol, int *sep, int *pri,
                                    int channel);
     void (*I_UpdateSoundParams)(int channel, int vol, int sep);
     boolean (*I_StartSound)(int channel, ALuint buffer, int pitch);
@@ -73,7 +82,12 @@ typedef struct sound_module_s
 } sound_module_t;
 
 extern const sound_module_t sound_mbf_module;
-extern const sound_module_t sound_oal_module;
+extern const sound_module_t sound_3d_module;
+//extern const sound_module_t sound_pcsound_module;
+
+void I_UpdateUserSoundSettings(void);
+boolean I_AllowReinitSound(void);
+void I_SetSoundModule(int device);
 
 // Initialize channels?
 void I_SetChannels(void);
@@ -98,7 +112,7 @@ boolean I_SoundIsPlaying(int handle);
 // Outputs adjusted volume, separation, and priority from the sound module.
 // Returns false if no sound should be played.
 boolean I_AdjustSoundParams(const mobj_t *listener, const mobj_t *source,
-                            int basevolume, int *vol, int *sep, int *pri,
+                            int chanvol, int *vol, int *sep, int *pri,
                             int handle);
 
 // Updates the volume, separation,

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -27,6 +27,22 @@
 #include "p_mobj.h"
 #include "sounds.h"
 
+// when to clip out sounds
+// Does not fit the large outdoor areas.
+#define S_CLIPPING_DIST (1200 << FRACBITS)
+
+// Distance to origin when sounds should be maxed out.
+// This should relate to movement clipping resolution
+// (see BLOCKMAP handling).
+// Originally: (200*0x10000).
+//
+// killough 12/98: restore original
+// #define S_CLOSE_DIST (160<<FRACBITS)
+
+#define S_CLOSE_DIST (200 << FRACBITS)
+
+#define S_ATTENUATOR ((S_CLIPPING_DIST - S_CLOSE_DIST) >> FRACBITS)
+
 // Adjustable by menu.
 // [FG] moved here from i_sound.c
 #define MAX_CHANNELS 32

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -91,6 +91,7 @@ typedef struct sound_module_s
     boolean (*AdjustSoundParams)(const mobj_t *listener, const mobj_t *source,
                                  int chanvol, int *vol, int *sep, int *pri);
     void (*UpdateSoundParams)(int channel, int vol, int sep);
+    void (*UpdateListenerParams)(const mobj_t *listener);
     boolean (*StartSound)(int channel, ALuint buffer, int pitch);
     void (*StopSound)(int channel);
     boolean (*SoundIsPlaying)(int channel);
@@ -141,6 +142,7 @@ boolean I_AdjustSoundParams(const mobj_t *listener, const mobj_t *source,
 // Updates the volume, separation,
 //  and pitch of a sound channel.
 void I_UpdateSoundParams(int handle, int vol, int sep);
+void I_UpdateListenerParams(const mobj_t *listener);
 void I_DeferSoundUpdates(void);
 void I_ProcessSoundUpdates(void);
 

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -89,8 +89,7 @@ typedef struct sound_module_s
     boolean (*CacheSound)(ALuint *buffer, ALenum format, const byte *data,
                           ALsizei size, ALsizei freq);
     boolean (*AdjustSoundParams)(const mobj_t *listener, const mobj_t *source,
-                                 int chanvol, int *vol, int *sep, int *pri,
-                                 int channel);
+                                 int chanvol, int *vol, int *sep, int *pri);
     void (*UpdateSoundParams)(int channel, int vol, int sep);
     boolean (*StartSound)(int channel, ALuint buffer, int pitch);
     void (*StopSound)(int channel);
@@ -140,8 +139,7 @@ boolean I_SoundIsPlaying(int handle);
 // Outputs adjusted volume, separation, and priority from the sound module.
 // Returns false if no sound should be played.
 boolean I_AdjustSoundParams(const mobj_t *listener, const mobj_t *source,
-                            int chanvol, int *vol, int *sep, int *pri,
-                            int handle);
+                            int chanvol, int *vol, int *sep, int *pri);
 
 // Updates the volume, separation,
 //  and pitch of a sound channel.

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -96,6 +96,8 @@ typedef struct sound_module_s
     void (*StopSound)(int channel);
     boolean (*SoundIsPlaying)(int channel);
     void (*ShutdownSound)(void);
+    void (*DeferUpdates)(void);
+    void (*ProcessUpdates)(void);
 } sound_module_t;
 
 extern const sound_module_t sound_mbf_module;
@@ -144,6 +146,8 @@ boolean I_AdjustSoundParams(const mobj_t *listener, const mobj_t *source,
 // Updates the volume, separation,
 //  and pitch of a sound channel.
 void I_UpdateSoundParams(int handle, int vol, int sep);
+void I_DeferSoundUpdates(void);
+void I_ProcessSoundUpdates(void);
 
 // haleyjd
 int I_SoundID(int handle);

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -73,6 +73,7 @@ void I_ShutdownSound(void);
 //  SFX I/O
 //
 
+extern int forceFlipPan;
 extern int snd_resampler;
 extern int snd_module;
 extern boolean snd_hrtf;

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -63,9 +63,6 @@ extern float steptable[256];
 // Init at program start...
 void I_InitSound(void);
 
-// ... update sound buffer and audio device at runtime...
-void I_UpdateSound(void);
-
 // ... shut down and relase at program termination.
 void I_ShutdownSound(void);
 

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -3945,9 +3945,9 @@ static const char *sound_resampler_menu_strings[] = {
 
 static void M_UpdateAdvancedSoundItems(void)
 {
-  DISABLE_ITEM(snd_module != 1, gen_settings2[gen2_sndhrtf]);
-  DISABLE_ITEM(snd_module != 1, gen_settings2[gen2_sndabsorption]);
-  DISABLE_ITEM(snd_module != 1, gen_settings2[gen2_snddoppler]);
+  DISABLE_ITEM(snd_module != SND_MODULE_3D, gen_settings2[gen2_sndhrtf]);
+  DISABLE_ITEM(snd_module != SND_MODULE_3D, gen_settings2[gen2_sndabsorption]);
+  DISABLE_ITEM(snd_module != SND_MODULE_3D, gen_settings2[gen2_snddoppler]);
 }
 
 static void M_SetSoundModule(void)

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -4200,7 +4200,7 @@ void M_ResetTimeScale(void)
 
 static void M_UpdateDirectVerticalAimingItem(void)
 {
-  DISABLE_ITEM(!mouselook && !padlook, gen_settings3[gen3_verticalaim]);
+  DISABLE_ITEM(!mouselook && !padlook, gen_settings4[gen4_verticalaim]);
 }
 
 static void M_UpdateMouseLook(void)

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -4071,7 +4071,7 @@ setup_menu_t gen_settings2[] = { // General Settings screen2
   {"Sound Module", S_CHOICE, m_null, M_X,
    M_Y + gen2_sndmodule*M_SPC, {"snd_module"}, 0, M_SetSoundModule, sound_module_menu_strings},
 
-  {"HRTF", S_YESNO, m_null, M_X,
+  {"Headphones Mode", S_YESNO, m_null, M_X,
    M_Y + gen2_sndhrtf*M_SPC, {"snd_hrtf"}, 0, M_SetSoundModule},
 
   {"Air Absorption", S_THERMO, m_null, M_X_THRM,

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -3852,7 +3852,7 @@ void M_DrawEnemy(void)
 
 extern int realtic_clock_rate, tran_filter_pct;
 
-setup_menu_t gen_settings1[], gen_settings2[], gen_settings3[], gen_settings4[];
+setup_menu_t gen_settings1[], gen_settings2[], gen_settings3[], gen_settings4[], gen_settings5[];
 
 setup_menu_t* gen_settings[] =
 {
@@ -3860,6 +3860,7 @@ setup_menu_t* gen_settings[] =
   gen_settings2,
   gen_settings3,
   gen_settings4,
+  gen_settings5,
   NULL
 };
 
@@ -3888,6 +3889,18 @@ enum {
   // [FG] music backend
   gen1_musicbackend,
   gen1_end2,
+};
+
+// Page 2
+
+enum {
+  gen2_title1,
+  gen2_sndresampler,
+  gen2_sndmodule,
+  gen2_sndhrtf,
+  gen2_sndabsorption,
+  gen2_snddoppler,
+  gen2_end1,
 };
 
 int midi_player_menu;
@@ -3920,6 +3933,40 @@ static const char *gamma_strings[] = {
 static void M_ResetGamma(void)
 {
   I_SetPalette(W_CacheLumpName("PLAYPAL",PU_CACHE));
+}
+
+static const char *sound_module_menu_strings[] = {
+  "Standard", "OpenAL 3D", NULL
+};
+
+static const char *sound_resampler_menu_strings[] = {
+  "Nearest", "Linear", "Cubic", NULL
+};
+
+static void M_UpdateAdvancedSoundItems(void)
+{
+  DISABLE_ITEM(snd_module != 1, gen_settings2[gen2_sndhrtf]);
+  DISABLE_ITEM(snd_module != 1, gen_settings2[gen2_sndabsorption]);
+  DISABLE_ITEM(snd_module != 1, gen_settings2[gen2_snddoppler]);
+}
+
+static void M_SetSoundModule(void)
+{
+  M_UpdateAdvancedSoundItems();
+
+  if (!I_AllowReinitSound())
+  {
+    // TODO: If extension not present, draw a warning to restart to see changes?
+    fprintf(stderr, "M_SetSoundModule: Reinitializing not supported.\n");
+    return;
+  }
+
+  I_SetSoundModule(snd_module);
+}
+
+static void M_UpdateUserSoundSettings(void)
+{
+  I_UpdateUserSoundSettings();
 }
 
 static void M_SetMidiPlayer(void)
@@ -4014,64 +4061,90 @@ setup_menu_t gen_settings1[] = { // General Settings screen1
   {0,S_SKIP|S_END,m_null}
 };
 
-// Page 2
+setup_menu_t gen_settings2[] = { // General Settings screen2
 
-enum {
-  gen2_title1,
-  gen2_smooth_scaling,
-  gen2_trans,
-  gen2_transpct,
-  gen2_stub1,
-  gen2_sky1,
-  gen2_sky2,
-  gen2_swirl,
-  gen2_smoothlight,
-  gen2_brightmaps,
-  gen2_stub2,
-  gen2_solidbackground,
-  gen2_menu_background,
-  gen2_diskicon,
-  gen2_endoom,
-  gen2_end1,
+  {"Advanced Sound", S_SKIP|S_TITLE, m_null, M_X, M_Y},
+
+  {"Resampler", S_CHOICE, m_null, M_X,
+   M_Y + gen2_sndresampler*M_SPC, {"snd_resampler"}, 0, M_UpdateUserSoundSettings, sound_resampler_menu_strings},
+
+  {"Sound Module", S_CHOICE, m_null, M_X,
+   M_Y + gen2_sndmodule*M_SPC, {"snd_module"}, 0, M_SetSoundModule, sound_module_menu_strings},
+
+  {"HRTF", S_YESNO, m_null, M_X,
+   M_Y + gen2_sndhrtf*M_SPC, {"snd_hrtf"}, 0, M_SetSoundModule},
+
+  {"Air Absorption", S_THERMO, m_null, M_X_THRM,
+   M_Y + gen2_sndabsorption*M_SPC, {"snd_absorption"}, 0, M_UpdateUserSoundSettings},
+
+  {"Doppler Effect", S_THERMO, m_null, M_X_THRM,
+   M_Y+ gen2_snddoppler*M_SPC, {"snd_doppler"}, 0, M_UpdateUserSoundSettings},
+
+  {"<- PREV",S_SKIP|S_PREV, m_null, M_X_PREV, M_Y_PREVNEXT, {gen_settings1}},
+  {"NEXT ->",S_SKIP|S_NEXT, m_null, M_X_NEXT, M_Y_PREVNEXT, {gen_settings3}},
+
+  // Final entry
+  {0,S_SKIP|S_END,m_null}
 };
 
 // Page 3
 
 enum {
   gen3_title1,
-  gen3_strictmode,
-  gen3_screen_melt,
-  gen3_death_action,
-  gen3_demobar,
-  gen3_palette_changes,
-  gen3_level_brightness,
+  gen3_smooth_scaling,
+  gen3_trans,
+  gen3_transpct,
+  gen3_stub1,
+  gen3_sky1,
+  gen3_sky2,
+  gen3_swirl,
+  gen3_smoothlight,
+  gen3_brightmaps,
+  gen3_stub2,
+  gen3_solidbackground,
+  gen3_menu_background,
+  gen3_diskicon,
+  gen3_endoom,
   gen3_end1,
-
-  gen3_title2,
-  gen3_hangsolid,
-  gen3_blockmapfix,
-  gen3_verticalaim,
-  gen3_pistolstart,
-  gen3_end2,
 };
 
 // Page 4
 
 enum {
   gen4_title1,
-  gen4_mouse1,
-  gen4_mouse2,
-  gen4_mouse3,
-  gen4_mouse_accel,
-  gen4_mouse_accel_threshold,
+  gen4_strictmode,
+  gen4_screen_melt,
+  gen4_death_action,
+  gen4_demobar,
+  gen4_palette_changes,
+  gen4_level_brightness,
   gen4_end1,
 
   gen4_title2,
-  gen4_realtic,
-  gen4_compat,
-  gen4_skill,
-  gen4_playername,
+  gen4_hangsolid,
+  gen4_blockmapfix,
+  gen4_verticalaim,
+  gen4_pistolstart,
   gen4_end2,
+};
+
+// Page 5
+
+enum {
+  gen5_title1,
+  gen5_mouse1,
+  gen5_mouse2,
+  gen5_mouse3,
+  gen5_mouse_accel,
+  gen5_mouse_accel_threshold,
+  gen5_end1,
+
+  gen5_title2,
+  gen5_realtic,
+  gen5_compat,
+  gen5_skill,
+  gen5_playername,
+  gen5_end2,
 };
 
 #define MOUSE_ACCEL_STRINGS_SIZE (40 + 2)
@@ -4164,97 +4237,50 @@ static const char *menu_background_strings[] = {
   "on", "off", "dark", NULL
 };
 
-setup_menu_t gen_settings2[] = { // General Settings screen2
-
-  {"Display Options"  ,S_SKIP|S_TITLE, m_null, M_X,
-   M_Y + gen2_title1*M_SPC},
-
-  {"Smooth Pixel Scaling", S_YESNO, m_null, M_X,
-   M_Y+ gen2_smooth_scaling*M_SPC, {"smooth_scaling"}, 0, M_ResetScreen},
-
-  {"Enable predefined translucency", S_YESNO|S_STRICT, m_null, M_X,
-   M_Y+ gen2_trans*M_SPC, {"translucency"}, 0, M_Trans},
-
-  {"Translucency filter percentage", S_NUM, m_null, M_X,
-   M_Y+ gen2_transpct*M_SPC, {"tran_filter_pct"}, 0, M_Trans},
-
-  {"", S_SKIP, m_null, M_X, M_Y + gen2_stub1*M_SPC},
-
-  {"Stretch Short Skies", S_YESNO, m_null, M_X,
-   M_Y + gen2_sky1*M_SPC, {"stretchsky"}, 0, R_InitSkyMap},
-
-  {"Linear Sky Scrolling", S_YESNO, m_null, M_X,
-   M_Y + gen2_sky2*M_SPC, {"linearsky"}, 0, R_InitPlanes},
-
-  {"Swirling Animated Flats", S_YESNO, m_null, M_X,
-   M_Y + gen2_swirl*M_SPC, {"r_swirl"}},
-
-  {"Smooth Diminishing Lighting", S_YESNO, m_null, M_X,
-   M_Y + gen2_smoothlight*M_SPC, {"smoothlight"}, 0, M_SmoothLight},
-
-  {"Brightmaps for Textures and Sprites", S_YESNO|S_STRICT, m_null, M_X,
-   M_Y + gen2_brightmaps*M_SPC, {"brightmaps"}},
-
-  {"", S_SKIP, m_null, M_X, M_Y + gen2_stub2*M_SPC},
-
-  {"Solid Status Bar Background", S_YESNO, m_null, M_X,
-   M_Y + gen2_solidbackground*M_SPC, {"st_solidbackground"}},
-
-  {"Draw Menu Background", S_CHOICE, m_null, M_X,
-   M_Y + gen2_menu_background*M_SPC, {"menu_background"}, 0, NULL, menu_background_strings},
-
-  {"Flash Icon During Disk IO", S_YESNO, m_null, M_X,
-   M_Y + gen2_diskicon*M_SPC, {"disk_icon"}},
-
-  {"Show ENDOOM screen", S_CHOICE, m_null, M_X,
-   M_Y + gen2_endoom*M_SPC, {"show_endoom"}, 0, NULL, default_endoom_strings},
-
-  {"<- PREV",S_SKIP|S_PREV, m_null, M_X_PREV, M_Y_PREVNEXT, {gen_settings1}},
-  {"NEXT ->",S_SKIP|S_NEXT, m_null, M_X_NEXT, M_Y_PREVNEXT, {gen_settings3}},
-
-  // Final entry
-
-  {0,S_SKIP|S_END,m_null}
-};
-
 setup_menu_t gen_settings3[] = { // General Settings screen3
 
-  {"Quality of life"  ,S_SKIP|S_TITLE, m_null, M_X, M_Y},
+  {"Display Options"  ,S_SKIP|S_TITLE, m_null, M_X,
+   M_Y + gen3_title1*M_SPC},
 
-  {"Strict Mode", S_YESNO|S_LEVWARN, m_null, M_X,
-   M_Y + gen3_strictmode*M_SPC, {"strictmode"}},
+  {"Smooth Pixel Scaling", S_YESNO, m_null, M_X,
+   M_Y+ gen3_smooth_scaling*M_SPC, {"smooth_scaling"}, 0, M_ResetScreen},
 
-  {"Screen melt", S_YESNO|S_STRICT, m_null, M_X,
-   M_Y + gen3_screen_melt*M_SPC, {"screen_melt"}},
+  {"Enable predefined translucency", S_YESNO|S_STRICT, m_null, M_X,
+   M_Y+ gen3_trans*M_SPC, {"translucency"}, 0, M_Trans},
 
-  {"On death action", S_CHOICE, m_null, M_X,
-   M_Y + gen3_death_action*M_SPC, {"death_use_action"}, 0, NULL, death_use_action_strings},
+  {"Translucency filter percentage", S_NUM, m_null, M_X,
+   M_Y+ gen3_transpct*M_SPC, {"tran_filter_pct"}, 0, M_Trans},
 
-  {"Show demo progress bar", S_YESNO, m_null, M_X,
-   M_Y + gen3_demobar*M_SPC, {"demobar"}},
+  {"", S_SKIP, m_null, M_X, M_Y + gen3_stub1*M_SPC},
 
-  {"Pain/pickup/powerup flashes", S_YESNO|S_STRICT, m_null, M_X,
-   M_Y + gen3_palette_changes*M_SPC, {"palette_changes"}},
+  {"Stretch Short Skies", S_YESNO, m_null, M_X,
+   M_Y + gen3_sky1*M_SPC, {"stretchsky"}, 0, R_InitSkyMap},
 
-  {"Level Brightness", S_THERMO|S_STRICT, m_null, M_X_THRM,
-   M_Y + gen3_level_brightness*M_SPC, {"extra_level_brightness"}},
+  {"Linear Sky Scrolling", S_YESNO, m_null, M_X,
+   M_Y + gen3_sky2*M_SPC, {"linearsky"}, 0, R_InitPlanes},
 
-  {"", S_SKIP, m_null, M_X, M_Y + gen3_end1*M_SPC},
+  {"Swirling Animated Flats", S_YESNO, m_null, M_X,
+   M_Y + gen3_swirl*M_SPC, {"r_swirl"}},
 
-  {"Compatibility-breaking Features"  ,S_SKIP|S_TITLE, m_null, M_X,
-   M_Y + gen3_title2*M_SPC},
+  {"Smooth Diminishing Lighting", S_YESNO, m_null, M_X,
+   M_Y + gen3_smoothlight*M_SPC, {"smoothlight"}, 0, M_SmoothLight},
 
-  {"Walk Under Solid Hanging Bodies", S_YESNO|S_STRICT|S_CRITICAL, m_null, M_X,
-   M_Y + gen3_hangsolid*M_SPC, {"hangsolid"}},
+  {"Brightmaps for Textures and Sprites", S_YESNO|S_STRICT, m_null, M_X,
+   M_Y + gen3_brightmaps*M_SPC, {"brightmaps"}},
 
-  {"Improved Hit Detection", S_YESNO|S_STRICT|S_CRITICAL, m_null, M_X,
-   M_Y + gen3_blockmapfix*M_SPC, {"blockmapfix"}},
+  {"", S_SKIP, m_null, M_X, M_Y + gen3_stub2*M_SPC},
 
-  {"Direct Vertical Aiming", S_YESNO|S_STRICT|S_CRITICAL, m_null, M_X,
-   M_Y + gen3_verticalaim*M_SPC, {"direct_vertical_aiming"}},
+  {"Solid Status Bar Background", S_YESNO, m_null, M_X,
+   M_Y + gen3_solidbackground*M_SPC, {"st_solidbackground"}},
 
-  {"Pistol Start", S_YESNO|S_STRICT|S_CRITICAL, m_null, M_X,
-   M_Y + gen3_pistolstart*M_SPC, {"pistolstart"}},
+  {"Draw Menu Background", S_CHOICE, m_null, M_X,
+   M_Y + gen3_menu_background*M_SPC, {"menu_background"}, 0, NULL, menu_background_strings},
+
+  {"Flash Icon During Disk IO", S_YESNO, m_null, M_X,
+   M_Y + gen3_diskicon*M_SPC, {"disk_icon"}},
+
+  {"Show ENDOOM screen", S_CHOICE, m_null, M_X,
+   M_Y + gen3_endoom*M_SPC, {"show_endoom"}, 0, NULL, default_endoom_strings},
 
   {"<- PREV",S_SKIP|S_PREV, m_null, M_X_PREV, M_Y_PREVNEXT, {gen_settings2}},
   {"NEXT ->",S_SKIP|S_NEXT, m_null, M_X_NEXT, M_Y_PREVNEXT, {gen_settings4}},
@@ -4266,42 +4292,89 @@ setup_menu_t gen_settings3[] = { // General Settings screen3
 
 setup_menu_t gen_settings4[] = { // General Settings screen4
 
+  {"Quality of life"  ,S_SKIP|S_TITLE, m_null, M_X, M_Y},
+
+  {"Strict Mode", S_YESNO|S_LEVWARN, m_null, M_X,
+   M_Y + gen4_strictmode*M_SPC, {"strictmode"}},
+
+  {"Screen melt", S_YESNO|S_STRICT, m_null, M_X,
+   M_Y + gen4_screen_melt*M_SPC, {"screen_melt"}},
+
+  {"On death action", S_CHOICE, m_null, M_X,
+   M_Y + gen4_death_action*M_SPC, {"death_use_action"}, 0, NULL, death_use_action_strings},
+
+  {"Show demo progress bar", S_YESNO, m_null, M_X,
+   M_Y + gen4_demobar*M_SPC, {"demobar"}},
+
+  {"Pain/pickup/powerup flashes", S_YESNO|S_STRICT, m_null, M_X,
+   M_Y + gen4_palette_changes*M_SPC, {"palette_changes"}},
+
+  {"Level Brightness", S_THERMO|S_STRICT, m_null, M_X_THRM,
+   M_Y + gen4_level_brightness*M_SPC, {"extra_level_brightness"}},
+
+  {"", S_SKIP, m_null, M_X, M_Y + gen4_end1*M_SPC},
+
+  {"Compatibility-breaking Features"  ,S_SKIP|S_TITLE, m_null, M_X,
+   M_Y + gen4_title2*M_SPC},
+
+  {"Walk Under Solid Hanging Bodies", S_YESNO|S_STRICT|S_CRITICAL, m_null, M_X,
+   M_Y + gen4_hangsolid*M_SPC, {"hangsolid"}},
+
+  {"Improved Hit Detection", S_YESNO|S_STRICT|S_CRITICAL, m_null, M_X,
+   M_Y + gen4_blockmapfix*M_SPC, {"blockmapfix"}},
+
+  {"Direct Vertical Aiming", S_YESNO|S_STRICT|S_CRITICAL, m_null, M_X,
+   M_Y + gen4_verticalaim*M_SPC, {"direct_vertical_aiming"}},
+
+  {"Pistol Start", S_YESNO|S_STRICT|S_CRITICAL, m_null, M_X,
+   M_Y + gen4_pistolstart*M_SPC, {"pistolstart"}},
+
+  {"<- PREV",S_SKIP|S_PREV, m_null, M_X_PREV, M_Y_PREVNEXT, {gen_settings3}},
+  {"NEXT ->",S_SKIP|S_NEXT, m_null, M_X_NEXT, M_Y_PREVNEXT, {gen_settings5}},
+
+  // Final entry
+
+  {0,S_SKIP|S_END,m_null}
+};
+
+setup_menu_t gen_settings5[] = { // General Settings screen5
+
   {"Mouse Settings"     ,S_SKIP|S_TITLE, m_null, M_X, M_Y},
 
   // [FG] double click acts as "use"
   {"Double Click acts as \"Use\"", S_YESNO, m_null, M_X,
-   M_Y+ gen4_mouse1*M_SPC, {"dclick_use"}},
+   M_Y+ gen5_mouse1*M_SPC, {"dclick_use"}},
 
   {"Permanent Mouselook", S_YESNO, m_null, M_X,
-   M_Y+ gen4_mouse2*M_SPC, {"mouselook"}, 0, M_UpdateMouseLook},
+   M_Y+ gen5_mouse2*M_SPC, {"mouselook"}, 0, M_UpdateMouseLook},
 
   // [FG] invert vertical axis
   {"Invert vertical axis", S_YESNO, m_null, M_X,
-   M_Y+ gen4_mouse3*M_SPC, {"mouse_y_invert"}},
+   M_Y+ gen5_mouse3*M_SPC, {"mouse_y_invert"}},
 
   {"Mouse acceleration", S_THERMO, m_null, M_X_THRM,
-   M_Y + gen4_mouse_accel * M_SPC, {"mouse_acceleration"}, 0, NULL, mouse_accel_strings},
+   M_Y + gen5_mouse_accel * M_SPC, {"mouse_acceleration"}, 0, NULL, mouse_accel_strings},
 
   {"Mouse threshold", S_NUM, m_null, M_X,
-   M_Y + gen4_mouse_accel_threshold * M_SPC, {"mouse_acceleration_threshold"}},
+   M_Y + gen5_mouse_accel_threshold * M_SPC, {"mouse_acceleration_threshold"}},
 
-  {"", S_SKIP, m_null, M_X, M_Y + gen4_end1*M_SPC},
+  {"", S_SKIP, m_null, M_X, M_Y + gen5_end1*M_SPC},
 
-  {"Miscellaneous"  ,S_SKIP|S_TITLE, m_null, M_X, M_Y + gen4_title2*M_SPC},
+  {"Miscellaneous"  ,S_SKIP|S_TITLE, m_null, M_X, M_Y + gen5_title2*M_SPC},
 
   {"Game speed, percentage of normal", S_NUM|S_STRICT, m_null, M_X,
-   M_Y + gen4_realtic*M_SPC, {"realtic_clock_rate"}, 0, M_ResetTimeScale},
+   M_Y + gen5_realtic*M_SPC, {"realtic_clock_rate"}, 0, M_ResetTimeScale},
 
   {"Default compatibility", S_CHOICE|S_LEVWARN, m_null, M_X,
-   M_Y + gen4_compat*M_SPC, {"default_complevel"}, 0, NULL, default_compatibility_strings},
+   M_Y + gen5_compat*M_SPC, {"default_complevel"}, 0, NULL, default_compatibility_strings},
 
   {"Default skill level", S_CHOICE|S_LEVWARN, m_null, M_X,
-   M_Y + gen4_skill*M_SPC, {"default_skill"}, 0, NULL, default_skill_strings},
+   M_Y + gen5_skill*M_SPC, {"default_skill"}, 0, NULL, default_skill_strings},
 
   {"Player Name", S_STRING, m_null, M_X,
-   M_Y + gen4_playername*M_SPC, {"net_player_name"}},
+   M_Y + gen5_playername*M_SPC, {"net_player_name"}},
 
-  {"<- PREV",S_SKIP|S_PREV, m_null, M_X_PREV, M_Y_PREVNEXT, {gen_settings3}},
+  {"<- PREV",S_SKIP|S_PREV, m_null, M_X_PREV, M_Y_PREVNEXT, {gen_settings4}},
 
   // Final entry
 
@@ -4498,7 +4571,7 @@ enum
 static void M_UpdateCriticalItems(void)
 {
   DISABLE_ITEM(demo_compatibility && overflow[emu_intercepts].enabled,
-               gen_settings3[gen3_blockmapfix]);
+               gen_settings4[gen4_blockmapfix]);
 }
 
 setup_menu_t comp_settings3[] =  // Compatibility Settings screen #3
@@ -7213,17 +7286,22 @@ void M_ResetSetupMenu(void)
 
   if (M_ParmExists("-strict"))
   {
-    gen_settings3[gen3_strictmode].m_flags |= S_DISABLE;
+    gen_settings4[gen4_strictmode].m_flags |= S_DISABLE;
   }
 
   if (M_ParmExists("-complevel"))
   {
-    gen_settings4[gen4_compat].m_flags |= S_DISABLE;
+    gen_settings5[gen5_compat].m_flags |= S_DISABLE;
   }
 
   if (M_ParmExists("-pistolstart"))
   {
-    gen_settings3[gen3_pistolstart].m_flags |= S_DISABLE;
+    gen_settings4[gen4_pistolstart].m_flags |= S_DISABLE;
+  }
+
+  if (M_ParmExists("-uncapped") || M_ParmExists("-nouncapped"))
+  {
+    gen_settings1[gen1_uncapped].m_flags |= S_DISABLE;
   }
 
   if (M_ParmExists("-uncapped") || M_ParmExists("-nouncapped"))
@@ -7238,7 +7316,7 @@ void M_ResetSetupMenu(void)
 
   if (!brightmaps_found || force_brightmaps)
   {
-    gen_settings2[gen2_brightmaps].m_flags |= S_DISABLE;
+    gen_settings3[gen3_brightmaps].m_flags |= S_DISABLE;
   }
 
   DISABLE_ITEM(!comp[comp_vile], enem_settings1[enem1_ghost]);
@@ -7249,6 +7327,7 @@ void M_ResetSetupMenu(void)
   M_UpdateMultiLineMsgItem();
   M_UpdateCriticalItems();
   M_UpdateDirectVerticalAimingItem();
+  M_UpdateAdvancedSoundItems();
 }
 
 void M_ResetSetupMenuVideo(void)

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -3956,8 +3956,9 @@ static void M_SetSoundModule(void)
 
   if (!I_AllowReinitSound())
   {
-    // TODO: If extension not present, draw a warning to restart to see changes?
-    fprintf(stderr, "M_SetSoundModule: Reinitializing not supported.\n");
+    // The OpenAL implementation doesn't support the ALC_SOFT_HRTF extension
+    // which is required for alcResetDeviceSOFT(). Warn the user to restart.
+    warn_about_changes(S_PRGWARN);
     return;
   }
 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -99,7 +99,6 @@ extern int winmm_reset_delay;
 #endif
 extern int opl_gain;
 extern int midi_player_menu;
-extern char *snd_resampler;
 extern boolean demobar;
 extern boolean smoothlight;
 extern boolean brightmaps;
@@ -416,8 +415,36 @@ default_t defaults[] = {
   {
     "snd_resampler",
     (config_t *) &snd_resampler, NULL,
-    {.s = "linear"}, {0}, string, ss_gen, wad_no,
-    "OpenAL resampler (\"nearest\", \"linear\" (default), \"cubic\")"
+    {1}, {0, 2}, number, ss_none, wad_no,
+    "OpenAL resampler (0 = Nearest, 1 = Linear, 2 = Cubic)"
+  },
+
+  {
+    "snd_module",
+    (config_t *) &snd_module, NULL,
+    {0}, {0, 1}, number, ss_none, wad_no,
+    "Sound module (0 = Standard, 1 = OpenAL 3D)" // 2 = PC Speaker Sound
+  },
+
+  {
+    "snd_hrtf",
+    (config_t *) &snd_hrtf, NULL,
+    {0}, {0, 1}, number, ss_none, wad_no,
+    "[OpenAL 3D] HRTF (binaural audio for headphones)"
+  },
+
+  {
+    "snd_absorption",
+    (config_t *) &snd_absorption, NULL,
+    {5}, {0, 10}, number, ss_none, wad_no,
+    "[OpenAL 3D] Air absorption effect (0 = Off, 10 = Max)"
+  },
+
+  {
+    "snd_doppler",
+    (config_t *) &snd_doppler, NULL,
+    {5}, {0, 10}, number, ss_none, wad_no,
+    "[OpenAL 3D] Dopper effect (0 = Off, 10 = Max)"
   },
 
   // [FG] music backend

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -422,7 +422,7 @@ default_t defaults[] = {
   {
     "snd_module",
     (config_t *) &snd_module, NULL,
-    {0}, {0, 1}, number, ss_none, wad_no,
+    {SND_MODULE_MBF}, {0, NUM_SND_MODULES - 1}, number, ss_none, wad_no,
     "Sound module (0 = Standard, 1 = OpenAL 3D)" // 2 = PC Speaker Sound
   },
 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -444,7 +444,7 @@ default_t defaults[] = {
     "snd_doppler",
     (config_t *) &snd_doppler, NULL,
     {0}, {0, 10}, number, ss_none, wad_no,
-    "[OpenAL 3D] Dopper effect (0 = Off, 10 = Max)"
+    "[OpenAL 3D] Doppler effect (0 = Off, 10 = Max)"
   },
 
   // [FG] music backend

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -436,14 +436,14 @@ default_t defaults[] = {
   {
     "snd_absorption",
     (config_t *) &snd_absorption, NULL,
-    {5}, {0, 10}, number, ss_none, wad_no,
+    {0}, {0, 10}, number, ss_none, wad_no,
     "[OpenAL 3D] Air absorption effect (0 = Off, 10 = Max)"
   },
 
   {
     "snd_doppler",
     (config_t *) &snd_doppler, NULL,
-    {5}, {0, 10}, number, ss_none, wad_no,
+    {0}, {0, 10}, number, ss_none, wad_no,
     "[OpenAL 3D] Dopper effect (0 = Off, 10 = Max)"
   },
 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -430,7 +430,7 @@ default_t defaults[] = {
     "snd_hrtf",
     (config_t *) &snd_hrtf, NULL,
     {0}, {0, 1}, number, ss_none, wad_no,
-    "[OpenAL 3D] HRTF (binaural audio for headphones)"
+    "[OpenAL 3D] Headphones mode (0 = No, 1 = Yes)"
   },
 
   {

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -75,7 +75,6 @@ extern int showMessages;
 extern int show_toggle_messages;
 extern int show_pickup_messages;
 
-extern int forceFlipPan;
 extern int window_width, window_height;
 extern int window_position_x, window_position_y;
 extern boolean grabmouse;

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -382,6 +382,8 @@ void S_UpdateSounds(const mobj_t *listener)
    if(nosfxparm)
       return;
    
+   I_DeferSoundUpdates();
+
    for(cnum = 0; cnum < numChannels; ++cnum)
    {
       channel_t *c = &channels[cnum];
@@ -430,6 +432,8 @@ void S_UpdateSounds(const mobj_t *listener)
             S_StopChannel(cnum);
         }
     }
+
+   I_ProcessSoundUpdates();
 }
 
 void S_SetMusicVolume(int volume)

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -370,6 +370,16 @@ void S_ResumeSound(void)
 // Updates music & sounds
 //
 
+void S_InitListener(const mobj_t *listener)
+{
+    if (nosfxparm)
+        return;
+
+    I_DeferSoundUpdates();
+    I_UpdateListenerParams(listener);
+    I_ProcessSoundUpdates();
+}
+
 void S_UpdateSounds(const mobj_t *listener)
 {
    int cnum;
@@ -428,6 +438,7 @@ void S_UpdateSounds(const mobj_t *listener)
         }
     }
 
+   I_UpdateListenerParams(listener);
    I_ProcessSoundUpdates();
 }
 

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -213,13 +213,6 @@ void S_StartSound(const mobj_t *origin, int sfx_id)
       I_Error("Bad sfx #: %d", sfx_id);
 #endif
 
-   // Assigns the handle to one of the channels in the mix/output buffer.
-   handle = I_GetChannel();
-   if (handle < 0)
-   {
-      return;
-   }
-
    sfx = &S_sfx[sfx_id];
    
    // Initialize sound parameters
@@ -281,8 +274,11 @@ void S_StartSound(const mobj_t *origin, int sfx_id)
    while(sfx->link)
       sfx = sfx->link;     // sf: skip thru link(s)
 
+   // Assigns the handle to one of the channels in the mix/output buffer.
+   handle = I_StartSound(sfx, volume, sep, pitch);
+
    // haleyjd: check to see if the sound was started
-   if (I_StartSound(sfx, volume, sep, pitch, handle))
+   if(handle >= 0)
    {
       channels[cnum].handle = handle;
       

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -31,22 +31,6 @@
 #include "m_misc2.h"
 #include "w_wad.h"
 
-// when to clip out sounds
-// Does not fit the large outdoor areas.
-#define S_CLIPPING_DIST (1200<<FRACBITS)
-
-// Distance to origin when sounds should be maxed out.
-// This should relate to movement clipping resolution
-// (see BLOCKMAP handling).
-// Originally: (200*0x10000).
-//
-// killough 12/98: restore original
-// #define S_CLOSE_DIST (160<<FRACBITS)
-
-#define S_CLOSE_DIST (200<<FRACBITS)
-
-#define S_ATTENUATOR ((S_CLIPPING_DIST-S_CLOSE_DIST)>>FRACBITS)
-
 //jff end sound enabling variables readable here
 
 typedef struct channel_s
@@ -127,10 +111,8 @@ static void S_StopChannel(int cnum)
 //
 static int S_AdjustSoundParams(const mobj_t *listener, const mobj_t *source,
                                int chanvol, int *vol, int *sep, int *pitch,
-                               int *pri)
+                               int *pri, int handle)
 {
-   fixed_t adx, ady, dist;
-   angle_t angle;
    int basevolume;            // haleyjd
 
    // haleyjd 08/12/04: we cannot adjust a sound for a NULL listener.
@@ -142,58 +124,11 @@ static int S_AdjustSoundParams(const mobj_t *listener, const mobj_t *source,
    if(!source)
       I_Error("S_AdjustSoundParams: NULL source\n");
 #endif
-   
-   // calculate the distance to sound origin
-   //  and clip it if necessary
-   //
-   // killough 11/98: scale coordinates down before calculations start
-   // killough 12/98: use exact distance formula instead of approximation
-   
-   adx = abs((listener->x >> FRACBITS) - (source->x >> FRACBITS));
-   ady = abs((listener->y >> FRACBITS) - (source->y >> FRACBITS));
-   
-   if(ady > adx)
-      dist = adx, adx = ady, ady = dist;
-   
-   dist = adx ? FixedDiv(adx, finesine[(tantoangle[FixedDiv(ady,adx) >> DBITS]
-                                        + ANG90) >> ANGLETOFINESHIFT]) : 0;
 
    // haleyjd 05/29/06: allow per-channel volume scaling
    basevolume = (snd_SfxVolume * chanvol) / 15;
 
-   if(!dist)  // killough 11/98: handle zero-distance as special case
-   {
-      *sep = NORM_SEP;
-      *vol = basevolume;
-      return *vol > 0;
-   }
-
-   if(dist > S_CLIPPING_DIST >> FRACBITS)
-      return 0;
-  
-   // angle of source to listener
-   angle = R_PointToAngle2(listener->x, listener->y, source->x, source->y);
-   
-   if(angle <= listener->angle)
-      angle += 0xffffffff;
-   angle -= listener->angle;
-   angle >>= ANGLETOFINESHIFT;
-
-   // stereo separation
-   *sep = NORM_SEP - FixedMul(S_STEREO_SWING>>FRACBITS,finesine[angle]);
-
-   // volume calculation
-   *vol = dist < S_CLOSE_DIST >> FRACBITS ? basevolume :
-      basevolume * ((S_CLIPPING_DIST>>FRACBITS)-dist) /
-      S_ATTENUATOR;
-
-   // haleyjd 09/27/06: decrease priority with volume attenuation
-   *pri = *pri + (127 - *vol);
-   
-   if(*pri > 255) // cap to 255
-      *pri = 255;
-
-  return *vol > 0;
+   return I_AdjustSoundParams(listener, source, basevolume, vol, sep, pri, handle);
 }
 
 //
@@ -293,6 +228,13 @@ void S_StartSound(const mobj_t *origin, int sfx_id)
       I_Error("Bad sfx #: %d", sfx_id);
 #endif
 
+   // Assigns the handle to one of the channels in the mix/output buffer.
+   handle = I_GetChannel();
+   if(handle < 0)
+   {
+      return;
+   }
+
    sfx = &S_sfx[sfx_id];
    
    // Initialize sound parameters
@@ -330,7 +272,7 @@ void S_StartSound(const mobj_t *origin, int sfx_id)
    else
    {
       if(!S_AdjustSoundParams(players[displayplayer].mo, origin, volumeScale,
-                              &volume, &sep, &pitch, &priority))
+                              &volume, &sep, &pitch, &priority, handle))
          return;
       else if(origin->x == players[displayplayer].mo->x &&
               origin->y == players[displayplayer].mo->y)
@@ -367,11 +309,8 @@ void S_StartSound(const mobj_t *origin, int sfx_id)
    while(sfx->link)
       sfx = sfx->link;     // sf: skip thru link(s)
 
-   // Assigns the handle to one of the channels in the mix/output buffer.
-   handle = I_StartSound(sfx, volume, sep, pitch);
-
    // haleyjd: check to see if the sound was started
-   if(handle >= 0)
+   if(I_StartSound(sfx, volume, sep, pitch, handle))
    {
       channels[cnum].handle = handle;
       
@@ -505,7 +444,8 @@ void S_UpdateSounds(const mobj_t *listener)
                                        &volume,
                                        &sep, 
                                        &pitch,
-                                       &pri))
+                                       &pri,
+                                       c->handle))
                   S_StopChannel(cnum);
                else
                {

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -92,8 +92,7 @@ static void S_StopChannel(int cnum)
 
    if(channels[cnum].sfxinfo)
    {
-      if(I_SoundIsPlaying(channels[cnum].handle))
-         I_StopSound(channels[cnum].handle);      // stop the sound playing
+      I_StopSound(channels[cnum].handle);      // stop the sound playing
 
       // haleyjd 09/27/06: clear the entire channel
       memset(&channels[cnum], 0, sizeof(channel_t));

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -215,7 +215,7 @@ void S_StartSound(const mobj_t *origin, int sfx_id)
 
    // Assigns the handle to one of the channels in the mix/output buffer.
    handle = I_GetChannel();
-   if(handle < 0)
+   if (handle < 0)
    {
       return;
    }
@@ -245,8 +245,8 @@ void S_StartSound(const mobj_t *origin, int sfx_id)
    // Check to see if it is audible, modify the params
    // killough 3/7/98, 4/25/98: code rearranged slightly
    
-   if(!S_AdjustSoundParams(players[displayplayer].mo, origin, volumeScale,
-                           &volume, &sep, &pitch, &priority, handle))
+   if (!S_AdjustSoundParams(players[displayplayer].mo, origin, volumeScale,
+                            &volume, &sep, &pitch, &priority, handle))
    {
       return;
    }
@@ -282,7 +282,7 @@ void S_StartSound(const mobj_t *origin, int sfx_id)
       sfx = sfx->link;     // sf: skip thru link(s)
 
    // haleyjd: check to see if the sound was started
-   if(I_StartSound(sfx, volume, sep, pitch, handle))
+   if (I_StartSound(sfx, volume, sep, pitch, handle))
    {
       channels[cnum].handle = handle;
       

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -111,9 +111,9 @@ static void S_StopChannel(int cnum)
 //
 static int S_AdjustSoundParams(const mobj_t *listener, const mobj_t *source,
                                int chanvol, int *vol, int *sep, int *pitch,
-                               int *pri, int handle)
+                               int *pri)
 {
-   return I_AdjustSoundParams(listener, source, chanvol, vol, sep, pri, handle);
+   return I_AdjustSoundParams(listener, source, chanvol, vol, sep, pri);
 }
 
 //
@@ -246,7 +246,7 @@ void S_StartSound(const mobj_t *origin, int sfx_id)
    // killough 3/7/98, 4/25/98: code rearranged slightly
    
    if (!S_AdjustSoundParams(players[displayplayer].mo, origin, volumeScale,
-                            &volume, &sep, &pitch, &priority, handle))
+                            &volume, &sep, &pitch, &priority))
    {
       return;
    }
@@ -418,8 +418,7 @@ void S_UpdateSounds(const mobj_t *listener)
                                        &volume,
                                        &sep, 
                                        &pitch,
-                                       &pri,
-                                       c->handle))
+                                       &pri))
                   S_StopChannel(cnum);
                else
                {

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -113,22 +113,7 @@ static int S_AdjustSoundParams(const mobj_t *listener, const mobj_t *source,
                                int chanvol, int *vol, int *sep, int *pitch,
                                int *pri, int handle)
 {
-   int basevolume;            // haleyjd
-
-   // haleyjd 08/12/04: we cannot adjust a sound for a NULL listener.
-   if(!listener)
-      return 1;
-
-   // haleyjd 05/29/06: this function isn't supposed to be called for NULL sources
-#ifdef RANGECHECK
-   if(!source)
-      I_Error("S_AdjustSoundParams: NULL source\n");
-#endif
-
-   // haleyjd 05/29/06: allow per-channel volume scaling
-   basevolume = (snd_SfxVolume * chanvol) / 15;
-
-   return I_AdjustSoundParams(listener, source, basevolume, vol, sep, pri, handle);
+   return I_AdjustSoundParams(listener, source, chanvol, vol, sep, pri, handle);
 }
 
 //
@@ -260,24 +245,11 @@ void S_StartSound(const mobj_t *origin, int sfx_id)
    // Check to see if it is audible, modify the params
    // killough 3/7/98, 4/25/98: code rearranged slightly
    
-   if(!origin || origin == players[displayplayer].mo)
+   if(!S_AdjustSoundParams(players[displayplayer].mo, origin, volumeScale,
+                           &volume, &sep, &pitch, &priority, handle))
    {
-      sep = NORM_SEP;
-      volume = (volume * volumeScale) / 15; // haleyjd 05/29/06: scale volume
-      if(volume < 1)
-         return;
-      if(volume > 127)
-         volume = 127;
+      return;
    }
-   else
-   {
-      if(!S_AdjustSoundParams(players[displayplayer].mo, origin, volumeScale,
-                              &volume, &sep, &pitch, &priority, handle))
-         return;
-      else if(origin->x == players[displayplayer].mo->x &&
-              origin->y == players[displayplayer].mo->y)
-         sep = NORM_SEP;
-  }
 
    if(pitched_sounds)
    {

--- a/src/s_sound.h
+++ b/src/s_sound.h
@@ -69,6 +69,7 @@ void S_RestartMusic(void);
 //
 // Updates music & sounds
 //
+void S_InitListener(const mobj_t *listener);
 void S_UpdateSounds(const mobj_t *listener);
 void S_SetMusicVolume(int volume);
 void S_SetSfxVolume(int volume);


### PR DESCRIPTION
Reference: https://github.com/fabiangreffrath/woof/issues/1094

<details><summary>Details</summary>
Here's a proof of concept for 3D audio support for Woof. I'm not sure if this is the best approach due to the amount of changes required, but it can be used to decide if this is something worth pursuing further.

There's a placeholder in-game menu with all the options for quick testing:
![settings](https://github.com/fabiangreffrath/woof/assets/56656010/aae7a666-1e90-47a6-9d53-61796a4d67b3)

Here's how it works:

### Standard 2D panning:

This is the original Woof sound module that's similar to vanilla Doom but with some WinMBF changes like a different channel priority system.
```
snd_module 0 (Standard)
(other settings ignored)
```

### OpenAL Soft 3D for speakers (stereo or up to 7.1 surround):
OpenAL Soft creates a virtualized 3D environment and then adapts it to the speaker configuration reported by the OS. So even with a pair of stereo speakers, there should be good positional audio. However, this mode will sound unnatural with headphones.
```
snd_module 1 (OpenAL 3D)
snd_hrtf 0   (HRTF: No)
```

### OpenAL Soft 3D for headphones using HRTF:
The effectiveness of this depends on the shape of each individual's head and ears and how closely the selected HRTF matches. There is a default HRTF (.mhr file) embedded in OpenAL Soft that is based on a commonly used MIT KEMAR data set. There is a collection of .mhr files [here](https://airtable.com/shruimhjdSakUPg2m/tbloLjoZKWJDnLtTc) that come from sources with favorable licenses. If this PR moves forward, I would like to populate a list of HRTF files in the menu by searching one or more paths, similar to how soundfonts currently work.
```
snd_module 1 (OpenAL 3D)
snd_hrtf 1   (HRTF: Yes)
```

### Optional OpenAL effects:
- The air absorption effect reduces the volume and applies a subtle low pass filter the further away a sound source is located.
- The Doppler effect is very exaggerated across most of the values. Maybe the velocity calculations or the map units to meters conversion factor need adjustment.
```
snd_absorption 0 to 10
snd_doppler 0 to 10
```

In general, positional audio works better with high quality sounds. My understanding is that this has to do with how we perceive higher frequencies. So I would suggest trying a high quality [sound wad](https://www.doomworld.com/forum/topic/110822-doom-sound-bulb-hd-sounds-that-stay-true-to-the-original/) even if you don't use one normally. You may be surprised by the results.
</details>