### PR TITLE
Use vertical sound position with `full_sounds`

### DIFF
--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -49,7 +49,7 @@ typedef struct channel_s
 // the set of channels available
 static channel_t channels[MAX_CHANNELS];
 // [FG] removed map objects may finish their sounds
-static degenmobj_t sobjs[MAX_CHANNELS];
+static mobj_t sobjs[MAX_CHANNELS];
 
 // These are not used, but should be (menu).
 // Maximum volume of a sound effect.
@@ -332,11 +332,12 @@ void S_UnlinkSound(mobj_t *origin)
         {
             if (channels[cnum].sfxinfo && channels[cnum].origin == origin)
             {
-                degenmobj_t *const sobj = &sobjs[cnum];
+                mobj_t *const sobj = &sobjs[cnum];
                 sobj->x = origin->x;
                 sobj->y = origin->y;
                 sobj->z = origin->z;
-                channels[cnum].origin = (mobj_t *) sobj;
+                sobj->info = origin->info;
+                channels[cnum].origin = sobj;
                 break;
             }
         }


### PR DESCRIPTION
Test wad: [verttest.zip](https://github.com/fabiangreffrath/woof/files/12018098/verttest.zip)

1. Settings:
a. Sound Module: OpenAL 3D
b. Headphones Mode: Yes (easier to hear difference)
c. Disable Sound Cutoffs: Yes and No

2. Fire the pistol and listen to the imp.

Before: With "Disable Sound Cutoffs: Yes" vertical sound position is lost.
After: Vertical sound position is preserved either way.

Verified by temporarily adding this to the end of `CalcDistance()`:
```c
printf("src->z = %d player->viewz = %d\n", src->z >> FRACBITS, listener->player->viewz >> FRACBITS);
```

Before:
- "Disable Sound Cutoffs: No" --> `src->z = 412 player->viewz = 41`
- "Disable Sound Cutoffs: Yes" --> `src->z = 41 player->viewz = 41`

After:
- Always `src->z = 412 player->viewz = 41`