### PR TITLE
fix automap marks in non-follow mode

### DIFF
--- a/src/am_map.c
+++ b/src/am_map.c
@@ -380,17 +380,8 @@ static void AM_addMark(void)
                             markpointnum_max*2 : 16) * sizeof(*markpoints),
                            PU_STATIC, 0);
 
-  // [crispy] keep the map static if not following the player
-  if (!followplayer)
-  {
-    markpoints[markpointnum].x = plr->mo->x >> FRACTOMAPBITS;
-    markpoints[markpointnum].y = plr->mo->y >> FRACTOMAPBITS;
-  }
-  else
-  {
   markpoints[markpointnum].x = m_x + m_w/2;
   markpoints[markpointnum].y = m_y + m_h/2;
-  }
   markpointnum++;
 }
 


### PR DESCRIPTION
I don't get it, why do we need `// [crispy] keep the map static if not following the player...` code? It seems to work correctly without it.