### PR TITLE
any resolution

### DIFF
--- a/src/am_map.c
+++ b/src/am_map.c
@@ -18,17 +18,16 @@
 //-----------------------------------------------------------------------------
 
 #include "doomstat.h"
-#include "doomkeys.h"
 #include "st_stuff.h"
 #include "r_main.h"
 #include "r_things.h"
 #include "p_setup.h"
 #include "p_maputl.h"
 #include "w_wad.h"
+#include "i_video.h"
 #include "v_video.h"
 #include "p_spec.h"
 #include "am_map.h"
-#include "dstrings.h"
 #include "d_deh.h"    // Ty 03/27/98 - externalizations
 #include "m_input.h"
 #include "m_menu.h"

--- a/src/d_loop.c
+++ b/src/d_loop.c
@@ -728,7 +728,7 @@ void TryRunTics (void)
 
     // [AM] If we've uncapped the framerate and there are no tics
     //      to run, return early instead of waiting around.
-    #define return_early (uncapped && counts == 0 && leveltime > oldleveltime)
+    #define return_early (uncapped && counts == 0)
 
     // get real tics
     entertic = I_GetTime() / ticdup;

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -247,7 +247,7 @@ void D_Display (void)
 
   // save the current screen if about to wipe
   if ((wipe = gamestate != wipegamestate) && NOTSTRICTMODE(screen_melt))
-    wipe_StartScreen(0, 0, video.unscaledw, video.unscaledh);
+    wipe_StartScreen(0, 0, video.unscaledw, SCREENHEIGHT);
 
   if (gamestate == GS_LEVEL && gametic)
     HU_Erase();
@@ -356,7 +356,7 @@ void D_Display (void)
     }
 
   // wipe update
-  wipe_EndScreen(0, 0, video.unscaledw, video.unscaledh);
+  wipe_EndScreen(0, 0, video.unscaledw, SCREENHEIGHT);
 
   wipestart = I_GetTime () - 1;
 
@@ -370,7 +370,7 @@ void D_Display (void)
         }
       while (!tics);
       wipestart = nowtime;
-      done = wipe_ScreenWipe(wipe_Melt, 0, 0, video.unscaledw, video.unscaledh, tics);
+      done = wipe_ScreenWipe(wipe_Melt, 0, 0, video.unscaledw, SCREENHEIGHT, tics);
       M_Drawer();                   // menu is drawn even on top of wipes
       I_FinishUpdate();             // page flip or blit buffer
     }

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -2646,9 +2646,6 @@ void D_DoomMain(void)
   I_Printf(VB_INFO, "S_Init: Setting up sound.");
   S_Init(snd_SfxVolume /* *8 */, snd_MusicVolume /* *8*/ );
 
-  // [FG] init graphics (video.widedelta) before HUD widgets
-  I_InitGraphics();
-
   I_Printf(VB_INFO, "HU_Init: Setting up heads up display.");
   HU_Init();
   M_SetMenuFontSpacing();
@@ -2806,6 +2803,9 @@ void D_DoomMain(void)
   {
     I_SetFastdemoTimer(true);
   }
+
+  // [FG] init graphics (video.widedelta) before HUD widgets
+  I_InitGraphics();
 
   if (startloadgame >= 0)
   {

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -212,6 +212,7 @@ void D_ProcessEvents (void)
 gamestate_t    wipegamestate = GS_DEMOSCREEN;
 boolean        screen_melt = true;
 extern int     showMessages;
+boolean        enable_drs;
 
 void D_Display (void)
 {
@@ -236,6 +237,8 @@ void D_Display (void)
   if (nodrawers)                    // for comparative timing / profiling
     return;
 
+  enable_drs = true;
+
   redrawsbar = false;
 
   if (setsizeneeded)                // change the view size if needed
@@ -247,7 +250,10 @@ void D_Display (void)
 
   // save the current screen if about to wipe
   if ((wipe = gamestate != wipegamestate) && NOTSTRICTMODE(screen_melt))
-    wipe_StartScreen(0, 0, video.unscaledw, SCREENHEIGHT);
+    {
+      enable_drs = false;
+      wipe_StartScreen(0, 0, video.unscaledw, SCREENHEIGHT);
+    }
 
   if (gamestate == GS_LEVEL && gametic)
     HU_Erase();
@@ -2834,8 +2840,6 @@ void D_DoomMain(void)
   {
     I_AtExitPrio(D_EndDoom, false, "D_EndDoom", exit_priority_last);
   }
-
-  TryRunTics();
 
   main_loop_started = true;
 

--- a/src/doomdef.h
+++ b/src/doomdef.h
@@ -81,11 +81,11 @@ typedef enum
 // allows us to avoid the overhead of dynamic allocation
 // when multiple screen sizes are supported
 
-#define ORIGWIDTH  320 // [crispy]
-#define ORIGHEIGHT 200 // [crispy]
+#define SCREENWIDTH  320
+#define SCREENHEIGHT 200
 
-#define MAX_SCREENWIDTH  1152 // [FG] corresponds to 2.4:1 in hires mode
-#define MAX_SCREENHEIGHT (ORIGHEIGHT << 1) // [crispy]
+#define MAX_SCREENWIDTH  (1152 * 8) // [FG] corresponds to 2.4:1 in hires mode
+#define MAX_SCREENHEIGHT (400  * 8) // [crispy]
 
 // The maximum number of players, multiplayer/networking.
 #define MAXPLAYERS       4

--- a/src/doomdef.h
+++ b/src/doomdef.h
@@ -77,12 +77,9 @@ typedef enum
 // [FG] flashing disk icon
 #define DISK_ICON_THRESHOLD (20 * 1024)
 
-// killough 2/8/98: MAX versions for maximum screen sizes
-// allows us to avoid the overhead of dynamic allocation
-// when multiple screen sizes are supported
-
 #define SCREENWIDTH  320
 #define SCREENHEIGHT 200
+#define NONWIDEWIDTH SCREENWIDTH // [crispy] non-widescreen SCREENWIDTH
 
 // The maximum number of players, multiplayer/networking.
 #define MAXPLAYERS       4

--- a/src/doomdef.h
+++ b/src/doomdef.h
@@ -84,9 +84,6 @@ typedef enum
 #define SCREENWIDTH  320
 #define SCREENHEIGHT 200
 
-#define MAX_SCREENWIDTH  (1152 * 8) // [FG] corresponds to 2.4:1 in hires mode
-#define MAX_SCREENHEIGHT (400  * 8) // [crispy]
-
 // The maximum number of players, multiplayer/networking.
 #define MAXPLAYERS       4
 

--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -367,6 +367,8 @@ extern  boolean precache;
 //  to force a wipe on the next draw
 extern  gamestate_t     wipegamestate;
 
+extern  boolean         enable_drs;
+
 extern  int             mouseSensitivity_horiz; // killough
 extern  int             mouseSensitivity_vert;
 extern  int             mouseSensitivity_horiz_strafe; // [FG] strafe

--- a/src/f_finale.c
+++ b/src/f_finale.c
@@ -713,6 +713,8 @@ void F_CastDrawer (void)
 
 static void F_DrawPatchCol(int x, patch_t *patch, int col)
 {
+// TODO
+#if 0
   const column_t *column = 
     (const column_t *)((byte *) patch + LONG(patch->columnofs[col]));
 
@@ -740,6 +742,7 @@ static void F_DrawPatchCol(int x, patch_t *patch, int col)
 	  *dest = *source++;
 	column = (column_t *)(source+1);
       }
+#endif
 }
 
 
@@ -771,7 +774,7 @@ void F_BunnyScroll (void)
   if (pillar_width > 0)
   {
     // [crispy] fill pillarboxes in widescreen mode
-    memset(I_VideoBuffer, 0, (SCREENWIDTH<<hires) * (SCREENHEIGHT<<hires));
+    memset(I_VideoBuffer, 0, video.width * video.height);
   }
   else
   {
@@ -779,24 +782,24 @@ void F_BunnyScroll (void)
   }
 
   // Calculate the portion of PFUB2 that would be offscreen at original res.
-  p1offset = (ORIGWIDTH - SHORT(p1->width)) / 2;
+  p1offset = (SCREENWIDTH - SHORT(p1->width)) / 2;
 
-  if (SHORT(p2->width) == ORIGWIDTH)
+  if (SHORT(p2->width) == SCREENWIDTH)
   {
     // Unity or original PFUBs.
     // PFUB1 only contains the pixels that scroll off.
-    p2offset = ORIGWIDTH - p1offset;
+    p2offset = SCREENWIDTH - p1offset;
   }
   else
   {
     // Widescreen mod PFUBs.
     // Right side of PFUB2 and left side of PFUB1 are identical.
-    p2offset = ORIGWIDTH + p1offset;
+    p2offset = SCREENWIDTH + p1offset;
   }
 
   for (x = pillar_width; x < SCREENWIDTH - pillar_width; x++)
   {
-    int x2 = x - WIDESCREENDELTA + scrolled;
+    int x2 = x - video.deltaw + scrolled;
 
     if (x2 < p2offset)
       F_DrawPatchCol (x, p1, x2 - p1offset);
@@ -808,8 +811,8 @@ void F_BunnyScroll (void)
     return;
   if (finalecount < 1180)
   {
-    V_DrawPatch ((ORIGWIDTH-13*8)/2,
-                 (ORIGHEIGHT-8*8)/2,
+    V_DrawPatch ((SCREENWIDTH-13*8)/2,
+                 (SCREENHEIGHT-8*8)/2,
                  W_CacheLumpName ("END0",PU_CACHE));
     laststage = 0;
     return;
@@ -825,8 +828,8 @@ void F_BunnyScroll (void)
   }
       
   sprintf (name,"END%i",stage);
-  V_DrawPatch ((ORIGWIDTH-13*8)/2,
-               (ORIGHEIGHT-8*8)/2,
+  V_DrawPatch ((SCREENWIDTH-13*8)/2,
+               (SCREENHEIGHT-8*8)/2,
                W_CacheLumpName (name,PU_CACHE));
 }
 

--- a/src/f_wipe.c
+++ b/src/f_wipe.c
@@ -78,7 +78,7 @@ static int *y;
 static int wipe_initMelt(int width, int height, int ticks)
 {
   int i;
-  const int hires_size = 1 << hires;
+  const int hires_size = (video.yscale >> FRACBITS);
 
   // copy start screen to main screen
   memcpy(wipe_scr, wipe_scr_start, width*height);
@@ -159,7 +159,7 @@ static int wipe_exitMelt(int width, int height, int ticks)
 
 int wipe_StartScreen(int x, int y, int width, int height)
 {
-  int size = (hires ? SCREENWIDTH * SCREENHEIGHT * 4 : SCREENWIDTH * SCREENHEIGHT);
+  int size = video.width * video.height;
   wipe_scr_start = Z_Malloc(size * sizeof(*wipe_scr_start), PU_STATIC, NULL);
   I_ReadScreen(wipe_scr_start);
   return 0;
@@ -167,7 +167,7 @@ int wipe_StartScreen(int x, int y, int width, int height)
 
 int wipe_EndScreen(int x, int y, int width, int height)
 {
-  int size = (hires ? SCREENWIDTH * SCREENHEIGHT * 4 : SCREENWIDTH * SCREENHEIGHT);
+  int size = video.width * video.height;
   wipe_scr_end = Z_Malloc(size * sizeof(*wipe_scr_end), PU_STATIC, NULL);
   I_ReadScreen(wipe_scr_end);
   V_DrawBlock(x, y, width, height, wipe_scr_start); // restore start scr.
@@ -188,8 +188,9 @@ int wipe_ScreenWipe(int wipeno, int x, int y, int width, int height, int ticks)
 {
   static boolean go;                               // when zero, stop the wipe
 
-  if (hires)     // killough 11/98: hires support
-    width <<= 1, height <<= 1, ticks <<= 1;
+  width = video.width;
+  height = video.height;
+  ticks = (ticks * video.yscale) >> FRACBITS;
 
   if (!go)                                         // initial stuff
     {

--- a/src/hu_lib.c
+++ b/src/hu_lib.c
@@ -35,10 +35,10 @@ void HUlib_set_margins (void)
 
   if (hud_widescreen_widgets)
   {
-    left_margin -= WIDESCREENDELTA;
+    left_margin -= video.deltaw;
   }
 
-  right_margin = ORIGWIDTH - left_margin;
+  right_margin = SCREENWIDTH - left_margin;
 }
 
 // [FG] vertical alignment
@@ -57,7 +57,7 @@ static int align_offset[num_offsets];
 
 void HUlib_reset_align_offsets (void)
 {
-  int bottom = ORIGHEIGHT - 1;
+  int bottom = SCREENHEIGHT - 1;
 
   if (scaledviewheight < SCREENHEIGHT ||
       (crispy_hud && hud_active > 0) ||
@@ -224,19 +224,19 @@ static int horz_align_widget(const hu_widget_t *const w, const hu_line_t *const 
   }
   else if (h_align == align_center)
   {
-    return ORIGWIDTH/2 - l->width/2;
+    return SCREENWIDTH/2 - l->width/2;
   }
 
   // [FG] align_direct
   if (hud_widescreen_widgets)
   {
-    if (w->x < ORIGWIDTH/2)
+    if (w->x < SCREENWIDTH/2)
     {
-      return w->x - WIDESCREENDELTA;
+      return w->x - video.deltaw;
     }
     else
     {
-      return w->x + WIDESCREENDELTA;
+      return w->x + video.deltaw;
     }
   }
 

--- a/src/hu_stuff.c
+++ b/src/hu_stuff.c
@@ -1405,8 +1405,8 @@ boolean HU_DemoProgressBar(boolean force)
     return false;
   }
 
-  V_DrawHorizLine(0, video.unscaledh - 2, progress, v_darkest_color);
-  V_DrawHorizLine(0, video.unscaledh - 1, progress, v_lightest_color);
+  V_FillRect(0, video.unscaledh - 2, progress, 1, v_darkest_color);
+  V_FillRect(0, video.unscaledh - 1, progress, 1, v_lightest_color);
 
   return true;
 }

--- a/src/hu_stuff.c
+++ b/src/hu_stuff.c
@@ -1405,8 +1405,8 @@ boolean HU_DemoProgressBar(boolean force)
     return false;
   }
 
-  V_FillRect(0, video.unscaledh - 2, progress, 1, v_darkest_color);
-  V_FillRect(0, video.unscaledh - 1, progress, 1, v_lightest_color);
+  V_FillRect(0, SCREENHEIGHT - 2, progress, 1, v_darkest_color);
+  V_FillRect(0, SCREENHEIGHT - 1, progress, 1, v_lightest_color);
 
   return true;
 }

--- a/src/hu_stuff.c
+++ b/src/hu_stuff.c
@@ -1239,8 +1239,8 @@ static void HU_widget_build_rate (void)
 {
   char hud_ratestr[HU_MAXLINELENGTH];
 
-  sprintf(hud_ratestr, "Sprites %4d Segs %4d Visplanes %4d FPS %3d",
-          rendered_vissprites, rendered_segs, rendered_visplanes, fps);
+  sprintf(hud_ratestr, "Sprites %4d Segs %4d Visplanes %4d FPS %3d %dx%d",
+          rendered_vissprites, rendered_segs, rendered_visplanes, fps, video.width, video.height);
   HUlib_add_string_to_cur_line(&w_rate, hud_ratestr);
 
   if (voxels_found)

--- a/src/hu_stuff.c
+++ b/src/hu_stuff.c
@@ -572,9 +572,6 @@ void HU_Start(void)
   message_count = (message_timer  * TICRATE) / 1000 + 1;
   chat_count    = (chat_msg_timer * TICRATE) / 1000 + 1;
 
-  // [crispy] re-calculate WIDESCREENDELTA
-  I_GetScreenDimensions();
-
   // create the message widget
   HUlib_init_multiline(&w_message, message_list ? hud_msg_lines : 1,
                        &doom_font, colrngs[hudcolor_mesg],
@@ -1318,8 +1315,8 @@ mobj_t *crosshair_target; // [Alaux] Lock crosshair on target
 
 static void HU_UpdateCrosshair(void)
 {
-  crosshair.x = ORIGWIDTH/2;
-  crosshair.y = (screenblocks <= 10) ? (ORIGHEIGHT-ST_HEIGHT)/2 : ORIGHEIGHT/2;
+  crosshair.x = SCREENWIDTH/2;
+  crosshair.y = (screenblocks <= 10) ? (SCREENHEIGHT-ST_HEIGHT)/2 : SCREENHEIGHT/2;
 
   if (hud_crosshair_health)
     crosshair.cr = ColorByHealth(plr->health, 100, st_invul);
@@ -1366,14 +1363,14 @@ static void HU_UpdateCrosshair(void)
 
 void HU_UpdateCrosshairLock(int x, int y)
 {
-  int w = (crosshair.w << hires);
-  int h = (crosshair.h << hires);
+  int w = (crosshair.w * video.xscale) >> FRACBITS;
+  int h = (crosshair.h * video.yscale) >> FRACBITS;
 
   x = viewwindowx + BETWEEN(w, viewwidth  - w - 1, x);
   y = viewwindowy + BETWEEN(h, viewheight - h - 1, y);
 
-  crosshair.x = (x >> hires) - WIDESCREENDELTA;
-  crosshair.y = (y >> hires);
+  crosshair.x = (x << FRACBITS) / video.xscale - video.deltaw;
+  crosshair.y = (y << FRACBITS) / video.yscale;
 }
 
 void HU_DrawCrosshair(void)
@@ -1396,7 +1393,7 @@ void HU_DrawCrosshair(void)
 // [crispy] print a bar indicating demo progress at the bottom of the screen
 boolean HU_DemoProgressBar(boolean force)
 {
-  const int progress = SCREENWIDTH * playback_tic / playback_totaltics;
+  const int progress = video.unscaledw * playback_tic / playback_totaltics;
   static int old_progress = 0;
 
   if (old_progress < progress)
@@ -1408,8 +1405,8 @@ boolean HU_DemoProgressBar(boolean force)
     return false;
   }
 
-  V_DrawHorizLine(0, SCREENHEIGHT - 2, progress, v_darkest_color);
-  V_DrawHorizLine(0, SCREENHEIGHT - 1, progress, v_lightest_color);
+  V_DrawHorizLine(0, video.unscaledh - 2, progress, v_darkest_color);
+  V_DrawHorizLine(0, video.unscaledh - 1, progress, v_lightest_color);
 
   return true;
 }
@@ -2007,14 +2004,14 @@ static boolean HU_AddHUDCoords (char *name, int hud, int x, int y)
   // [FG] relative alignment to the edges
   if (x < 0)
   {
-    x += ORIGWIDTH;
+    x += SCREENWIDTH;
   }
   if (y < 0)
   {
-    y += ORIGHEIGHT;
+    y += SCREENHEIGHT;
   }
 
-  if (x < 0 || x >= ORIGWIDTH || y < 0 || y >= ORIGHEIGHT)
+  if (x < 0 || x >= SCREENWIDTH || y < 0 || y >= SCREENHEIGHT)
   {
     return false;
   }

--- a/src/hu_stuff.h
+++ b/src/hu_stuff.h
@@ -25,12 +25,6 @@
 
 #define HU_BROADCAST    5
 
-//#define HU_MSGREFRESH   KEY_ENTER                                // phares
-#define HU_MSGX         (0 - WIDESCREENDELTA)
-#define HU_MSGY         0
-#define HU_MSGWIDTH     64      /* in characters */
-#define HU_MSGHEIGHT    1       /* in lines */
-
 #define HU_MSGTIMEOUT   (4*TICRATE)
 
 //

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -895,7 +895,7 @@ static void I_GetWindowPosition(int *x, int *y, int w, int h)
     }
 }
 
-void I_GetScreenDimensions(void)
+static void I_GetScreenDimensions(void)
 {
     SDL_DisplayMode mode;
     int w = 16, h = 9;
@@ -961,10 +961,6 @@ void I_GetScreenDimensions(void)
     video.width = (video.width + 3) & ~3;
     video.height = (video.height + 3) & ~3;
 
-    // [crispy] ... but never exceeds MAX_SCREENWIDTH (array size!)
-    video.width = MIN(video.width, MAX_SCREENWIDTH);
-    video.height = MIN(video.height, MAX_SCREENHEIGHT);
-
     video.deltaw = (video.unscaledw - NONWIDEWIDTH) / 2;
 
     video.fov = 2 * atan(video.unscaledw / (1.2 * video.unscaledh) * 3 / 4) / M_PI * ANG180;
@@ -973,6 +969,8 @@ void I_GetScreenDimensions(void)
     video.yscale = (video.height << FRACBITS) / video.unscaledh;
     video.xstep  = ((video.unscaledw << FRACBITS) / video.width) + 1;
     video.ystep  = ((video.unscaledh << FRACBITS) / video.height) + 1;
+
+    R_InitAnyRes();
 
     printf("render resolution: %dx%d\n", video.width, video.height);
 }

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -960,6 +960,7 @@ static void I_GetScreenDimensions(void)
     // [FG] For performance reasons, SDL2 insists that the screen pitch, i.e.
     // the *number of bytes* that one horizontal row of pixels occupy in
     // memory, must be a multiple of 4.
+    video.unscaledw = (video.unscaledw + 3) & ~3;
     video.width = (video.width + 3) & ~3;
     video.height = (video.height + 3) & ~3;
 

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -46,8 +46,6 @@ typedef struct
 
 extern video_t video;
 
-void I_GetScreenDimensions(void);
-
 enum
 {
   RATIO_ORIG,

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -23,27 +23,6 @@
 
 
 #include "doomtype.h"
-#include "doomdef.h"
-#include "tables.h"
-
-#define NONWIDEWIDTH SCREENWIDTH // [crispy] non-widescreen SCREENWIDTH
-
-typedef struct
-{
-    int width;
-    int height;
-    int unscaledw;
-    int deltaw;
-
-    fixed_t xscale;
-    fixed_t yscale;
-    fixed_t xstep;
-    fixed_t ystep;
-
-    angle_t fov;
-} video_t;
-
-extern video_t video;
 
 enum
 {
@@ -87,7 +66,7 @@ void I_ToggleVsync(void); // [JN] Calls native SDL vsync toggle
 
 extern boolean use_vsync;  // killough 2/8/98: controls whether vsync is called
 extern boolean disk_icon;  // killough 10/98
-extern int resolution_mode, default_resolution_mode;      // killough 11/98
+extern resolution_mode_t resolution_mode, default_resolution_mode;
 
 extern boolean use_aspect;
 extern boolean uncapped, default_uncapped; // [FG] uncapped rendering frame rate

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -47,13 +47,22 @@ extern video_t video;
 
 enum
 {
-  RATIO_ORIG,
-  RATIO_MATCH_SCREEN,
-  RATIO_16_10,
-  RATIO_16_9,
-  RATIO_21_9,
-  NUM_RATIOS
+    RATIO_ORIG,
+    RATIO_MATCH_SCREEN,
+    RATIO_16_10,
+    RATIO_16_9,
+    RATIO_21_9,
+    NUM_RATIOS
 };
+
+typedef enum
+{
+    RES_ORIGINAL,
+    RES_DOUBLE,
+    RES_TRIPLE,
+    RES_DRS,
+    NUM_RES
+} resolution_mode_t;
 
 // [FG] support more joystick and mouse buttons
 #define MAX_JSB NUM_CONTROLLER_BUTTONS
@@ -78,7 +87,7 @@ void I_ToggleVsync(void); // [JN] Calls native SDL vsync toggle
 
 extern boolean use_vsync;  // killough 2/8/98: controls whether vsync is called
 extern boolean disk_icon;  // killough 10/98
-extern int hires, default_hires;      // killough 11/98
+extern int resolution_mode, default_resolution_mode;      // killough 11/98
 
 extern boolean use_aspect;
 extern boolean uncapped, default_uncapped; // [FG] uncapped rendering frame rate

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -23,16 +23,30 @@
 
 
 #include "doomtype.h"
+#include "doomdef.h"
 #include "tables.h"
 
-extern int SCREENWIDTH;
-extern int SCREENHEIGHT;
-extern int NONWIDEWIDTH; // [crispy] non-widescreen SCREENWIDTH
-extern int WIDESCREENDELTA; // [crispy] horizontal widescreen offset
+#define NONWIDEWIDTH SCREENWIDTH // [crispy] non-widescreen SCREENWIDTH
 
-extern angle_t FOV;
+typedef struct
+{
+    int width;
+    int height;
+    int unscaledw;
+    int unscaledh;
+    int deltaw;
 
-void I_GetScreenDimensions (void); // [crispy] re-calculate WIDESCREENDELTA
+    fixed_t xscale;
+    fixed_t yscale;
+    fixed_t xstep;
+    fixed_t ystep;
+
+    angle_t fov;
+} video_t;
+
+extern video_t video;
+
+void I_GetScreenDimensions(void);
 
 enum
 {

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -33,7 +33,6 @@ typedef struct
     int width;
     int height;
     int unscaledw;
-    int unscaledh;
     int deltaw;
 
     fixed_t xscale;

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -3770,6 +3770,10 @@ enum {
   gen2_end1,
 };
 
+static const char *resolution_mode_strings[] = {
+  "original", "double", "triple", "high", NULL
+};
+
 int midi_player_menu;
 
 static const char *midi_player_menu_strings[MAX_MIDI_PLAYER_MENU_ITEMS];
@@ -3877,8 +3881,8 @@ setup_menu_t gen_settings1[] = { // General Settings screen1
 
   {"Video"       ,S_SKIP|S_TITLE, m_null, M_X, M_Y},
 
-  {"High Resolution", S_YESNO, m_null, M_X, M_Y+ gen1_hires*M_SPC,
-   {"hires"}, 0, M_ResetScreen},
+  {"Resolution Mode", S_CHOICE, m_null, M_X, M_Y+ gen1_hires*M_SPC,
+   {"resolution_mode"}, 0, M_ResetScreen, resolution_mode_strings},
 
   {"Widescreen Rendering", S_YESNO, m_null, M_X, M_Y+ gen1_widescreen*M_SPC,
    {"widescreen"}, 0, M_ResetScreen},
@@ -7203,7 +7207,6 @@ void M_ResetSetupMenu(void)
 
 void M_ResetSetupMenuVideo(void)
 {
-  DISABLE_ITEM(!hires, enem_settings1[enem1_fuzz]);
   M_EnableDisableFPSLimit();
 }
 

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -814,22 +814,22 @@ static void M_DrawBorderedSnapshot (int n)
 {
   const char *txt = "n/a";
 
-  const int snapshot_x = MAX((WIDESCREENDELTA + SaveDef.x + SKULLXOFF - snapshot_width) / 2, 8);
+  const int snapshot_x = MAX((video.deltaw + SaveDef.x + SKULLXOFF - snapshot_width) / 2, 8);
   const int snapshot_y = LoadDef.y + MAX((load_end * LINEHEIGHT - snapshot_height) * n / load_end, 0);
 
   // [FG] a snapshot window smaller than 80*48 px is considered too small
-  if (snapshot_width < ORIGWIDTH/4)
+  if (snapshot_width < SCREENWIDTH/4)
     return;
 
   if (!M_DrawSnapshot(n, snapshot_x, snapshot_y, snapshot_width, snapshot_height))
   {
-    M_WriteText(snapshot_x + snapshot_width/2 - M_StringWidth(txt)/2 - WIDESCREENDELTA,
+    M_WriteText(snapshot_x + snapshot_width/2 - M_StringWidth(txt)/2 - video.deltaw,
                 snapshot_y + snapshot_height/2 - M_StringHeight(txt)/2,
                 txt);
   }
 
   txt = M_GetSavegameTime(n);
-  M_DrawString(snapshot_x + snapshot_width/2 - M_GetPixelWidth(txt)/2 - WIDESCREENDELTA,
+  M_DrawString(snapshot_x + snapshot_width/2 - M_GetPixelWidth(txt)/2 - video.deltaw,
                snapshot_y + snapshot_height + M_StringHeight(txt),
                CR_GOLD, txt);
 
@@ -1026,11 +1026,11 @@ void M_ReadSaveStrings(void)
 
   // [FG] shift savegame descriptions a bit to the right
   //      to make room for the snapshots on the left
-  SaveDef.x = LoadDef.x = M_X_LOADSAVE + MIN(M_LOADSAVE_WIDTH/2, WIDESCREENDELTA);
+  SaveDef.x = LoadDef.x = M_X_LOADSAVE + MIN(M_LOADSAVE_WIDTH/2, video.deltaw);
 
   // [FG] fit the snapshots into the resulting space
-  snapshot_width = MIN((WIDESCREENDELTA + SaveDef.x + 2 * SKULLXOFF) & ~7, ORIGWIDTH/2); // [FG] multiple of 8
-  snapshot_height = MIN((snapshot_width * ORIGHEIGHT / ORIGWIDTH) & ~7, ORIGHEIGHT/2);
+  snapshot_width = MIN((video.deltaw + SaveDef.x + 2 * SKULLXOFF) & ~7, SCREENWIDTH/2); // [FG] multiple of 8
+  snapshot_height = MIN((snapshot_width * SCREENHEIGHT / SCREENWIDTH) & ~7, SCREENHEIGHT/2);
 
   for (i = 0 ; i < load_end ; i++)
     {
@@ -2422,8 +2422,8 @@ void M_DrawSetting(setup_menu_t* s)
 
 	  for (i = 0 ; i < char_width ; i++)
 	    colorblock[i] = PAL_WHITE;
-	  if (x+cursor_start-1+WIDESCREENDELTA+char_width < SCREENWIDTH)
-	    V_DrawBlock(x+cursor_start-1+WIDESCREENDELTA,y+7,char_width,1,colorblock);
+	  if (x+cursor_start-1+video.deltaw+char_width < video.unscaledw)
+	    V_DrawBlock(x+cursor_start-1+video.deltaw,y+7,char_width,1,colorblock);
 	}
 
       // Draw the setting for the item
@@ -2545,7 +2545,7 @@ void M_DrawScreenItems(setup_menu_t* src)
       strcpy(menu_buffer, "Warning: Changes are pending until next game");
     }
 
-    x_warn = ORIGWIDTH/2 - M_GetPixelWidth(menu_buffer)/2;
+    x_warn = SCREENWIDTH/2 - M_GetPixelWidth(menu_buffer)/2;
     M_DrawMenuString(x_warn, M_Y_WARN, CR_RED);
   }
 
@@ -6977,7 +6977,7 @@ void M_DrawTitle(int x, int y, const char *patch, const char *alttext, int pages
   {
     // patch doesn't exist, draw some text in place of it
     M_snprintf(menu_buffer, sizeof(menu_buffer), "%s", alttext);
-    M_DrawMenuString(ORIGWIDTH/2 - M_StringWidth(alttext)/2,
+    M_DrawMenuString(SCREENWIDTH/2 - M_StringWidth(alttext)/2,
                      y + 8 - M_StringHeight(alttext)/2, // assumes patch height 16
                      CR_TITLE);
   }
@@ -6986,7 +6986,7 @@ void M_DrawTitle(int x, int y, const char *patch, const char *alttext, int pages
   {
     M_snprintf(menu_buffer, sizeof(menu_buffer), "page %d/%d",
                mult_screens_index + 1, pages - 1);
-    M_DrawMenuString(ORIGWIDTH/2 - M_StringWidth(menu_buffer)/2,
+    M_DrawMenuString(SCREENWIDTH/2 - M_StringWidth(menu_buffer)/2,
                      M_Y_PREVNEXT, CR_TITLE);
   }
 }
@@ -7094,7 +7094,7 @@ void M_Init(void)
   if (W_CheckNumForName("M_GDHIGH") != -1)
   {
     patch_t *patch = W_CacheLumpName("M_GDHIGH", PU_CACHE);
-    if (OptionsDef.x + 175 + SHORT(patch->width) >= ORIGWIDTH)
+    if (OptionsDef.x + 175 + SHORT(patch->width) >= SCREENWIDTH)
     {
       if (W_CheckNumForName("M_DISP") != -1)
         strcpy(OptionsMenu[scrnsize].name, "M_DISP");

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -134,9 +134,9 @@ default_t defaults[] = {
   //
 
   { // killough 11/98: hires
-    "hires", (config_t *) &default_hires, NULL,
-    {1}, {0,1}, number, ss_none, wad_no,
-    "1 to enable 640x400 resolution for rendering scenes"
+    "resolution_mode", (config_t *) &default_resolution_mode, NULL,
+    {RES_DRS}, {RES_ORIGINAL, NUM_RES - 1}, number, ss_none, wad_no,
+    "0 - original 200p, 1 - double 400p, 2 - triple 600p, 4 - native (dynamic)"
   },
 
   {

--- a/src/m_snapshot.c
+++ b/src/m_snapshot.c
@@ -28,7 +28,7 @@
 
 static const char snapshot_str[] = "WOOF_SNAPSHOT";
 static const int snapshot_len = arrlen(snapshot_str);
-static const int snapshot_size = ORIGWIDTH * ORIGHEIGHT;
+static const int snapshot_size = SCREENWIDTH * SCREENHEIGHT;
 
 static byte *snapshots[10];
 static byte *current_snapshot;
@@ -97,12 +97,14 @@ char *M_GetSavegameTime (int i)
   return savegametimes[i];
 }
 
-// [FG] take a snapshot in ORIGWIDTH*ORIGHEIGHT resolution, i.e.
+// [FG] take a snapshot in SCREENWIDTH*SCREENHEIGHT resolution, i.e.
 //      in hires mode only only each second pixel in each second row is saved,
 //      in widescreen mode only the non-widescreen part in the middle is saved
 
 static void M_TakeSnapshot (void)
 {
+// TODO
+#if 0
   const int inc = hires ? 2 : 1;
   int x, y;
   byte *p;
@@ -123,11 +125,12 @@ static void M_TakeSnapshot (void)
   {
     for (x = 0; x < (NONWIDEWIDTH << hires); x += inc)
     {
-      *p++ = s[y * (SCREENWIDTH << hires) + (WIDESCREENDELTA << hires) + x];
+      *p++ = s[y * (SCREENWIDTH << hires) + (video.widedelta << hires) + x];
     }
   }
 
   R_SetViewSize(old_screenblocks);
+#endif
 }
 
 void M_WriteSnapshot (byte *p)
@@ -146,6 +149,8 @@ void M_WriteSnapshot (byte *p)
 
 boolean M_DrawSnapshot (int n, int x, int y, int w, int h)
 {
+// TODO
+#if 0
   byte *dest = I_VideoBuffer + y * (SCREENWIDTH << (2 * hires)) + (x << hires);
 
   if (!snapshots[n])
@@ -162,8 +167,8 @@ boolean M_DrawSnapshot (int n, int x, int y, int w, int h)
   }
   else
   {
-    const fixed_t step_x = (ORIGWIDTH << FRACBITS) / (w << hires);
-    const fixed_t step_y = (ORIGHEIGHT << FRACBITS) / (h << hires);
+    const fixed_t step_x = (SCREENWIDTH << FRACBITS) / (w << hires);
+    const fixed_t step_y = (SCREENHEIGHT << FRACBITS) / (h << hires);
     int destx, desty;
     fixed_t srcx, srcy;
     byte *destline, *srcline;
@@ -171,7 +176,7 @@ boolean M_DrawSnapshot (int n, int x, int y, int w, int h)
     for (desty = 0, srcy = 0; desty < (h << hires); desty++, srcy += step_y)
     {
       destline = dest + desty * (SCREENWIDTH << hires);
-      srcline = snapshots[n] + (srcy >> FRACBITS) * ORIGWIDTH;
+      srcline = snapshots[n] + (srcy >> FRACBITS) * SCREENWIDTH;
 
       for (destx = 0, srcx = 0; destx < (w << hires); destx++, srcx += step_x)
       {
@@ -179,6 +184,7 @@ boolean M_DrawSnapshot (int n, int x, int y, int w, int h)
       }
     }
   }
+#endif
 
   return true;
 }

--- a/src/m_snapshot.c
+++ b/src/m_snapshot.c
@@ -114,24 +114,16 @@ static void M_TakeSnapshot (void)
     current_snapshot = malloc(snapshot_size * sizeof(**snapshots));
   }
 
-  int x, y;
-  vrect_t rect;
-  rect.w = NONWIDEWIDTH;
-  rect.h = SCREENHEIGHT;
-
   byte *p = current_snapshot;
 
   const byte *s = I_VideoBuffer;
 
+  int x, y;
   for (y = 0; y < SCREENHEIGHT; y++)
   {
     for (x = video.deltaw; x < NONWIDEWIDTH + video.deltaw; x++)
     {
-      rect.x = x;
-      rect.y = y;
-      V_ScaleRect(&rect);
-
-      *p++ = s[rect.sy * video.width + rect.sx];
+      *p++ = s[V_ScaleY(y) * video.width + V_ScaleX(x)];
     }
   }
 

--- a/src/r_bsp.c
+++ b/src/r_bsp.c
@@ -85,7 +85,7 @@ typedef struct {
 // Replaces the old R_Clip*WallSegment functions. It draws bits of walls in those
 // columns which aren't solid, and updates the solidcol[] array appropriately
 
-byte solidcol[MAX_SCREENWIDTH];
+byte *solidcol = NULL;
 
 static void R_ClipWallSegment(int first, int last, boolean solid)
 {
@@ -124,7 +124,7 @@ static void R_ClipWallSegment(int first, int last, boolean solid)
 
 void R_ClearClipSegs (void)
 {
-  memset(solidcol, 0, MAX_SCREENWIDTH);
+  memset(solidcol, 0, video.width);
 }
 
 // killough 1/18/98 -- This function is used to fix the automap bug which

--- a/src/r_bsp.c
+++ b/src/r_bsp.c
@@ -25,6 +25,7 @@
 #include "r_segs.h"
 #include "r_plane.h"
 #include "r_things.h"
+#include "v_video.h"
 
 seg_t     *curline;
 side_t    *sidedef;

--- a/src/r_bsp.h
+++ b/src/r_bsp.h
@@ -41,7 +41,7 @@ extern unsigned maxdrawsegs;
 
 extern drawseg_t *ds_p;
 
-extern byte solidcol[];
+extern byte *solidcol;
 
 void R_ClearClipSegs(void);
 void R_ClearDrawSegs(void);

--- a/src/r_defs.h
+++ b/src/r_defs.h
@@ -449,11 +449,9 @@ typedef struct visplane
   int picnum, lightlevel, minx, maxx;
   fixed_t height;
   fixed_t xoffs, yoffs;         // killough 2/28/98: Support scrolling flats
+  unsigned short *bottom;
   unsigned short pad1;          // leave pads for [minx-1]/[maxx+1]
-  unsigned short top[MAX_SCREENWIDTH];
-  unsigned short pad2, pad3;    // killough 2/8/98, 4/25/98
-  unsigned short bottom[MAX_SCREENWIDTH];
-  unsigned short pad4;
+  unsigned short top[3];
 } visplane_t;
 
 #endif

--- a/src/r_draw.c
+++ b/src/r_draw.c
@@ -21,13 +21,11 @@
 
 #include "doomstat.h"
 #include "w_wad.h"
+#include "r_bsp.h"
 #include "r_draw.h" // [FG]
 #include "r_main.h"
 #include "v_video.h"
 #include "m_menu.h"
-
-#define MAXWIDTH  MAX_SCREENWIDTH          /* kilough 2/8/98 */
-#define MAXHEIGHT MAX_SCREENHEIGHT
 
 //
 // All drawing to the view buffer is accomplished in this file.
@@ -47,8 +45,8 @@ int  scaledviewy;
 int  viewheight;
 int  viewwindowx;
 int  viewwindowy; 
-static byte *ylookup[MAXHEIGHT]; 
-static int  columnofs[MAXWIDTH]; 
+static byte **ylookup = NULL;
+static int  *columnofs = NULL;
 static int  linesize = SCREENWIDTH;  // killough 11/98
 
 // Color tables for different players,
@@ -102,9 +100,9 @@ void R_DrawColumn (void)
     return; 
                                  
 #ifdef RANGECHECK 
-  if ((unsigned)dc_x >= MAX_SCREENWIDTH
+  if ((unsigned)dc_x >= video.width
       || dc_yl < 0
-      || dc_yh >= MAX_SCREENHEIGHT) 
+      || dc_yh >= video.height) 
     I_Error ("R_DrawColumn: %i to %i at %i", dc_yl, dc_yh, dc_x); 
 #endif 
 
@@ -205,9 +203,9 @@ void R_DrawTLColumn (void)
     return; 
                                  
 #ifdef RANGECHECK 
-  if ((unsigned)dc_x >= MAX_SCREENWIDTH
+  if ((unsigned)dc_x >= video.width
       || dc_yl < 0
-      || dc_yh >= MAX_SCREENHEIGHT) 
+      || dc_yh >= video.height) 
     I_Error ("R_DrawColumn: %i to %i at %i", dc_yl, dc_yh, dc_x); 
 #endif 
 
@@ -292,9 +290,9 @@ void R_DrawSkyColumn(void)
     return;
 
 #ifdef RANGECHECK
-  if ((unsigned)dc_x >= MAX_SCREENWIDTH
+  if ((unsigned)dc_x >= video.width
     || dc_yl < 0
-    || dc_yh >= MAX_SCREENHEIGHT)
+    || dc_yh >= video.height)
     I_Error ("R_DrawSkyColumn: %i to %i at %i", dc_yl, dc_yh, dc_x);
 #endif
 
@@ -473,9 +471,9 @@ static void R_DrawFuzzColumn_orig(void)
     return; 
     
 #ifdef RANGECHECK 
-  if ((unsigned) dc_x >= MAX_SCREENWIDTH
+  if ((unsigned) dc_x >= video.width
       || dc_yl < 0 
-      || dc_yh >= MAX_SCREENHEIGHT)
+      || dc_yh >= video.height)
     I_Error ("R_DrawFuzzColumn: %i to %i at %i",
              dc_yl, dc_yh, dc_x);
 #endif
@@ -555,9 +553,9 @@ static void R_DrawFuzzColumn_block(void)
     return;
 
 #ifdef RANGECHECK
-  if ((unsigned) dc_x >= MAX_SCREENWIDTH
+  if ((unsigned) dc_x >= video.width
       || dc_yl < 0
-      || dc_yh >= MAX_SCREENHEIGHT)
+      || dc_yh >= video.height)
     I_Error ("R_DrawFuzzColumn: %i to %i at %i",
              dc_yl, dc_yh, dc_x);
 #endif
@@ -638,9 +636,9 @@ void R_DrawTranslatedColumn (void)
     return; 
                                  
 #ifdef RANGECHECK 
-  if ((unsigned)dc_x >= MAX_SCREENWIDTH
+  if ((unsigned)dc_x >= video.width
       || dc_yl < 0
-      || dc_yh >= MAX_SCREENHEIGHT)
+      || dc_yh >= video.height)
     I_Error ( "R_DrawColumn: %i to %i at %i",
               dc_yl, dc_yh, dc_x);
 #endif 
@@ -799,6 +797,18 @@ void R_DrawSpan (void)
       count--;
     } 
 } 
+
+void R_InitBufferRes(void)
+{
+  if (solidcol) Z_Free(solidcol);
+  if (columnofs) Z_Free(columnofs);
+  if (ylookup) Z_Free(ylookup);
+
+  columnofs = Z_Malloc(video.width * sizeof(*columnofs), PU_STATIC, NULL);
+  ylookup = Z_Malloc(video.height * sizeof(*ylookup), PU_STATIC, NULL);
+
+  solidcol = Z_Calloc(1, video.width * sizeof(*solidcol), PU_STATIC, NULL);
+}
 
 //
 // R_InitBuffer 

--- a/src/r_draw.h
+++ b/src/r_draw.h
@@ -30,7 +30,6 @@ extern fixed_t  dc_iscale;
 extern fixed_t  dc_texturemid;
 extern int      dc_texheight;    // killough
 extern byte     dc_skycolor;
-extern int      linesize;        // killough 11/98
 
 // first pixel in a column
 extern byte     *dc_source;         
@@ -77,7 +76,7 @@ extern const byte *ds_brightmap;
 // Span blitting for rows, floor/ceiling. No Spectre effect needed.
 void R_DrawSpan(void);
 
-void R_InitBuffer(int width, int height);
+void R_InitBuffer(void);
 
 // Initialize color translation tables, for player rendering etc.
 void R_InitTranslationTables(void);

--- a/src/r_draw.h
+++ b/src/r_draw.h
@@ -88,7 +88,7 @@ void R_DrawBorder(int x, int y, int w, int h);
 // If the view size is not full screen, draws a border around it.
 void R_DrawViewBorder(void);
 
-extern byte *ylookup[];       // killough 11/98
+void R_InitBufferRes(void);
 
 #endif
 

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -27,10 +27,10 @@
 #include "r_draw.h"
 #include "r_sky.h"
 #include "r_voxel.h"
+#include "i_video.h"
 #include "v_video.h"
 #include "am_map.h"
 #include "st_stuff.h"
-#include "hu_stuff.h"
 
 // Fineangles in the SCREENWIDTH wide window.
 #define FIELDOFVIEW 2048    

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -71,10 +71,10 @@ int viewangletox[FINEANGLES/2];
 // to the lowest viewangle that maps back to x ranges
 // from clipangle to -clipangle.
 
-angle_t xtoviewangle[MAX_SCREENWIDTH+1];   // killough 2/8/98
+angle_t *xtoviewangle = NULL;   // killough 2/8/98
 
 // [FG] linear horizontal sky scrolling
-angle_t linearskyangle[MAX_SCREENWIDTH+1];
+angle_t *linearskyangle = NULL;
 
 int LIGHTLEVELS;
 int LIGHTSEGSHIFT;
@@ -854,6 +854,14 @@ void R_RenderPlayerView (player_t* player)
 
   // Check for new console commands.
   NetUpdate ();
+}
+
+void R_InitAnyRes(void)
+{
+  R_InitSpritesRes();
+  R_InitBufferRes();
+  R_InitPlanesRes();
+  R_InitVisplanesRes();
 }
 
 //----------------------------------------------------------------------------

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -27,7 +27,6 @@
 #include "r_draw.h"
 #include "r_sky.h"
 #include "r_voxel.h"
-#include "m_bbox.h"
 #include "v_video.h"
 #include "am_map.h"
 #include "st_stuff.h"
@@ -448,18 +447,18 @@ void R_ExecuteSetViewSize (void)
     {
       scaledviewwidth_nonwide = NONWIDEWIDTH;
       scaledviewwidth = video.unscaledw;
-      scaledviewheight = video.unscaledh;                    // killough 11/98
+      scaledviewheight = SCREENHEIGHT;                    // killough 11/98
     }
   // [crispy] hard-code to SCREENWIDTH and SCREENHEIGHT minus status bar height
   else if (setblocks == 10)
     {
       scaledviewwidth_nonwide = NONWIDEWIDTH;
       scaledviewwidth = video.unscaledw;
-      scaledviewheight = video.unscaledh - ST_HEIGHT;
+      scaledviewheight = SCREENHEIGHT - ST_HEIGHT;
     }
   else
     {
-      const int st_screen = video.unscaledh - ST_HEIGHT;
+      const int st_screen = SCREENHEIGHT - ST_HEIGHT;
 
       scaledviewwidth_nonwide = setblocks * 32;
       scaledviewheight = (setblocks * st_screen / 10) & ~7; // killough 11/98
@@ -475,7 +474,7 @@ void R_ExecuteSetViewSize (void)
   if (scaledviewwidth == video.unscaledw)
     scaledviewy = 0;
   else
-    scaledviewy = (video.unscaledh - ST_HEIGHT - scaledviewheight) / 2;
+    scaledviewy = (SCREENHEIGHT - ST_HEIGHT - scaledviewheight) / 2;
 
   view.x = scaledviewx;
   view.y = scaledviewy;
@@ -486,12 +485,12 @@ void R_ExecuteSetViewSize (void)
 
   viewwidth = view.sw;
   viewheight = view.sh;
-  viewwidth_nonwide = (scaledviewwidth_nonwide * video.xscale) >> FRACBITS;
+  viewwidth_nonwide = V_ScaleX(scaledviewwidth_nonwide);
 
   viewwindowx = view.sx;
   viewwindowy = view.sy;
 
-  viewblocks = (MIN(setblocks, 10) * video.yscale) >> FRACBITS;
+  viewblocks = V_ScaleX(MIN(setblocks, 10));
 
   centery = viewheight/2;
   centerx = viewwidth/2;

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -482,7 +482,6 @@ void R_ExecuteSetViewSize (void)
   view.w = scaledviewwidth;
   view.h = scaledviewheight;
 
-  V_ClipRect(&view);
   V_ScaleRect(&view);
 
   viewwidth = view.sw;
@@ -754,12 +753,11 @@ void R_RenderPlayerView (player_t* player)
   R_ClearSprites ();
   VX_ClearVoxels ();
 
-// TODO
-#if 0
   if (autodetect_hom)
     { // killough 2/10/98: add flashing red HOM indicators
       pixel_t c[47*47];
       extern int lastshottic;
+      const int linesize = video.width;
       int i , color = !flashing_hom || (gametic % 20) < 9 ? 0xb0 : 0;
       memset(I_VideoBuffer+viewwindowy*linesize,color,viewheight*linesize);
       for (i=0;i<47*47;i++)
@@ -822,11 +820,10 @@ void R_RenderPlayerView (player_t* player)
           c[i] = t=='/' ? color : t;
         }
       if (gametic-lastshottic < TICRATE*2 && gametic-lastshottic > TICRATE/8)
-        V_DrawBlock((viewwindowx +  viewwidth/2 - 24)>>hires,
-                    (viewwindowy + viewheight/2 - 24)>>hires, 47, 47, c);
+        V_DrawBlock(scaledviewx +  scaledviewwidth/2 - 24,
+                    scaledviewy + scaledviewheight/2 - 24, 47, 47, c);
       R_DrawViewBorder();
     }
-#endif
 
   // check for new console commands.
   NetUpdate ();

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -393,7 +393,10 @@ void R_InitLightTables (void)
       int j, startmap = ((LIGHTLEVELS-LIGHTBRIGHT-i)*2)*NUMCOLORMAPS/LIGHTLEVELS;
 
       for (cm = 0; cm < numcolormaps; ++cm)
+      {
+        c_scalelight[cm][i] = Z_Malloc(MAXLIGHTSCALE * sizeof(***c_scalelight), PU_STATIC, 0);
         c_zlight[cm][i] = Z_Malloc(MAXLIGHTZ * sizeof(***c_zlight), PU_STATIC, 0);
+      }
 
       for (j=0; j<MAXLIGHTZ; j++)
         {
@@ -535,15 +538,11 @@ void R_ExecuteSetViewSize (void)
   for (i=0; i<LIGHTLEVELS; i++)
     {
       int j, startmap = ((LIGHTLEVELS-LIGHTBRIGHT-i)*2)*NUMCOLORMAPS/LIGHTLEVELS;
-      int cm;
-
-      for (cm = 0; cm < numcolormaps; ++cm)
-        c_scalelight[cm][i] = Z_Malloc(MAXLIGHTSCALE * sizeof(***c_scalelight), PU_STATIC, 0);
 
       for (j=0 ; j<MAXLIGHTSCALE ; j++)
         {                                       // killough 11/98:
           int t, level = startmap - j*NONWIDEWIDTH/scaledviewwidth_nonwide/DISTMAP;
-            
+
           if (level < 0)
             level = 0;
 
@@ -558,7 +557,7 @@ void R_ExecuteSetViewSize (void)
         }
     }
 
-    HU_disable_all_widgets();
+    //HU_disable_all_widgets();
 
     // [crispy] forcefully initialize the status bar backing screen
     ST_refreshBackground(true);
@@ -857,7 +856,6 @@ void R_InitAnyRes(void)
   R_InitSpritesRes();
   R_InitBufferRes();
   R_InitPlanesRes();
-  R_InitVisplanesRes();
 }
 
 //----------------------------------------------------------------------------

--- a/src/r_main.h
+++ b/src/r_main.h
@@ -117,6 +117,8 @@ void R_ExecuteSetViewSize(void);
 // [crispy] smooth texture scrolling
 void R_InterpolateTextureOffsets (void);
 
+void R_InitAnyRes(void);
+
 #endif
 
 //----------------------------------------------------------------------------

--- a/src/r_plane.c
+++ b/src/r_plane.c
@@ -266,9 +266,9 @@ static visplane_t *new_visplane(unsigned hash)
   visplane_t *check = freetail;
   if (!check)
   {
-    const int size = sizeof(*check) + sizeof(*check->top) * (video.width * 2 + sizeof(*check->bottom) * 4);
-    check = Z_Calloc(1, size, PU_STATIC, NULL);
-    check->bottom = &check->top[video.width + sizeof(*check->bottom)];
+    const int size = sizeof(*check) + (video.width * 2) * sizeof(*check->top);
+    check = Z_Calloc(1, size, PU_VALLOC, NULL);
+    check->bottom = &check->top[video.width + 2];
   }
   else
     if (!(freetail = freetail->next))

--- a/src/r_plane.c
+++ b/src/r_plane.c
@@ -31,7 +31,6 @@
 //
 //-----------------------------------------------------------------------------
 
-#include "i_video.h"
 #include "z_zone.h"  /* memory allocation wrappers -- killough */
 
 #include "doomstat.h"
@@ -43,6 +42,7 @@
 #include "r_plane.h"
 #include "r_bmaps.h" // [crispy] R_BrightmapForTexName()
 #include "r_swirl.h" // [crispy] R_DistortedFlat()
+#include "v_video.h"
 
 #define MAXVISPLANES 128    /* must be a power of 2 */
 

--- a/src/r_plane.c
+++ b/src/r_plane.c
@@ -408,12 +408,12 @@ static void do_draw_plane(visplane_t *pl)
         else if (!vertically_scrolling)
         {
           // Make sure the fade-to-color effect doesn't happen too early
-          fixed_t diff = dc_texturemid - ORIGHEIGHT / 2 * FRACUNIT;
+          fixed_t diff = dc_texturemid - SCREENHEIGHT / 2 * FRACUNIT;
           if (diff < 0)
           {
             diff += textureheight[texture];
             diff %= textureheight[texture];
-            dc_texturemid = ORIGHEIGHT / 2 * FRACUNIT + diff;
+            dc_texturemid = SCREENHEIGHT / 2 * FRACUNIT + diff;
           }
           dc_skycolor = R_GetSkyColor(texture);
           colfunc = R_DrawSkyColumn;

--- a/src/r_plane.h
+++ b/src/r_plane.h
@@ -28,8 +28,8 @@
 // Visplane related.
 extern  int *lastopening; // [FG] 32-bit integer math
 
-extern int floorclip[], ceilingclip[]; // [FG] 32-bit integer math
-extern fixed_t *yslope, yslopes[LOOKDIRS][MAX_SCREENHEIGHT], distscale[];
+extern int *floorclip, *ceilingclip; // [FG] 32-bit integer math
+extern fixed_t *yslope, **yslopes, *distscale;
 
 void R_InitPlanes(void);
 void R_ClearPlanes(void);
@@ -47,6 +47,10 @@ visplane_t *R_CheckPlane(visplane_t *pl, int start, int stop);
 
 // cph 2003/04/18 - create duplicate of existing visplane and set initial range
 visplane_t *R_DupPlane(const visplane_t *pl, int start, int stop);
+
+void R_InitPlanesRes(void);
+
+void R_InitVisplanesRes(void);
 
 #endif
 

--- a/src/r_segs.c
+++ b/src/r_segs.c
@@ -21,7 +21,7 @@
 
 #include "doomstat.h"
 #include "i_video.h"
-#include "p_tick.h"
+#include "v_video.h"
 #include "r_main.h"
 #include "r_bsp.h"
 #include "r_plane.h"
@@ -157,7 +157,7 @@ void R_RenderMaskedSegRange(drawseg_t *ds, int x1, int x2)
       {
         if (!fixedcolormap)      // calculate lighting
           {                             // killough 11/98:
-            unsigned index = spryscale >> (LIGHTSCALESHIFT + (video.xscale >> FRACBITS));
+            unsigned index = FixedDiv(spryscale, video.xscale) >> LIGHTSCALESHIFT;
 
             if (index >=  MAXLIGHTSCALE )
               index = MAXLIGHTSCALE-1;
@@ -374,7 +374,7 @@ static void R_RenderSegLoop (void)
           texturecolumn >>= FRACBITS;
 
           // calculate lighting
-          index = rw_scale >> (LIGHTSCALESHIFT + (video.xscale >> FRACBITS));  // killough 11/98
+          index = FixedDiv(rw_scale, video.xscale) >> LIGHTSCALESHIFT;  // killough 11/98
 
           if (index >=  MAXLIGHTSCALE )
             index = MAXLIGHTSCALE-1;

--- a/src/r_segs.c
+++ b/src/r_segs.c
@@ -157,7 +157,7 @@ void R_RenderMaskedSegRange(drawseg_t *ds, int x1, int x2)
       {
         if (!fixedcolormap)      // calculate lighting
           {                             // killough 11/98:
-            unsigned index = spryscale>>(LIGHTSCALESHIFT+hires);
+            unsigned index = spryscale >> (LIGHTSCALESHIFT + (video.xscale >> FRACBITS));
 
             if (index >=  MAXLIGHTSCALE )
               index = MAXLIGHTSCALE-1;
@@ -374,7 +374,7 @@ static void R_RenderSegLoop (void)
           texturecolumn >>= FRACBITS;
 
           // calculate lighting
-          index = rw_scale>>(LIGHTSCALESHIFT+hires);  // killough 11/98
+          index = rw_scale >> (LIGHTSCALESHIFT + (video.xscale >> FRACBITS));  // killough 11/98
 
           if (index >=  MAXLIGHTSCALE )
             index = MAXLIGHTSCALE-1;

--- a/src/r_segs.c
+++ b/src/r_segs.c
@@ -179,7 +179,7 @@ void R_RenderMaskedSegRange(drawseg_t *ds, int x1, int x2)
           int64_t t = ((int64_t) centeryfrac << FRACBITS) -
             (int64_t) dc_texturemid * spryscale;
           if (t + (int64_t) textureheight[texnum] * spryscale < 0 ||
-              t > (int64_t) MAX_SCREENHEIGHT << FRACBITS*2)
+              t > (int64_t) video.height << FRACBITS*2)
             continue;        // skip if the texture is out of screen's range
           sprtopscreen = (int64_t)(t >> FRACBITS); // [FG] 64-bit integer math
         }

--- a/src/r_state.h
+++ b/src/r_state.h
@@ -100,12 +100,12 @@ extern player_t         *viewplayer;
 extern angle_t          clipangle;
 extern angle_t          vx_clipangle;
 extern int              viewangletox[FINEANGLES/2];
-extern angle_t          xtoviewangle[MAX_SCREENWIDTH+1];  // killough 2/8/98
+extern angle_t          *xtoviewangle;  // killough 2/8/98
 extern fixed_t          rw_distance;
 extern angle_t          rw_normalangle;
 
 // [FG] linear horizontal sky scrolling
-extern angle_t          linearskyangle[MAX_SCREENWIDTH+1];
+extern angle_t          *linearskyangle;
 
 // angle to line origin
 extern int              rw_angle1;

--- a/src/r_state.h
+++ b/src/r_state.h
@@ -44,8 +44,10 @@ extern lighttable_t *fullcolormap;        // killough 3/20/98
 
 extern int viewwidth;
 extern int scaledviewwidth;
+extern int scaledviewx;
 extern int viewheight;
 extern int scaledviewheight;              // killough 11/98
+extern int scaledviewy;
 
 extern int firstflat;
 

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -664,7 +664,7 @@ void R_ProjectSprite (mobj_t* thing)
     vis->colormap[0] = vis->colormap[1] = fullcolormap;       // full bright  // killough 3/20/98
   else
     {      // diminished light
-      int index = xscale>>(LIGHTSCALESHIFT+hires);  // killough 11/98
+      int index = FixedDiv(xscale, video.xscale) >> LIGHTSCALESHIFT;  // killough 11/98
       if (index >= MAXLIGHTSCALE)
         index = MAXLIGHTSCALE-1;
       vis->colormap[0] = spritelights[index];

--- a/src/r_things.h
+++ b/src/r_things.h
@@ -27,8 +27,8 @@
 // Constant arrays used for psprite clipping and initializing clipping.
 
 // [FG] 32-bit integer math
-extern int negonearray[MAX_SCREENWIDTH];         // killough 2/8/98:
-extern int screenheightarray[MAX_SCREENWIDTH];   // change to MAX_*
+extern int *negonearray;         // killough 2/8/98:
+extern int *screenheightarray;   // change to MAX_*
 
 // Vars for R_DrawMaskedColumn
 
@@ -53,6 +53,8 @@ void R_ClearSprites(void);
 void R_DrawMasked(void);
 
 void R_ClipVisSprite(vissprite_t *vis, int xl, int xh);
+
+void R_InitSpritesRes(void);
 
 #endif
 

--- a/src/r_things.h
+++ b/src/r_things.h
@@ -20,7 +20,6 @@
 #ifndef __R_THINGS__
 #define __R_THINGS__
 
-#include "doomdef.h"
 #include "m_fixed.h"
 #include "r_defs.h"
 

--- a/src/r_voxel.c
+++ b/src/r_voxel.c
@@ -696,7 +696,7 @@ boolean VX_ProjectVoxel (mobj_t * thing)
 	else
 	{
 		// diminished light
-		int index = xscale >> (LIGHTSCALESHIFT + hires);  // killough 11/98
+		int index = FixedDiv(xscale, video.xscale) >> LIGHTSCALESHIFT;  // killough 11/98
 
 		if (index < 0)               index = 0;
 		if (index > MAXLIGHTSCALE-1) index = MAXLIGHTSCALE-1;

--- a/src/r_voxel.c
+++ b/src/r_voxel.c
@@ -813,6 +813,7 @@ static void VX_DrawColumn (vissprite_t * spr, int x, int y)
 
 	boolean shadow = ((spr->mobjflags & MF_SHADOW) != 0);
 
+	int linesize = video.width;
 	byte * dest = I_VideoBuffer + viewwindowy * linesize + viewwindowx;
 
 	// iterate over screen columns

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -24,6 +24,7 @@
 #include "doomstat.h"
 #include "m_random.h"
 #include "i_video.h"
+#include "v_video.h"
 #include "w_wad.h"
 #include "st_stuff.h"
 #include "hu_stuff.h" // [FG] hud_displayed
@@ -182,7 +183,7 @@ extern boolean inhelpscreens;
 // killough 2/8/98: weapon info position macros UNUSED, removed here
 
 // graphics are drawn to a backing screen and blitted to the real screen
-pixel_t *st_backing_screen = NULL;
+static pixel_t *st_backing_screen = NULL;
 
 // main player in game
 static player_t *plyr;
@@ -317,153 +318,157 @@ void ST_Stop(void);
 
 int st_solidbackground;
 
-void ST_refreshBackground(boolean force)
+static void ST_DrawSolidBackground(void)
 {
-  if (st_classicstatusbar)
+// TODO
+#if 0
+  // [FG] calculate average color of the 16px left and right of the status bar
+  const int vstep[][2] = {{0, 1}, {1, 2}, {2, ST_HEIGHT}};
+  const int hstep = video.width;
+  const int lo = MAX(st_x + video.widedelta - SHORT(sbar->leftoffset), 0);
+  const int w = MIN(SHORT(sbar->width), SCREENWIDTH);
+  const int depth = 16;
+  byte *pal = W_CacheLumpName("PLAYPAL", PU_STATIC);
+  int v;
+
+  // [FG] temporarily draw status bar to background buffer
+  V_DrawPatch(st_x, 0, sbar);
+
+  // [FG] separate colors for the top rows
+  for (v = 0; v < arrlen(vstep); v++)
+  {
+    int x, y;
+    const int v0 = vstep[v][0], v1 = vstep[v][1];
+    unsigned r = 0, g = 0, b = 0;
+    byte col;
+
+    for (y = v0; y < v1; y++)
     {
-      const int st_x = (SHORT(sbar->width) > ORIGWIDTH && SHORT(sbar->leftoffset) == 0) ?
-                       ST_X + (ORIGWIDTH - SHORT(sbar->width)) / 2 :
-                       ST_X;
-
-      V_UseBuffer(st_backing_screen);
-
-      if (SCREENWIDTH != ST_WIDTH)
+      for (x = 0; x < depth; x++)
       {
-        int x, y;
-        byte *dest = st_backing_screen;
+        byte *c = st_backing_screen + y * hstep + ((x + lo) << hires);
+        r += pal[3 * c[0] + 0];
+        g += pal[3 * c[0] + 1];
+        b += pal[3 * c[0] + 2];
 
-        if (st_solidbackground)
-        {
-          // [FG] calculate average color of the 16px left and right of the status bar
-          const int vstep[][2] = {{0, 1}, {1, 2}, {2, ST_HEIGHT}};
-          const int hstep = hires ? (4 * SCREENWIDTH) : SCREENWIDTH;
-          const int lo = MAX(st_x + WIDESCREENDELTA - SHORT(sbar->leftoffset), 0);
-          const int w = MIN(SHORT(sbar->width), SCREENWIDTH);
-          const int depth = 16;
-          byte *pal = W_CacheLumpName("PLAYPAL", PU_STATIC);
-          int v;
-
-          // [FG] temporarily draw status bar to background buffer
-          V_DrawPatch(st_x, 0, sbar);
-
-          // [FG] separate colors for the top rows
-          for (v = 0; v < arrlen(vstep); v++)
-          {
-            const int v0 = vstep[v][0], v1 = vstep[v][1];
-            unsigned r = 0, g = 0, b = 0;
-            byte col;
-
-            for (y = v0; y < v1; y++)
-            {
-              for (x = 0; x < depth; x++)
-              {
-                byte *c = dest + y * hstep + ((x + lo) << hires);
-                r += pal[3 * c[0] + 0];
-                g += pal[3 * c[0] + 1];
-                b += pal[3 * c[0] + 2];
-
-                c += (w - 2 * x - 1) << hires;
-                r += pal[3 * c[0] + 0];
-                g += pal[3 * c[0] + 1];
-                b += pal[3 * c[0] + 2];
-              }
-            }
-
-            r /= 2 * depth * (v1 - v0);
-            g /= 2 * depth * (v1 - v0);
-            b /= 2 * depth * (v1 - v0);
-
-            // [FG] tune down to half saturation (for empiric reasons)
-            col = I_GetPaletteIndex(pal, r/2, g/2, b/2);
-
-            // [FG] fill background buffer with average status bar color
-            for (y = (v0 << hires); y < (v1 << hires); y++)
-            {
-              memset(dest + y * (SCREENWIDTH << hires), col, (SCREENWIDTH << hires));
-            }
-          }
-
-          Z_ChangeTag (pal, PU_CACHE);
-        }
-        else
-        {
-          // [crispy] this is our own local copy of R_FillBackScreen() to
-          // fill the entire background of st_backing_screen with the bezel pattern,
-          // so it appears to the left and right of the status bar in widescreen mode
-          byte *src;
-          const char *name = (gamemode == commercial) ? "GRNROCK" : "FLOOR7_2";
-
-          src = W_CacheLumpNum(firstflat + R_FlatNumForName(name), PU_CACHE);
-
-          if (hires)
-          {
-            for (y = (SCREENHEIGHT-ST_HEIGHT)<<1; y < SCREENHEIGHT<<1; y++)
-                for (x = 0; x < SCREENWIDTH<<1; x += 2)
-                {
-                    const byte dot = src[(((y>>1)&63)<<6) + ((x>>1)&63)];
-
-                    *dest++ = dot;
-                    *dest++ = dot;
-                }
-          }
-          else
-          {
-            for (y = SCREENHEIGHT-ST_HEIGHT; y < SCREENHEIGHT; y++)
-              for (x = 0; x < SCREENWIDTH; x++)
-              {
-                *dest++ = src[((y&63)<<6) + (x&63)];
-              }
-          }
-
-          // [crispy] preserve bezel bottom edge
-          if (scaledviewwidth == SCREENWIDTH)
-          {
-            patch_t *const patch = W_CacheLumpName("brdr_b", PU_CACHE);
-
-            for (x = 0; x < WIDESCREENDELTA; x += 8)
-            {
-              V_DrawPatch(x - WIDESCREENDELTA, 0, patch);
-              V_DrawPatch(ORIGWIDTH + WIDESCREENDELTA - x - 8, 0, patch);
-            }
-          }
-        }
+        c += (w - 2 * x - 1) << hires;
+        r += pal[3 * c[0] + 0];
+        g += pal[3 * c[0] + 1];
+        b += pal[3 * c[0] + 2];
       }
-
-      // [crispy] center unity rerelease wide status bar
-      V_DrawPatch(st_x, 0, sbar);
-
-      // draw right side of bar if needed (Doom 1.0)
-      if (sbarr)
-        V_DrawPatch(ST_ARMSBGX, 0, sbarr);
-
-      if (st_notdeathmatch)
-        V_DrawPatch(ST_ARMSBGX, 0, armsbg);
-
-      // killough 3/7/98: make face background change with displayplayer
-      if (netgame)
-        V_DrawPatch(ST_FX, 0, faceback[displayplayer]);
-
-      V_RestoreBuffer();
-
-      // [crispy] copy entire SCREENWIDTH, to preserve the pattern
-      // to the left and right of the status bar in widescren mode
-      if (!force)
-      {
-        V_CopyRect(ST_X, 0, st_backing_screen, SCREENWIDTH, ST_HEIGHT, ST_X, ST_Y);
-      }
-      else
-      {
-        if (WIDESCREENDELTA > 0 && !st_firsttime)
-        {
-          V_CopyRect(0, 0, st_backing_screen, WIDESCREENDELTA, ST_HEIGHT, 0, ST_Y);
-          V_CopyRect(ORIGWIDTH + WIDESCREENDELTA, 0, st_backing_screen,
-                     WIDESCREENDELTA, ST_HEIGHT, ORIGWIDTH + WIDESCREENDELTA, ST_Y);
-        }
-      }
-
     }
+
+    r /= 2 * depth * (v1 - v0);
+    g /= 2 * depth * (v1 - v0);
+    b /= 2 * depth * (v1 - v0);
+
+    // [FG] tune down to half saturation (for empiric reasons)
+    col = I_GetPaletteIndex(pal, r/2, g/2, b/2);
+
+    // [FG] fill background buffer with average status bar color
+    for (y = (v0 << hires); y < (v1 << hires); y++)
+    {
+      memset(dest + y * (SCREENWIDTH << hires), col, (SCREENWIDTH << hires));
+    }
+  }
+
+  Z_ChangeTag (pal, PU_CACHE);
+#endif
 }
 
+void ST_refreshBackground(boolean force)
+{
+    int st_x;
+
+    if (!st_classicstatusbar)
+    {
+        return;
+    }
+
+    if (SHORT(sbar->width) > video.unscaledw && SHORT(sbar->leftoffset) == 0)
+    {
+        st_x = ST_X + (video.unscaledw - SHORT(sbar->width)) / 2;
+    }
+    else
+    {
+        st_x = ST_X;
+    }
+
+    V_UseBuffer(st_backing_screen);
+
+    if (video.unscaledw != ST_WIDTH)
+    {
+// TODO
+#if 0
+        if (st_solidbackground)
+        {
+            ST_DrawSolidBackground();
+        }
+        else
+#endif
+        {
+            // [crispy] this is our own local copy of R_FillBackScreen() to fill
+            // the entire background of st_backing_screen with the bezel
+            // pattern, so it appears to the left and right of the status bar
+            // in widescreen mode
+            const char *name = (gamemode == commercial) ? "GRNROCK" : "FLOOR7_2";
+
+            const byte *src = W_CacheLumpNum(firstflat + R_FlatNumForName(name), PU_CACHE);
+
+            V_TileBlock64(video.unscaledh - ST_HEIGHT, video.unscaledw, ST_HEIGHT, src);
+
+            // [crispy] preserve bezel bottom edge
+            if (scaledviewwidth == video.unscaledw)
+            {
+                int x;
+                patch_t *patch = W_CacheLumpName("brdr_b", PU_CACHE);
+
+                for (x = 0; x < video.deltaw; x += 8)
+                {
+                    V_DrawPatch(x - video.deltaw, 0, patch);
+                    V_DrawPatch(video.unscaledw - x - 8 - video.deltaw, 0, patch);
+                }
+            }
+        }
+    }
+
+    // [crispy] center unity rerelease wide status bar
+    V_DrawPatch(st_x, 0, sbar);
+
+    // draw right side of bar if needed (Doom 1.0)
+    if (sbarr)
+        V_DrawPatch(ST_ARMSBGX, 0, sbarr);
+
+    if (st_notdeathmatch)
+        V_DrawPatch(ST_ARMSBGX, 0, armsbg);
+
+    // killough 3/7/98: make face background change with displayplayer
+    if (netgame)
+        V_DrawPatch(ST_FX, 0, faceback[displayplayer]);
+
+    V_RestoreBuffer();
+
+    // [crispy] copy entire video.unscaledw, to preserve the pattern to the left
+    // and right of the status bar in widescren mode
+    if (!force)
+    {
+        V_CopyRect(ST_X, 0, st_backing_screen,
+                   video.unscaledw, ST_HEIGHT,
+                   ST_X, ST_Y);
+    }
+    else
+    {
+        if (video.deltaw > 0 && !st_firsttime)
+        {
+            V_CopyRect(0, 0, st_backing_screen,
+                       video.deltaw, ST_HEIGHT,
+                       0, ST_Y);
+            V_CopyRect(video.unscaledw - video.deltaw, 0, st_backing_screen,
+                       video.deltaw, ST_HEIGHT,
+                       video.unscaledw - video.deltaw, ST_Y);
+        }
+    }
+}
 
 // Respond to keyboard input events,
 //  intercept cheats.
@@ -881,8 +886,8 @@ void ST_drawWidgets(void)
   // clear area
   if (!st_crispyhud && st_statusbaron)
   {
-    V_CopyRect(WIDESCREENDELTA, 0, st_backing_screen, ST_WIDTH, ST_HEIGHT,
-               WIDESCREENDELTA, ST_Y);
+    V_CopyRect(video.deltaw, 0, st_backing_screen, ST_WIDTH, ST_HEIGHT,
+               video.deltaw, ST_Y);
   }
 
   // used by w_arms[] widgets
@@ -1277,7 +1282,7 @@ static void ST_MoveHud (void)
     static int odelta = 0;
 
     if (st_crispyhud && hud_active == 2)
-        distributed_delta = WIDESCREENDELTA;
+        distributed_delta = video.deltaw;
     else
         distributed_delta = 0;
 
@@ -1333,12 +1338,17 @@ static int StatusBarBufferHeight(void)
 
 void ST_Init(void)
 {
-  int st_height, size;
+  vrect_t rect;
 
   ST_loadData();
 
-  st_height = StatusBarBufferHeight();
-  size = SCREENWIDTH * (st_height << (2 * hires));
+  rect.x = 0;
+  rect.y = 0;
+  rect.w = video.unscaledw;
+  rect.h = StatusBarBufferHeight();
+
+  V_ClipRect(&rect);
+  V_ScaleRect(&rect);
 
   if (st_backing_screen)
   {
@@ -1346,7 +1356,7 @@ void ST_Init(void)
   }
 
   // killough 11/98: allocate enough for hires
-  st_backing_screen = Z_Malloc(size, PU_STATIC, 0);
+  st_backing_screen = Z_Malloc(rect.sw * rect.sh * sizeof(*st_backing_screen), PU_STATIC, 0);
 }
 
 void ST_Warnings(void)

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -325,11 +325,8 @@ static void ST_DrawSolidBackground(int st_x)
   // [FG] temporarily draw status bar to background buffer
   V_DrawPatch(st_x, 0, sbar);
 
-  vrect_t rect;
-  rect.w = MIN(SHORT(sbar->width), video.unscaledw);
-  rect.h = ST_HEIGHT;
-
   const int offset = MAX(st_x + video.deltaw - SHORT(sbar->leftoffset), 0);
+  const int width  = MIN(SHORT(sbar->width), video.unscaledw);
   const int depth  = 16;
   int v;
 
@@ -345,16 +342,12 @@ static void ST_DrawSolidBackground(int st_x)
     {
       for (x = 0; x < depth; x++)
       {
-        rect.x = x + offset;
-        rect.y = y;
-        V_ScaleRect(&rect);
-
-        byte *c = st_backing_screen + rect.sy * video.width + rect.sx;
+        byte *c = st_backing_screen + V_ScaleY(y) * video.width + V_ScaleX(x + offset);
         r += pal[3 * c[0] + 0];
         g += pal[3 * c[0] + 1];
         b += pal[3 * c[0] + 2];
 
-        c += rect.sw - 2 * rect.sx - 1;
+        c += V_ScaleX(width - 2 * x - 1);
         r += pal[3 * c[0] + 0];
         g += pal[3 * c[0] + 1];
         b += pal[3 * c[0] + 2];
@@ -410,7 +403,7 @@ void ST_refreshBackground(boolean force)
 
             const byte *src = W_CacheLumpNum(firstflat + R_FlatNumForName(name), PU_CACHE);
 
-            V_TileBlock64(video.unscaledh - ST_HEIGHT, video.unscaledw, ST_HEIGHT, src);
+            V_TileBlock64(SCREENHEIGHT - ST_HEIGHT, video.unscaledw, ST_HEIGHT, src);
 
             // [crispy] preserve bezel bottom edge
             if (scaledviewwidth == video.unscaledw)

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -1296,7 +1296,8 @@ void ST_Stop(void)
 {
   if (st_stopped)
     return;
-  I_SetPalette (W_CacheLumpNum (lu_palette, PU_CACHE));
+  if (!nodrawers)
+    I_SetPalette (W_CacheLumpNum (lu_palette, PU_CACHE));
   st_stopped = true;
 }
 

--- a/src/st_stuff.h
+++ b/src/st_stuff.h
@@ -29,8 +29,8 @@
 // Now sensitive for scaling.
 
 #define ST_HEIGHT 32
-#define ST_WIDTH  ORIGWIDTH
-#define ST_Y      (ORIGHEIGHT - ST_HEIGHT)
+#define ST_WIDTH  SCREENWIDTH
+#define ST_Y      (SCREENHEIGHT - ST_HEIGHT)
 
 //
 // STATUS BAR

--- a/src/st_stuff.h
+++ b/src/st_stuff.h
@@ -53,7 +53,9 @@ void ST_Init(void);
 void ST_Warnings(void);
 
 // [crispy] forcefully initialize the status bar backing screen
-extern void ST_refreshBackground(boolean force);
+void ST_refreshBackground(boolean force);
+
+void ST_InitRes(void);
 
 // killough 5/2/98: moved from m_misc.c:
 

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -23,9 +23,6 @@
 
 #include "doomstat.h"
 #include "doomtype.h"
-#include "r_draw.h"
-#include "r_main.h"
-#include "m_bbox.h"
 #include "w_wad.h"   /* needed for color translation lump lookup */
 #include "v_trans.h"
 #include "v_video.h"
@@ -285,7 +282,7 @@ void WriteGeneratedLumpWad(const char *filename)
     free(lumps);
 }
 
-#define WIDE_SCREENWIDTH 576 // corresponds to 2.4:1 in original resolution
+#define WIDE_SCREENWIDTH 576 // corresponds to 2.4 aspect ratio
 
 static int x1lookup[WIDE_SCREENWIDTH + 1];
 static int y1lookup[SCREENHEIGHT + 1];

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -427,7 +427,7 @@ static void V_DrawMaskedColumn(patch_column_t *patchcol, const int ytop,
       if (columntop >= 0)
       {
           // SoM: Make sure the lut is never referenced out of range
-          if (columntop >= video.unscaledh)
+          if (columntop >= SCREENHEIGHT)
               return;
 
           patchcol->y1 = y1lookup[columntop];
@@ -441,10 +441,10 @@ static void V_DrawMaskedColumn(patch_column_t *patchcol, const int ytop,
 
       if (columntop + column->length - 1 < 0)
           continue;
-      if (columntop + column->length - 1 < video.unscaledh)
+      if (columntop + column->length - 1 < SCREENHEIGHT)
           patchcol->y2 = y2lookup[columntop + column->length - 1];
       else
-          patchcol->y2 = y2lookup[video.unscaledh - 1];
+          patchcol->y2 = y2lookup[SCREENHEIGHT - 1];
 
       // SoM: The failsafes should be completely redundant now...
       // haleyjd 05/13/08: fix clipping; y2lookup not clamped properly
@@ -620,6 +620,16 @@ void V_ScaleRect(vrect_t *rect)
     rect->sh = y2lookup[rect->y + rect->h - 1] - rect->sy + 1;
 }
 
+int V_ScaleX(int x)
+{
+    return x1lookup[x];
+}
+
+int V_ScaleY(int y)
+{
+    return y1lookup[y];
+}
+
 static void V_ClipRect(vrect_t *rect)
 {
     // clip to left and top edges
@@ -633,8 +643,8 @@ static void V_ClipRect(vrect_t *rect)
     // clip right and bottom edges
     if (rect->cx2 >= video.unscaledw)
         rect->cx2 =  video.unscaledw - 1;
-    if (rect->cy2 >= video.unscaledh)
-        rect->cy2 =  video.unscaledh - 1;
+    if (rect->cy2 >= SCREENHEIGHT)
+        rect->cy2 =  SCREENHEIGHT - 1;
 
     // determine clipped width and height
     rect->cw = rect->cx2 - rect->cx1 + 1;
@@ -699,9 +709,9 @@ void V_CopyRect(int srcx, int srcy, pixel_t *source,
 #ifdef RANGECHECK
     // rejection if source rect is off-screen
     if (srcx + width < 0 || srcy + height < 0 ||
-        srcx >= video.unscaledw || srcy >= video.unscaledh ||
+        srcx >= video.unscaledw || srcy >= SCREENHEIGHT ||
         destx + width < 0 || desty + height < 0 ||
-        destx >= video.unscaledw || desty >= video.unscaledh)
+        destx >= video.unscaledw || desty >= SCREENHEIGHT)
     {
         I_Error("Bad V_CopyRect");
     }
@@ -947,7 +957,7 @@ void V_DrawBackground(const char *patchname)
 {
     const byte *src = W_CacheLumpNum(firstflat + R_FlatNumForName(patchname), PU_CACHE);
 
-    V_TileBlock64(0, video.unscaledw, video.unscaledh, src);
+    V_TileBlock64(0, video.unscaledw, SCREENHEIGHT, src);
 }
 
 //

--- a/src/v_video.h
+++ b/src/v_video.h
@@ -25,7 +25,6 @@
 
 #include "doomtype.h"
 #include "doomdef.h"
-#include "i_video.h"
 // Needed because we are refering to patches.
 #include "r_data.h"
 
@@ -92,22 +91,39 @@ void V_InitColorTranslation(void);
 
 typedef struct
 {
-   int x;   // original x coordinate for upper left corner
-   int y;   // original y coordinate for upper left corner
-   int w;   // original width
-   int h;   // original height
+    int width;
+    int height;
+    int unscaledw;
+    int deltaw;
 
-   int cx1; // clipped x coordinate for left edge
-   int cx2; // clipped x coordinate for right edge
-   int cy1; // clipped y coordinate for upper edge
-   int cy2; // clipped y coordinate for lower edge
-   int cw;  // clipped width
-   int ch;  // clipped height
+    fixed_t xscale;
+    fixed_t yscale;
+    fixed_t xstep;
+    fixed_t ystep;
 
-   int sx;  // scaled x
-   int sy;  // scaled y
-   int sw;  // scaled width
-   int sh;  // scaled height
+    angle_t fov;
+} video_t;
+
+extern video_t video;
+
+typedef struct
+{
+    int x;   // original x coordinate for upper left corner
+    int y;   // original y coordinate for upper left corner
+    int w;   // original width
+    int h;   // original height
+
+    int cx1; // clipped x coordinate for left edge
+    int cx2; // clipped x coordinate for right edge
+    int cy1; // clipped y coordinate for upper edge
+    int cy2; // clipped y coordinate for lower edge
+    int cw;  // clipped width
+    int ch;  // clipped height
+
+    int sx;  // scaled x
+    int sy;  // scaled y
+    int sw;  // scaled width
+    int sh;  // scaled height
 } vrect_t;
 
 void V_ScaleRect(vrect_t *rect);

--- a/src/v_video.h
+++ b/src/v_video.h
@@ -111,6 +111,8 @@ typedef struct
 } vrect_t;
 
 void V_ScaleRect(vrect_t *rect);
+int  V_ScaleX(int x);
+int  V_ScaleY(int y);
 
 // Allocates buffer screens, call before R_Init.
 void V_Init (void);

--- a/src/v_video.h
+++ b/src/v_video.h
@@ -90,6 +90,30 @@ extern byte gammatable[5][256];
 //jff 4/24/98 loads color translation lumps
 void V_InitColorTranslation(void);
 
+typedef struct
+{
+   int x;   // original x coordinate for upper left corner
+   int y;   // original y coordinate for upper left corner
+   int w;   // original width
+   int h;   // original height
+
+   int cx1; // clipped x coordinate for left edge
+   int cx2; // clipped x coordinate for right edge
+   int cy1; // clipped y coordinate for upper edge
+   int cy2; // clipped y coordinate for lower edge
+   int cw;  // clipped width
+   int ch;  // clipped height
+
+   int sx;  // scaled x
+   int sy;  // scaled y
+   int sw;  // scaled width
+   int sh;  // scaled height
+} vrect_t;
+
+void V_ClipRect(vrect_t *rect);
+
+void V_ScaleRect(vrect_t *rect);
+
 // Allocates buffer screens, call before R_Init.
 void V_Init (void);
 
@@ -130,6 +154,8 @@ void V_PutBlock(int x, int y, int width, int height, pixel_t *src);
 void V_DrawHorizLine(int x, int y, int width, byte color);
 
 void V_ShadeScreen(void);
+
+void V_TileBlock64(int line, int width, int height, const byte *src);
 
 void V_DrawBackground(const char *patchname);
 

--- a/src/v_video.h
+++ b/src/v_video.h
@@ -110,8 +110,6 @@ typedef struct
    int sh;  // scaled height
 } vrect_t;
 
-void V_ClipRect(vrect_t *rect);
-
 void V_ScaleRect(vrect_t *rect);
 
 // Allocates buffer screens, call before R_Init.
@@ -151,7 +149,7 @@ void V_GetBlock(int x, int y, int width, int height, pixel_t *dest);
 
 void V_PutBlock(int x, int y, int width, int height, pixel_t *src);
 
-void V_DrawHorizLine(int x, int y, int width, byte color);
+void V_FillRect(int x, int y, int width, int height, byte color);
 
 void V_ShadeScreen(void);
 

--- a/src/wi_stuff.c
+++ b/src/wi_stuff.c
@@ -454,7 +454,7 @@ static void WI_drawLF(void)
   {
     patch_t* lpic = W_CacheLumpName(wbs->lastmapinfo->levelpic, PU_CACHE);
 
-    V_DrawPatch((ORIGWIDTH - SHORT(lpic->width))/2,
+    V_DrawPatch((SCREENWIDTH - SHORT(lpic->width))/2,
                y, lpic);
 
     y += (5 * SHORT(lpic->height)) / 4;
@@ -464,14 +464,14 @@ static void WI_drawLF(void)
   if (wbs->last >= 0 && wbs->last < num_lnames && lnames[wbs->last] != NULL )
   {
   // draw <LevelName> 
-  V_DrawPatch((ORIGWIDTH - SHORT(lnames[wbs->last]->width))/2,
+  V_DrawPatch((SCREENWIDTH - SHORT(lnames[wbs->last]->width))/2,
               y, lnames[wbs->last]);
 
   // draw "Finished!"
   y += (5*SHORT(lnames[wbs->last]->height))/4;
   }
   
-  V_DrawPatch((ORIGWIDTH - SHORT(finished->width))/2,
+  V_DrawPatch((SCREENWIDTH - SHORT(finished->width))/2,
               y, finished);
 }
 
@@ -487,7 +487,7 @@ static void WI_drawEL(void)
   int y = WI_TITLEY;
 
   // draw "Entering"
-  V_DrawPatch((ORIGWIDTH - SHORT(entering->width))/2,
+  V_DrawPatch((SCREENWIDTH - SHORT(entering->width))/2,
               y, entering);
 
   // The level defines a new name but no texture for the name
@@ -510,7 +510,7 @@ static void WI_drawEL(void)
 
     y += (5 * SHORT(lpic->height)) / 4;
 
-    V_DrawPatch((ORIGWIDTH - SHORT(lpic->width))/2,
+    V_DrawPatch((SCREENWIDTH - SHORT(lpic->width))/2,
                y, lpic);
   }
   // [FG] prevent crashes for levels without name graphics
@@ -518,10 +518,10 @@ static void WI_drawEL(void)
   {
   // draw level
   // haleyjd: corrected to use height of entering, not map name
-  if (SHORT(lnames[wbs->next]->height) < ORIGHEIGHT)
+  if (SHORT(lnames[wbs->next]->height) < SCREENHEIGHT)
     y += (5 * SHORT(entering->height)) / 4;
 
-  V_DrawPatch((ORIGWIDTH - SHORT(lnames[wbs->next]->width))/2,
+  V_DrawPatch((SCREENWIDTH - SHORT(lnames[wbs->next]->width))/2,
               y, lnames[wbs->next]);
   }
 }
@@ -1817,16 +1817,16 @@ static void WI_drawStats(void)
   WI_drawLF();
 
   V_DrawPatch(SP_STATSX, SP_STATSY, kills);
-  WI_drawPercent(ORIGWIDTH - SP_STATSX, SP_STATSY, cnt_kills[0]);
+  WI_drawPercent(SCREENWIDTH - SP_STATSX, SP_STATSY, cnt_kills[0]);
 
   V_DrawPatch(SP_STATSX, SP_STATSY+lh, items);
-  WI_drawPercent(ORIGWIDTH - SP_STATSX, SP_STATSY+lh, cnt_items[0]);
+  WI_drawPercent(SCREENWIDTH - SP_STATSX, SP_STATSY+lh, cnt_items[0]);
 
   V_DrawPatch(SP_STATSX, SP_STATSY+2*lh, sp_secret);
-  WI_drawPercent(ORIGWIDTH - SP_STATSX, SP_STATSY+2*lh, cnt_secret[0]);
+  WI_drawPercent(SCREENWIDTH - SP_STATSX, SP_STATSY+2*lh, cnt_secret[0]);
 
   V_DrawPatch(SP_TIMEX, SP_TIMEY, witime);
-  WI_drawTime(ORIGWIDTH/2 - SP_TIMEX, SP_TIMEY, cnt_time, true);
+  WI_drawTime(SCREENWIDTH/2 - SP_TIMEX, SP_TIMEY, cnt_time, true);
 
   // Ty 04/11/98: redid logic: should skip only if with pwad but 
   // without deh patch
@@ -1836,17 +1836,17 @@ static void WI_drawStats(void)
   if (W_IsIWADLump(maplump) || deh_pars || um_pars)
     if (wbs->epsd < 3 || um_pars)
       {
-	V_DrawPatch(ORIGWIDTH/2 + SP_TIMEX, SP_TIMEY, par);
-	WI_drawTime(ORIGWIDTH - SP_TIMEX, SP_TIMEY, cnt_par, true);
+	V_DrawPatch(SCREENWIDTH/2 + SP_TIMEX, SP_TIMEY, par);
+	WI_drawTime(SCREENWIDTH - SP_TIMEX, SP_TIMEY, cnt_par, true);
       }
 
   // [FG] draw total time alongside level time and par time
   {
-    const boolean wide = (wbs->totaltimes / TICRATE > 61*59) || (SP_TIMEX + SHORT(total->width) >= ORIGWIDTH/4);
+    const boolean wide = (wbs->totaltimes / TICRATE > 61*59) || (SP_TIMEX + SHORT(total->width) >= SCREENWIDTH/4);
 
     V_DrawPatch(SP_TIMEX, SP_TIMEY + 16, total);
     // [FG] choose x-position depending on width of time string
-    WI_drawTime((wide ? ORIGWIDTH : ORIGWIDTH/2) - SP_TIMEX, SP_TIMEY + 16, cnt_total_time, false);
+    WI_drawTime((wide ? SCREENWIDTH : SCREENWIDTH/2) - SP_TIMEX, SP_TIMEY + 16, cnt_total_time, false);
   }
 }
 

--- a/src/z_zone.h
+++ b/src/z_zone.h
@@ -41,6 +41,7 @@
 typedef enum {
   PU_STATIC,
   PU_LEVEL,
+  PU_VALLOC,
   PU_CACHE,
   /* Must always be last -- killough */
   PU_MAX


### PR DESCRIPTION
* Use modified `R_DrawColumn` for patches scaling. Taken from Eternity Engine.

* Restore old `SCREENWIDTH` and `SCREENHEIGHT` macros, use `video_t` structure instead.

Alternative to #1292 

This is very much incomplete. Currently it will set the internal resolution to 1536x720 if `hires` is enabled. `hires` has been removed from most places.