### PR TITLE
remove escape strings in wad filenames in the setup tool

### DIFF
--- a/setup/multiplayer.c
+++ b/setup/multiplayer.c
@@ -139,7 +139,7 @@ static void AddWADs(execute_context_t *exec)
                 have_wads = 1;
             }
 
-            AddCmdLineParameter(exec, "\"%s\"", wads[i]);
+            AddCmdLineParameter(exec, "%s", wads[i]);
         }
     }
 }


### PR DESCRIPTION
It seems that `_wopen()` does not open escaped filenames in Windows.

Fixes a bug reported in Discord. Curious how `open()` works on other OS.