### PR TITLE
Fix cheat key typos

### DIFF
--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -1651,7 +1651,7 @@ default_t defaults[] = {
     NULL, NULL,
     {0}, {UL,UL}, input, ss_keys, wad_no,
     "key to give ammo",
-    input_idkfa, { {0, 0} }
+    input_idfa, { {0, 0} }
   },
 
   {
@@ -1667,7 +1667,7 @@ default_t defaults[] = {
     NULL, NULL,
     {0}, {UL,UL}, input, ss_keys, wad_no,
     "key to give health",
-    input_idbeholdv, { {0, 0} }
+    input_idbeholdh, { {0, 0} }
   },
 
   {


### PR DESCRIPTION
Apart from the typo mentioned in Discord, I found a second one which I also fixed.

For what it's worth, the consequences of these typos were that: if you set a bind to either of those inputs in-game, the bind would be cleared upon exiting; and if you set a bind to either of them by editing the .cfg manually, the bind would be copied to the erroneously-specified input.