### PR TITLE
add ability to set SDL render driver

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -73,6 +73,8 @@ fixed_t fractionaltic;
 boolean disk_icon;  // killough 10/98
 int fps; // [FG] FPS counter widget
 
+char *sdl_renderdriver = "";
+
 // [FG] rendering window, renderer, intermediate ARGB frame buffer and texture
 
 static SDL_Window *screen;
@@ -1363,6 +1365,8 @@ static void I_InitGraphicsMode(void)
         flags |= SDL_RENDERER_PRESENTVSYNC;
     }
 
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, sdl_renderdriver);
+
     // [FG] create renderer
     renderer = SDL_CreateRenderer(screen, -1, flags);
 
@@ -1385,6 +1389,12 @@ static void I_InitGraphicsMode(void)
     {
         I_Error("Error creating renderer for screen window: %s",
                 SDL_GetError());
+    }
+
+    SDL_RendererInfo info;
+    if (SDL_GetRendererInfo(renderer, &info) == 0)
+    {
+        I_Printf(VB_DEBUG, "SDL render driver: %s", info.name);
     }
 }
 

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -67,6 +67,8 @@ void I_ToggleVsync(void); // [JN] Calls native SDL vsync toggle
 
 void I_DynamicResolution(void);
 
+extern char *sdl_renderdriver;
+
 extern boolean use_vsync;  // killough 2/8/98: controls whether vsync is called
 extern boolean disk_icon;  // killough 10/98
 extern resolution_mode_t resolution_mode, default_resolution_mode;

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -135,7 +135,25 @@ default_t defaults[] = {
   { // killough 11/98: hires
     "resolution_mode", (config_t *) &default_resolution_mode, NULL,
     {RES_DRS}, {RES_ORIGINAL, NUM_RES - 1}, number, ss_none, wad_no,
-    "0 - original 200p, 1 - double 400p, 2 - triple 600p, 4 - native (dynamic)"
+    "0 - original 200p, 1 - double 400p, 2 - triple 600p, 3 - native (dynamic)"
+  },
+
+  {
+    "sdl_renderdriver",
+    (config_t *) &sdl_renderdriver, NULL,
+#if defined(_WIN32)
+    {.s = "direct3d11"},
+#else
+    {.s = "opengl"},
+#endif
+    {0}, string, ss_none, wad_no,
+    "SDL render driver, possible values are "
+#if defined(_WIN32)
+    "direct3d, direct3d11, direct3d12, "
+#elif defined(__APPLE__)
+    "metal, "
+#endif
+    "opengl, opengles2, opengles, software"
   },
 
   {
@@ -444,7 +462,7 @@ default_t defaults[] = {
     (config_t *) &midi_player, NULL,
     {0}, {0, 2},
     number, ss_gen, wad_no,
-#if defined(_WIN32)
+#if defined(_WIN32) || defined (__APPLE__)
     "0 for Native (default), "
 #else
     "0 for SDL2 (default), "


### PR DESCRIPTION
"direct3d11" is about 10% faster than the default. Screenshots are fixed in new SDL versions.