### PR TITLE
implement organize save files QOL option

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -150,6 +150,8 @@ char    *basedefault = NULL;   // default file
 char    *basesavegame = NULL;  // killough 2/16/98: savegame directory
 char    *screenshotdir = NULL; // [FG] screenshot directory
 
+boolean organize_savefiles;
+
 // If true, the main game loop has started.
 boolean main_loop_started = false;
 
@@ -2201,36 +2203,6 @@ void D_DoomMain(void)
             D_AddFile(myargv[p]);
     }
 
-  if (!M_CheckParm("-save"))
-  {
-    int i;
-    char *wadname = wadfiles[0], *oldsavegame = basesavegame;
-
-    for (i = mainwadfile; i < numwadfiles; i++)
-    {
-      if (FileContainsMaps(wadfiles[i]))
-      {
-        wadname = wadfiles[i];
-        break;
-      }
-    }
-
-    basesavegame = M_StringJoin(oldsavegame, DIR_SEPARATOR_S,
-                                "savegames", NULL);
-    free(oldsavegame);
-
-    NormalizeSlashes(basesavegame);
-    M_MakeDirectory(basesavegame);
-
-    oldsavegame = basesavegame;
-    basesavegame = M_StringJoin(oldsavegame, DIR_SEPARATOR_S,
-                                M_BaseName(wadname), NULL);
-    free(oldsavegame);
-
-    NormalizeSlashes(basesavegame);
-    M_MakeDirectory(basesavegame);
-  }
-
   // add wad files from autoload PWAD directories
 
   D_AutoloadPWadDir();
@@ -2467,6 +2439,38 @@ void D_DoomMain(void)
   M_LoadDefaults();  // load before initing other systems
 
   PrintVersion();
+
+  if (!M_CheckParm("-save") && organize_savefiles)
+  {
+    int i;
+    char *wadname = wadfiles[0], *oldsavegame = basesavegame;
+
+    for (i = mainwadfile; i < numwadfiles; i++)
+    {
+      if (FileContainsMaps(wadfiles[i]))
+      {
+        wadname = wadfiles[i];
+        break;
+      }
+    }
+
+    basesavegame = M_StringJoin(oldsavegame, DIR_SEPARATOR_S,
+                                "savegames", NULL);
+    free(oldsavegame);
+
+    NormalizeSlashes(basesavegame);
+    M_MakeDirectory(basesavegame);
+
+    oldsavegame = basesavegame;
+    basesavegame = M_StringJoin(oldsavegame, DIR_SEPARATOR_S,
+                                M_BaseName(wadname), NULL);
+    free(oldsavegame);
+
+    NormalizeSlashes(basesavegame);
+    M_MakeDirectory(basesavegame);
+
+    I_Printf(VB_INFO, "Savegame directory: %s\n", basesavegame);
+  }
 
   bodyquesize = default_bodyquesize; // killough 10/98
 

--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -358,6 +358,7 @@ extern wbstartstruct_t wminfo;
 
 // File handling stuff.
 extern  char   *basedefault;
+extern  boolean organize_savefiles;
 
 // if true, load all graphics at level load
 extern  boolean precache;

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -4186,6 +4186,7 @@ enum {
   gen4_demobar,
   gen4_palette_changes,
   gen4_level_brightness,
+  gen4_organize_savefiles,
   gen4_end1,
 
   gen4_title2,
@@ -4379,6 +4380,9 @@ setup_menu_t gen_settings4[] = { // General Settings screen4
 
   {"Level Brightness", S_THERMO|S_STRICT, m_null, M_X_THRM,
    M_Y + gen4_level_brightness*M_SPC, {"extra_level_brightness"}},
+
+  {"Organize save files", S_YESNO|S_PRGWARN, m_null, M_X,
+   M_Y + gen4_organize_savefiles*M_SPC, {"organize_savefiles"}},
 
   {"", S_SKIP, m_null, M_X, M_Y + gen4_end1*M_SPC},
 

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -1117,17 +1117,25 @@ static void SetDefaultSaveName (int slot)
 {
     char *maplump = MAPNAME(gameepisode, gamemap);
     int maplumpnum = W_CheckNumForName(maplump);
-    char *wadname = M_StringDuplicate(W_WadNameForLump(maplumpnum));
-    char *ext = strrchr(wadname, '.');
 
-    if (ext != NULL)
+    if (!organize_savefiles)
     {
-        *ext = '\0';
-    }
+        char *wadname = M_StringDuplicate(W_WadNameForLump(maplumpnum));
+        char *ext = strrchr(wadname, '.');
 
-    M_snprintf(savegamestrings[slot], SAVESTRINGSIZE,
-               "%s (%s)", maplump, wadname);
-    free(wadname);
+        if (ext != NULL)
+        {
+            *ext = '\0';
+        }
+
+        M_snprintf(savegamestrings[slot], SAVESTRINGSIZE,
+                  "%s (%s)", maplump, wadname);
+        free(wadname);
+    }
+    else
+    {
+        M_snprintf(savegamestrings[slot], SAVESTRINGSIZE, "%s", maplump);
+    }
 
     M_ForceUppercase(savegamestrings[slot]);
 }

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -110,6 +110,7 @@ extern boolean screen_melt;
 extern boolean hangsolid;
 extern boolean blockmapfix;
 extern int extra_level_brightness;
+extern int organize_savefiles;
 
 extern char *chat_macros[];  // killough 10/98
 
@@ -597,7 +598,7 @@ default_t defaults[] = {
     "number of dead bodies in view supported (negative value = no limit)"
   },
 
-  { // killough 2/8/98
+  {
     "death_use_action",
     (config_t *) &death_use_action, NULL,
     {0}, {0,2}, number, ss_gen, wad_no,
@@ -611,18 +612,25 @@ default_t defaults[] = {
     "1 to enable demo progress bar"
   },
 
-  { // killough 2/8/98
+  {
     "palette_changes",
     (config_t *) &palette_changes, NULL,
     {1}, {0,1}, number, ss_gen, wad_no,
     "0 to disable palette changes"
   },
 
-  { // killough 2/8/98
+  {
     "screen_melt",
     (config_t *) &screen_melt, NULL,
     {1}, {0,1}, number, ss_gen, wad_no,
     "0 to disable screen melt"
+  },
+
+  {
+    "organize_savefiles",
+    (config_t *) &organize_savefiles, NULL,
+    {0}, {0,1}, number, ss_gen, wad_no,
+    "1 to organize save files"
   },
 
   {

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -110,7 +110,6 @@ extern boolean screen_melt;
 extern boolean hangsolid;
 extern boolean blockmapfix;
 extern int extra_level_brightness;
-extern int organize_savefiles;
 
 extern char *chat_macros[];  // killough 10/98
 


### PR DESCRIPTION
If we move save files automatically, it may cause confusion "All saves disappear!"
This solution is conservative, but I think we should not mess with save files, particularly if they are backward compatible.