### PR TITLE
Smoother frametimes

### DIFF
--- a/src/d_loop.c
+++ b/src/d_loop.c
@@ -729,7 +729,8 @@ void TryRunTics (void)
 
     // [AM] If we've uncapped the framerate and there are no tics
     //      to run, return early instead of waiting around.
-    #define return_early (uncapped && counts == 0)
+    // Only check counts so that I_FinishUpdate() can handle frame timing.
+    #define return_early (counts == 0)
 
     // get real tics
     entertic = I_GetTime() / ticdup;

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -635,7 +635,7 @@ void I_FinishUpdate(void)
         need_resize = false;
     }
 
-    if (!uncapped || fpslimit >= TICRATE)
+    if (uncapped && fpslimit >= TICRATE)
     {
         uint64_t target_time = 1000000ull / targetrefresh;
 

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -635,7 +635,7 @@ void I_FinishUpdate(void)
         need_resize = false;
     }
 
-    if (uncapped && fpslimit >= TICRATE)
+    if (!uncapped || fpslimit >= TICRATE)
     {
         uint64_t target_time = 1000000ull / targetrefresh;
 

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -350,7 +350,7 @@ static void UpdateLimiter(void)
 {
     if (uncapped)
     {
-        if (fpslimit >= native_refresh_rate && native_refresh_rate && use_vsync)
+        if (fpslimit >= native_refresh_rate && native_refresh_rate > 0 && use_vsync)
         {
             // SDL will limit framerate using vsync.
             use_limiter = false;


### PR DESCRIPTION
I noticed that capped fps has some frame pacing issues that are easy to verify with any gpu overlay software. This PR is one idea to fix it, and it's pretty simple. Another solution probably lies somewhere in `TryRunTics()`.

Here's "uncapped frame rate" set to "no", so the target is 35 fps but it's very uneven. The framerate indicator in the upper right actually bounces between 34 and 35:
![before](https://github.com/fabiangreffrath/woof/assets/56656010/6299b808-4da3-4e12-acc0-038364f6de89)

Here's the same thing after this PR, or by manually setting "uncapped frame rate" set to "yes" with "frame rate limit" set to "35":
![after](https://github.com/fabiangreffrath/woof/assets/56656010/38f90c85-e4b9-4d59-b099-71901fb28e51)

Another way to check is adding this to the very end of `I_FinishUpdate()`:
```c
    {
        static uint64_t last_frametime;
        uint64_t frametime = frametime_start - last_frametime;
        last_frametime = frametime_start;
        printf("%f ms\n", (float)frametime / 1000.0f);
    }
```

`1000 / frametime` is instantaneous framerate:

![frametimes](https://github.com/fabiangreffrath/woof/assets/56656010/3e4426d7-b4ab-48f7-9092-0e35bff78b46)