### PR TITLE
More mouse improvements

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -174,7 +174,7 @@ int eventhead, eventtail;
 //
 void D_PostEvent(event_t *ev)
 {
-  if (ev->type == ev_mouse && !menuactive && gamestate == GS_LEVEL && !paused)
+  if (ev->type == ev_mouse)
   {
     G_MouseMovementResponder(ev);
     return;
@@ -240,9 +240,10 @@ void D_Display (void)
     // [AM] Figure out how far into the current tic we're in as a fixed_t.
     fractionaltic = I_GetFracTime();
 
-    if (window_focused)
+    if (!menuactive && gamestate == GS_LEVEL && !paused)
     {
-      I_ReadMouse();
+      I_StartDisplay();
+      G_PrepTiccmd();
     }
   }
 

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -177,6 +177,7 @@ void D_PostEvent(event_t *ev)
   if (ev->type == ev_mouse)
   {
     G_MouseMovementResponder(ev);
+    G_PrepTiccmd();
     return;
   }
 
@@ -243,7 +244,6 @@ void D_Display (void)
     if (!menuactive && gamestate == GS_LEVEL && !paused)
     {
       I_StartDisplay();
-      G_PrepTiccmd();
     }
   }
 

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -241,7 +241,7 @@ void D_Display (void)
     // [AM] Figure out how far into the current tic we're in as a fixed_t.
     fractionaltic = I_GetFracTime();
 
-    if (!menuactive && gamestate == GS_LEVEL && !paused)
+    if (!menuactive && gamestate == GS_LEVEL && !paused && mouse_raw_input)
     {
       I_StartDisplay();
     }

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -30,7 +30,8 @@
 
 #define MBF21_GAME_OPTION_SIZE (21 + MBF21_COMP_TOTAL)
 
-void G_MouseMovementResponder(const event_t *ev);
+void G_PrepTiccmd(void);
+boolean G_MouseMovementResponder(event_t *ev);
 boolean G_Responder(event_t *ev);
 boolean G_CheckDemoStatus(void);
 void G_DeathMatchSpawnPlayer(int playernum);

--- a/src/i_input.c
+++ b/src/i_input.c
@@ -403,7 +403,6 @@ void I_ReadMouse(void)
     int x, y;
     static event_t ev;
 
-    SDL_PumpEvents();
     SDL_GetRelativeMouseState(&x, &y);
 
     if (x != 0 || y != 0)

--- a/src/i_system.h
+++ b/src/i_system.h
@@ -45,6 +45,8 @@ void I_StartFrame (void);
 
 void I_StartTic (void);
 
+void I_StartDisplay(void);
+
 // Asynchronous interrupt functions should maintain private queues
 // that are read by the synchronous functions
 // to be converted into events.

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -417,13 +417,23 @@ static void I_GetEvent(void)
 //
 void I_StartTic (void)
 {
+    I_GetEvent();
+
     if (window_focused)
     {
         I_ReadMouse();
     }
 
-    I_GetEvent();
     I_UpdateJoystick();
+}
+
+void I_StartDisplay(void)
+{
+    if (window_focused)
+    {
+        SDL_PumpEvents();
+        I_ReadMouse();
+    }
 }
 
 //

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -3941,6 +3941,7 @@ enum {
   gen5_mouse3,
   gen5_mouse_accel,
   gen5_mouse_accel_threshold,
+  gen5_mouse_smoothing,
   gen5_end1,
 
   gen5_title2,
@@ -4164,6 +4165,9 @@ setup_menu_t gen_settings5[] = { // General Settings screen5
 
   {"Mouse threshold", S_NUM, m_null, M_X,
    M_Y + gen5_mouse_accel_threshold * M_SPC, {"mouse_acceleration_threshold"}},
+
+  {"Mouse smoothing", S_YESNO, m_null, M_X,
+   M_Y+ gen5_mouse_smoothing * M_SPC, {"mouse_smoothing"}},
 
   {"", S_SKIP, m_null, M_X, M_Y + gen5_end1*M_SPC},
 

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -3941,7 +3941,7 @@ enum {
   gen5_mouse3,
   gen5_mouse_accel,
   gen5_mouse_accel_threshold,
-  gen5_mouse_smoothing,
+  gen5_mouse_raw_input,
   gen5_end1,
 
   gen5_title2,
@@ -4166,8 +4166,8 @@ setup_menu_t gen_settings5[] = { // General Settings screen5
   {"Mouse threshold", S_NUM, m_null, M_X,
    M_Y + gen5_mouse_accel_threshold * M_SPC, {"mouse_acceleration_threshold"}},
 
-  {"Mouse smoothing", S_YESNO, m_null, M_X,
-   M_Y+ gen5_mouse_smoothing * M_SPC, {"mouse_smoothing"}},
+  {"Raw mouse input", S_YESNO, m_null, M_X,
+   M_Y+ gen5_mouse_raw_input * M_SPC, {"mouse_raw_input"}},
 
   {"", S_SKIP, m_null, M_X, M_Y + gen5_end1*M_SPC},
 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -84,7 +84,6 @@ extern boolean flipcorpses; // [crispy] randomly flip corpse, blood and death an
 extern boolean ghost_monsters; // [crispy] resurrected pools of gore ("ghost monsters") are translucent
 extern int mouse_acceleration;
 extern int mouse_acceleration_threshold;
-extern boolean mouse_raw_input;
 extern int show_endoom;
 #if defined(HAVE_FLUIDSYNTH)
 extern char *soundfont_path;

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -84,7 +84,7 @@ extern boolean flipcorpses; // [crispy] randomly flip corpse, blood and death an
 extern boolean ghost_monsters; // [crispy] resurrected pools of gore ("ghost monsters") are translucent
 extern int mouse_acceleration;
 extern int mouse_acceleration_threshold;
-extern boolean mouse_smoothing;
+extern boolean mouse_raw_input;
 extern int show_endoom;
 #if defined(HAVE_FLUIDSYNTH)
 extern char *soundfont_path;
@@ -2061,10 +2061,10 @@ default_t defaults[] = {
   },
 
   {
-    "mouse_smoothing",
-    (config_t *) &mouse_smoothing, NULL,
-    {0}, {0, 1}, number, ss_none, wad_no,
-    "1 to enable interpolation for mouse turning/looking"
+    "mouse_raw_input",
+    (config_t *) &mouse_raw_input, NULL,
+    {1}, {0, 1}, number, ss_none, wad_no,
+    "Raw mouse input for turning/looking (0 = Interpolate, 1 = Raw)"
   },
 
   // [FG] invert vertical axis

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -84,6 +84,7 @@ extern boolean flipcorpses; // [crispy] randomly flip corpse, blood and death an
 extern boolean ghost_monsters; // [crispy] resurrected pools of gore ("ghost monsters") are translucent
 extern int mouse_acceleration;
 extern int mouse_acceleration_threshold;
+extern boolean mouse_smoothing;
 extern int show_endoom;
 #if defined(HAVE_FLUIDSYNTH)
 extern char *soundfont_path;
@@ -2057,6 +2058,13 @@ default_t defaults[] = {
     (config_t *) &mouse_acceleration_threshold, NULL,
     {10}, {0,32}, number, ss_none, wad_no,
     "adjust mouse acceleration threshold"
+  },
+
+  {
+    "mouse_smoothing",
+    (config_t *) &mouse_smoothing, NULL,
+    {0}, {0, 1}, number, ss_none, wad_no,
+    "1 to enable interpolation for mouse turning/looking"
   },
 
   // [FG] invert vertical axis

--- a/src/p_user.c
+++ b/src/p_user.c
@@ -190,6 +190,12 @@ void P_MovePlayer (player_t* player)
   mo->angle += cmd->angleturn << 16;
   onground = mo->z <= mo->floorz;
 
+  if (player == &players[consoleplayer])
+  {
+    localview.ticangle += localview.ticangleturn << 16;
+    localview.ticangleturn = 0;
+  }
+
   // killough 10/98:
   //
   // We must apply thrust to the player and bobbing separately, to avoid
@@ -352,6 +358,11 @@ void P_PlayerThink (player_t* player)
   player->oldviewz = player->viewz;
   player->oldlookdir = player->lookdir;
   player->oldrecoilpitch = player->recoilpitch;
+
+  if (player == &players[consoleplayer])
+  {
+    localview.oldticangle = localview.ticangle;
+  }
 
   // killough 2/8/98, 3/21/98:
   // (this code is necessary despite questions raised elsewhere in a comment)

--- a/src/p_user.c
+++ b/src/p_user.c
@@ -386,7 +386,11 @@ void P_PlayerThink (player_t* player)
     if (abs(player->lookdir) < 8 * MLOOKUNIT)
     {
       player->lookdir = 0;
-      player->centering = false;
+
+      if (player->oldlookdir == 0)
+      {
+        player->centering = false;
+      }
     }
 
     player->slope = PLAYER_SLOPE(player);

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -48,7 +48,7 @@ fixed_t  projection;
 fixed_t  viewx, viewy, viewz;
 angle_t  viewangle;
 localview_t localview;
-boolean mouse_smoothing;
+boolean mouse_raw_input;
 fixed_t  viewcos, viewsin;
 player_t *viewplayer;
 extern lighttable_t **walllights;
@@ -651,8 +651,8 @@ void R_SetupFrame (player_t *player)
       leveltime > oldleveltime)
   {
     const boolean use_localview = (
-      // Don't use localview if mouse smoothing is enabled.
-      !mouse_smoothing &&
+      // Don't use localview when interpolation is preferred.
+      mouse_raw_input &&
       // Don't use localview if the player is spying.
       player == &players[consoleplayer] &&
       // Don't use localview if the player is dead.

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -669,8 +669,12 @@ void R_SetupFrame (player_t *player)
 
     // Use localview unless the player or game is in an invalid state or if
     // mouse input was interrupted, in which case fall back to interpolation.
-    if (localview.useangle && use_localview)
-      viewangle = player->mo->angle - ((short)localview.angle << FRACBITS);
+    if (use_localview)
+    {
+      viewangle = (player->mo->angle + localview.angle - localview.ticangle +
+                   R_InterpolateAngle(localview.oldticangle, localview.ticangle,
+                                      fractionaltic));
+    }
     else
       viewangle = R_InterpolateAngle(player->mo->oldangle, player->mo->angle, fractionaltic);
 

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -670,9 +670,9 @@ void R_SetupFrame (player_t *player)
     // Use localview unless the player or game is in an invalid state or if
     // mouse input was interrupted, in which case fall back to interpolation.
     if (localview.useangle && use_localview)
-      viewangle = player->mo->angle - ((short)localview.angle << FRACBITS) + viewangleoffset;
+      viewangle = player->mo->angle - ((short)localview.angle << FRACBITS);
     else
-      viewangle = R_InterpolateAngle(player->mo->oldangle, player->mo->angle, fractionaltic) + viewangleoffset;
+      viewangle = R_InterpolateAngle(player->mo->oldangle, player->mo->angle, fractionaltic);
 
     if (localview.usepitch && use_localview && !player->centering)
       pitch = (player->lookdir + localview.pitch) / MLOOKUNIT;
@@ -684,13 +684,17 @@ void R_SetupFrame (player_t *player)
   }
   else
   {
-  viewx = player->mo->x;
-  viewy = player->mo->y;
-  viewz = player->viewz; // [FG] moved here
-  viewangle = player->mo->angle + viewangleoffset;
-  // [crispy] pitch is actual lookdir and weapon pitch
-  pitch = player->lookdir / MLOOKUNIT + player->recoilpitch;
+    viewx = player->mo->x;
+    viewy = player->mo->y;
+    viewz = player->viewz; // [FG] moved here
+    viewangle = player->mo->angle;
+    // [crispy] pitch is actual lookdir and weapon pitch
+    pitch = player->lookdir / MLOOKUNIT + player->recoilpitch;
   }
+
+  // 3-screen display mode.
+  viewangle += viewangleoffset;
+
   extralight = player->extralight;
   extralight += STRICTMODE(LIGHTBRIGHT * extra_level_brightness);
     

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -48,6 +48,7 @@ fixed_t  projection;
 fixed_t  viewx, viewy, viewz;
 angle_t  viewangle;
 localview_t localview;
+boolean mouse_smoothing;
 fixed_t  viewcos, viewsin;
 player_t *viewplayer;
 extern lighttable_t **walllights;
@@ -650,6 +651,8 @@ void R_SetupFrame (player_t *player)
       leveltime > oldleveltime)
   {
     const boolean use_localview = (
+      // Don't use localview if mouse smoothing is enabled.
+      !mouse_smoothing &&
       // Don't use localview if the player is spying.
       player == &players[consoleplayer] &&
       // Don't use localview if the player is dead.

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -674,7 +674,7 @@ void R_SetupFrame (player_t *player)
     else
       viewangle = R_InterpolateAngle(player->mo->oldangle, player->mo->angle, fractionaltic) + viewangleoffset;
 
-    if (localview.usepitch && use_localview && !player->centering && player->lookdir)
+    if (localview.usepitch && use_localview && !player->centering)
       pitch = (player->lookdir + localview.pitch) / MLOOKUNIT;
     else
       pitch = (player->oldlookdir + (player->lookdir - player->oldlookdir) * FIXED2DOUBLE(fractionaltic)) / MLOOKUNIT;

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -653,7 +653,7 @@ void R_SetupFrame (player_t *player)
       // Don't use localview if the player is spying.
       player == &players[consoleplayer] &&
       // Don't use localview if the player is dead.
-      player->health > 0 &&
+      player->playerstate != PST_DEAD &&
       // Don't use localview if the player just teleported.
       !player->mo->reactiontime &&
       // Don't use localview if a demo is playing.

--- a/src/r_main.h
+++ b/src/r_main.h
@@ -81,6 +81,8 @@ extern lighttable_t *fixedcolormap;
 //      range of [0.0, 1.0).  Used for interpolation.
 extern fixed_t          fractionaltic;
 
+extern boolean mouse_raw_input;
+
 // [AM] Interpolate between two angles.
 angle_t R_InterpolateAngle(angle_t oangle, angle_t nangle, fixed_t scale);
 

--- a/src/r_state.h
+++ b/src/r_state.h
@@ -90,8 +90,10 @@ extern side_t           *sides;
 
 typedef struct localview_s
 {
-    boolean useangle;
     boolean usepitch;
+    angle_t oldticangle;
+    angle_t ticangle;
+    int ticangleturn;
     int angle;
     int pitch;
 } localview_t;

--- a/src/r_state.h
+++ b/src/r_state.h
@@ -94,6 +94,7 @@ typedef struct localview_s
     angle_t oldticangle;
     angle_t ticangle;
     int ticangleturn;
+    double rawangle;
     int angle;
     int pitch;
 } localview_t;


### PR DESCRIPTION
See commit comments for details.

Previous PRs: https://github.com/fabiangreffrath/woof/pull/1312 and https://github.com/fabiangreffrath/woof/pull/1326

Add this to `am_map.c` for a visualization:

<details><summary>diff</summary>

```diff
diff --git a/src/am_map.c b/src/am_map.c
index 2d81b71c..29195457 100644
--- a/src/am_map.c
+++ b/src/am_map.c
@@ -1952,6 +1952,25 @@ static void AM_drawPlayers(void)
         pt.y
       ); 
     else
+    {
+      AM_drawLineCharacter
+      (
+        player_arrow,
+        NUMPLYRLINES,
+        0,
+        plr->mo->oldangle,
+        mapcolor_plyr[1],
+        pt.x,
+        pt.y);
+      AM_drawLineCharacter
+      (
+        player_arrow,
+        NUMPLYRLINES,
+        0,
+        plr->mo->angle,
+        mapcolor_plyr[0],
+        pt.x,
+        pt.y);
       AM_drawLineCharacter
       (
         player_arrow,
@@ -1961,6 +1980,7 @@ static void AM_drawPlayers(void)
         mapcolor_sngl,      //jff color
         pt.x,
         pt.y);        
+    }
     return;
   }
```

Turn on the automap and move the mouse around, combine with keyboard turning, etc.

Arrows:
- White: `viewangle`
- Green: `player->mo->angle`
- Gray: `player->mo->oldangle`

Notice that mouse input causes the displayed frame to run ahead of the game simulation (white arrow ahead of others).

</details>