### PR TITLE
Gamepad improvements

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,7 @@ set(WOOF_SOURCES
     hu_stuff.c             hu_stuff.h
     i_3dsound.c
     i_endoom.c             i_endoom.h
+    i_gamepad.c            i_gamepad.h
     i_glob.c               i_glob.h
     i_input.c              i_input.h
     i_main.c

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -246,7 +246,7 @@ void D_Display (void)
     // [AM] Figure out how far into the current tic we're in as a fixed_t.
     fractionaltic = I_GetFracTime();
 
-    if (!menuactive && gamestate == GS_LEVEL && !paused && mouse_raw_input)
+    if (!menuactive && gamestate == GS_LEVEL && !paused && raw_input)
     {
       I_StartDisplay();
     }

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -176,15 +176,19 @@ int eventhead, eventtail;
 //
 void D_PostEvent(event_t *ev)
 {
-  if (ev->type == ev_mouse)
+  switch (ev->type)
   {
-    G_MouseMovementResponder(ev);
-    G_PrepTiccmd();
-    return;
-  }
+    case ev_mouse:
+    case ev_joystick:
+      G_MovementResponder(ev);
+      G_PrepTiccmd();
+      break;
 
-  events[eventhead++] = *ev;
-  eventhead &= MAXEVENTS-1;
+    default:
+      events[eventhead++] = *ev;
+      eventhead &= MAXEVENTS-1;
+      break;
+  }
 }
 
 //

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -208,6 +208,34 @@ void D_ProcessEvents (void)
     }
 }
 
+static boolean input_ready;
+
+void D_UpdateDeltaTics(void)
+{
+  if (uncapped && raw_input)
+  {
+    static uint64_t last_time;
+    const uint64_t current_time = I_GetTimeUS();
+
+    if (input_ready)
+    {
+      const uint64_t delta_time = current_time - last_time;
+      deltatics = (double)delta_time * TICRATE / 1000000.0;
+      deltatics = BETWEEN(0.0, 1.0, deltatics);
+    }
+    else
+    {
+      deltatics = 0.0;
+    }
+
+    last_time = current_time;
+  }
+  else
+  {
+    deltatics = 1.0;
+  }
+}
+
 //
 // D_Display
 //  draw current display, possibly wiping it from the previous
@@ -241,12 +269,14 @@ void D_Display (void)
   if (nodrawers)                    // for comparative timing / profiling
     return;
 
+  input_ready = (!menuactive && gamestate == GS_LEVEL && !paused);
+
   if (uncapped)
   {
     // [AM] Figure out how far into the current tic we're in as a fixed_t.
     fractionaltic = I_GetFracTime();
 
-    if (!menuactive && gamestate == GS_LEVEL && !paused && raw_input)
+    if (input_ready && raw_input)
     {
       I_StartDisplay();
     }

--- a/src/d_main.h
+++ b/src/d_main.h
@@ -49,6 +49,8 @@ boolean D_CheckEndDoom(void);
 // Called by IO functions when input is detected.
 void D_PostEvent(event_t* ev);
 
+void D_UpdateDeltaTics(void);
+
 //
 // BASE LEVEL
 //

--- a/src/doomkeys.h
+++ b/src/doomkeys.h
@@ -211,9 +211,25 @@ enum
     AXIS_RIGHTX,
     AXIS_RIGHTY,
 
-    AXIS_NONE,
-
     NUM_AXES
+};
+
+enum
+{
+    AXIS_STRAFE,
+    AXIS_FORWARD,
+    AXIS_TURN,
+    AXIS_LOOK,
+};
+
+enum
+{
+    LAYOUT_DEFAULT,
+    LAYOUT_SWAP,
+    LAYOUT_LEGACY,
+    LAYOUT_LEGACY_SWAP,
+
+    NUM_LAYOUTS
 };
 
 #endif          // __DOOMKEYS__

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -495,7 +495,7 @@ void G_PrepTiccmd(void)
 
   // Gamepad
 
-  if (joy_enable)
+  if (I_UseController())
   {
     const int speed = autorun ^ M_InputGameActive(input_speed);
 
@@ -623,7 +623,7 @@ void G_BuildTiccmd(ticcmd_t* cmd)
 
   // Gamepad
 
-  if (joy_enable)
+  if (I_UseController())
   {
     if (axes[AXIS_TURN] && strafe)
     {

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -625,8 +625,6 @@ void G_BuildTiccmd(ticcmd_t* cmd)
 
   if (joy_enable)
   {
-    I_CalcControllerAxes();
-
     if (axes[AXIS_TURN] && strafe)
     {
       side += CalcControllerSideTurn(speed);

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -1001,18 +1001,29 @@ static boolean G_StrictModeSkipEvent(event_t *ev)
   return false;
 }
 
-boolean G_MouseMovementResponder(event_t *ev)
+boolean G_MovementResponder(event_t *ev)
 {
   if (G_StrictModeSkipEvent(ev))
   {
     return true;
   }
 
-  if (ev->type == ev_mouse)
+  switch (ev->type)
   {
-    mousex += ev->data2;
-    mousey += ev->data3;
-    return true;
+    case ev_mouse:
+      mousex += ev->data2;
+      mousey += ev->data3;
+      return true;
+
+    case ev_joystick:
+      *axes_data[AXIS_LEFTX] = ev->data1;
+      *axes_data[AXIS_LEFTY] = ev->data2;
+      *axes_data[AXIS_RIGHTX] = ev->data3;
+      *axes_data[AXIS_RIGHTY] = ev->data4;
+      return true;
+
+    default:
+      break;
   }
 
   return false;
@@ -1132,7 +1143,7 @@ boolean G_Responder(event_t* ev)
     return true;
   }
 
-  if (G_MouseMovementResponder(ev))
+  if (G_MovementResponder(ev))
   {
     return true; // eat events
   }
@@ -1168,13 +1179,6 @@ boolean G_Responder(event_t* ev)
       if (ev->data1 < NUM_CONTROLLER_BUTTONS)
         joybuttons[ev->data1] = false;
       return true;
-
-    case ev_joystick:
-      *axes_data[AXIS_LEFTX] = ev->data1;
-      *axes_data[AXIS_LEFTY] = ev->data2;
-      *axes_data[AXIS_RIGHTX] = ev->data3;
-      *axes_data[AXIS_RIGHTY] = ev->data4;
-      return true;    // eat events
 
     default:
       break;

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -364,16 +364,34 @@ static int CalcControllerForward(int speed)
 
 static int CalcControllerSideTurn(int speed)
 {
-  const int side = lroundf(forwardmove[speed] * axes[AXIS_TURN] *
-                           direction[joy_invert_turn] * 0.5f) * 2;
+  const float fside = (forwardmove[speed] * axes[AXIS_TURN] *
+                       direction[joy_invert_turn]);
+  int side;
+
+  if (strictmode || (netgame && !solonet))
+    side = lroundf(fside * 0.5f) * 2; // Even values only.
+  else
+    side = lroundf(fside);
+
   return BETWEEN(-forwardmove[speed], forwardmove[speed], side);
 }
 
 static int CalcControllerSideStrafe(int speed)
 {
-  const int side = lroundf(forwardmove[speed] * axes[AXIS_STRAFE] *
-                           direction[joy_invert_strafe] * 0.5f) * 2;
-  return BETWEEN(-sidemove[speed], sidemove[speed], side);
+  const float fside = (forwardmove[speed] * axes[AXIS_STRAFE] *
+                       direction[joy_invert_strafe]);
+  int side;
+
+  if (strictmode || (netgame && !solonet))
+  {
+    side = lroundf(fside * 0.5f) * 2; // Even values only.
+    return BETWEEN(-sidemove[speed], sidemove[speed], side); // Limit speed.
+  }
+  else
+  {
+    side = lroundf(fside);
+    return BETWEEN(-forwardmove[speed], forwardmove[speed], side);
+  }
 }
 
 static double CalcControllerAngle(int speed)
@@ -413,7 +431,13 @@ static int CarryMouseVert(double vert)
 static int CarryMouseSide(double side)
 {
   const double desired = side + prevcarry.side;
-  const int actual = lround(desired * 0.5) * 2; // Even values only.
+  int actual;
+
+  if (strictmode || (netgame && !solonet))
+    actual = lround(desired * 0.5) * 2; // Even values only.
+  else
+    actual = lround(desired);
+
   carry.side = desired - actual;
   return actual;
 }

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -31,7 +31,7 @@
 #define MBF21_GAME_OPTION_SIZE (21 + MBF21_COMP_TOTAL)
 
 void G_PrepTiccmd(void);
-boolean G_MouseMovementResponder(event_t *ev);
+boolean G_MovementResponder(event_t *ev);
 boolean G_Responder(event_t *ev);
 boolean G_CheckDemoStatus(void);
 void G_DeathMatchSpawnPlayer(int playernum);

--- a/src/i_gamepad.c
+++ b/src/i_gamepad.c
@@ -139,12 +139,12 @@ static void CircleToSquare(float *x, float *y)
     const float sgnuv = SGNF(uv);
     const float sqrto = sqrtf(0.5f * (r2 - sqrtf(r2 * (r2 - 4.0f * uv * uv))));
 
-    if (fabsf(u) > SDL_FLT_EPSILON)
+    if (fabsf(u) > 0.000001f)
     {
         *y = sgnuv / u * sqrto;
     }
 
-    if (fabsf(v) > SDL_FLT_EPSILON)
+    if (fabsf(v) > 0.000001f)
     {
         *x = sgnuv / v * sqrto;
     }
@@ -210,7 +210,7 @@ static void CalcAxial(axes_t *ax, float *xaxis, float *yaxis)
     const float y_axial = CalcAxialValue(ax, y_input);
     const float axial_mag = sqrtf(x_axial * x_axial + y_axial * y_axial);
 
-    if (axial_mag > SDL_FLT_EPSILON)
+    if (axial_mag > 0.000001f)
     {
         float scaled_mag;
 

--- a/src/i_gamepad.c
+++ b/src/i_gamepad.c
@@ -1,0 +1,357 @@
+//
+// Copyright(C) 2024 ceski
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//
+
+#include <math.h>
+
+#include "SDL.h"
+
+#include "doomkeys.h"
+#include "g_game.h"
+#include "i_timer.h"
+
+#define MIN_DEADZONE 0.00003f // 1/32768
+#define SGNF(x) ((float)((0.0f < (x)) - ((x) < 0.0f)))
+#define REMAP(x, min, max) (((x) - (min)) / ((max) - (min)))
+
+boolean joy_enable;
+int joy_layout;
+int joy_sensitivity_forward;
+int joy_sensitivity_strafe;
+int joy_sensitivity_turn;
+int joy_sensitivity_look;
+int joy_extra_sensitivity_turn;
+int joy_extra_sensitivity_look;
+int joy_extra_ramp_time;
+boolean joy_scale_diagonal_movement;
+int joy_response_curve_movement;
+int joy_response_curve_camera;
+int joy_deadzone_type_movement;
+int joy_deadzone_type_camera;
+int joy_deadzone_movement;
+int joy_deadzone_camera;
+int joy_threshold_movement;
+int joy_threshold_camera;
+int joy_threshold_trigger;
+boolean joy_invert_forward;
+boolean joy_invert_strafe;
+boolean joy_invert_turn;
+boolean joy_invert_look;
+
+int *axes_data[NUM_AXES];
+float axes[NUM_AXES];
+int trigger_threshold;
+
+typedef struct axis_s
+{
+    int data;           // ev_joystick event data.
+    float sens;         // Sensitivity.
+    float extra;        // Extra sensitivity.
+} axis_t;
+
+typedef struct axes_s
+{
+    axis_t x;
+    axis_t y;
+    float exponent;     // Exponent for response curve.
+    float deadzone;     // Normalized deadzone.
+    float threshold;    // Normalized outer threshold.
+    boolean useextra;   // Using extra sensitivity?
+    float extrascale;   // Scaling factor for extra sensitivity.
+} axes_t;
+
+static axes_t movement; // Strafe/Forward
+static axes_t camera;   // Turn/Look
+
+static void CalcExtraScale(axes_t *ax, float magnitude)
+{
+    if (ax != &camera)
+    {
+        return;
+    }
+
+    if ((joy_extra_sensitivity_turn || joy_extra_sensitivity_look) &&
+        magnitude > ax->threshold)
+    {
+        if (joy_extra_ramp_time)
+        {
+            static int start_time;
+            static int elapsed_time;
+
+            if (ax->useextra)
+            {
+                if (elapsed_time < joy_extra_ramp_time)
+                {
+                    // Continue ramp.
+                    elapsed_time = I_GetTimeMS() - start_time;
+                    ax->extrascale = (float)elapsed_time / joy_extra_ramp_time;
+                    ax->extrascale = BETWEEN(0.0f, 1.0f, ax->extrascale);
+                }
+            }
+            else
+            {
+                // Start ramp.
+                start_time = I_GetTimeMS();
+                elapsed_time = 0;
+                ax->extrascale = 0.0f;
+                ax->useextra = true;
+            }
+        }
+        else
+        {
+            // Instant ramp.
+            ax->extrascale = 1.0f;
+            ax->useextra = true;
+        }
+    }
+    else
+    {
+        // Reset ramp.
+        ax->extrascale = 0.0f;
+        ax->useextra = false;
+    }
+}
+
+//
+// CircleToSquare
+// Radial mapping of a circle to a square using the Fernandez-Guasti method.
+// https://squircular.blogspot.com/2015/09/fg-squircle-mapping.html
+//
+
+static void CircleToSquare(float *x, float *y)
+{
+    const float u = *x;
+    const float v = *y;
+    const float r2 = u * u + v * v;
+    const float uv = u * v;
+    const float sgnuv = SGNF(uv);
+    const float sqrto = sqrtf(0.5f * (r2 - sqrtf(r2 * (r2 - 4.0f * uv * uv))));
+
+    if (fabsf(u) > SDL_FLT_EPSILON)
+    {
+        *y = sgnuv / u * sqrto;
+    }
+
+    if (fabsf(v) > SDL_FLT_EPSILON)
+    {
+        *x = sgnuv / v * sqrto;
+    }
+}
+
+static void ApplySensitivity(const axes_t *ax, float *xaxis, float *yaxis)
+{
+    if (*xaxis || *yaxis)
+    {
+        if (ax == &movement)
+        {
+            if (joy_scale_diagonal_movement)
+            {
+                CircleToSquare(xaxis, yaxis);
+            }
+
+            *xaxis *= ax->x.sens;
+            *yaxis *= ax->y.sens;
+        }
+        else // camera
+        {
+            *xaxis *= (ax->x.sens + ax->extrascale * ax->x.extra);
+            *yaxis *= (ax->y.sens + ax->extrascale * ax->y.extra);
+        }
+    }
+}
+
+static float CalcAxialValue(axes_t *ax, float input)
+{
+    if (fabsf(input) > ax->deadzone)
+    {
+        return (SGNF(input) * REMAP(fabsf(input), ax->deadzone, ax->threshold));
+    }
+    else
+    {
+        return 0.0f;
+    }
+}
+
+static float GetInputValue(int value)
+{
+    if (value > 0)
+    {
+        return (value / (float)SDL_JOYSTICK_AXIS_MAX);
+    }
+    else if (value < 0)
+    {
+        return (value / (float)(-SDL_JOYSTICK_AXIS_MIN));
+    }
+    else
+    {
+        return 0.0f;
+    }
+}
+
+static void CalcAxial(axes_t *ax, float *xaxis, float *yaxis)
+{
+    const float x_input = GetInputValue(ax->x.data);
+    const float y_input = GetInputValue(ax->y.data);
+    const float input_mag = sqrtf(x_input * x_input + y_input * y_input);
+
+    const float x_axial = CalcAxialValue(ax, x_input);
+    const float y_axial = CalcAxialValue(ax, y_input);
+    const float axial_mag = sqrtf(x_axial * x_axial + y_axial * y_axial);
+
+    if (axial_mag > SDL_FLT_EPSILON)
+    {
+        float scaled_mag;
+
+        scaled_mag = BETWEEN(0.0f, 1.0f, axial_mag);
+        scaled_mag = powf(scaled_mag, ax->exponent);
+
+        *xaxis = scaled_mag * x_axial / axial_mag;
+        *yaxis = scaled_mag * y_axial / axial_mag;
+    }
+    else
+    {
+        *xaxis = 0.0f;
+        *yaxis = 0.0f;
+    }
+
+    CalcExtraScale(ax, input_mag);
+    ApplySensitivity(ax, xaxis, yaxis);
+}
+
+static void CalcRadial(axes_t *ax, float *xaxis, float *yaxis)
+{
+    const float x_input = GetInputValue(ax->x.data);
+    const float y_input = GetInputValue(ax->y.data);
+    const float input_mag = sqrtf(x_input * x_input + y_input * y_input);
+
+    if (input_mag > ax->deadzone)
+    {
+        float scaled_mag = REMAP(input_mag, ax->deadzone, ax->threshold);
+
+        scaled_mag = BETWEEN(0.0f, 1.0f, scaled_mag);
+        scaled_mag = powf(scaled_mag, ax->exponent);
+
+        *xaxis = scaled_mag * x_input / input_mag;
+        *yaxis = scaled_mag * y_input / input_mag;
+    }
+    else
+    {
+        *xaxis = 0.0f;
+        *yaxis = 0.0f;
+    }
+
+    CalcExtraScale(ax, input_mag);
+    ApplySensitivity(ax, xaxis, yaxis);
+}
+
+static void (*CalcMovement)(axes_t *ax, float *xaxis, float *yaxis);
+static void (*CalcCamera)(axes_t *ax, float *xaxis, float *yaxis);
+
+void I_CalcControllerAxes(void)
+{
+    if (movement.x.data || movement.y.data)
+    {
+        CalcMovement(&movement, &axes[AXIS_STRAFE], &axes[AXIS_FORWARD]);
+
+        movement.x.data = 0;
+        movement.y.data = 0;
+    }
+
+    if (camera.x.data || camera.y.data)
+    {
+        if (!padlook)
+        {
+            camera.y.data = 0;
+        }
+
+        CalcCamera(&camera, &axes[AXIS_TURN], &axes[AXIS_LOOK]);
+
+        camera.x.data = 0;
+        camera.y.data = 0;
+    }
+}
+
+void I_ResetControllerAxes(void)
+{
+    memset(axes, 0, sizeof(axes));
+}
+
+void I_ResetControllerLevel(void)
+{
+    I_ResetControllerAxes();
+    movement.x.data = 0;
+    movement.y.data = 0;
+    camera.x.data = 0;
+    camera.y.data = 0;
+    camera.extrascale = 0.0f;
+    camera.useextra = false;
+}
+
+static void UpdateStickLayout(void)
+{
+    int i;
+    int *layouts[NUM_LAYOUTS][NUM_AXES] = {
+        // Default
+        {&movement.x.data, &movement.y.data, &camera.x.data, &camera.y.data},
+        // Swap
+        {&camera.x.data, &camera.y.data, &movement.x.data, &movement.y.data},
+        // Legacy
+        {&camera.x.data, &movement.y.data, &movement.x.data, &camera.y.data},
+        // Legacy Swap
+        {&movement.x.data, &camera.y.data, &camera.x.data, &movement.y.data},
+    };
+
+    for (i = 0; i < NUM_AXES; i++)
+    {
+        axes_data[i] = layouts[joy_layout][i];
+    }
+}
+
+static void RefreshSettings(void)
+{
+    void *axes_func[] = {CalcAxial, CalcRadial};
+
+    CalcMovement = axes_func[joy_deadzone_type_movement];
+    CalcCamera = axes_func[joy_deadzone_type_camera];
+
+    movement.x.sens = joy_sensitivity_strafe / 50.0f;
+    movement.y.sens = joy_sensitivity_forward / 50.0f;
+
+    camera.x.sens = joy_sensitivity_turn / 50.0f;
+    camera.y.sens = joy_sensitivity_look / 50.0f;
+
+    camera.x.extra = joy_extra_sensitivity_turn / 50.0f;
+    camera.y.extra = joy_extra_sensitivity_look / 50.0f;
+
+    movement.exponent = 1.0f + joy_response_curve_movement / 10.0f;
+    camera.exponent = 1.0f + joy_response_curve_camera / 10.0f;
+
+    movement.deadzone = joy_deadzone_movement / 100.0f;
+    camera.deadzone = joy_deadzone_camera / 100.0f;
+    movement.deadzone = MAX(MIN_DEADZONE, movement.deadzone);
+    camera.deadzone = MAX(MIN_DEADZONE, camera.deadzone);
+
+    movement.threshold = 1.0f - joy_threshold_movement / 100.0f;
+    camera.threshold = 1.0f - joy_threshold_camera / 100.0f;
+
+    trigger_threshold = SDL_JOYSTICK_AXIS_MAX * joy_threshold_trigger / 100;
+}
+
+void I_ResetController(void)
+{
+    I_ResetControllerLevel();
+    UpdateStickLayout();
+    RefreshSettings();
+}

--- a/src/i_gamepad.h
+++ b/src/i_gamepad.h
@@ -1,0 +1,55 @@
+//
+// Copyright(C) 2024 ceski
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//
+
+#ifndef __I_GAMEPAD__
+#define __I_GAMEPAD__
+
+#include "doomkeys.h"
+
+extern boolean joy_enable;                  // Enable game controller.
+extern int joy_layout;                      // Analog stick layout.
+extern int joy_sensitivity_forward;         // Forward axis sensitivity.
+extern int joy_sensitivity_strafe;          // Strafe axis sensitivity.
+extern int joy_sensitivity_turn;            // Turn axis sensitivity.
+extern int joy_sensitivity_look;            // Look axis sensitivity.
+extern int joy_extra_sensitivity_turn;      // Extra turn sensitivity.
+extern int joy_extra_sensitivity_look;      // Extra look sensitivity.
+extern int joy_extra_ramp_time;             // Ramp time for extra sensitivity.
+extern boolean joy_scale_diagonal_movement; // Scale diagonal movement.
+extern int joy_response_curve_movement;     // Movement response curve.
+extern int joy_response_curve_camera;       // Camera response curve.
+extern int joy_deadzone_type_movement;      // Movement deadzone type.
+extern int joy_deadzone_type_camera;        // Camera deadzone type.
+extern int joy_deadzone_movement;           // Movement deadzone percent.
+extern int joy_deadzone_camera;             // Camera deadzone percent.
+extern int joy_threshold_movement;          // Movement outer threshold percent.
+extern int joy_threshold_camera;            // Camera outer threshold percent.
+extern int joy_threshold_trigger;           // Trigger threshold percent.
+extern boolean joy_invert_forward;          // Invert forward axis.
+extern boolean joy_invert_strafe;           // Invert strafe axis.
+extern boolean joy_invert_turn;             // Invert turn axis.
+extern boolean joy_invert_look;             // Invert look axis.
+
+extern int *axes_data[NUM_AXES];    // Pointers to ev_joystick event data.
+extern float axes[NUM_AXES];        // Calculated controller values.
+extern int trigger_threshold;       // Trigger threshold (axis resolution).
+
+void I_CalcControllerAxes(void);
+void I_ResetControllerAxes(void);
+void I_ResetControllerLevel(void);
+void I_ResetController(void);
+
+#endif

--- a/src/i_input.c
+++ b/src/i_input.c
@@ -170,6 +170,11 @@ static void UpdateControllerAxisState(unsigned int value, boolean left_trigger)
     D_PostEvent(&event);
 }
 
+boolean I_UseController(void)
+{
+    return (controller && joy_enable);
+}
+
 void I_OpenController(int which)
 {
     if (controller)

--- a/src/i_input.c
+++ b/src/i_input.c
@@ -73,7 +73,15 @@ static void AxisToButton(int value, int *state, int direction)
 
 static int axisbuttons[] = { -1, -1, -1, -1 };
 
-void I_UpdateJoystick(void)
+static void AxisToButtons(event_t *ev)
+{
+    AxisToButton(ev->data1, &axisbuttons[0], CONTROLLER_LEFT_STICK_LEFT);
+    AxisToButton(ev->data2, &axisbuttons[1], CONTROLLER_LEFT_STICK_UP);
+    AxisToButton(ev->data3, &axisbuttons[2], CONTROLLER_RIGHT_STICK_LEFT);
+    AxisToButton(ev->data4, &axisbuttons[3], CONTROLLER_RIGHT_STICK_UP);
+}
+
+void I_UpdateJoystick(boolean axis_buttons)
 {
     static event_t ev;
 
@@ -88,10 +96,10 @@ void I_UpdateJoystick(void)
     ev.data3 = GetAxisState(SDL_CONTROLLER_AXIS_RIGHTX);
     ev.data4 = GetAxisState(SDL_CONTROLLER_AXIS_RIGHTY);
 
-    AxisToButton(ev.data1, &axisbuttons[0], CONTROLLER_LEFT_STICK_LEFT);
-    AxisToButton(ev.data2, &axisbuttons[1], CONTROLLER_LEFT_STICK_UP);
-    AxisToButton(ev.data3, &axisbuttons[2], CONTROLLER_RIGHT_STICK_LEFT);
-    AxisToButton(ev.data4, &axisbuttons[3], CONTROLLER_RIGHT_STICK_UP);
+    if (axis_buttons)
+    {
+        AxisToButtons(&ev);
+    }
 
     D_PostEvent(&ev);
 }

--- a/src/i_input.h
+++ b/src/i_input.h
@@ -24,7 +24,7 @@ void I_CloseController(int which);
 
 double I_AccelerateMouse(int val);
 void I_ReadMouse(void);
-void I_UpdateJoystick(void);
+void I_UpdateJoystick(boolean axis_buttons);
 
 void I_DelayEvent(void);
 void I_HandleJoystickEvent(SDL_Event *sdlevent);

--- a/src/i_input.h
+++ b/src/i_input.h
@@ -19,6 +19,7 @@
 
 #include "SDL.h"
 
+boolean I_UseController(void);
 void I_OpenController(int which);
 void I_CloseController(int which);
 

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -395,7 +395,7 @@ static void I_GetEvent(void)
             case SDL_CONTROLLERBUTTONDOWN:
             case SDL_CONTROLLERBUTTONUP:
             case SDL_CONTROLLERAXISMOTION:
-                if (joy_enable)
+                if (I_UseController())
                 {
                     I_HandleJoystickEvent(&sdlevent);
                 }
@@ -434,7 +434,7 @@ void I_StartTic (void)
         I_ReadMouse();
     }
 
-    if (joy_enable)
+    if (I_UseController())
     {
         I_UpdateJoystick(true);
     }
@@ -449,7 +449,7 @@ void I_StartDisplay(void)
         I_ReadMouse();
     }
 
-    if (joy_enable)
+    if (I_UseController())
     {
         I_UpdateJoystick(false);
     }

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -436,16 +436,22 @@ void I_StartTic (void)
 
     if (joy_enable)
     {
-        I_UpdateJoystick();
+        I_UpdateJoystick(true);
     }
 }
 
 void I_StartDisplay(void)
 {
+    SDL_PumpEvents();
+
     if (window_focused)
     {
-        SDL_PumpEvents();
         I_ReadMouse();
+    }
+
+    if (joy_enable)
+    {
+        I_UpdateJoystick(false);
     }
 }
 

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -37,6 +37,7 @@
 #include "m_menu.h"
 #include "wi_stuff.h"
 #include "i_input.h"
+#include "i_gamepad.h"
 #include "i_video.h"
 #include "m_io.h"
 
@@ -394,7 +395,10 @@ static void I_GetEvent(void)
             case SDL_CONTROLLERBUTTONDOWN:
             case SDL_CONTROLLERBUTTONUP:
             case SDL_CONTROLLERAXISMOTION:
-                I_HandleJoystickEvent(&sdlevent);
+                if (joy_enable)
+                {
+                    I_HandleJoystickEvent(&sdlevent);
+                }
                 break;
 
             case SDL_QUIT:
@@ -430,7 +434,10 @@ void I_StartTic (void)
         I_ReadMouse();
     }
 
-    I_UpdateJoystick();
+    if (joy_enable)
+    {
+        I_UpdateJoystick();
+    }
 }
 
 void I_StartDisplay(void)

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -49,6 +49,7 @@
 #include "w_wad.h" // [FG] W_IsIWADLump() / W_WadNameForLump()
 #include "p_saveg.h" // saveg_compat
 #include "m_input.h"
+#include "i_gamepad.h"
 #include "r_draw.h" // [FG] R_SetFuzzColumnMode
 #include "r_sky.h" // [FG] R_InitSkyMap()
 #include "r_plane.h" // [FG] R_InitPlanes()
@@ -1474,8 +1475,6 @@ menu_t MouseDef =
 
 #define MOUSE_SENS_MAX 100
 
-extern int axis_turn_sens;
-
 //
 // Change Mouse Sensitivities -- killough
 //
@@ -2789,10 +2788,6 @@ int mult_screens_index; // the index of the current screen in a set
 // to the previous screen. If you leave these off, you can't move from
 // screen to screen.
 
-static const char *controller_axes_strings[] = {
-  "Left Stick X", "Left Stick Y", "Right Stick X", "Right Stick Y", "None", NULL
-};
-
 setup_menu_t keys_settings1[] =  // Key Binding screen strings       
 {
   {"ACTION"    ,S_SKIP|S_TITLE,m_null,KB_X,M_Y},
@@ -2849,30 +2844,57 @@ setup_menu_t keys_settings2[] =  // Key Binding screen strings
 
 };
 
+static const char *layout_strings[] = {
+  "Default", "Swap", "Legacy", "Legacy Swap", NULL
+};
+
+static const char *curve_strings[] = {
+  "Linear", "1.1", "1.2", "1.3", "1.4", "1.5", "1.6", "1.7", "1.8", "1.9",
+  "Squared", "2.1", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "2.8", "2.9",
+  "Cubed", NULL
+};
+
+#define GP_X 136
+
 setup_menu_t keys_settings3[] =
 {
-  {"GAMEPAD", S_SKIP|S_TITLE,m_null,KB_X,M_Y},
+  {"Gamepad", S_SKIP|S_TITLE, m_null, GP_X, M_Y},
 
-  {"ANALOG CONTROLS", S_YESNO, m_scrn, KB_X, M_Y+1*M_SPC, {"analog_controls"}},
+  {"Enable", S_YESNO, m_scrn, GP_X, M_Y + 1 * M_SPC,
+   {"joy_enable"}, 0, I_ResetController},
 
-  {"MOVING FORWARD", S_CHOICE, m_scrn, KB_X, M_Y+2*M_SPC,
-    {"axis_forward"}, 0, NULL, controller_axes_strings},
-  {"INVERT", S_YESNO, m_scrn, KB_X, M_Y+3*M_SPC, {"invert_forward"}},
-  {"STRAFING", S_CHOICE, m_scrn, KB_X, M_Y+4*M_SPC,
-    {"axis_strafe"}, 0, NULL, controller_axes_strings},
-  {"INVERT", S_YESNO, m_scrn, KB_X, M_Y+5*M_SPC, {"invert_strafe"}},
-  {"SENSITIVITY", S_THERMO, m_scrn, KB_X, M_Y+6*M_SPC, {"axis_move_sens"}},
+  {"Stick Layout", S_CHOICE, m_scrn, GP_X, M_Y + 2 * M_SPC,
+   {"joy_layout"}, 0, I_ResetController, layout_strings},
 
-  {"TURNING", S_CHOICE, m_scrn, KB_X, M_Y+8*M_SPC,
-    {"axis_turn"}, 0, NULL, controller_axes_strings},
-  {"INVERT", S_YESNO, m_scrn, KB_X, M_Y+9*M_SPC, {"invert_turn"}},
-  {"SENSITIVITY", S_THERMO, m_scrn, KB_X, M_Y+10*M_SPC, {"axis_turn_sens"}},
+  {"Toggle Look", S_INPUT, m_scrn, GP_X, M_Y + 3 * M_SPC,
+   {0}, input_padlook},
 
-  {"PADLOOK TOGGLE", S_INPUT, m_scrn, KB_X, M_Y+12*M_SPC, {0}, input_padlook},
-  {"LOOKING", S_CHOICE, m_scrn, KB_X, M_Y+13*M_SPC,
-    {"axis_look"}, 0, NULL, controller_axes_strings},
-  {"INVERT", S_YESNO, m_scrn, KB_X, M_Y+14*M_SPC, {"invert_look"}},
-  {"SENSITIVITY", S_THERMO, m_scrn, KB_X, M_Y+15*M_SPC, {"axis_look_sens"}},
+  {"Invert Look", S_YESNO, m_scrn, GP_X, M_Y + 4 * M_SPC,
+   {"joy_invert_look"}},
+
+  {"", S_SKIP, m_null, GP_X, M_Y + 5 * M_SPC},
+
+  {"Turn Sensitivity", S_THERMO, m_scrn, GP_X, M_Y + 6 * M_SPC,
+   {"joy_sensitivity_turn"}, 0, I_ResetController},
+
+  {"Look Sensitivity", S_THERMO, m_scrn, GP_X, M_Y + 7 * M_SPC,
+   {"joy_sensitivity_look"}, 0, I_ResetController},
+
+  {"", S_SKIP, m_null, GP_X, M_Y + 8 * M_SPC},
+
+  {"Movement Curve", S_THERMO, m_scrn, GP_X, M_Y + 9 * M_SPC,
+   {"joy_response_curve_movement"}, 0, I_ResetController, curve_strings},
+
+  {"Camera Curve", S_THERMO, m_scrn, GP_X, M_Y + 10 * M_SPC,
+   {"joy_response_curve_camera"}, 0, I_ResetController, curve_strings},
+
+  {"", S_SKIP, m_null, GP_X, M_Y + 11 * M_SPC},
+
+  {"Movement Deadzone", S_THERMO, m_scrn, GP_X, M_Y + 12 * M_SPC,
+   {"joy_deadzone_movement"}, 0, I_ResetController},
+
+  {"Camera Deadzone", S_THERMO, m_scrn, GP_X, M_Y + 13 * M_SPC,
+   {"joy_deadzone_camera"}, 0, I_ResetController},
 
   {"<- PREV", S_SKIP|S_PREV,m_null,M_X_PREV,M_Y_PREVNEXT, {keys_settings2}},
   {"NEXT ->", S_SKIP|S_NEXT,m_null,M_X_NEXT,M_Y_PREVNEXT, {keys_settings4}},

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -3960,7 +3960,6 @@ enum {
   gen5_mouse3,
   gen5_mouse_accel,
   gen5_mouse_accel_threshold,
-  gen5_mouse_raw_input,
   gen5_end1,
 
   gen5_title2,
@@ -4184,9 +4183,6 @@ setup_menu_t gen_settings5[] = { // General Settings screen5
 
   {"Mouse threshold", S_NUM, m_null, M_X,
    M_Y + gen5_mouse_accel_threshold * M_SPC, {"mouse_acceleration_threshold"}},
-
-  {"Raw mouse input", S_YESNO, m_null, M_X,
-   M_Y+ gen5_mouse_raw_input * M_SPC, {"mouse_raw_input"}},
 
   {"", S_SKIP, m_null, M_X, M_Y + gen5_end1*M_SPC},
 

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -2854,31 +2854,31 @@ static const char *curve_strings[] = {
   "Cubed", NULL
 };
 
-#define GP_X 136
+#define GP_X 152
 
 setup_menu_t keys_settings3[] =
 {
   {"Gamepad", S_SKIP|S_TITLE, m_null, GP_X, M_Y},
 
-  {"Enable", S_YESNO, m_scrn, GP_X, M_Y + 1 * M_SPC,
-   {"joy_enable"}, 0, I_ResetController},
-
-  {"Stick Layout", S_CHOICE, m_scrn, GP_X, M_Y + 2 * M_SPC,
+  {"Stick Layout", S_CHOICE, m_scrn, GP_X, M_Y + 1 * M_SPC,
    {"joy_layout"}, 0, I_ResetController, layout_strings},
 
-  {"Toggle Look", S_INPUT, m_scrn, GP_X, M_Y + 3 * M_SPC,
+  {"Toggle Look", S_INPUT, m_scrn, GP_X, M_Y + 2 * M_SPC,
    {0}, input_padlook},
 
-  {"Invert Look", S_YESNO, m_scrn, GP_X, M_Y + 4 * M_SPC,
+  {"Invert Look", S_YESNO, m_scrn, GP_X, M_Y + 3 * M_SPC,
    {"joy_invert_look"}},
 
-  {"", S_SKIP, m_null, GP_X, M_Y + 5 * M_SPC},
+  {"", S_SKIP, m_null, GP_X, M_Y + 4 * M_SPC},
 
-  {"Turn Sensitivity", S_THERMO, m_scrn, GP_X, M_Y + 6 * M_SPC,
+  {"Turn Sensitivity", S_THERMO, m_scrn, GP_X, M_Y + 5 * M_SPC,
    {"joy_sensitivity_turn"}, 0, I_ResetController},
 
-  {"Look Sensitivity", S_THERMO, m_scrn, GP_X, M_Y + 7 * M_SPC,
+  {"Look Sensitivity", S_THERMO, m_scrn, GP_X, M_Y + 6 * M_SPC,
    {"joy_sensitivity_look"}, 0, I_ResetController},
+
+  {"Extra Turn Sensitivity", S_THERMO, m_scrn, GP_X, M_Y + 7 * M_SPC,
+   {"joy_extra_sensitivity_turn"}, 0, I_ResetController},
 
   {"", S_SKIP, m_null, GP_X, M_Y + 8 * M_SPC},
 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -2139,13 +2139,6 @@ default_t defaults[] = {
     "adjust mouse acceleration threshold"
   },
 
-  {
-    "mouse_raw_input",
-    (config_t *) &mouse_raw_input, NULL,
-    {1}, {0, 1}, number, ss_none, wad_no,
-    "Raw mouse input for turning/looking (0 = Interpolate, 1 = Raw)"
-  },
-
   // [FG] invert vertical axis
   {
     "mouse_y_invert",
@@ -2181,6 +2174,13 @@ default_t defaults[] = {
     (config_t *) &default_grabmouse, NULL,
     {1}, {0, 1}, number, ss_none, wad_no,
     "1 to grab mouse during play"
+  },
+
+  {
+    "raw_input",
+    (config_t *) &raw_input, NULL,
+    {1}, {0, 1}, number, ss_none, wad_no,
+    "Raw gamepad/mouse input for turning/looking (0 = Interpolate, 1 = Raw)"
   },
 
   //

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -1952,21 +1952,21 @@ default_t defaults[] = {
   {
     "joy_sensitivity_turn",
     (config_t *) &joy_sensitivity_turn, NULL,
-    {50}, {0, 100}, number, ss_keys, wad_no,
+    {36}, {0, 100}, number, ss_keys, wad_no,
     "Turn axis sensitivity"
   },
 
   {
     "joy_sensitivity_look",
     (config_t *) &joy_sensitivity_look, NULL,
-    {50}, {0, 100}, number, ss_keys, wad_no,
+    {28}, {0, 100}, number, ss_keys, wad_no,
     "Look axis sensitivity"
   },
 
   {
     "joy_extra_sensitivity_turn",
     (config_t *) &joy_extra_sensitivity_turn, NULL,
-    {0}, {0, 100}, number, ss_keys, wad_no,
+    {14}, {0, 100}, number, ss_keys, wad_no,
     "Extra turn sensitivity at outer threshold (joy_threshold_camera)"
   },
 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -47,6 +47,7 @@
 #include "r_sky.h" // [FG] stretchsky
 #include "hu_lib.h" // HU_MAXMESSAGES
 #include "net_client.h" // net_player_name
+#include "i_gamepad.h"
 
 #include "m_io.h"
 #include <errno.h>
@@ -60,18 +61,6 @@ static int config_help;         //jff 3/3/98
 extern int dclick_use;
 // [FG] invert vertical axis
 extern int mouse_y_invert;
-extern int axis_forward;
-extern int axis_strafe;
-extern int axis_turn;
-extern int axis_look;
-extern int axis_turn_sens;
-extern int axis_move_sens;
-extern int axis_look_sens;
-extern boolean invert_turn;
-extern boolean invert_forward;
-extern boolean invert_strafe;
-extern boolean invert_look;
-extern boolean analog_controls;
 extern int realtic_clock_rate;         // killough 4/13/98: adjustable timer
 extern int tran_filter_pct;            // killough 2/21/98
 extern int showMessages;
@@ -1933,59 +1922,164 @@ default_t defaults[] = {
   },
 
   {
-    "axis_forward",
-    (config_t *) &axis_forward, NULL,
-    {AXIS_LEFTY}, {0,4}, number, ss_keys, wad_no,
-    "0 axis left x, 1 axis left y, 2 axis right x, 3 axis right y, 4 none"
-  },
-
-  {
-    "axis_strafe",
-    (config_t *) &axis_strafe, NULL,
-    {AXIS_LEFTX}, {0,4}, number, ss_keys, wad_no,
-    "0 axis left x, 1 axis left y, 2 axis right x, 3 axis right y, 4 none"
-  },
-
-  {
-    "axis_turn",
-    (config_t *) &axis_turn, NULL,
-    {AXIS_RIGHTX}, {0,4}, number, ss_keys, wad_no,
-    "0 axis left x, 1 axis left y, 2 axis right x, 3 axis right y, 4 none"
-  },
-
-  {
-    "axis_look",
-    (config_t *) &axis_look, NULL,
-    {AXIS_RIGHTY}, {0,4}, number, ss_keys, wad_no,
-    "0 axis left x, 1 axis left y, 2 axis right x, 3 axis right y, 4 none"
-  },
-
-  {
-    "axis_move_sens",
-    (config_t *) &axis_move_sens, NULL,
-    {10}, {0,UL}, number, ss_none, wad_no,
-    "game controller movement sensitivity"
-  },
-
-  {
-    "axis_turn_sens",
-    (config_t *) &axis_turn_sens, NULL,
-    {10}, {0,UL}, number, ss_none, wad_no,
-    "game controller turning sensitivity"
-  },
-
-  {
-    "axis_look_sens",
-    (config_t *) &axis_look_sens, NULL,
-    {10}, {0,UL}, number, ss_none, wad_no,
-    "game controller looking sensitivity"
-  },
-
-  {
-    "analog_controls",
-    (config_t *) &analog_controls, NULL,
+    "joy_enable",
+    (config_t *) &joy_enable, NULL,
     {1}, {0, 1}, number, ss_keys, wad_no,
-    "1 to enable analog controls"
+    "Enable game controller"
+  },
+
+  {
+    "joy_layout",
+    (config_t *) &joy_layout, NULL,
+    {LAYOUT_DEFAULT}, {0, NUM_LAYOUTS - 1}, number, ss_keys, wad_no,
+    "Analog stick layout (0 = Default, 1 = Swap, 2 = Legacy, 3 = Legacy Swap)"
+  },
+
+  {
+    "joy_sensitivity_forward",
+    (config_t *) &joy_sensitivity_forward, NULL,
+    {50}, {0, 100}, number, ss_keys, wad_no,
+    "Forward axis sensitivity"
+  },
+
+  {
+    "joy_sensitivity_strafe",
+    (config_t *) &joy_sensitivity_strafe, NULL,
+    {50}, {0, 100}, number, ss_keys, wad_no,
+    "Strafe axis sensitivity"
+  },
+
+  {
+    "joy_sensitivity_turn",
+    (config_t *) &joy_sensitivity_turn, NULL,
+    {50}, {0, 100}, number, ss_keys, wad_no,
+    "Turn axis sensitivity"
+  },
+
+  {
+    "joy_sensitivity_look",
+    (config_t *) &joy_sensitivity_look, NULL,
+    {50}, {0, 100}, number, ss_keys, wad_no,
+    "Look axis sensitivity"
+  },
+
+  {
+    "joy_extra_sensitivity_turn",
+    (config_t *) &joy_extra_sensitivity_turn, NULL,
+    {0}, {0, 100}, number, ss_keys, wad_no,
+    "Extra turn sensitivity at outer threshold (joy_threshold_camera)"
+  },
+
+  {
+    "joy_extra_sensitivity_look",
+    (config_t *) &joy_extra_sensitivity_look, NULL,
+    {0}, {0, 100}, number, ss_keys, wad_no,
+    "Extra look sensitivity at outer threshold (joy_threshold_camera)"
+  },
+
+  {
+    "joy_extra_ramp_time",
+    (config_t *) &joy_extra_ramp_time, NULL,
+    {300}, {0,1000}, number, ss_keys, wad_no,
+    "Ramp time for extra sensitivity (0 = Instant, 1000 = 1 second)"
+  },
+
+  {
+    "joy_scale_diagonal_movement",
+    (config_t *) &joy_scale_diagonal_movement, NULL,
+    {1}, {0, 1}, number, ss_keys, wad_no,
+    "Scale diagonal movement (0 = Linear, 1 = Circle to Square)"
+  },
+
+  {
+    "joy_response_curve_movement",
+    (config_t *) &joy_response_curve_movement, NULL,
+    {0}, {0, 20}, number, ss_keys, wad_no,
+    "Movement response curve (0 = Linear, 10 = Squared, 20 = Cubed)"
+  },
+
+  {
+    "joy_response_curve_camera",
+    (config_t *) &joy_response_curve_camera, NULL,
+    {10}, {0, 20}, number, ss_keys, wad_no,
+    "Camera response curve (0 = Linear, 10 = Squared, 20 = Cubed)"
+  },
+
+  {
+    "joy_deadzone_type_movement",
+    (config_t *) &joy_deadzone_type_movement, NULL,
+    {1}, {0, 1}, number, ss_keys, wad_no,
+    "Movement deadzone type (0 = Axial, 1 = Radial)"
+  },
+
+  {
+    "joy_deadzone_type_camera",
+    (config_t *) &joy_deadzone_type_camera, NULL,
+    {1}, {0, 1}, number, ss_keys, wad_no,
+    "Camera deadzone type (0 = Axial, 1 = Radial)"
+  },
+
+  {
+    "joy_deadzone_movement",
+    (config_t *) &joy_deadzone_movement, NULL,
+    {15}, {0, 50}, number, ss_keys, wad_no,
+    "Movement deadzone percent"
+  },
+
+  {
+    "joy_deadzone_camera",
+    (config_t *) &joy_deadzone_camera, NULL,
+    {15}, {0, 50}, number, ss_keys, wad_no,
+    "Camera deadzone percent"
+  },
+
+  {
+    "joy_threshold_movement",
+    (config_t *) &joy_threshold_movement, NULL,
+    {2}, {0, 30}, number, ss_keys, wad_no,
+    "Movement outer threshold percent"
+  },
+
+  {
+    "joy_threshold_camera",
+    (config_t *) &joy_threshold_camera, NULL,
+    {2}, {0, 30}, number, ss_keys, wad_no,
+    "Camera outer threshold percent"
+  },
+
+  {
+    "joy_threshold_trigger",
+    (config_t *) &joy_threshold_trigger, NULL,
+    {12}, {0, 50}, number, ss_keys, wad_no,
+    "Trigger threshold percent"
+  },
+
+  {
+    "joy_invert_forward",
+    (config_t *) &joy_invert_forward, NULL,
+    {0}, {0, 1}, number, ss_keys, wad_no,
+    "Invert forward axis"
+  },
+
+  {
+    "joy_invert_strafe",
+    (config_t *) &joy_invert_strafe, NULL,
+    {0}, {0, 1}, number, ss_keys, wad_no,
+    "Invert strafe axis"
+  },
+
+  {
+    "joy_invert_turn",
+    (config_t *) &joy_invert_turn, NULL,
+    {0}, {0, 1}, number, ss_keys, wad_no,
+    "Invert turn axis"
+  },
+
+  {
+    "joy_invert_look",
+    (config_t *) &joy_invert_look, NULL,
+    {0}, {0, 1}, number, ss_keys, wad_no,
+    "Invert look axis"
   },
 
   {
@@ -2001,34 +2095,6 @@ default_t defaults[] = {
     {0}, {UL,UL}, input, ss_keys, wad_no,
     "key to toggle padlook",
     input_padlook, { {0, 0} }
-  },
-
-  {
-    "invert_turn",
-    (config_t *) &invert_turn, NULL,
-    {0}, {0, 1}, number, ss_keys, wad_no,
-    "1 to invert gamepad turning axis"
-  },
-
-  {
-    "invert_forward",
-    (config_t *) &invert_forward, NULL,
-    {0}, {0, 1}, number, ss_keys, wad_no,
-    "1 to invert gamepad forward axis"
-  },
-
-  {
-    "invert_strafe",
-    (config_t *) &invert_strafe, NULL,
-    {0}, {0, 1}, number, ss_keys, wad_no,
-    "1 to invert gamepad strafe axis"
-  },
-
-  {
-    "invert_look",
-    (config_t *) &invert_look, NULL,
-    {0}, {0, 1}, number, ss_keys, wad_no,
-    "1 to invert gamepad look axis"
   },
 
   { //jff 4/3/98 allow unlimited sensitivity

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -45,6 +45,7 @@ fixed_t  projection;
 fixed_t  viewx, viewy, viewz;
 angle_t  viewangle;
 localview_t localview;
+double deltatics;
 boolean raw_input;
 fixed_t  viewcos, viewsin;
 player_t *viewplayer;
@@ -710,7 +711,7 @@ void R_SetupFrame (player_t *player)
       viewangle = LerpAngle(player->mo->oldangle, player->mo->angle);
     }
 
-    if (localview.usepitch && use_localview && !player->centering)
+    if (use_localview && !player->centering)
     {
       pitch = player->pitch + localview.pitch;
       pitch = BETWEEN(-MAX_PITCH_ANGLE, MAX_PITCH_ANGLE, pitch);

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -642,6 +642,34 @@ static void R_SetupMouselook(fixed_t viewpitch)
   }
 }
 
+static inline angle_t LerpAngle(angle_t oldvalue, angle_t newvalue)
+{
+  return R_InterpolateAngle(oldvalue, newvalue, fractionaltic);
+}
+
+static inline fixed_t LerpFixed(fixed_t oldvalue, fixed_t newvalue)
+{
+  return (oldvalue + FixedMul(newvalue - oldvalue, fractionaltic));
+}
+
+static inline boolean CheckLocalView(const player_t *player)
+{
+  return (
+    // Don't use localview when interpolation is preferred.
+    raw_input &&
+    // Don't use localview if the player is spying.
+    player == &players[consoleplayer] &&
+    // Don't use localview if the player is dead.
+    player->playerstate != PST_DEAD &&
+    // Don't use localview if the player just teleported.
+    !player->mo->reactiontime &&
+    // Don't use localview if a demo is playing.
+    !demoplayback &&
+    // Don't use localview during a netgame (single-player or solo-net only).
+    (!netgame || solonet)
+  );
+}
+
 //
 // R_SetupFrame
 //
@@ -663,36 +691,24 @@ void R_SetupFrame (player_t *player)
       // Don't interpolate during a paused state
       leveltime > oldleveltime)
   {
-    const boolean use_localview = (
-      // Don't use localview when interpolation is preferred.
-      raw_input &&
-      // Don't use localview if the player is spying.
-      player == &players[consoleplayer] &&
-      // Don't use localview if the player is dead.
-      player->playerstate != PST_DEAD &&
-      // Don't use localview if the player just teleported.
-      !player->mo->reactiontime &&
-      // Don't use localview if a demo is playing.
-      !demoplayback &&
-      // Don't use localview during a netgame (single-player and solo-net only).
-      (!netgame || solonet)
-    );
+    // Use localview unless the player or game is in an invalid state, in which
+    // case fall back to interpolation.
+    const boolean use_localview = CheckLocalView(player);
 
     // Interpolate player camera from their old position to their current one.
-    viewx = player->mo->oldx + FixedMul(player->mo->x - player->mo->oldx, fractionaltic);
-    viewy = player->mo->oldy + FixedMul(player->mo->y - player->mo->oldy, fractionaltic);
-    viewz = player->oldviewz + FixedMul(player->viewz - player->oldviewz, fractionaltic);
+    viewx = LerpFixed(player->mo->oldx, player->mo->x);
+    viewy = LerpFixed(player->mo->oldy, player->mo->y);
+    viewz = LerpFixed(player->oldviewz, player->viewz);
 
-    // Use localview unless the player or game is in an invalid state or if
-    // mouse input was interrupted, in which case fall back to interpolation.
     if (use_localview)
     {
       viewangle = (player->mo->angle + localview.angle - localview.ticangle +
-                   R_InterpolateAngle(localview.oldticangle, localview.ticangle,
-                                      fractionaltic));
+                   LerpAngle(localview.oldticangle, localview.ticangle));
     }
     else
-      viewangle = R_InterpolateAngle(player->mo->oldangle, player->mo->angle, fractionaltic);
+    {
+      viewangle = LerpAngle(player->mo->oldangle, player->mo->angle);
+    }
 
     if (localview.usepitch && use_localview && !player->centering)
     {
@@ -701,11 +717,11 @@ void R_SetupFrame (player_t *player)
     }
     else
     {
-      pitch = player->oldpitch + FixedMul(player->pitch - player->oldpitch, fractionaltic);
+      pitch = LerpFixed(player->oldpitch, player->pitch);
     }
 
     // [crispy] pitch is actual lookdir and weapon pitch
-    pitch += player->oldrecoilpitch + FixedMul(player->recoilpitch - player->oldrecoilpitch, fractionaltic);
+    pitch += LerpFixed(player->oldrecoilpitch, player->recoilpitch);
   }
   else
   {

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -45,7 +45,7 @@ fixed_t  projection;
 fixed_t  viewx, viewy, viewz;
 angle_t  viewangle;
 localview_t localview;
-boolean mouse_raw_input;
+boolean raw_input;
 fixed_t  viewcos, viewsin;
 player_t *viewplayer;
 extern lighttable_t **walllights;
@@ -665,7 +665,7 @@ void R_SetupFrame (player_t *player)
   {
     const boolean use_localview = (
       // Don't use localview when interpolation is preferred.
-      mouse_raw_input &&
+      raw_input &&
       // Don't use localview if the player is spying.
       player == &players[consoleplayer] &&
       // Don't use localview if the player is dead.

--- a/src/r_main.h
+++ b/src/r_main.h
@@ -84,6 +84,7 @@ extern lighttable_t *fixedcolormap;
 //      range of [0.0, 1.0).  Used for interpolation.
 extern fixed_t          fractionaltic;
 
+extern double deltatics;
 extern boolean raw_input;
 
 // [AM] Interpolate between two angles.

--- a/src/r_main.h
+++ b/src/r_main.h
@@ -84,7 +84,7 @@ extern lighttable_t *fixedcolormap;
 //      range of [0.0, 1.0).  Used for interpolation.
 extern fixed_t          fractionaltic;
 
-extern boolean mouse_raw_input;
+extern boolean raw_input;
 
 // [AM] Interpolate between two angles.
 angle_t R_InterpolateAngle(angle_t oangle, angle_t nangle, fixed_t scale);

--- a/src/r_state.h
+++ b/src/r_state.h
@@ -95,6 +95,7 @@ typedef struct localview_s
     angle_t ticangle;
     int ticangleturn;
     double rawangle;
+    double rawpitch;
     int angle;
     int pitch;
 } localview_t;

--- a/src/r_state.h
+++ b/src/r_state.h
@@ -90,7 +90,6 @@ extern side_t           *sides;
 
 typedef struct localview_s
 {
-    boolean usepitch;
     angle_t oldticangle;
     angle_t ticangle;
     int ticangleturn;


### PR DESCRIPTION
The goal of this PR is to modernize gamepad support, focusing mainly on improvements to analog stick behavior. This is a topic with a lot of jargon, so I prepared a [response curves page](https://ceski-1.github.io/response-curves/index.html) to help visualize what's described below.

<details><summary>Summary of changes:</summary>

- The [gamepad menu](https://github.com/fabiangreffrath/woof/assets/56656010/d8906e6e-5a1a-4361-b2d8-f70426b8df51) has been redone, showing relevant options that are expected to be present in any typical FPS game. Advanced settings (the majority of the items below) are available as config only with reasonable defaults. The intention is an easy to follow menu backed by deep customization in the config for those looking for it, or easily ignored by those who aren't.

- Faster gamepad polling. Similar to the recent mouse updates, this reduces perceived input lag for turning and looking by bypassing interpolation and updating every frame instead of every tic. Renamed `mouse_raw_input` to `raw_input` to account for this change and moved the setting to config only.

- Response curve support. A power function is used to adjust the input-to-output curve. The exponent is configurable from 1.0 (linear) to 3.0 (cubed). It was previously always linear for movement and cubed for camera control. Camera control default is now squared for better responsiveness and it is commonly used in modern games. Movement default is still linear.

- Deadzone support. It was previously set to a fixed 33% and would abruptly start moving or cut off when passing through the deadzone. Now stick magnitude is remapped properly from 0 to 1, which feels more precise. Deadzones for movement and camera control can be individually configured, with a default of 15%.

- Two deadzone types are available: axial or radial (default). They each have pros and cons, but generally radial provides finer control. It's also the type used in many competitive FPS games. There are other deadzone types but these two are common and appropriate for Doom.

- Outer threshold support. This controls 1) how far the stick must be tilted before any extra sensitivity is applied, and 2) where the input is considered 100%. The default is 2%, meaning 98% and above stick tilt is mapped to 100%.

- Trigger threshold support. How far the triggers must be pulled before they register. Default is 12%.

- Added independent control of forward, strafe, turn, and look sensitivity.

- Optional extra sensitivity at outer threshold of analog stick, with a configurable ramp time. Many games use this with their default settings. Disabled by default for Woof.

- Optional diagonal movement correction. Remaps circular analog input to a square to account for Doom's unique diagonal movement. Without this, full diagonal speed is never reached unless forward/strafe sensitivity is boosted, which would have the side effect of reducing the useable range of motion.

- The "run" key switches between two speeds for turning and looking, similar to existing forward and strafe behavior. For example, if autorun is enabled and "run" is bound to left trigger, holding it will allow precise aiming and releasing it will return to normal aiming.

- Side speed restrictions added in strict mode and net games for "strafe + turn axis" (mouse/gamepad) and "strafe axis" (gamepad only).

- Axes configuration has been simplified to 4 standard presets (default, flipped, legacy, legacy flipped).
 
</details>