### PR TITLE
Update player slope immediately after lookdir

### DIFF
--- a/src/p_user.c
+++ b/src/p_user.c
@@ -388,6 +388,8 @@ void P_PlayerThink (player_t* player)
       player->lookdir = 0;
       player->centering = false;
     }
+
+    player->slope = PLAYER_SLOPE(player);
   }
 
   // [crispy] weapon recoil pitch
@@ -405,7 +407,6 @@ void P_PlayerThink (player_t* player)
 
   if (player->playerstate == PST_DEAD)
     {
-      player->slope = PLAYER_SLOPE(player); // For 3D audio pitch angle.
       P_DeathThink (player);
       return;
     }


### PR DESCRIPTION
Fixes https://github.com/fabiangreffrath/woof/issues/1234

To avoid bugs like this, I should have updated `player->slope` immediately after every `player->lookdir` change. @MrAlaux That means for Nugget, do this immediately after "dead freelook" updates `player->lookdir`.