### PR TITLE
disable returning to the episodes menu if only one episode is present

### DIFF
--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -7184,7 +7184,7 @@ void M_Init(void)
       MainMenu[readthis] = MainMenu[quitdoom];
       MainDef.numitems--;
       MainDef.y += 8;
-      if (!EpiCustom)
+      if (!EpiCustom || EpiDef.numitems <= 1)
       {
       NewDef.prevMenu = &MainDef;
       }


### PR DESCRIPTION
Fix this issue: [[doomworld]](https://www.doomworld.com/forum/topic/112333-this-is-woof-1130-july-06-2023/?do=findComment&comment=2676304)