### PR TITLE
Fast mouse polling

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -182,6 +182,13 @@ int eventhead, eventtail;
 //
 void D_PostEvent(event_t *ev)
 {
+  if (ev->type == ev_mouse && localview.active)
+  {
+    M_InputTrackEvent(ev);
+    G_Responder(ev);
+    return;
+  }
+
   events[eventhead++] = *ev;
   eventhead &= MAXEVENTS-1;
 }

--- a/src/i_input.c
+++ b/src/i_input.c
@@ -394,43 +394,27 @@ static int AccelerateMouse(int val)
     }
 }
 
-// [crispy] Distribute the mouse movement between the current tic and the next
-// based on how far we are into the current tic. Compensates for mouse sampling
-// jitter.
-
-static void SmoothMouse(int* x, int* y)
-{
-    static int x_remainder_old = 0;
-    static int y_remainder_old = 0;
-    int x_remainder, y_remainder;
-    fixed_t correction_factor;
-    fixed_t fractic;
-
-    *x += x_remainder_old;
-    *y += y_remainder_old;
-
-    fractic = I_GetFracTime();
-    correction_factor = FixedDiv(fractic, FRACUNIT + fractic);
-
-    x_remainder = FixedMul(*x, correction_factor);
-    *x -= x_remainder;
-    x_remainder_old = x_remainder;
-
-    y_remainder = FixedMul(*y, correction_factor);
-    *y -= y_remainder;
-    y_remainder_old = y_remainder;
-}
+#define MAX_EVENTS_PER_TIC 8192
 
 void I_ReadMouse(void)
 {
-    int x, y;
+    int x = 0;
+    int y = 0;
     static event_t ev;
+    int num_events;
+    SDL_Event events[MAX_EVENTS_PER_TIC];
 
-    SDL_GetRelativeMouseState(&x, &y);
-
-    if (uncapped)
+    SDL_PumpEvents();
+    while ((num_events = SDL_PeepEvents(events, MAX_EVENTS_PER_TIC, SDL_GETEVENT,
+                                        SDL_MOUSEMOTION, SDL_MOUSEMOTION)) > 0)
     {
-        SmoothMouse(&x, &y);
+        int i;
+
+        for (i = 0; i < num_events; i++)
+        {
+            x += events[i].motion.xrel;
+            y += events[i].motion.yrel;
+        }
     }
 
     if (x != 0 || y != 0)

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -377,13 +377,12 @@ static void I_GetEvent(void)
 //
 void I_StartTic (void)
 {
-    I_GetEvent();
-
     if (window_focused)
     {
         I_ReadMouse();
     }
 
+    I_GetEvent();
     I_UpdateJoystick();
 }
 
@@ -392,7 +391,10 @@ void I_StartTic (void)
 //
 void I_StartFrame(void)
 {
-
+    if (window_focused && localview.active)
+    {
+        I_ReadMouse();
+    }
 }
 
 static inline void I_UpdateRender (void)
@@ -1326,6 +1328,8 @@ static void I_InitGraphicsMode(void)
     {
         flags |= SDL_WINDOW_BORDERLESS;
     }
+
+    SDL_SetHint(SDL_HINT_MOUSE_RELATIVE_SCALING, "0");
 
     I_GetWindowPosition(&window_x, &window_y, w, h);
 

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -47,6 +47,7 @@ fixed_t  centerxfrac, centeryfrac;
 fixed_t  projection;
 fixed_t  viewx, viewy, viewz;
 angle_t  viewangle;
+localview_t localview;
 fixed_t  viewcos, viewsin;
 player_t *viewplayer;
 extern lighttable_t **walllights;
@@ -642,10 +643,19 @@ void R_SetupFrame (player_t *player)
     viewx = player->mo->oldx + FixedMul(player->mo->x - player->mo->oldx, fractionaltic);
     viewy = player->mo->oldy + FixedMul(player->mo->y - player->mo->oldy, fractionaltic);
     viewz = player->oldviewz + FixedMul(player->viewz - player->oldviewz, fractionaltic);
-    viewangle = R_InterpolateAngle(player->mo->oldangle, player->mo->angle, fractionaltic) + viewangleoffset;
+
+    if (localview.useangle && localview.active)
+      viewangle = player->mo->angle - localview.angle + viewangleoffset;
+    else
+      viewangle = R_InterpolateAngle(player->mo->oldangle, player->mo->angle, fractionaltic) + viewangleoffset;
+
+    if (localview.usepitch && localview.active && !player->centering && player->lookdir)
+      pitch = (player->lookdir + localview.pitch) / MLOOKUNIT;
+    else
+      pitch = (player->oldlookdir + (player->lookdir - player->oldlookdir) * FIXED2DOUBLE(fractionaltic)) / MLOOKUNIT;
+
     // [crispy] pitch is actual lookdir and weapon pitch
-    pitch = (player->oldlookdir + (player->lookdir - player->oldlookdir) * FIXED2DOUBLE(fractionaltic)) / MLOOKUNIT
-                + (player->oldrecoilpitch + FixedMul(player->recoilpitch - player->oldrecoilpitch, fractionaltic));
+    pitch += player->oldrecoilpitch + FixedMul(player->recoilpitch - player->oldrecoilpitch, fractionaltic);
   }
   else
   {

--- a/src/r_state.h
+++ b/src/r_state.h
@@ -86,6 +86,14 @@ extern line_t           *lines;
 extern int              numsides;
 extern side_t           *sides;
 
+typedef struct localview_s
+{
+    boolean active;
+    boolean useangle;
+    boolean usepitch;
+    int64_t angle;
+    int pitch;
+} localview_t;
 
 //
 // POV data.
@@ -94,6 +102,7 @@ extern fixed_t          viewx;
 extern fixed_t          viewy;
 extern fixed_t          viewz;
 extern angle_t          viewangle;
+extern localview_t      localview;
 extern player_t         *viewplayer;
 extern angle_t          clipangle;
 extern angle_t          vx_clipangle;


### PR DESCRIPTION
This is loosely based on the implementation in Odamex. Instead of sampling the mouse input once per tic, it's now sampled once per frame. This lowers the input lag considerably at high framerates, especially with a high refresh rate monitor. For example, at 140 fps the input delay is ~7 ms (1/140) vs. ~29 ms (1/35) previously. The mouse input is direct with no interpolation unless interrupted by other input combinations (e.g. keyboard or gamepad turning, view centering, etc.).

Please try it out and compare the difference before and after this PR. I'll leave this as a draft for now since it could use some more refactoring. I'll work on this more in a few days.

Current issues:
- Multiplayer
- `-shorttics`
- `AccelerateMouse()` may behave differently due to smaller, more frequent mouse events