### PR TITLE
Invoke ST_doPaletteStuff every game tic, not every frame

### DIFF
--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -794,6 +794,8 @@ void ST_Ticker(void)
   st_invul = (plyr->powers[pw_invulnerability] > 4*32 ||
               plyr->powers[pw_invulnerability] & 8) ||
               plyr->cheats & CF_GODMODE;
+
+  ST_doPaletteStuff();  // Do red-/gold-shifts from damage/items
 }
 
 static int st_palette = 0;
@@ -980,8 +982,6 @@ void ST_Drawer(boolean fullscreen, boolean refresh)
   st_classicstatusbar = st_statusbaron && !st_crispyhud;
 
   ST_MoveHud();
-
-  ST_doPaletteStuff();  // Do red-/gold-shifts from damage/items
 
   if (st_firsttime)     // If just after ST_Start(), refresh all
   {

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -781,6 +781,7 @@ static int SmoothCount(int shownval, int realval)
 }
 
 boolean st_invul;
+static void ST_doPaletteStuff(void);
 
 void ST_Ticker(void)
 {
@@ -801,7 +802,7 @@ void ST_Ticker(void)
 static int st_palette = 0;
 boolean palette_changes = true;
 
-void ST_doPaletteStuff(void)
+static void ST_doPaletteStuff(void)
 {
   int         palette;
   byte*       pal;

--- a/src/st_stuff.h
+++ b/src/st_stuff.h
@@ -52,6 +52,8 @@ void ST_Start(void);
 void ST_Init(void);
 void ST_Warnings(void);
 
+void ST_doPaletteStuff(void);
+
 // [crispy] forcefully initialize the status bar backing screen
 extern void ST_refreshBackground(boolean force);
 

--- a/src/st_stuff.h
+++ b/src/st_stuff.h
@@ -52,8 +52,6 @@ void ST_Start(void);
 void ST_Init(void);
 void ST_Warnings(void);
 
-void ST_doPaletteStuff(void);
-
 // [crispy] forcefully initialize the status bar backing screen
 extern void ST_refreshBackground(boolean force);
 


### PR DESCRIPTION
AFAIR, we was discussing it with @fabiangreffrath ages ago, but somehow it didn't get into Crispy Doom and Woof.

The idea is simple: back in a day when there was no uncapped mode, both `ST_Drawer` and `ST_Ticker` were updating on same speed. Nowadays, in uncapped mode `ST_Drawer` is updating every frame, while `ST_Ticker` is still updating every game tic. But in uncapped framerate there is no need to check for palette changes every frame, since such changes are still related to game tics and game is not actually "faster".

So, this must be a micro-optimization, for getting rid of some unnecessary often checks. 

P.S. Is it okay to have extern declaration in .h file? `ST_doPaletteStuff` is not needed globally, but making prototypes in the middle of .c files feels yucky. 