### PR TITLE
dark menu backdrop by default, change am preset order

### DIFF
--- a/src/am_map.c
+++ b/src/am_map.c
@@ -2251,39 +2251,39 @@ void AM_ColorPreset(void)
   struct
   {
     int *var;
-    int color[3]; // Boom, Vanilla Doom, ZDoom
+    int color[3]; // Vanilla Doom, Boom, ZDoom
   } mapcolors[] =
   {                                       // ZDoom CVAR name
-    {&mapcolor_back,    {247,   0, 139}}, // am_backcolor
+    {&mapcolor_back,    {  0, 247, 139}}, // am_backcolor
     {&mapcolor_grid,    {104, 104,  70}}, // am_gridcolor
-    {&mapcolor_wall,    { 23, 176, 239}}, // am_wallcolor
-    {&mapcolor_fchg,    { 55,  64, 135}}, // am_fdwallcolor
-    {&mapcolor_cchg,    {215, 231,  76}}, // am_cdwallcolor
-    {&mapcolor_clsd,    {208,   0,   0}},
-    {&mapcolor_rkey,    {175,   0, 176}}, // P_GetMapColorForLock()
-    {&mapcolor_bkey,    {204,   0, 200}}, // P_GetMapColorForLock()
-    {&mapcolor_ykey,    {231,   0, 231}}, // P_GetMapColorForLock()
-    {&mapcolor_rdor,    {175,   0, 176}}, // P_GetMapColorForLock()
-    {&mapcolor_bdor,    {204,   0, 200}}, // P_GetMapColorForLock()
-    {&mapcolor_ydor,    {231,   0, 231}}, // P_GetMapColorForLock()
-    {&mapcolor_tele,    {119,   0, 200}}, // am_intralevelcolor
-    {&mapcolor_secr,    {252,   0, 251}}, // am_unexploredsecretcolor
-    {&mapcolor_revsecr, {112,   0, 251}}, // am_secretsectorcolor
+    {&mapcolor_wall,    {176,  23, 239}}, // am_wallcolor
+    {&mapcolor_fchg,    { 64,  55, 135}}, // am_fdwallcolor
+    {&mapcolor_cchg,    {231, 215,  76}}, // am_cdwallcolor
+    {&mapcolor_clsd,    {  0, 208,   0}},
+    {&mapcolor_rkey,    {  0, 175, 176}}, // P_GetMapColorForLock()
+    {&mapcolor_bkey,    {  0, 204, 200}}, // P_GetMapColorForLock()
+    {&mapcolor_ykey,    {  0, 231, 231}}, // P_GetMapColorForLock()
+    {&mapcolor_rdor,    {  0, 175, 176}}, // P_GetMapColorForLock()
+    {&mapcolor_bdor,    {  0, 204, 200}}, // P_GetMapColorForLock()
+    {&mapcolor_ydor,    {  0, 231, 231}}, // P_GetMapColorForLock()
+    {&mapcolor_tele,    {  0, 119, 200}}, // am_intralevelcolor
+    {&mapcolor_secr,    {  0, 252, 251}}, // am_unexploredsecretcolor
+    {&mapcolor_revsecr, {  0, 112, 251}}, // am_secretsectorcolor
     {&mapcolor_exit,    {  0,   0, 176}}, // am_interlevelcolor
-    {&mapcolor_unsn,    {104,  99, 100}}, // am_notseencolor
-    {&mapcolor_flat,    { 88,  97,  95}}, // am_tswallcolor
+    {&mapcolor_unsn,    { 99, 104, 100}}, // am_notseencolor
+    {&mapcolor_flat,    { 97,  88,  95}}, // am_tswallcolor
     {&mapcolor_sprt,    {112, 112,   4}}, // am_thingcolor
-    {&mapcolor_hair,    {208,  96,  97}}, // am_xhaircolor
-    {&mapcolor_sngl,    {208, 209, 209}}, // am_yourcolor
+    {&mapcolor_hair,    { 96, 208,  97}}, // am_xhaircolor
+    {&mapcolor_sngl,    {209, 208, 209}}, // am_yourcolor
     {&mapcolor_plyr[0], {112, 112, 112}},
     {&mapcolor_plyr[1], { 88,  88,  88}},
     {&mapcolor_plyr[2], { 64,  64,  64}},
     {&mapcolor_plyr[3], {176, 176, 176}},
     {&mapcolor_frnd,    {252, 252,   4}}, // am_thingcolor_friend
-    {&mapcolor_enemy,   {177, 112,   4}}, // am_thingcolor_monster
-    {&mapcolor_item,    {231, 112,   4}}, // am_thingcolor_item
+    {&mapcolor_enemy,   {112, 177,   4}}, // am_thingcolor_monster
+    {&mapcolor_item,    {112, 231,   4}}, // am_thingcolor_item
 
-    {&hudcolor_titl,    {CR_GOLD, CR_NONE, CR_GRAY}}, // DrawAutomapHUD()
+    {&hudcolor_titl,    {CR_NONE, CR_GOLD, CR_GRAY}}, // DrawAutomapHUD()
 
     {NULL,              {  0,   0,   0}},
   };

--- a/src/am_map.c
+++ b/src/am_map.c
@@ -201,7 +201,7 @@ int automap_grid = 0;
 boolean automapactive = false;
 static boolean automapfirststart = true;
 
-overlay_t automapoverlay = overlay_off;
+overlay_t automapoverlay = AM_OVERLAY_OFF;
 
 // location of window on screen
 static int  f_x;
@@ -868,8 +868,8 @@ boolean AM_Responder
     else
     if (M_InputActivated(input_map_overlay))
     {
-      if (++automapoverlay > overlay_dark)
-        automapoverlay = overlay_off;
+      if (++automapoverlay > AM_OVERLAY_DARK)
+        automapoverlay = AM_OVERLAY_OFF;
 
       switch (automapoverlay)
       {
@@ -2230,7 +2230,7 @@ void AM_Drawer (void)
     pspr_interp = false;
   }
   // [Alaux] Dark automap overlay
-  else if (automapoverlay == overlay_dark && !M_MenuIsShaded())
+  else if (automapoverlay == AM_OVERLAY_DARK && !M_MenuIsShaded())
     V_ShadeScreen();
 
   if (automap_grid)                  // killough 2/28/98: change var name
@@ -2296,7 +2296,7 @@ void AM_ColorPreset(void)
   }
 
   // [FG] immediately apply changes if the automap is visible through the menu
-  if (automapactive && menu_background != background_on)
+  if (automapactive && menu_backdrop != MENU_BG_TEXTURE)
   {
     HU_Start();
   }

--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -234,9 +234,9 @@ extern  boolean automapactive; // In AutoMap mode?
 
 typedef enum
 {
-  overlay_off,
-  overlay_on,
-  overlay_dark,
+  AM_OVERLAY_OFF,
+  AM_OVERLAY_ON,
+  AM_OVERLAY_DARK,
 } overlay_t;
 
 extern  overlay_t automapoverlay;

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -120,7 +120,9 @@ boolean inhelpscreens; // indicates we are in or just left a help screen
 
 boolean menuactive;    // The menus are up
 
-background_t menu_background;
+static boolean optionsactive;
+
+backdrop_t menu_backdrop;
 
 #define SKULLXOFF  -32
 #define LINEHEIGHT  16
@@ -383,6 +385,8 @@ static void M_DrawMainMenu(void)
 {
   // [crispy] force status bar refresh
   inhelpscreens = true;
+
+  optionsactive = false;
 
   V_DrawPatchDirect (94,2,W_CacheLumpName("M_DOOM",PU_CACHE));
 }
@@ -1853,7 +1857,7 @@ static menu_t CompatDef =                                           // killough 
 
 static void M_DrawBackground(char *patchname)
 {
-  if (setup_active && menu_background != background_on)
+  if (setup_active && menu_backdrop != MENU_BG_TEXTURE)
     return;
 
   V_DrawBackground(patchname);
@@ -1875,6 +1879,8 @@ static void M_DrawSetup(void)
 
 static void M_Setup(int choice)
 {
+  optionsactive = true;
+
   M_SetupNextMenu(&SetupDef);
 }
 
@@ -1942,7 +1948,7 @@ enum
     str_default_complevel,
     str_endoom,
     str_death_use_action,
-    str_menu_background,
+    str_menu_backdrop,
 };
 
 static const char **GetStrings(int id);
@@ -4188,8 +4194,8 @@ static const char *death_use_action_strings[] = {
   "default", "last save", "nothing"
 };
 
-static const char *menu_background_strings[] = {
-  "on", "off", "dark"
+static const char *menu_backdrop_strings[] = {
+  "Dark", "Off", "Texture"
 };
 
 #define CNTR_X 162
@@ -4294,8 +4300,8 @@ setup_menu_t gen_settings5[] = {
 
   {"", S_SKIP, m_null, M_X, M_SPC},
 
-  {"Menu Background", S_CHOICE, m_null, M_X, M_SPC,
-   {"menu_background"}, 0, NULL, str_menu_background},
+  {"Menu Backdrop", S_CHOICE, m_null, M_X, M_SPC,
+   {"menu_backdrop"}, 0, NULL, str_menu_backdrop},
 
   {"Disk IO Icon", S_YESNO, m_null, M_X, M_SPC, {"disk_icon"}},
 
@@ -6606,16 +6612,11 @@ void M_StartControlPanel (void)
 
 boolean M_MenuIsShaded(void)
 {
-  return setup_active && menu_background == background_dark;
+  return optionsactive && menu_backdrop == MENU_BG_DARK;
 }
 
 void M_Drawer (void)
 {
-    if (M_MenuIsShaded())
-    {
-        V_ShadeScreen();
-    }
-
     inhelpscreens = false;
 
     // Horiz. & Vertically center string and print it.
@@ -6650,6 +6651,12 @@ void M_Drawer (void)
     if (!menuactive)
     {
         return;
+    }
+
+    if (M_MenuIsShaded())
+    {
+        inhelpscreens = true;
+        V_ShadeScreen();
     }
 
     if (currentMenu->routine)
@@ -6962,7 +6969,7 @@ static const char **selectstrings[] = {
     default_complevel_strings,
     endoom_strings,
     death_use_action_strings,
-    menu_background_strings,
+    menu_backdrop_strings,
 };
 
 static const char **GetStrings(int id)

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -6757,6 +6757,7 @@ void M_Drawer (void)
 static void M_ClearMenus(void)
 {
   menuactive = 0;
+  optionsactive = false;
   print_warning_about_changes = 0;     // killough 8/15/98
   default_verify = 0;                  // killough 10/98
 

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -3422,7 +3422,7 @@ static const char *overlay_strings[] = {
 };
 
 static const char *automap_preset_strings[] = {
-    "Boom", "Vanilla", "ZDoom"
+    "Vanilla", "Boom", "ZDoom"
 };
 
 setup_menu_t auto_settings1[] =  // 1st AutoMap Settings screen       

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -4195,7 +4195,7 @@ static const char *death_use_action_strings[] = {
 };
 
 static const char *menu_backdrop_strings[] = {
-  "Dark", "Off", "Texture"
+  "Off", "Dark", "Texture"
 };
 
 #define CNTR_X 162

--- a/src/m_menu.h
+++ b/src/m_menu.h
@@ -181,12 +181,12 @@ typedef struct setup_menu_s
 
 typedef enum
 {
-  background_on,
-  background_off,
-  background_dark,
-} background_t;
+  MENU_BG_DARK,
+  MENU_BG_OFF,
+  MENU_BG_TEXTURE,
+} backdrop_t;
 
-extern background_t menu_background;
+extern backdrop_t menu_backdrop;
 extern boolean M_MenuIsShaded(void);
 
 extern void M_SetQuickSaveSlot (int slot);

--- a/src/m_menu.h
+++ b/src/m_menu.h
@@ -181,8 +181,8 @@ typedef struct setup_menu_s
 
 typedef enum
 {
-  MENU_BG_DARK,
   MENU_BG_OFF,
+  MENU_BG_DARK,
   MENU_BG_TEXTURE,
 } backdrop_t;
 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -2386,8 +2386,8 @@ default_t defaults[] = {
   {
     "mapcolor_preset",
     (config_t *) &mapcolor_preset, NULL,
-    {0}, {0,2}, number, ss_auto, wad_no,
-    "automap color preset (0 = Boom (default), 1 = Vanilla Doom, 2 = ZDoom)"
+    {1}, {0,2}, number, ss_auto, wad_no,
+    "automap color preset (0 = Vanilla Doom, 1 = Boom (default), 2 = ZDoom)"
   },
 
   {

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -351,10 +351,10 @@ default_t defaults[] = {
   },
 
   {
-    "menu_background",
-    (config_t *) &menu_background, NULL,
-    {background_on}, {background_on,background_dark}, number, ss_gen, wad_no,
-    "draw menu background (0 = on, 1 = off, 2 = dark)"
+    "menu_backdrop",
+    (config_t *) &menu_backdrop, NULL,
+    {MENU_BG_DARK}, {MENU_BG_DARK,MENU_BG_TEXTURE}, number, ss_gen, wad_no,
+    "draw menu backdrop (0 = dark, 1 = off, 2 = texture)"
   },
 
   { // killough 10/98
@@ -2430,7 +2430,7 @@ default_t defaults[] = {
   {
     "automapoverlay",
     (config_t *) &automapoverlay, NULL,
-    {overlay_off}, {overlay_off,overlay_dark}, number, ss_auto, wad_no,
+    {AM_OVERLAY_OFF}, {AM_OVERLAY_OFF,AM_OVERLAY_DARK}, number, ss_auto, wad_no,
     "automap overlay mode (1 = on, 2 = dark)"
   },
 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -353,8 +353,8 @@ default_t defaults[] = {
   {
     "menu_backdrop",
     (config_t *) &menu_backdrop, NULL,
-    {MENU_BG_DARK}, {MENU_BG_DARK,MENU_BG_TEXTURE}, number, ss_gen, wad_no,
-    "draw menu backdrop (0 = dark, 1 = off, 2 = texture)"
+    {MENU_BG_DARK}, {MENU_BG_OFF, MENU_BG_TEXTURE}, number, ss_gen, wad_no,
+    "draw menu backdrop (0 = off, 1 = dark (default), 2 = texture)"
   },
 
   { // killough 10/98

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -919,36 +919,39 @@ void V_PutBlock(int x, int y, int width, int height, byte *src)
 
 void V_ShadeScreen(void)
 {
-  int x, y;
-  byte *dest = dest_screen;
-  const int targshade = 20, step = 2;
-  static int oldtic = -1;
-  static int screenshade;
+    int x, y;
+    static int oldtic = -1;
+    static int screenshade;
 
-  // [FG] start a new sequence
-  if (gametic - oldtic > targshade / step)
-  {
-    screenshade = 0;
-  }
+    #define SHADE_TARGET 12
+    #define SHADE_STEP   4
 
-  for (y = 0; y < video.height; y++)
-  {
-    for (x = 0; x < video.width; x++)
+    // [FG] start a new sequence
+    if (gametic - oldtic > SHADE_TARGET / SHADE_STEP)
     {
-      dest[x] = colormaps[0][screenshade * 256 + dest[x]];
+        screenshade = 0;
     }
-    dest += linesize;
-  }
 
-  if (screenshade < targshade && gametic != oldtic)
-  {
-    screenshade += step;
+    byte *dest = dest_screen;
 
-    if (screenshade > targshade)
-      screenshade = targshade;
-  }
+    for (y = 0; y < video.height; y++)
+    {
+        for (x = 0; x < video.width; x++)
+        {
+            dest[x] = colormaps[0][screenshade * 256 + dest[x]];
+        }
+        dest += linesize;
+    }
 
-  oldtic = gametic;
+    if (screenshade < SHADE_TARGET && gametic != oldtic)
+    {
+        screenshade += SHADE_STEP;
+
+        if (screenshade > SHADE_TARGET)
+            screenshade = SHADE_TARGET;
+    }
+
+    oldtic = gametic;
 }
 
 //

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -927,7 +927,7 @@ void V_ShadeScreen(void)
     {
         for (x = 0; x < video.width; x++)
         {
-            dest[x] = colormaps[0][10 * 256 + dest[x]];
+            dest[x] = colormaps[0][12 * 256 + dest[x]];
         }
         dest += linesize;
     }

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -920,17 +920,6 @@ void V_PutBlock(int x, int y, int width, int height, byte *src)
 void V_ShadeScreen(void)
 {
     int x, y;
-    static int oldtic = -1;
-    static int screenshade;
-
-    #define SHADE_TARGET 12
-    #define SHADE_STEP   4
-
-    // [FG] start a new sequence
-    if (gametic - oldtic > SHADE_TARGET / SHADE_STEP)
-    {
-        screenshade = 0;
-    }
 
     byte *dest = dest_screen;
 
@@ -938,20 +927,10 @@ void V_ShadeScreen(void)
     {
         for (x = 0; x < video.width; x++)
         {
-            dest[x] = colormaps[0][screenshade * 256 + dest[x]];
+            dest[x] = colormaps[0][10 * 256 + dest[x]];
         }
         dest += linesize;
     }
-
-    if (screenshade < SHADE_TARGET && gametic != oldtic)
-    {
-        screenshade += SHADE_STEP;
-
-        if (screenshade > SHADE_TARGET)
-            screenshade = SHADE_TARGET;
-    }
-
-    oldtic = gametic;
 }
 
 //


### PR DESCRIPTION
* Replaced "Menu Background" with "Menu Backdrop" with different logic and "Dark" by default

* Options menu now also has a dark background

* Speed up fading

Perhaps controversial changes.

> I'm late to the discussion but yes, even though the "fading" effect is nice the first few times, I actually prefer instant feedback for both the menu and the automap. Sort of like how I disable animations in an OS.

I agree, and in modern UI there's not much to disable - usually there's very little animation and it's fast.