### PR TITLE
reset button state when automap is turned on

### DIFF
--- a/src/am_map.c
+++ b/src/am_map.c
@@ -840,6 +840,7 @@ boolean AM_Responder
     {
       bigstate = 0;
       viewactive = true;
+      memset(buttons_state, 0, sizeof(buttons_state));
       AM_Stop ();
     }
     else if (M_InputActivated(input_map_gobig))


### PR DESCRIPTION
Fix the bug report from Discord:
> It seems closing the automap while holding zoom in/out will get the map stuck in that state until the zoom button is pressed again