### PR TITLE
move sfx caching to i_oalsound.c from i_sound.c

### DIFF
--- a/src/i_3dsound.c
+++ b/src/i_3dsound.c
@@ -296,7 +296,7 @@ static void I_3D_UpdateListenerParams(const mobj_t *listener)
     I_OAL_UpdateListenerParams(lis.position, lis.velocity, lis.orientation);
 }
 
-static boolean I_3D_StartSound(int channel, ALuint buffer, int pitch)
+static boolean I_3D_StartSound(int channel, sfxinfo_t *sfx, int pitch)
 {
     if (src.use_3d)
     {
@@ -307,7 +307,7 @@ static boolean I_3D_StartSound(int channel, ALuint buffer, int pitch)
         I_OAL_ResetSource2D(channel);
     }
 
-    return I_OAL_StartSound(channel, buffer, pitch);
+    return I_OAL_StartSound(channel, sfx, pitch);
 }
 
 const sound_module_t sound_3d_module =

--- a/src/i_oalsound.c
+++ b/src/i_oalsound.c
@@ -538,7 +538,7 @@ boolean I_OAL_CacheSound(sfxinfo_t *sfx)
 
     if (lumpnum < 0)
     {
-      return false;
+        return false;
     }
 
     lumplen = W_LumpLength(lumpnum);
@@ -571,7 +571,7 @@ boolean I_OAL_CacheSound(sfxinfo_t *sfx)
             // only contain padding, or are shorter than the padding size.
             if (size > lumplen - SOUNDHDRSIZE || size <= SOUNDPADSIZE * 2)
             {
-              break;
+                break;
             }
 
             sampledata = lumpdata + SOUNDHDRSIZE;

--- a/src/i_oalsound.c
+++ b/src/i_oalsound.c
@@ -33,6 +33,9 @@
 #define OAL_DEFAULT_PITCH 1.0f
 #define OAL_NUM_ATTRIBS 5
 
+#define DMXHDRSIZE 8
+#define DMXPADSIZE 16
+
 #define VOL_TO_GAIN(x) ((ALfloat)(x) / 127)
 
 // C doesn't allow casting between function and non-function pointer types, so
@@ -491,9 +494,6 @@ boolean I_OAL_AllowReinitSound(void)
     return (alcIsExtensionPresent(oal->device, "ALC_SOFT_HRTF") == ALC_TRUE);
 }
 
-#define SOUNDHDRSIZE 8
-#define SOUNDPADSIZE 16
-
 //
 // IsPaddedSound
 //
@@ -503,13 +503,13 @@ boolean I_OAL_AllowReinitSound(void)
 //
 static boolean IsPaddedSound(const byte *data, int size)
 {
-    const int sound_end = size - SOUNDPADSIZE;
+    const int sound_end = size - DMXPADSIZE;
     int i;
 
-    for (i = 0; i < SOUNDPADSIZE; i++)
+    for (i = 0; i < DMXPADSIZE; i++)
     {
         // Check padding before sound.
-        if (data[i] != data[SOUNDPADSIZE])
+        if (data[i] != data[DMXPADSIZE])
         {
             return false;
         }
@@ -566,18 +566,18 @@ boolean I_OAL_CacheSound(sfxinfo_t *sfx)
 
             // Don't play sounds that think they're longer than they really are,
             // only contain padding, or are shorter than the padding size.
-            if (size > lumplen - SOUNDHDRSIZE || size <= SOUNDPADSIZE * 2)
+            if (size > lumplen - DMXHDRSIZE || size <= DMXPADSIZE * 2)
             {
                 break;
             }
 
-            sampledata = lumpdata + SOUNDHDRSIZE;
+            sampledata = lumpdata + DMXHDRSIZE;
 
             if (IsPaddedSound(sampledata, size))
             {
                 // Ignore DMX padding.
-                sampledata += SOUNDPADSIZE;
-                size -= SOUNDPADSIZE * 2;
+                sampledata += DMXPADSIZE;
+                size -= DMXPADSIZE * 2;
             }
 
             // All Doom sounds are 8-bit

--- a/src/i_oalsound.c
+++ b/src/i_oalsound.c
@@ -526,7 +526,7 @@ static boolean IsPaddedSound(const byte *data, int size)
 
 boolean I_OAL_CacheSound(sfxinfo_t *sfx)
 {
-    int lumpnum, lumplen;
+    int lumpnum;
     byte *lumpdata = NULL, *wavdata = NULL;
 
     if (!oal)
@@ -541,17 +541,12 @@ boolean I_OAL_CacheSound(sfxinfo_t *sfx)
         return false;
     }
 
-    lumplen = W_LumpLength(lumpnum);
-
-    if (lumplen <= SOUNDHDRSIZE)
-    {
-        return false;
-    }
-
     // haleyjd 06/03/06: rewrote again to make sound data properly freeable
     while (sfx->cached == false)
     {
         byte *sampledata;
+        int lumplen;
+
         ALsizei size, freq;
         ALenum format;
         ALuint buffer;
@@ -559,6 +554,8 @@ boolean I_OAL_CacheSound(sfxinfo_t *sfx)
         // haleyjd: this should always be called (if lump is already loaded,
         // W_CacheLumpNum handles that for us).
         lumpdata = (byte *)W_CacheLumpNum(lumpnum, PU_STATIC);
+
+        lumplen = W_LumpLength(lumpnum);
 
         // Check the header, and ensure this is a valid sound
         if (lumpdata[0] == 0x03 && lumpdata[1] == 0x00)

--- a/src/i_oalsound.h
+++ b/src/i_oalsound.h
@@ -50,10 +50,9 @@ boolean I_OAL_ReinitSound(void);
 
 boolean I_OAL_AllowReinitSound(void);
 
-boolean I_OAL_CacheSound(ALuint *buffer, ALenum format, const byte *data,
-                         ALsizei size, ALsizei freq);
+boolean I_OAL_CacheSound(sfxinfo_t *sfx);
 
-boolean I_OAL_StartSound(int channel, ALuint buffer, int pitch);
+boolean I_OAL_StartSound(int channel, sfxinfo_t *sfx, int pitch);
 
 void I_OAL_StopSound(int channel);
 

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -414,7 +414,6 @@ void I_InitSound(void)
 
         sound_module->CacheSound(&S_sfx[i]);
       }
-      StopChannel(0);
       printf("done.\n");
 
       // [FG] add links for likely missing sounds

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -83,13 +83,12 @@ typedef struct sound_module_s
     boolean (*ReinitSound)(void);
     boolean (*AllowReinitSound)(void);
     void (*UpdateUserSoundSettings)(void);
-    boolean (*CacheSound)(ALuint *buffer, ALenum format, const byte *data,
-                          ALsizei size, ALsizei freq);
+    boolean (*CacheSound)(sfxinfo_t *sfx);
     boolean (*AdjustSoundParams)(const mobj_t *listener, const mobj_t *source,
                                  int chanvol, int *vol, int *sep, int *pri);
     void (*UpdateSoundParams)(int channel, int vol, int sep);
     void (*UpdateListenerParams)(const mobj_t *listener);
-    boolean (*StartSound)(int channel, ALuint buffer, int pitch);
+    boolean (*StartSound)(int channel, sfxinfo_t *sfx, int pitch);
     void (*StopSound)(int channel);
     boolean (*SoundIsPlaying)(int channel);
     void (*ShutdownSound)(void);


### PR DESCRIPTION
For better "encapsulation" we can move the `buffer` and `cached` fields from `sfxinfo_t` to a new data structure in `i_oalsound.c`, as is done in Chocolate Doom. Not sure if it's worth it.