### PR TITLE
CLI flags -uncapped, -nouncapped, -dedicated

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -70,6 +70,7 @@
 #include "dsdhacked.h"
 
 #include "net_client.h"
+#include "net_dedicated.h"
 
 // DEHacked support - Ty 03/09/97
 // killough 10/98:
@@ -1922,6 +1923,22 @@ void D_DoomMain(void)
   }
 
   FindResponseFile();         // Append response file arguments to command-line
+
+  //!
+  // @category net
+  //
+  // Start a dedicated server, routing packets but not participating
+  // in the game itself.
+  //
+
+  if (M_CheckParm("-dedicated") > 0)
+  {
+          printf("Dedicated server mode.\n");
+          I_InitTimer();
+          NET_DedicatedServer();
+
+          // Never returns
+  }
 
   // killough 10/98: set default savename based on executable's name
   sprintf(savegamename = malloc(16), "%.4ssav", D_DoomExeName());

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1196,6 +1196,24 @@ static void I_InitVideoParms(void)
     else if (M_CheckParm("-nohires"))
         hires = false;
 
+    //!
+    // @category video
+    //
+    // Enables uncapped framerate.
+    //
+
+    if (M_CheckParm("-uncapped"))
+        uncapped = true;
+
+    //!
+    // @category video
+    //
+    // Disables uncapped framerate.
+    //
+
+    else if (M_CheckParm("-nouncapped"))
+        uncapped = false;
+
     if (M_CheckParm("-grabmouse"))
         grabmouse = true;
 

--- a/src/params.h
+++ b/src/params.h
@@ -47,6 +47,9 @@ static const char *params[] = {
 "-strict",
 "-cdrom",
 "-nogui",
+"-dedicated",
+"-uncapped",
+"-nouncapped",
 };
 
 static const char *params_with_args[] = {


### PR DESCRIPTION
Adding flags useful for multiplayer:

`-dedicated` for a universal choco/crispy/woof dedicated server.
`-nouncapped` to let Doomseeker easily override the uncapped framerate option in cfg to be able to use newsync.
`-uncapped` added for consistency.

I added comments for doc generation, hopefully the descriptions / categories are fine?