### PR TITLE
[CI] AppImage CPACK

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,6 +103,14 @@ jobs:
           cd build
           cpack
 
+      - name: Upload AppImage
+        uses: actions/upload-artifact@v3
+        with:
+          name: Woof-AppImage
+          path: |
+            build/*.appimage
+        if: runner.os == 'Linux'
+
   cppcheck:
     name: Cppcheck
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,10 +123,55 @@ endif()
 # Generate distribution packages with CPack.
 if(WIN32)
     set(CPACK_GENERATOR ZIP)
+elseif(LINUX)
+    set(CPACK_GENERATOR External)
+	set(CPACK_EXTERNAL_ENABLE_STAGING YES)
+	set(CPACK_EXTERNAL_PACKAGE_SCRIPT "${PROJECT_BINARY_DIR}/appimage-generate.cmake")
+
+	file(GENERATE
+	OUTPUT "${PROJECT_BINARY_DIR}/appimage-generate.cmake"
+	CONTENT [[
+	include(CMakePrintHelpers)
+	cmake_print_variables(CPACK_TEMPORARY_DIRECTORY)
+	cmake_print_variables(CPACK_TOPLEVEL_DIRECTORY)
+	cmake_print_variables(CPACK_PACKAGE_DIRECTORY)
+	cmake_print_variables(CPACK_PACKAGE_FILE_NAME)
+
+	find_program(LINUXDEPLOY_EXECUTABLE
+	NAMES linuxdeploy linuxdeploy-x86_64.AppImage
+	PATHS ${CPACK_PACKAGE_DIRECTORY}/linuxdeploy)
+
+	if (NOT LINUXDEPLOY_EXECUTABLE)
+	message(STATUS "Downloading linuxdeploy")
+	set(LINUXDEPLOY_EXECUTABLE ${CPACK_PACKAGE_DIRECTORY}/linuxdeploy/linuxdeploy)
+	file(DOWNLOAD 
+	https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+	${LINUXDEPLOY_EXECUTABLE}
+	INACTIVITY_TIMEOUT 10
+	LOG ${CPACK_PACKAGE_DIRECTORY}/linuxdeploy/download.log
+	STATUS LINUXDEPLOY_DOWNLOAD)
+	execute_process(COMMAND chmod +x ${LINUXDEPLOY_EXECUTABLE} COMMAND_ECHO STDOUT)
+	endif()
+
+	execute_process(
+	COMMAND
+	${CMAKE_COMMAND} -E env
+	OUTPUT=${CPACK_PACKAGE_FILE_NAME}.appimage
+	VERSION=$<IF:$<BOOL:${CPACK_PACKAGE_VERSION}>,${CPACK_PACKAGE_VERSION},0.1.0>
+	${LINUXDEPLOY_EXECUTABLE}
+	--appimage-extract-and-run
+	--appdir=${CPACK_TEMPORARY_DIRECTORY}
+	--executable=$<TARGET_FILE:woof>
+	--desktop-file=${CPACK_TEMPORARY_DIRECTORY}/share/applications/woof.desktop
+	--icon-file=${CPACK_TEMPORARY_DIRECTORY}/share/icons/hicolor/128x128/apps/woof.png
+	--output=appimage
+	# --verbosity=2
+	)
+	]])
 else()
     set(CPACK_GENERATOR TGZ)
 endif()
-set(CPACK_SOURCE_GENERATOR TGZ ZIP)
+set(CPACK_SOURCE_GENERATOR TGZ ZIP EXTERNAL)
 set(CPACK_SOURCE_IGNORE_FILES "/.git/;/build;/.vs/;/out/;CMakeSettings.json")
 set(CPACK_STRIP_FILES TRUE)
 include(CPack)


### PR DESCRIPTION
To execute the AppImage run `chmod +x Woof*.AppImage` or select to make executable from the properties menu.

Fixes https://github.com/fabiangreffrath/woof/issues/1135