### PR TITLE
check the status of music records in DEH

### DIFF
--- a/src/d_deh.c
+++ b/src/d_deh.c
@@ -2837,21 +2837,15 @@ void deh_procText(DEHFILE *fpin, FILE* fpout, char *line)
           }
         if (!found)  // not yet
           {
-            // Try music name entries - see sounds.c
-            for (i=1; i<NUMMUSIC; i++)
+            i = dsdh_GetDehMusicIndex(inbuffer, fromlen);
+            if (i >= 0)
               {
-                // avoid short prefix erroneous match
-                if (strlen(S_music[i].name) != fromlen) continue;
-                if (!strncasecmp(S_music[i].name,inbuffer,fromlen))
-                  {
-                    if (fpout) fprintf(fpout,
-                                       "Changing name of music from %s to %*s\n",
-                                       S_music[i].name,usedlen,&inbuffer[fromlen]);
+                if (fpout) fprintf(fpout,
+                                        "Changing name of music from %s to %*s\n",
+                                        S_music[i].name,usedlen,&inbuffer[fromlen]);
 
-                    S_music[i].name = strdup(&inbuffer[fromlen]);
-                    found = true;
-                    break;  // only one matches, quit early
-                  }
+                S_music[i].name = strdup(&inbuffer[fromlen]);
+                found = true;
               }
           }  // end !found test
       }

--- a/src/dsdhacked.c
+++ b/src/dsdhacked.c
@@ -325,6 +325,46 @@ int dsdh_GetOriginalSFXIndex(const char* key)
 }
 
 //
+//   Music
+//
+
+musicinfo_t *S_music;
+int num_music;
+static byte *music_state;
+
+static void InitMusic(void)
+{
+  S_music = original_S_music;
+  num_music = NUMMUSIC;
+
+  music_state = calloc(num_music, sizeof(*music_state));
+}
+
+int dsdh_GetDehMusicIndex(const char* key, int length)
+{
+  int i;
+
+  for (i = 1; i < num_music; ++i)
+  {
+    if (S_music[i].name &&
+      strlen(S_music[i].name) == length &&
+      !strncasecmp(S_music[i].name, key, length) &&
+      !music_state[i])
+    {
+      music_state[i] = true; // music has been edited
+      return i;
+    }
+  }
+
+  return -1;
+}
+
+static void FreeMusic(void)
+{
+  free(music_state);
+}
+
+//
 //  Things
 //
 #include "p_map.h" // MELEERANGE
@@ -380,6 +420,7 @@ void dsdh_InitTables(void)
   InitStates();
   InitSprites();
   InitSFX();
+  InitMusic();
   InitMobjInfo();
 }
 
@@ -388,4 +429,5 @@ void dsdh_FreeTables(void)
   FreeStates();
   FreeSprites();
   FreeSFX();
+  FreeMusic();
 }

--- a/src/dsdhacked.h
+++ b/src/dsdhacked.h
@@ -26,6 +26,7 @@ void dsdh_EnsureMobjInfoCapacity(int limit);
 int dsdh_GetDehSpriteIndex(const char* key);
 int dsdh_GetOriginalSpriteIndex(const char* key);
 int dsdh_GetDehSFXIndex(const char* key, size_t length);
+int dsdh_GetDehMusicIndex(const char* key, int length);
 int dsdh_GetOriginalSFXIndex(const char* key);
 
 #endif

--- a/src/sounds.c
+++ b/src/sounds.c
@@ -28,7 +28,7 @@
 // Information about all the music
 //
 
-musicinfo_t S_music[] = {
+musicinfo_t original_S_music[] = {
   { 0 },
   { "e1m1", 0 },
   { "e1m2", 0 },

--- a/src/sounds.h
+++ b/src/sounds.h
@@ -86,7 +86,7 @@ typedef struct {
 extern sfxinfo_t    original_S_sfx[];
 
 // the complete set of music
-extern musicinfo_t  S_music[];
+extern musicinfo_t  original_S_music[];
 
 //
 // Identifiers for all music in game.
@@ -173,6 +173,10 @@ typedef enum {
   NUMMUSIC,
   mus_musinfo
 } musicenum_t;
+
+// DSDHacked
+extern musicinfo_t *S_music;
+extern int num_music;
 
 //
 // Identifiers for all sfx in game.


### PR DESCRIPTION
For example PL2.wad. We don't have support for BEX music blocks and I'm not sure if it's needed (no PWAD with it in the wild?). So maybe we don't need DSDHacked support.

Fix this issue: [[doomworld]](https://www.doomworld.com/forum/topic/112333-this-is-woof-1120-jun-13-2023/?do=findComment&comment=2668630)