### PR TITLE
switch order of shaded and gold translation für submenu bar

### DIFF
--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -2092,7 +2092,7 @@ static void M_DrawTabs(void)
         if (i == mult_screens_index)
         {
             V_FillRect(x + video.deltaw, rect->y + M_SPC, rect->w, 1,
-                       cr_shaded[cr_gold[v_lightest_color]]);
+                       cr_gold[cr_shaded[v_lightest_color]]);
         }
 
         rect->x = x;


### PR DESCRIPTION
My sentiment is: If `v_lightest_color` is plain white, then this color translated to gold may result in a very desaturated color, which then gets shaded. I'd prefer if we translate a light shade of gray to gold instead. Also, the colors in the HUD font are in general not full bright, so translating from a moderate gray to gold may fit better.