### PR TITLE
linear sky and DRS mode

### DIFF
--- a/src/r_main.c
+++ b/src/r_main.c
@@ -295,7 +295,7 @@ static void R_InitTextureMapping (void)
         ;
       xtoviewangle[x] = (i<<ANGLETOFINESHIFT)-ANG90;
       // [FG] linear horizontal sky scrolling
-      linearskyangle[x] = ((viewwidth/2-x)*((SCREENWIDTH<<6)/viewwidth))*(ANG90/(NONWIDEWIDTH<<6));
+      linearskyangle[x] = ((viewwidth/2-x)*((video.unscaledw<<6)/viewwidth))*(ANG90/(NONWIDEWIDTH<<6));
     }
     
   // Take out the fencepost cases from viewangletox.


### PR DESCRIPTION
Linear sky jumps too much when the resolution changes. Maybe we should change its formula? Normal sky works fine.