### PR TITLE
Don't limit menus to 35 fps

### DIFF
--- a/src/d_loop.c
+++ b/src/d_loop.c
@@ -728,7 +728,7 @@ void TryRunTics (void)
 
     // [AM] If we've uncapped the framerate and there are no tics
     //      to run, return early instead of waiting around.
-    #define return_early (uncapped && counts == 0 && leveltime > oldleveltime)
+    #define return_early (uncapped && counts == 0)
 
     // get real tics
     entertic = I_GetTime() / ticdup;


### PR DESCRIPTION
Forcing the framerate to 35 fps in the menus causes flickering on VRR (variable refresh rate) monitors and TVs, which are very common now. This is a very old problem that I've noticed on my monitor and TV as well. Downside is slightly more power usage for laptops, etc.

[Doomworld post](https://www.doomworld.com/forum/topic/125256-nugget-doom-221-updated-october-16th-23/?do=findComment&comment=2745082)
[Similar Crispy issue](https://github.com/fabiangreffrath/crispy-doom/issues/363#issuecomment-446248038)