### PR TITLE
do not clear the entire musinfo.items[] array when loading a savegame

### DIFF
--- a/src/g_game.c
+++ b/src/g_game.c
@@ -2176,7 +2176,9 @@ static void G_DoLoadGame(void)
 
     if (lump[0] && i > 0)
     {
-      memset(&musinfo, 0, sizeof(musinfo));
+      musinfo.mapthing = NULL;
+      musinfo.lastmapthing = NULL;
+      musinfo.tics = 0;
       musinfo.current_item = i;
       musinfo.from_savegame = true;
       S_ChangeMusInfoMusic(i, true);


### PR DESCRIPTION
So it is not necessary to parse the MUSINFO lump again.

Fixes #1308