### PR TITLE
Add auto "strafe50" option

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -2239,8 +2239,6 @@ void D_DoomMain(void)
   if ((p=M_CheckParm ("-turbo")))
     {
       int scale = 200;
-      extern int forwardmove[2];
-      extern int sidemove[2];
 
       if (p < myargc - 1 && myargv[p + 1][0] != '-')
         scale = M_ParmArgToInt(p);

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -2253,6 +2253,12 @@ void D_DoomMain(void)
       forwardmove[1] = forwardmove[1]*scale/100;
       sidemove[0] = sidemove[0]*scale/100;
       sidemove[1] = sidemove[1]*scale/100;
+
+      // Prevent ticcmd overflow.
+      forwardmove[0] = MIN(forwardmove[0], SCHAR_MAX);
+      forwardmove[1] = MIN(forwardmove[1], SCHAR_MAX);
+      sidemove[0] = MIN(sidemove[0], SCHAR_MAX);
+      sidemove[1] = MIN(sidemove[1], SCHAR_MAX);
     }
 
   if (beta_emulation)

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -355,6 +355,30 @@ static void G_DemoSkipTics(void)
   }
 }
 
+static int RoundSide_Strict(double side)
+{
+  return lround(side * 0.5) * 2; // Even values only.
+}
+
+static int RoundSide_Full(double side)
+{
+  return lround(side);
+}
+
+static int (*RoundSide)(double side) = RoundSide_Full;
+
+void G_UpdateSideMove(void)
+{
+  if (strictmode || (netgame && !solonet))
+  {
+    RoundSide = RoundSide_Strict;
+  }
+  else
+  {
+    RoundSide = RoundSide_Full;
+  }
+}
+
 static int CalcControllerForward(int speed)
 {
   const int forward = lroundf(forwardmove[speed] * axes[AXIS_FORWARD] *
@@ -364,29 +388,15 @@ static int CalcControllerForward(int speed)
 
 static int CalcControllerSideTurn(int speed)
 {
-  const float fside = (forwardmove[speed] * axes[AXIS_TURN] *
-                       direction[joy_invert_turn]);
-  int side;
-
-  if (strictmode || (netgame && !solonet))
-    side = lroundf(fside * 0.5f) * 2; // Even values only.
-  else
-    side = lroundf(fside);
-
+  const int side = RoundSide(forwardmove[speed] * axes[AXIS_TURN] *
+                             direction[joy_invert_turn]);
   return BETWEEN(-forwardmove[speed], forwardmove[speed], side);
 }
 
 static int CalcControllerSideStrafe(int speed)
 {
-  const float fside = (forwardmove[speed] * axes[AXIS_STRAFE] *
-                       direction[joy_invert_strafe]);
-  int side;
-
-  if (strictmode || (netgame && !solonet))
-    side = lroundf(fside * 0.5f) * 2; // Even values only.
-  else
-    side = lroundf(fside);
-
+  const int side = RoundSide(forwardmove[speed] * axes[AXIS_STRAFE] *
+                             direction[joy_invert_strafe]);
   return BETWEEN(-sidemove[speed], sidemove[speed], side);
 }
 
@@ -427,13 +437,7 @@ static int CarryMouseVert(double vert)
 static int CarryMouseSide(double side)
 {
   const double desired = side + prevcarry.side;
-  int actual;
-
-  if (strictmode || (netgame && !solonet))
-    actual = lround(desired * 0.5) * 2; // Even values only.
-  else
-    actual = lround(desired);
-
+  const int actual = RoundSide(desired);
   carry.side = desired - actual;
   return actual;
 }
@@ -3273,6 +3277,7 @@ void G_ReloadDefaults(boolean keep_demover)
   if (M_CheckParm("-strict"))
     strictmode = true;
 
+  G_UpdateSideMove();
   P_UpdateDirectVerticalAiming();
 
   pistolstart = default_pistolstart;

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -124,6 +124,7 @@ wbstartstruct_t wminfo;               // parms for world map / intermission
 boolean         haswolflevels = false;// jff 4/18/98 wolf levels present
 byte            *savebuffer;
 int             autorun = false;      // always running?          // phares
+boolean         autostrafe50;
 int             novert = false;
 boolean         mouselook = false;
 boolean         padlook = false;
@@ -156,8 +157,10 @@ int     mouse_y_invert;
 #define QUICKREVERSE 32768 // 180 degree reverse                    // phares
 #define NUMKEYS   256
 
-fixed_t forwardmove[2] = {0x19, 0x32};
-fixed_t sidemove[2]    = {0x18, 0x28};
+static fixed_t default_forwardmove[2] = {0x19, 0x32};
+static fixed_t default_sidemove[2] = {0x18, 0x28};
+fixed_t *forwardmove = default_forwardmove;
+fixed_t *sidemove = default_sidemove;
 fixed_t angleturn[3]   = {640, 1280, 320};  // + slow turn
 
 boolean gamekeydown[NUMKEYS];
@@ -372,10 +375,12 @@ void G_UpdateSideMove(void)
   if (strictmode || (netgame && !solonet))
   {
     RoundSide = RoundSide_Strict;
+    sidemove = default_sidemove;
   }
   else
   {
     RoundSide = RoundSide_Full;
+    sidemove = autostrafe50 ? default_forwardmove : default_sidemove;
   }
 }
 

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -383,15 +383,11 @@ static int CalcControllerSideStrafe(int speed)
   int side;
 
   if (strictmode || (netgame && !solonet))
-  {
     side = lroundf(fside * 0.5f) * 2; // Even values only.
-    return BETWEEN(-sidemove[speed], sidemove[speed], side); // Limit speed.
-  }
   else
-  {
     side = lroundf(fside);
-    return BETWEEN(-forwardmove[speed], forwardmove[speed], side);
-  }
+
+  return BETWEEN(-sidemove[speed], sidemove[speed], side);
 }
 
 static double CalcControllerAngle(int speed)

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -20,6 +20,7 @@
 #include "doomdef.h"
 #include "d_event.h"
 #include "d_ticcmd.h"
+#include "m_fixed.h"
 
 //
 // GAME
@@ -76,9 +77,13 @@ extern int  key_escape;
 extern int  key_enter;
 extern int  key_help;
 extern int  autorun;           // always running?                   // phares
+extern boolean autostrafe50;
 extern int  novert;
 extern boolean mouselook;
 extern boolean padlook;
+
+extern fixed_t *forwardmove;
+extern fixed_t *sidemove;
 
 extern int  defaultskill;      //jff 3/24/98 default skill
 extern boolean haswolflevels;  //jff 4/18/98 wolf levels present

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -49,6 +49,7 @@ void G_SecretExitLevel(void);
 void G_WorldDone(void);
 void G_Ticker(void);
 void G_ScreenShot(void);
+void G_UpdateSideMove(void);
 void G_ReloadDefaults(boolean keep_demover); // killough 3/1/98: loads game defaults
 char *G_SaveGameName(int); // killough 3/22/98: sets savegame filename
 char *G_MBFSaveGameName(int); // MBF savegame filename

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -570,6 +570,13 @@ default_t defaults[] = {
   },
 
   {
+    "autostrafe50",
+    (config_t *) &autostrafe50, NULL,
+    {0}, {0,1}, number, ss_none, wad_no,
+    "1 to enable auto strafe50"
+  },
+
+  {
     "strictmode",
     (config_t *) &default_strictmode, (config_t *) &strictmode,
     {0}, {0,1}, number, ss_gen, wad_no,


### PR DESCRIPTION
- Doesn't apply to strict mode or multiplayer.
- The Unity release of Doom does this by default, and there is already the Unity view bobbing option in Woof.
- It's nice for consistent feeling gamepad movement, but even outside of strict mode it's not a very conservative feature to enable by default.
- Maybe good as a menu option, but I'll leave that alone for now. `G_UpdateSideMove()` should be called whenever `strictmode` or `autostrafe50` change.