### PR TITLE
Fast mouse polling

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -69,6 +69,7 @@
 #include "d_quit.h"
 #include "r_bmaps.h"
 #include "p_inter.h" // maxhealthbonus
+#include "i_input.h"
 
 #include "dsdhacked.h"
 
@@ -183,6 +184,12 @@ int eventhead, eventtail;
 //
 void D_PostEvent(event_t *ev)
 {
+  if (ev->type == ev_mouse && !menuactive && gamestate == GS_LEVEL && !paused)
+  {
+    G_MouseMovementResponder(ev);
+    return;
+  }
+
   events[eventhead++] = *ev;
   eventhead &= MAXEVENTS-1;
 }
@@ -224,6 +231,17 @@ void D_Display (void)
   static int borderdrawcount;
   int wipestart;
   boolean done, wipe, redrawsbar;
+
+  if (uncapped)
+  {
+    // [AM] Figure out how far into the current tic we're in as a fixed_t.
+    fractionaltic = I_GetFracTime();
+
+    if (window_focused)
+    {
+      I_ReadMouse();
+    }
+  }
 
   if (demobar && PLAYBACK_SKIP)
   {

--- a/src/d_net.c
+++ b/src/d_net.c
@@ -268,6 +268,7 @@ void D_ConnectNetGame(void)
     if (M_CheckParm("-solo-net") > 0)
     {
         netgame = true;
+        solonet = true;
     }
 }
 

--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -196,6 +196,7 @@ extern  boolean         respawnmonsters;
 
 // Netgame? Only true if >1 player.
 extern  boolean netgame;
+extern  boolean solonet;
 
 extern boolean D_CheckNetConnect(void);
 

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -399,6 +399,8 @@ void G_BuildTiccmd(ticcmd_t* cmd)
   extern boolean boom_weapon_state_injection;
   static boolean done_autoswitch = false;
 
+  // Assume localview can be used unless mouse input is interrupted by other
+  // inputs that apply turning or looking up/down (e.g. keyboard or gamepad).
   localview.useangle = true;
   localview.usepitch = true;
 

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -639,29 +639,28 @@ void G_BuildTiccmd(ticcmd_t* cmd)
   {
     if (mouseSensitivity_horiz_strafe)
     {
-      side += ((I_AccelerateMouse(mousex) *
-                (mouseSensitivity_horiz_strafe + 5) * 2 / 10) >> FRACBITS);
+      side += (I_AccelerateMouse(mousex) *
+               (mouseSensitivity_horiz_strafe + 5) * 2 / 10);
     }
   }
   else if (mouseSensitivity_horiz)
   {
-    cmd->angleturn -= localview.angle >> FRACBITS;
+    cmd->angleturn -= localview.angle;
   }
 
   if (mouselook)
   {
     if (mouseSensitivity_vert_look)
-      cmd->lookdir += localview.pitch >> FRACBITS;
+      cmd->lookdir += localview.pitch;
   }
   else if (!novert && mouseSensitivity_vert)
   {
-    forward += ((I_AccelerateMouse(mousey) *
-                 (mouseSensitivity_vert + 5) / 10) >> FRACBITS);
+    forward += I_AccelerateMouse(mousey) * (mouseSensitivity_vert + 5) / 10;
   }
 
   mousex = mousey = 0;
-  localview.angle = 0;
-  localview.pitch = 0;
+  localview.angle = 0.0f;
+  localview.pitch = 0.0f;
 
   if (forward > MAXPLMOVE)
     forward = MAXPLMOVE;

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -101,6 +101,7 @@ int             starttime;     // for comparative timing purposes
 boolean         viewactive;
 int             deathmatch;    // only if started as net death
 boolean         netgame;       // only true if packets are broadcast
+boolean         solonet;
 boolean         playeringame[MAXPLAYERS];
 player_t        players[MAXPLAYERS];
 int             consoleplayer; // player taking events and displaying
@@ -2082,6 +2083,7 @@ static void G_DoLoadGame(void)
   {
     netdemo = false;
     netgame = false;
+    solonet = false;
     deathmatch = false;
   }
 
@@ -3218,6 +3220,7 @@ void G_DoNewGame (void)
   I_SetFastdemoTimer(false);
   G_ReloadDefaults(false); // killough 3/1/98
   netgame = false;               // killough 3/29/98
+  solonet = false;
   deathmatch = false;
   basetic = gametic;             // killough 9/29/98
 
@@ -4061,6 +4064,7 @@ boolean G_CheckDemoStatus(void)
 
       G_ReloadDefaults(false); // killough 3/1/98
       netgame = false;       // killough 3/29/98
+      solonet = false;
       deathmatch = false;
       D_AdvanceDemo();
       return true;

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -401,7 +401,7 @@ void G_BuildTiccmd(ticcmd_t* cmd)
 
   // Assume localview can be used unless mouse input is interrupted by other
   // inputs that apply turning or looking up/down (e.g. keyboard or gamepad).
-  localview.useangle = true;
+  localview.useangle = !lowres_turn;
   localview.usepitch = true;
 
   G_DemoSkipTics();

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -30,6 +30,7 @@
 
 #define MBF21_GAME_OPTION_SIZE (21 + MBF21_COMP_TOTAL)
 
+void G_MouseMovementResponder(const event_t *ev);
 boolean G_Responder(event_t *ev);
 boolean G_CheckDemoStatus(void);
 void G_DeathMatchSpawnPlayer(int playernum);

--- a/src/i_input.c
+++ b/src/i_input.c
@@ -377,28 +377,18 @@ void I_DelayEvent(void)
 // mouse_acceleration to increase the speed.
 
 #define MAX_EVENTS 8192
-#define M_MIN (10 << FRACBITS)
-static fixed_t m_accel;
-static fixed_t m_thresh;
 int mouse_acceleration;
 int mouse_acceleration_threshold;
 
-void I_UpdateMouseAccel(void)
-{
-    m_accel = mouse_acceleration << FRACBITS;
-    m_thresh = mouse_acceleration_threshold << FRACBITS;
-}
-
-int64_t I_AccelerateMouse(int64_t val)
+float I_AccelerateMouse(int val)
 {
     if (val < 0)
         return -I_AccelerateMouse(-val);
 
-    val <<= FRACBITS;
-
-    if (val > m_thresh)
+    if (val > mouse_acceleration_threshold)
     {
-        return (val - m_thresh) * (m_accel + M_MIN) / M_MIN + m_thresh;
+        return ((float)(val - mouse_acceleration_threshold) *
+                (mouse_acceleration + 10) / 10 + mouse_acceleration_threshold);
     }
     else
     {

--- a/src/i_input.c
+++ b/src/i_input.c
@@ -381,6 +381,9 @@ int mouse_acceleration_threshold;
 
 float I_AccelerateMouse(int val)
 {
+    if (!mouse_acceleration)
+        return val;
+
     if (val < 0)
         return -I_AccelerateMouse(-val);
 

--- a/src/i_input.c
+++ b/src/i_input.c
@@ -376,7 +376,6 @@ void I_DelayEvent(void)
 // exceed the value of mouse_acceleration_threshold, they are multiplied by
 // mouse_acceleration to increase the speed.
 
-#define MAX_EVENTS 8192
 int mouse_acceleration;
 int mouse_acceleration_threshold;
 
@@ -398,31 +397,18 @@ float I_AccelerateMouse(int val)
 
 void I_ReadMouse(void)
 {
-    int x = 0;
-    int y = 0;
+    int x, y;
     static event_t ev;
-    int num_events;
-    SDL_Event events[MAX_EVENTS];
 
     SDL_PumpEvents();
-    while ((num_events = SDL_PeepEvents(events, MAX_EVENTS, SDL_GETEVENT,
-                                        SDL_MOUSEMOTION, SDL_MOUSEMOTION)) > 0)
-    {
-        int i;
-
-        for (i = 0; i < num_events; i++)
-        {
-            x += events[i].motion.xrel;
-            y -= events[i].motion.yrel;
-        }
-    }
+    SDL_GetRelativeMouseState(&x, &y);
 
     if (x != 0 || y != 0)
     {
         ev.type = ev_mouse;
         ev.data1 = 0;
         ev.data2 = x;
-        ev.data3 = y;
+        ev.data3 = -y;
 
         D_PostEvent(&ev);
     }

--- a/src/i_input.c
+++ b/src/i_input.c
@@ -379,7 +379,7 @@ void I_DelayEvent(void)
 int mouse_acceleration;
 int mouse_acceleration_threshold;
 
-float I_AccelerateMouse(int val)
+double I_AccelerateMouse(int val)
 {
     if (!mouse_acceleration)
         return val;
@@ -389,7 +389,7 @@ float I_AccelerateMouse(int val)
 
     if (val > mouse_acceleration_threshold)
     {
-        return ((float)(val - mouse_acceleration_threshold) *
+        return ((double)(val - mouse_acceleration_threshold) *
                 (mouse_acceleration + 10) / 10 + mouse_acceleration_threshold);
     }
     else

--- a/src/i_input.h
+++ b/src/i_input.h
@@ -25,7 +25,7 @@
 void I_OpenController(int which);
 void I_CloseController(int which);
 
-float I_AccelerateMouse(int val);
+double I_AccelerateMouse(int val);
 void I_ReadMouse(void);
 void I_UpdateJoystick(void);
 

--- a/src/i_input.h
+++ b/src/i_input.h
@@ -25,8 +25,7 @@
 void I_OpenController(int which);
 void I_CloseController(int which);
 
-void I_UpdateMouseAccel(void);
-int64_t I_AccelerateMouse(int64_t val);
+float I_AccelerateMouse(int val);
 void I_ReadMouse(void);
 void I_UpdateJoystick(void);
 

--- a/src/i_input.h
+++ b/src/i_input.h
@@ -25,6 +25,8 @@
 void I_OpenController(int which);
 void I_CloseController(int which);
 
+void I_UpdateMouseAccel(void);
+int64_t I_AccelerateMouse(int64_t val);
 void I_ReadMouse(void);
 void I_UpdateJoystick(void);
 

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -100,7 +100,7 @@ boolean grabmouse = true, default_grabmouse;
 // when the screen isnt visible, don't render the screen
 boolean screenvisible = true;
 
-static boolean window_focused = true;
+boolean window_focused = true;
 
 void *I_GetSDLWindow(void)
 {
@@ -377,13 +377,12 @@ static void I_GetEvent(void)
 //
 void I_StartTic (void)
 {
-    I_GetEvent();
-
     if (window_focused)
     {
         I_ReadMouse();
     }
 
+    I_GetEvent();
     I_UpdateJoystick();
 }
 
@@ -542,9 +541,6 @@ void I_FinishUpdate(void)
                     I_Sleep((remaining_time - 1000) / 1000);
             }
         }
-
-        // [AM] Figure out how far into the current tic we're in as a fixed_t.
-        fractionaltic = I_GetFracTime();
     }
 
     I_RestoreDiskBackground();
@@ -1330,6 +1326,10 @@ static void I_InitGraphicsMode(void)
     {
         flags |= SDL_WINDOW_BORDERLESS;
     }
+
+    // Keep relative motion of mouse consistent regardless of DPI or logical
+    // size of renderer.
+    SDL_SetHint(SDL_HINT_MOUSE_RELATIVE_SCALING, "0");
 
     I_GetWindowPosition(&window_x, &window_y, w, h);
 

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1327,10 +1327,6 @@ static void I_InitGraphicsMode(void)
         flags |= SDL_WINDOW_BORDERLESS;
     }
 
-    // Keep relative motion of mouse consistent regardless of DPI or logical
-    // size of renderer.
-    SDL_SetHint(SDL_HINT_MOUSE_RELATIVE_SCALING, "0");
-
     I_GetWindowPosition(&window_x, &window_y, w, h);
 
     // [FG] create rendering window

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -81,6 +81,7 @@ extern boolean vga_porch_flash; // emulate VGA "porch" behaviour
 extern int widescreen; // widescreen mode
 extern int video_display; // display index
 extern boolean screenvisible;
+extern boolean window_focused;
 extern boolean need_reset;
 extern boolean smooth_scaling;
 extern boolean toggle_fullscreen;

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -56,6 +56,7 @@
 #include "m_snapshot.h"
 #include "i_sound.h"
 #include "r_bmaps.h"
+#include "i_input.h"
 
 // [crispy] remove DOS reference from the game quit confirmation dialogs
 #include "SDL_platform.h"
@@ -3949,6 +3950,11 @@ enum {
 
 static const char *mouse_accel_strings[MOUSE_ACCEL_STRINGS_SIZE];
 
+static void M_UpdateMouseAccel(void)
+{
+  I_UpdateMouseAccel();
+}
+
 static void M_InitMouseAccel(void)
 {
   int i;
@@ -3962,6 +3968,8 @@ static void M_InitMouseAccel(void)
   }
 
   mouse_accel_strings[i] = NULL;
+
+  M_UpdateMouseAccel();
 }
 
 void M_ResetTimeScale(void)
@@ -4154,10 +4162,10 @@ setup_menu_t gen_settings5[] = { // General Settings screen5
    M_Y+ gen5_mouse3*M_SPC, {"mouse_y_invert"}},
 
   {"Mouse acceleration", S_THERMO, m_null, M_X_THRM,
-   M_Y + gen5_mouse_accel * M_SPC, {"mouse_acceleration"}, 0, NULL, mouse_accel_strings},
+   M_Y + gen5_mouse_accel * M_SPC, {"mouse_acceleration"}, 0, M_UpdateMouseAccel, mouse_accel_strings},
 
   {"Mouse threshold", S_NUM, m_null, M_X,
-   M_Y + gen5_mouse_accel_threshold * M_SPC, {"mouse_acceleration_threshold"}},
+   M_Y + gen5_mouse_accel_threshold * M_SPC, {"mouse_acceleration_threshold"}, 0, M_UpdateMouseAccel},
 
   {"", S_SKIP, m_null, M_X, M_Y + gen5_end1*M_SPC},
 

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -56,7 +56,6 @@
 #include "m_snapshot.h"
 #include "i_sound.h"
 #include "r_bmaps.h"
-#include "i_input.h"
 
 // [crispy] remove DOS reference from the game quit confirmation dialogs
 #include "SDL_platform.h"
@@ -3950,11 +3949,6 @@ enum {
 
 static const char *mouse_accel_strings[MOUSE_ACCEL_STRINGS_SIZE];
 
-static void M_UpdateMouseAccel(void)
-{
-  I_UpdateMouseAccel();
-}
-
 static void M_InitMouseAccel(void)
 {
   int i;
@@ -3968,8 +3962,6 @@ static void M_InitMouseAccel(void)
   }
 
   mouse_accel_strings[i] = NULL;
-
-  M_UpdateMouseAccel();
 }
 
 void M_ResetTimeScale(void)
@@ -4162,10 +4154,10 @@ setup_menu_t gen_settings5[] = { // General Settings screen5
    M_Y+ gen5_mouse3*M_SPC, {"mouse_y_invert"}},
 
   {"Mouse acceleration", S_THERMO, m_null, M_X_THRM,
-   M_Y + gen5_mouse_accel * M_SPC, {"mouse_acceleration"}, 0, M_UpdateMouseAccel, mouse_accel_strings},
+   M_Y + gen5_mouse_accel * M_SPC, {"mouse_acceleration"}, 0, NULL, mouse_accel_strings},
 
   {"Mouse threshold", S_NUM, m_null, M_X,
-   M_Y + gen5_mouse_accel_threshold * M_SPC, {"mouse_acceleration_threshold"}, 0, M_UpdateMouseAccel},
+   M_Y + gen5_mouse_accel_threshold * M_SPC, {"mouse_acceleration_threshold"}},
 
   {"", S_SKIP, m_null, M_X, M_Y + gen5_end1*M_SPC},
 

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -653,12 +653,12 @@ void R_SetupFrame (player_t *player)
     viewz = player->oldviewz + FixedMul(player->viewz - player->oldviewz, fractionaltic);
 
     if (localview.useangle && use_local)
-      viewangle = player->mo->angle - localview.angle + viewangleoffset;
+      viewangle = player->mo->angle - (double)localview.angle * FRACUNIT + viewangleoffset;
     else
       viewangle = R_InterpolateAngle(player->mo->oldangle, player->mo->angle, fractionaltic) + viewangleoffset;
 
     if (localview.usepitch && use_local && !player->centering && player->lookdir)
-      pitch = (((player->lookdir << FRACBITS) + localview.pitch) / MLOOKUNIT) >> FRACBITS;
+      pitch = (player->lookdir + localview.pitch) / MLOOKUNIT;
     else
       pitch = (player->oldlookdir + (player->lookdir - player->oldlookdir) * FIXED2DOUBLE(fractionaltic)) / MLOOKUNIT;
 

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -644,7 +644,7 @@ void R_SetupFrame (player_t *player)
       player->health > 0 &&
       !player->mo->reactiontime &&
       !demoplayback &&
-      !netgame
+      (!netgame || solonet)
     );
 
     // Interpolate player camera from their old position to their current one.

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -639,11 +639,16 @@ void R_SetupFrame (player_t *player)
       // Don't interpolate during a paused state
       leveltime > oldleveltime)
   {
-    const boolean use_local = (
+    const boolean use_localview = (
+      // Don't use localview if the player is spying.
       player == &players[consoleplayer] &&
+      // Don't use localview if the player is dead.
       player->health > 0 &&
+      // Don't use localview if the player just teleported.
       !player->mo->reactiontime &&
+      // Don't use localview if a demo is playing.
       !demoplayback &&
+      // Don't use localview during a netgame (single-player and solo-net only).
       (!netgame || solonet)
     );
 
@@ -652,12 +657,14 @@ void R_SetupFrame (player_t *player)
     viewy = player->mo->oldy + FixedMul(player->mo->y - player->mo->oldy, fractionaltic);
     viewz = player->oldviewz + FixedMul(player->viewz - player->oldviewz, fractionaltic);
 
-    if (localview.useangle && use_local)
+    // Use localview unless the player or game is in an invalid state or if
+    // mouse input was interrupted, in which case fall back to interpolation.
+    if (localview.useangle && use_localview)
       viewangle = player->mo->angle - (double)localview.angle * FRACUNIT + viewangleoffset;
     else
       viewangle = R_InterpolateAngle(player->mo->oldangle, player->mo->angle, fractionaltic) + viewangleoffset;
 
-    if (localview.usepitch && use_local && !player->centering && player->lookdir)
+    if (localview.usepitch && use_localview && !player->centering && player->lookdir)
       pitch = (player->lookdir + localview.pitch) / MLOOKUNIT;
     else
       pitch = (player->oldlookdir + (player->lookdir - player->oldlookdir) * FIXED2DOUBLE(fractionaltic)) / MLOOKUNIT;

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -660,7 +660,7 @@ void R_SetupFrame (player_t *player)
     // Use localview unless the player or game is in an invalid state or if
     // mouse input was interrupted, in which case fall back to interpolation.
     if (localview.useangle && use_localview)
-      viewangle = player->mo->angle - (double)localview.angle * FRACUNIT + viewangleoffset;
+      viewangle = player->mo->angle - ((short)localview.angle << FRACBITS) + viewangleoffset;
     else
       viewangle = R_InterpolateAngle(player->mo->oldangle, player->mo->angle, fractionaltic) + viewangleoffset;
 

--- a/src/r_state.h
+++ b/src/r_state.h
@@ -86,6 +86,13 @@ extern line_t           *lines;
 extern int              numsides;
 extern side_t           *sides;
 
+typedef struct localview_s
+{
+    boolean useangle;
+    boolean usepitch;
+    int64_t angle;
+    fixed_t pitch;
+} localview_t;
 
 //
 // POV data.
@@ -94,6 +101,7 @@ extern fixed_t          viewx;
 extern fixed_t          viewy;
 extern fixed_t          viewz;
 extern angle_t          viewangle;
+extern localview_t      localview;
 extern player_t         *viewplayer;
 extern angle_t          clipangle;
 extern angle_t          vx_clipangle;

--- a/src/r_state.h
+++ b/src/r_state.h
@@ -90,8 +90,8 @@ typedef struct localview_s
 {
     boolean useangle;
     boolean usepitch;
-    int64_t angle;
-    fixed_t pitch;
+    float angle;
+    float pitch;
 } localview_t;
 
 //

--- a/src/r_state.h
+++ b/src/r_state.h
@@ -90,8 +90,8 @@ typedef struct localview_s
 {
     boolean useangle;
     boolean usepitch;
-    float angle;
-    float pitch;
+    int angle;
+    int pitch;
 } localview_t;
 
 //

--- a/src/r_state.h
+++ b/src/r_state.h
@@ -101,7 +101,7 @@ extern fixed_t          viewx;
 extern fixed_t          viewy;
 extern fixed_t          viewz;
 extern angle_t          viewangle;
-extern localview_t      localview;
+extern localview_t      localview; // View orientation offsets for current frame.
 extern player_t         *viewplayer;
 extern angle_t          clipangle;
 extern angle_t          vx_clipangle;


### PR DESCRIPTION
Second attempt, additional details here: https://github.com/fabiangreffrath/woof/pull/1262  (I wasn't able to reopen it)

The issues from the previous experiment should be resolved now, thanks to everyone for the feedback. Note: even before this PR, interpolation has been a little weird in multiplayer. I'm treating it as out of scope for now.

Conceptually, this is the same as before. At the start of each display update, and also at the start of each game simulation update, mouse x/y movement events are collected from SDL until the buffer is empty. 

This data is accumulated in the `mousex/y` and `localview.angle/pitch` variables, and is used to apply an offset to the player's viewpoint in `R_SetupFrame()`. This "virtual" viewpoint gives the impression that the mouse response is near instantaneous, depending on the display's refresh rate.

When `G_BuildTiccmd()` is eventually called during the next game simulation update, it uses that "virtual" viewpoint data (`mousex/y` and `localview.angle/pitch`) to create a ticcmd which eventually updates the "real" viewpoint data (`player->mo->angle` and  `player->lookdir`).

After that, the variables are reset and the process repeats.