### PR TITLE
fix rightmost column in weapon rendering with interpolation enabled

### DIFF
--- a/src/r_things.c
+++ b/src/r_things.c
@@ -811,10 +811,11 @@ void R_DrawPSprite (pspdef_t *psp)
 
     if (lump == oldlump && pspr_interp)
     {
-      int deltax = vis->x2 - vis->x1;
+      int deltax = x2 - vis->x1;
       vis->x1 = oldx1 + FixedMul(vis->x1 - oldx1, fractionaltic);
       vis->x2 = vis->x1 + deltax;
-      vis->x2 = vis->x2 >= viewwidth ? viewwidth - 1 : vis->x2;
+      if (vis->x2 >= viewwidth)
+        vis->x2 = viewwidth - 1;
       vis->texturemid = oldtexturemid + FixedMul(vis->texturemid - oldtexturemid, fractionaltic);
     }
     else


### PR DESCRIPTION
Fix #1123 