### PR TITLE
Implement sky top color algorithm from Eternity

### DIFF
--- a/src/r_sky.c
+++ b/src/r_sky.c
@@ -64,6 +64,23 @@ void R_InitSkyMap (void)
   skytexturemid = 100*FRACUNIT;
 }
 
+typedef struct rgb_s {
+    int r;
+    int g;
+    int b;
+} rgb_t;
+
+static int CompareSkyColors(const void *a, const void *b)
+{
+  const rgb_t *rgb_a = (const rgb_t *) a;
+  const rgb_t *rgb_b = (const rgb_t *) b;
+
+  int sum_a = rgb_a->r + rgb_a->g + rgb_a->b;
+  int sum_b = rgb_b->r + rgb_b->g + rgb_b->b;
+
+  return sum_a - sum_b;
+}
+
 static byte R_SkyBlendColor(int tex)
 {
   byte *pal = W_CacheLumpName("PLAYPAL", PU_STATIC);
@@ -71,21 +88,23 @@ static byte R_SkyBlendColor(int tex)
 
   const int width = texturewidth[tex];
 
+  rgb_t *colors = Z_Malloc(sizeof(rgb_t)*width, PU_STATIC, 0);
+
   // [FG] count colors
   for (i = 0; i < width; i++)
   {
     byte *c = R_GetColumn(tex, i);
-    r += pal[3 * c[0] + 0];
-    g += pal[3 * c[0] + 1];
-    b += pal[3 * c[0] + 2];
+    colors[i] = (rgb_t) {pal[3 * c[0] + 0], pal[3 * c[0] + 1], pal[3 * c[0] + 2]};
   }
 
-  r /= width;
-  g /= width;
-  b /= width;
+  qsort(colors, width, sizeof(rgb_t), CompareSkyColors);
 
-  // Get 1/3 for empiric reasons
-  return I_GetPaletteIndex(pal, r/3, g/3, b/3);
+  r = colors[width/3].r;
+  g = colors[width/3].g;
+  b = colors[width/3].b;
+  Z_Free(colors);
+
+  return I_GetPaletteIndex(pal, r, g, b);
 }
 
 typedef struct skycolor_s

--- a/src/r_sky.c
+++ b/src/r_sky.c
@@ -75,8 +75,11 @@ static int CompareSkyColors(const void *a, const void *b)
   const rgb_t *rgb_a = (const rgb_t *) a;
   const rgb_t *rgb_b = (const rgb_t *) b;
 
-  int sum_a = rgb_a->r + rgb_a->g + rgb_a->b;
-  int sum_b = rgb_b->r + rgb_b->g + rgb_b->b;
+  int red_a = rgb_a->r, grn_a = rgb_a->g, blu_a = rgb_a->b;
+  int red_b = rgb_b->r, grn_b = rgb_b->g, blu_b = rgb_b->b;
+
+  int sum_a = red_a*red_a + grn_a*grn_a + blu_a*blu_a;
+  int sum_b = red_b*red_b + grn_b*grn_b + blu_b*blu_b;
 
   return sum_a - sum_b;
 }


### PR DESCRIPTION
When mouselook is enabled and "Stretch short skies" is disabled, the area above the sky is filled with a solid color. The current implementation very often picks a color that is too dark and clashes with the rest of the sky.

Looking at the commits that introduced this feature (#483), it seems that the intention was to copy Eternity Engine's solution, but what was actually implemented is entirely different. EE sorts the sky top row's colors, and then gets the color that's 1/3 through the sorted array (see code [here](https://github.com/team-eternity/eternity/blob/bad26209b4ccef5d74e8ad6da32fdda96a8acbdd/source/r_sky.cpp#L117)); whereas Woof calculates the average color and divides the RGB components by 3.

This change implements EE's solution, which (IMO) looks better in a lot of cases, without looking substantially worse in others. Below are some screenshots for comparison.
On the left, the current implementation.
On the middle, the new one.
On the right, the result of just taking the average color (without dividing by 3), in case you're wondering what that looks like **(not included in this pull request)**.

Ultimate Doom Episode 1
![diff0000](https://github.com/fabiangreffrath/woof/assets/77364520/b8166ac1-b6f6-49cc-b708-6062ff9b0b8d)

Ultimate Doom Episode 2
![diff0001](https://github.com/fabiangreffrath/woof/assets/77364520/7d9ed2b3-bef8-4d47-9873-a99b85a80a1c)

Ultimate Doom Episode 4
![diff0003](https://github.com/fabiangreffrath/woof/assets/77364520/5e92dd43-bcbe-43e5-9146-1894e1730422)

Doom 2 "Episode" 1
![diff0004](https://github.com/fabiangreffrath/woof/assets/77364520/b5115f6a-1d1d-4cba-b969-c9f218cb545a)

Doom 2 "Episode" 2
![diff0005](https://github.com/fabiangreffrath/woof/assets/77364520/7a406ea1-022f-4072-891b-e46fef28966e)

TNT "Episode" 3
![diff0011](https://github.com/fabiangreffrath/woof/assets/77364520/e216a11a-de3c-4913-895a-10e06aae4572)

Plutonia "Episode" 1
![diff0008](https://github.com/fabiangreffrath/woof/assets/77364520/a94e5d6b-90ef-4655-91fa-6f347adc808a)

Eviternity Chapter 3
![diff0007](https://github.com/fabiangreffrath/woof/assets/77364520/f90381b0-11b2-4cc5-9777-6218715a1000)
