### PR TITLE
improve logging to console (again)

### DIFF
--- a/src/g_game.c
+++ b/src/g_game.c
@@ -1895,8 +1895,7 @@ static void G_DoPlayDemo(void)
   }
 
   // [FG] report compatibility mode
-  I_Printf(VB_INFO, "G_DoPlayDemo: Playing demo with %s (%d) compatibility.",
-    G_GetCurrentComplevelName(), demover);
+  I_Printf(VB_INFO, "G_DoPlayDemo: %s (%s)", basename, W_WadNameForLump(lumpnum));
 }
 
 #define VERSIONSIZE   16
@@ -2333,14 +2332,7 @@ static void G_DoLoadGame(void)
       if (demorecording) // So this can only possibly be a -recordfrom command.
 	G_BeginRecording();// Start the -recordfrom, since the game was loaded.
 
-  // [FG] log game loading
-  {
-    char *maplump = MAPNAME(gameepisode, gamemap);
-    int maplumpnum = W_CheckNumForName(maplump);
-
-    I_Printf(VB_INFO, "G_DoLoadGame: Slot %d, %.8s (%s)",
-      10*savepage+savegameslot, maplump, W_WadNameForLump(maplumpnum));
-  }
+  I_Printf(VB_INFO, "G_DoLoadGame: Slot %02d", 10*savepage+savegameslot);
 
   M_SetQuickSaveSlot(savegameslot);
 }

--- a/src/i_oalsound.c
+++ b/src/i_oalsound.c
@@ -623,6 +623,7 @@ boolean I_OAL_CacheSound(sfxinfo_t *sfx)
 
             if (I_SND_LoadFile(lumpdata, &format, &wavdata, &size, &freq) == false)
             {
+                I_Printf(VB_WARNING, " I_OAL_CacheSound: %s", lumpinfo[lumpnum].name);
                 break;
             }
 

--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -1670,17 +1670,18 @@ void P_SetupLevel(int episode, int map, int playermask, skill_t skill)
 
   // [FG] log level setup
   {
-    I_Printf(VB_INFO, "P_SetupLevel: %.8s (%s), %s%s%s, %s complevel",
+    I_Printf(VB_INFO, "P_SetupLevel: %.8s (%s), Skill %d, %s%s%s, %s (%d)",
       lumpname, W_WadNameForLump(lumpnum),
-      mapformat == MFMT_XNOD ? "XNOD nodes" :
-      mapformat == MFMT_ZNOD ? "ZNOD nodes" :
-      mapformat == MFMT_XGLN ? "XGLN nodes" :
-      mapformat == MFMT_ZGLN ? "ZGLN nodes" :
-      mapformat == MFMT_DEEP ? "DeepBSP nodes" :
-      "Doom nodes",
-      gen_blockmap ? " + Blockmap" : "",
-      pad_reject ? " + Reject" : "",
-      G_GetCurrentComplevelName());
+      gameskill + 1,
+      mapformat == MFMT_XNOD ? "XNOD" :
+      mapformat == MFMT_ZNOD ? "ZNOD" :
+      mapformat == MFMT_XGLN ? "XGLN" :
+      mapformat == MFMT_ZGLN ? "ZGLN" :
+      mapformat == MFMT_DEEP ? "DeepBSP" :
+      "Doom",
+      gen_blockmap ? "+Blockmap" : "",
+      pad_reject ? "+Reject" : "",
+      G_GetCurrentComplevelName(), demo_version);
   }
 }
 

--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -1669,7 +1669,7 @@ void P_SetupLevel(int episode, int map, int playermask, skill_t skill)
     R_PrecacheLevel();
 
   // [FG] log level setup
-  I_Printf(VB_INFO, "P_SetupLevel: %.8s (%s), Skill %d, %s%s%s, %s (%d)",
+  I_Printf(VB_INFO, "P_SetupLevel: %.8s (%s), Skill %d, %s%s%s, %s",
     lumpname, W_WadNameForLump(lumpnum),
     gameskill + 1,
     mapformat == MFMT_XNOD ? "XNOD" :
@@ -1680,7 +1680,7 @@ void P_SetupLevel(int episode, int map, int playermask, skill_t skill)
     "Doom",
     gen_blockmap ? "+Blockmap" : "",
     pad_reject ? "+Reject" : "",
-    G_GetCurrentComplevelName(), demo_version);
+    G_GetCurrentComplevelName());
 }
 
 //

--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -1669,20 +1669,18 @@ void P_SetupLevel(int episode, int map, int playermask, skill_t skill)
     R_PrecacheLevel();
 
   // [FG] log level setup
-  {
-    I_Printf(VB_INFO, "P_SetupLevel: %.8s (%s), Skill %d, %s%s%s, %s (%d)",
-      lumpname, W_WadNameForLump(lumpnum),
-      gameskill + 1,
-      mapformat == MFMT_XNOD ? "XNOD" :
-      mapformat == MFMT_ZNOD ? "ZNOD" :
-      mapformat == MFMT_XGLN ? "XGLN" :
-      mapformat == MFMT_ZGLN ? "ZGLN" :
-      mapformat == MFMT_DEEP ? "DeepBSP" :
-      "Doom",
-      gen_blockmap ? "+Blockmap" : "",
-      pad_reject ? "+Reject" : "",
-      G_GetCurrentComplevelName(), demo_version);
-  }
+  I_Printf(VB_INFO, "P_SetupLevel: %.8s (%s), Skill %d, %s%s%s, %s (%d)",
+    lumpname, W_WadNameForLump(lumpnum),
+    gameskill + 1,
+    mapformat == MFMT_XNOD ? "XNOD" :
+    mapformat == MFMT_ZNOD ? "ZNOD" :
+    mapformat == MFMT_XGLN ? "XGLN" :
+    mapformat == MFMT_ZGLN ? "ZGLN" :
+    mapformat == MFMT_DEEP ? "DeepBSP" :
+    "Doom",
+    gen_blockmap ? "+Blockmap" : "",
+    pad_reject ? "+Reject" : "",
+    G_GetCurrentComplevelName(), demo_version);
 }
 
 //


### PR DESCRIPTION
G_DoPlayDemo: Do not print compatibility, P_SetupLevel already does this. Instead, print the demo lump name and lump source name.

G_DoLoadGame: Do not print map lump name and lump source name, P_SetupLevel already does this. Just print the slot number.

I_OAL_CacheSound: Print the names of lumps failed to load with I_SND_LoadFile.

P_SetupLevel: Print skill (interesting for demos and savegames), print complevel name and numerical value, condense nodes format reporting.