### PR TITLE
Improve menu option for FOV

### DIFF
--- a/src/i_video.h
+++ b/src/i_video.h
@@ -24,8 +24,9 @@
 
 #include "doomtype.h"
 
-#define FOVMIN 40
-#define FOVMAX 140 // Up to 32:9 ultrawide.
+#define FOV_DEFAULT 90
+#define FOV_MIN 60
+#define FOV_MAX 120
 #define ASPECT_RATIO_MAX 3.6 // Up to 32:9 ultrawide.
 
 typedef enum

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -3927,11 +3927,6 @@ static void M_CoerceFPSLimit(void)
 
 static void M_UpdateFOV(void)
 {
-  if (custom_fov < FOVMIN)
-  {
-    custom_fov = 0;
-  }
-
   setsizeneeded = true; // run R_ExecuteSetViewSize;
 }
 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -216,8 +216,8 @@ default_t defaults[] = {
   {
     "fov",
     (config_t *) &custom_fov, NULL,
-    {0}, {0, FOVMAX}, number, ss_gen, wad_no,
-    "Field of view in degrees (0 = Auto, 40 to 140 = Custom)"
+    {FOV_DEFAULT}, {FOV_MIN, FOV_MAX}, number, ss_gen, wad_no,
+    "Field of view in degrees"
   },
 
   // display index

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -269,12 +269,14 @@ static void R_InitTextureMapping(void)
   // Calc focallength
   //  so FIELDOFVIEW angles covers SCREENWIDTH.
 
-  if (custom_fov)
+  if (custom_fov != FOV_DEFAULT)
   {
-    fov = custom_fov * FINEANGLES / 360;
+    const double angle = atan(tan(custom_fov * M_PI / 360.0) *
+                              centerxfrac / centerxfrac_nonwide);
+    fov = angle * FINEANGLES / M_PI;
     slopefrac = finetangent[FINEANGLES / 4 + fov / 2];
     focallength = FixedDiv(centerxfrac, slopefrac);
-    projection = centerxfrac / tan(custom_fov * M_PI / 360.0);
+    projection = centerxfrac / tan(angle);
   }
   else
   {

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -271,12 +271,12 @@ static void R_InitTextureMapping(void)
 
   if (custom_fov != FOV_DEFAULT)
   {
-    const double angle = atan(tan(custom_fov * M_PI / 360.0) *
-                              centerxfrac / centerxfrac_nonwide);
-    fov = angle * FINEANGLES / M_PI;
+    const double slope = (tan(custom_fov * M_PI / 360.0) *
+                          centerxfrac / centerxfrac_nonwide);
+    fov = atan(slope) * FINEANGLES / M_PI;
     slopefrac = finetangent[FINEANGLES / 4 + fov / 2];
     focallength = FixedDiv(centerxfrac, slopefrac);
-    projection = centerxfrac / tan(angle);
+    projection = centerxfrac / slope;
   }
   else
   {


### PR DESCRIPTION
This uses a 4:3 horizontal FOV and automatically adjusts it to the current aspect ratio. That means most users should leave the FOV at 90 (default) unless they have a specific reason to change it.

<details><summary>Some extra details for future reference</summary>

Use this formula to find the actual FOV:

```c
actual_fov = atan(aspect_ratio * 3 / 4 * tan(menu_fov * pi / 360)) * 360 / pi
```

Menu thermo FOV:

| Aspect Ratio | Min FOV | Default FOV | Max FOV |
|:------------:|:-------:|:-----------:|:-------:|
|      Any     |    60   |      90     |   120   |

Actual FOV:

| Aspect Ratio | Min FOV | Default FOV | Max FOV |
|:------------:|:-------:|:-----------:|:-------:|
|      4:3     |    60   |      90     |   120   |
|     16:9     |    75   |     106     |   133   |
|     21:9     |    92   |     122     |   144   |
|     32:9     |   114   |     139     |   156   |

There are other ways to present FOV (vertical FOV, actual FOV) but 4:3 horizontal FOV is the most simple and intuitive. [Interesting commentary here](https://www.pcgamingwiki.com/wiki/Glossary:Field_of_view_(FOV)).

</details>