### PR TITLE
overflow into the next gamemissions's map name array for MAP33-MAP35

### DIFF
--- a/src/hu_stuff.c
+++ b/src/hu_stuff.c
@@ -692,6 +692,14 @@ static void HU_widget_build_title (void)
           (gamemission == pack_plut) ? HU_TITLEP :
           HU_TITLE2;
     }
+    // WADs like pl2.wad have a MAP33, and rely on the layout in the
+    // Vanilla executable, where it is possible to overflow the end of one
+    // array into the next.
+    else if (gamemode == commercial && gamemap >= 33 && gamemap <= 35)
+    {
+      s = (gamemission == doom2) ? (*mapnamesp[gamemap-33]) :
+          (gamemission == pack_plut) ? (*mapnamest[gamemap-33]) : "";
+    }
     else
     {
       // initialize the map title widget with the generic map lump name


### PR DESCRIPTION
Relevant code/comments in Chocolate Doom:
https://github.com/chocolate-doom/chocolate-doom/blob/203f5da3f9bfd38b5db7d9e2b501748ac550b602/src/doom/hu_stuff.c#L210-L214
https://github.com/chocolate-doom/chocolate-doom/blob/203f5da3f9bfd38b5db7d9e2b501748ac550b602/src/doom/hu_stuff.c#L329-L330