### PR TITLE
Fix weapon lowering in `A_CheckReload()`/`P_CheckAmmo()`

### DIFF
--- a/src/p_pspr.c
+++ b/src/p_pspr.c
@@ -361,6 +361,7 @@ boolean P_CheckAmmo(player_t *player)
       player->pendingweapon = P_SwitchWeapon(player);      // phares
       // Now set appropriate weapon overlay.
       P_SetPsprite(player,ps_weapon,weaponinfo[player->readyweapon].downstate);
+      player->switching = weapswitch_lowering;
     }
 
 #if 0 /* PROBABLY UNSAFE */
@@ -538,6 +539,7 @@ void A_CheckReload(player_t *player, pspdef_t *psp)
     // for us later on.
     boom_weapon_state_injection = true;
     P_SetPsprite(player, ps_weapon, weaponinfo[player->readyweapon].downstate);
+    player->switching = weapswitch_lowering;
   }
 }
 


### PR DESCRIPTION
Seems like I missed these code paths. Found thanks to https://github.com/MrAlaux/Nugget-Doom/issues/50.

EDIT: Should we make a helper function for this?