### PR TITLE
calculate actualheight based on the current sprite's height

### DIFF
--- a/src/i_3dsound.c
+++ b/src/i_3dsound.c
@@ -173,13 +173,13 @@ static void CalcDistance(const mobj_t *listener, const mobj_t *source,
 
     // Treat monsters and projectiles as point sources.
     src->point_source = (source->thinker.function.v != (actionf_v)P_DegenMobjThinker &&
-                        source->info && source->info->actualheight);
+                        source->info && source->actualheight);
 
     if (src->point_source)
     {
         fixed_t adz;
         // Vertical distance is from player's view to middle of source's sprite.
-        src->z = source->z + (source->info->actualheight >> 1);
+        src->z = source->z + (source->actualheight >> 1);
         adz = abs((listener->player->viewz >> FRACBITS) - (src->z >> FRACBITS));
         CalcHypotenuse(distxy, adz, dist);
     }

--- a/src/info.h
+++ b/src/info.h
@@ -1524,8 +1524,6 @@ typedef struct
     int bloodcolor;   // [FG] colored blood and gibs
     // DEHEXTRA
     mobjtype_t droppeditem; // mobj to drop after death
-    // [crispy] height of the spawnstate's first sprite in pixels
-    int	actualheight;
 } mobjinfo_t;
 
 #define NO_ALTSPEED -1

--- a/src/p_map.c
+++ b/src/p_map.c
@@ -567,7 +567,7 @@ static boolean PIT_CheckThing(mobj_t *thing) // killough 3/26/98: make static
     {
       // [crispy] mobj or actual sprite height
       const fixed_t thingheight = (direct_vertical_aiming && tmthing->target && tmthing->target->player) ?
-        thing->info->actualheight : thing->height;
+        thing->actualheight : thing->height;
 
       // see if it went over / under
 
@@ -1618,7 +1618,7 @@ static boolean PTR_ShootTraverse(intercept_t *in)
   {
   // [crispy] mobj or actual sprite height
   const fixed_t thingheight = (direct_vertical_aiming && shootthing->player) ?
-    th->info->actualheight : th->height;
+    th->actualheight : th->height;
   thingtopslope = FixedDiv (th->z+thingheight - shootz , dist);
   }
 

--- a/src/p_map.c
+++ b/src/p_map.c
@@ -565,13 +565,9 @@ static boolean PIT_CheckThing(mobj_t *thing) // killough 3/26/98: make static
   if (tmthing->flags & MF_MISSILE || (tmthing->flags & MF_BOUNCES &&
 				      !(tmthing->flags & MF_SOLID)))
     {
-      // [crispy] mobj or actual sprite height
-      const fixed_t thingheight = (direct_vertical_aiming && tmthing->target && tmthing->target->player) ?
-        thing->actualheight : thing->height;
-
       // see if it went over / under
 
-      if (tmthing->z > thing->z + thingheight)
+      if (tmthing->z > thing->z + thing->actualheight)
 	return true;    // overhead
 
       if (tmthing->z+tmthing->height < thing->z)
@@ -1487,7 +1483,7 @@ static boolean PTR_AimTraverse (intercept_t *in)
   // check angles to see if the thing can be aimed at
 
   dist = FixedMul(attackrange, in->frac);
-  thingtopslope = FixedDiv(th->z+th->height - shootz , dist);
+  thingtopslope = FixedDiv(th->z+th->actualheight - shootz , dist);
 
   if (thingtopslope < bottomslope)
     return true;    // shot over the thing
@@ -1615,12 +1611,7 @@ static boolean PTR_ShootTraverse(intercept_t *in)
   // check angles to see if the thing can be aimed at
 
   dist = FixedMul (attackrange, in->frac);
-  {
-  // [crispy] mobj or actual sprite height
-  const fixed_t thingheight = (direct_vertical_aiming && shootthing->player) ?
-    th->actualheight : th->height;
-  thingtopslope = FixedDiv (th->z+thingheight - shootz , dist);
-  }
+  thingtopslope = FixedDiv (th->z+th->actualheight - shootz , dist);
 
   if (thingtopslope < aimslope)
     return true;  // shot over the thing

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -883,28 +883,8 @@ mobj_t *P_SpawnMobj(fixed_t x, fixed_t y, fixed_t z, mobjtype_t type)
       mobj->intflags &= ~MIF_FLIP;
   }
 
-  // [crispy] height of the spawnstate's first sprite in pixels
-  if (!info->actualheight)
-  {
-    const spritedef_t *const sprdef = &sprites[mobj->sprite];
-
-    if (!sprdef->numframes || !(mobj->flags & (MF_SOLID|MF_SHOOTABLE)))
-    {
-      info->actualheight = info->height;
-    }
-    else
-    {
-      spriteframe_t *sprframe;
-      int lump;
-      patch_t *patch;
-
-      sprframe = &sprdef->spriteframes[mobj->frame & FF_FRAMEMASK];
-      lump = sprframe->lump[0];
-      patch = W_CacheLumpNum(lump + firstspritelump, PU_CACHE);
-
-      info->actualheight = SHORT(patch->height) << FRACBITS;
-    }
-  }
+  // [FG] initialize object's actual height
+  mobj->actualheight = mobj->height;
 
   P_AddThinker(&mobj->thinker);
 

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -893,7 +893,14 @@ mobj_t *P_SpawnMobj(fixed_t x, fixed_t y, fixed_t z, mobjtype_t type)
   }
 
   // [FG] initialize object's actual height
-  mobj->actualheight = mobj->height;
+  if (direct_vertical_aiming)
+  {
+    mobj->actualheight = spriteheight[sprites[st->sprite].spriteframes[st->frame & FF_FRAMEMASK].lump[0]];
+  }
+  else
+  {
+    mobj->actualheight = mobj->height;
+  }
 
   P_AddThinker(&mobj->thinker);
 

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -108,6 +108,15 @@ boolean P_SetMobjState(mobj_t* mobj,statenum_t state)
   if (tempstate)
     Z_Free(tempstate);
 
+  if (ret && direct_vertical_aiming)
+  {
+    mobj->actualheight = spriteheight[sprites[mobj->sprite].spriteframes[mobj->frame & FF_FRAMEMASK].lump[0]];
+  }
+  else
+  {
+    mobj->actualheight = mobj->height;
+  }
+
   return ret;
 }
 

--- a/src/p_mobj.h
+++ b/src/p_mobj.h
@@ -379,6 +379,9 @@ typedef struct mobj_s
 
     // [FG] colored blood and gibs
     int bloodcolor;
+
+    // [FG] height of the sprite in pixels
+    int actualheight;
 } mobj_t;
 
 // External declarations (fomerly in p_local.h) -- killough 5/2/98

--- a/src/p_saveg.c
+++ b/src/p_saveg.c
@@ -497,6 +497,15 @@ static void saveg_read_mobj_t(mobj_t *str)
     {
       str->bloodcolor = 0;
     }
+
+    if (direct_vertical_aiming)
+    {
+        str->actualheight = spriteheight[sprites[str->sprite].spriteframes[str->frame & FF_FRAMEMASK].lump[0]];
+    }
+    else
+    {
+        str->actualheight = str->height;
+    }
 }
 
 static void saveg_write_mobj_t(mobj_t *str)

--- a/src/r_data.c
+++ b/src/r_data.c
@@ -120,7 +120,7 @@ const byte **texturebrightmap; // [crispy] brightmaps
 
 
 // needed for pre-rendering
-fixed_t   *spritewidth, *spriteoffset, *spritetopoffset;
+fixed_t   *spritewidth, *spriteheight, *spriteoffset, *spritetopoffset;
 
 //
 // MAPTEXTURE_T CACHING
@@ -790,6 +790,7 @@ void R_InitSpriteLumps(void)
   // clean up malloc-ing to use sizeof
 
   spritewidth = Z_Malloc(numspritelumps*sizeof*spritewidth, PU_STATIC, 0);
+  spriteheight = Z_Malloc(numspritelumps*sizeof*spritewidth, PU_STATIC, 0);
   spriteoffset = Z_Malloc(numspritelumps*sizeof*spriteoffset, PU_STATIC, 0);
   spritetopoffset =
     Z_Malloc(numspritelumps*sizeof*spritetopoffset, PU_STATIC, 0);
@@ -801,6 +802,7 @@ void R_InitSpriteLumps(void)
 
       patch = W_CacheLumpNum(firstspritelump+i, PU_CACHE);
       spritewidth[i] = SHORT(patch->width)<<FRACBITS;
+      spriteheight[i] = SHORT(patch->height)<<FRACBITS;
       spriteoffset[i] = SHORT(patch->leftoffset)<<FRACBITS;
       spritetopoffset[i] = SHORT(patch->topoffset)<<FRACBITS;
     }

--- a/src/r_state.h
+++ b/src/r_state.h
@@ -35,6 +35,7 @@ extern fixed_t *texturewidth;
 
 // needed for pre rendering (fracs)
 extern fixed_t *spritewidth;
+extern fixed_t *spriteheight;
 
 extern fixed_t *spriteoffset;
 extern fixed_t *spritetopoffset;

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -625,7 +625,7 @@ void R_ProjectSprite (mobj_t* thing)
     vis->startfrac += vis->xiscale*(vis->x1-x1);
   vis->patch = lump;
 
-  thing->actualheight = spriteheight[lump];
+  thing->actualheight = direct_vertical_aiming ? spriteheight[lump] : thing->height;
 
   // get light level
   if (thing->flags & MF_SHADOW)

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -625,8 +625,6 @@ void R_ProjectSprite (mobj_t* thing)
     vis->startfrac += vis->xiscale*(vis->x1-x1);
   vis->patch = lump;
 
-  thing->actualheight = direct_vertical_aiming ? spriteheight[lump] : thing->height;
-
   // get light level
   if (thing->flags & MF_SHADOW)
     vis->colormap[0] = vis->colormap[1] = NULL;               // shadow draw

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -625,6 +625,8 @@ void R_ProjectSprite (mobj_t* thing)
     vis->startfrac += vis->xiscale*(vis->x1-x1);
   vis->patch = lump;
 
+  thing->actualheight = spriteheight[lump];
+
   // get light level
   if (thing->flags & MF_SHADOW)
     vis->colormap[0] = vis->colormap[1] = NULL;               // shadow draw


### PR DESCRIPTION
@MrAlaux This should fix the issue with Dimension of the Boom's "Spawn" enemy.