### PR TITLE
create/destroy mutex when start/stop song

### DIFF
--- a/src/i_oalmusic.c
+++ b/src/i_oalmusic.c
@@ -259,9 +259,7 @@ static void I_OAL_SetMusicVolume(int volume)
     if (!music_initialized)
         return;
 
-    SDL_LockMutex(music_lock);
     alSourcef(player.source, AL_GAIN, (ALfloat)volume / 15.0f);
-    SDL_UnlockMutex(music_lock);
 }
 
 static void I_OAL_PauseSong(void *handle)


### PR DESCRIPTION
Might fix #1429 

I can't replicate the issue, MusChange.wad is still fast for me with the latest master. I assume the problem is in the mutex creation.

The `i_winmusic.c` device switch is slow, but I thought this is normal as we make the exit sequence more robust (it's also slow in GZDoom). 