### PR TITLE
fix CMake ASan test in MSYS2 Clang and WSL

### DIFF
--- a/cmake/WoofSettings.cmake
+++ b/cmake/WoofSettings.cmake
@@ -87,7 +87,15 @@ endif()
 
 option(ENABLE_ASAN "Enable ASan" OFF)
 if(ENABLE_ASAN)
-    _checked_add_compile_option(-fsanitize=address)
+    if(MSVC)
+        _checked_add_compile_option(-fsanitize=address)
+    else()
+        # Set -Werror to catch "argument unused during compilation" warnings.
+        # Also needs to be a link flag for test to pass.
+        set(CMAKE_REQUIRED_FLAGS "-Werror -fsanitize=address")
+        _checked_add_compile_option(-fsanitize=address)
+        unset(CMAKE_REQUIRED_FLAGS)
+    endif()
     _checked_add_compile_option(-fno-omit-frame-pointer)
     _checked_add_link_option(-fsanitize=address)
 endif()


### PR DESCRIPTION
@MrAlaux I have ASan running in MSYS2 CLANG64 environment and in WSL with this change.
```
cd woof
cmake -B build_asan -DENABLE_ASAN=ON
cmake --build build_asan
```