### PR TITLE
Blink missing keys

### DIFF
--- a/src/d_player.h
+++ b/src/d_player.h
@@ -87,10 +87,10 @@ typedef enum
 typedef enum
 {
   KEYBLINK_NONE,
-  KEYBLINK_EITHER,
   KEYBLINK_CARD,
   KEYBLINK_SKULL,
   KEYBLINK_BOTH,
+  KEYBLINK_EITHER,
 } keyblink_t;
 
 //

--- a/src/d_player.h
+++ b/src/d_player.h
@@ -82,6 +82,17 @@ typedef enum
   weapswitch_raising,
 } weapswitch_t;
 
+
+// [crispy] blinking key or skull in the status bar
+typedef enum
+{
+  KEYBLINK_NONE,
+  KEYBLINK_EITHER,
+  KEYBLINK_CARD,
+  KEYBLINK_SKULL,
+  KEYBLINK_BOTH,
+} keyblink_t;
+
 //
 // Extended player object info: player_t
 //
@@ -180,6 +191,10 @@ typedef struct player_s
 
   // [Woof!] show centered "A secret is revealed!" message
   char*               secretmessage;
+
+  // [crispy] blinking key or skull in the status bar
+  keyblink_t          keyblinkkeys[3];
+  int                 keyblinktics;
 
   int                 btuse, btuse_tics;
 

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -1385,6 +1385,8 @@ static void G_PlayerFinishLevel(int player)
   p->bonuscount = 0;
   // [crispy] reset additional player properties
   p->btuse_tics = 0;
+  memset(p->keyblinkkeys, 0, sizeof p->keyblinkkeys);
+  p->keyblinktics = 0;
   p->oldpitch = p->pitch = 0;
   p->centering = false;
   p->slope = 0;

--- a/src/hu_stuff.c
+++ b/src/hu_stuff.c
@@ -983,38 +983,45 @@ static void HU_widget_build_keys (void)
   // build text string whose characters call out graphic keys
   for (k = 0; k < 6; k++)
   {
-    int card = plr->cards[k];
-    const keyblink_t keyblink = ST_BlinkKey(plr, k % 3);
-
-    if (!card && keyblink)
-    {
-      switch (keyblink)
-      {
-        case KEYBLINK_CARD:
-          card = (k < 3);
-          break;
-
-        case KEYBLINK_SKULL:
-          card = (k >= 3);
-          break;
-
-        case KEYBLINK_BOTH:
-          card = true;
-          break;
-
-        default:
-          break;
-      }
-    }
-
     // skip keys not possessed
-    if (!card)
+    if (!plr->cards[k])
       continue;
 
     hud_keysstr[i++] = HU_FONTEND + k + 1; // key number plus HU_FONTEND is char for key
     hud_keysstr[i++] = ' ';   // spacing
     hud_keysstr[i++] = ' ';
   }
+
+  // [Alaux] Blink missing keys *after* possessed keys
+  for (k = 0; k < 6; k++)
+  {
+    if (plr->cards[k])
+      continue;
+
+    switch (ST_BlinkKey(plr, k % 3))
+    {
+      case KEYBLINK_CARD:
+        if (k >= 3)
+          continue;
+        break;
+
+      case KEYBLINK_SKULL:
+        if (k < 3)
+          continue;
+        break;
+
+      case KEYBLINK_BOTH:
+        break;
+
+      default:
+        continue;
+    }
+
+    hud_keysstr[i++] = HU_FONTEND + k + 1;
+    hud_keysstr[i++] = ' ';
+    hud_keysstr[i++] = ' ';
+  }
+
   hud_keysstr[i] = '\0';
 
   // transfer the built string (frags or key title) to the widget

--- a/src/hu_stuff.c
+++ b/src/hu_stuff.c
@@ -984,18 +984,28 @@ static void HU_widget_build_keys (void)
   for (k = 0; k < 6; k++)
   {
     int card = plr->cards[k];
-    const int keyblinkkeys = plr->keyblinkkeys[k%3];
   
-    if (!card && keyblinkkeys && plr->keyblinktics & KEYBLINKMASK)
+    if (!card && plr->keyblinkkeys[k%3] && plr->keyblinktics & KEYBLINKMASK)
     {
-      switch (keyblinkkeys)
+      switch (plr->keyblinkkeys[k%3])
       {
         case KEYBLINK_EITHER:
-          if ( (plr->keyblinktics & (2*KEYBLINKMASK)) &&
-              !(plr->keyblinktics & (4*KEYBLINKMASK)))
+          if (st_keyorskull[k%3] == KEYBLINK_SKULL)
+          {
             card = (k >= 3);
-          else
+          }
+          else if (st_keyorskull[k%3] == KEYBLINK_CARD)
+          {
             card = (k < 3);
+          }
+          else
+          {
+            if ( (plr->keyblinktics & (2*KEYBLINKMASK)) &&
+                !(plr->keyblinktics & (4*KEYBLINKMASK)))
+              card = (k >= 3);
+            else
+              card = (k < 3);
+          }
           break;
 
         case KEYBLINK_CARD:

--- a/src/hu_stuff.c
+++ b/src/hu_stuff.c
@@ -986,18 +986,34 @@ static void HU_widget_build_keys (void)
     int card;
     const int keyblinkkeys = plr->keyblinkkeys[k%3];
   
-    if (!(card = plr->cards[k]) && keyblinkkeys)
+    if (!(card = plr->cards[k]) && keyblinkkeys &&
+        plr->keyblinktics & KEYBLINKMASK)
     {
-      card = plr->keyblinktics & KEYBLINKMASK
-             ? keyblinkkeys == KEYBLINK_BOTH
-               ? true
-               : (keyblinkkeys == KEYBLINK_SKULL
-                  || (keyblinkkeys == KEYBLINK_EITHER
-                      &&  (plr->keyblinktics & (2*KEYBLINKMASK))
-                      && !(plr->keyblinktics & (4*KEYBLINKMASK))))
-                 ? k >= 3
-                 : k <  3
-             : false;
+      switch (keyblinkkeys)
+      {
+        case KEYBLINK_EITHER:
+          if ( (plr->keyblinktics & (2*KEYBLINKMASK)) &&
+              !(plr->keyblinktics & (4*KEYBLINKMASK)))
+            card = k >= 3;
+          else
+            card = k < 3;
+          break;
+
+        case KEYBLINK_CARD:
+          card = k < 3;
+          break;
+
+        case KEYBLINK_SKULL:
+          card = k >= 3;
+          break;
+
+        case KEYBLINK_BOTH:
+          card = true;
+          break;
+
+        default:
+          break;
+      }
     }
 
     // skip keys not possessed

--- a/src/hu_stuff.c
+++ b/src/hu_stuff.c
@@ -979,8 +979,25 @@ static void HU_widget_build_keys (void)
   // build text string whose characters call out graphic keys
   for (k = 0; k < 6; k++)
   {
+    int card;
+    const int keyblinkkeys = plr->keyblinkkeys[k%3];
+  
+    if (!(card = plr->cards[k]) && keyblinkkeys)
+    {
+      card = plr->keyblinktics & KEYBLINKMASK
+             ? keyblinkkeys == KEYBLINK_BOTH
+               ? true
+               : (keyblinkkeys == KEYBLINK_SKULL
+                  || (keyblinkkeys == KEYBLINK_EITHER
+                      &&  (plr->keyblinktics & (2*KEYBLINKMASK))
+                      && !(plr->keyblinktics & (4*KEYBLINKMASK))))
+                 ? k >= 3
+                 : k <  3
+             : false;
+    }
+
     // skip keys not possessed
-    if (!plr->cards[k])
+    if (!card)
       continue;
 
     hud_keysstr[i++] = HU_FONTEND + k + 1; // key number plus HU_FONTEND is char for key

--- a/src/hu_stuff.c
+++ b/src/hu_stuff.c
@@ -984,30 +984,12 @@ static void HU_widget_build_keys (void)
   for (k = 0; k < 6; k++)
   {
     int card = plr->cards[k];
-  
-    if (!card && plr->keyblinkkeys[k%3] && plr->keyblinktics & KEYBLINKMASK)
-    {
-      switch (plr->keyblinkkeys[k%3])
-      {
-        case KEYBLINK_EITHER:
-          if (st_keyorskull[k%3] == KEYBLINK_SKULL)
-          {
-            card = (k >= 3);
-          }
-          else if (st_keyorskull[k%3] == KEYBLINK_CARD)
-          {
-            card = (k < 3);
-          }
-          else
-          {
-            if ( (plr->keyblinktics & (2*KEYBLINKMASK)) &&
-                !(plr->keyblinktics & (4*KEYBLINKMASK)))
-              card = (k >= 3);
-            else
-              card = (k < 3);
-          }
-          break;
+    const keyblink_t keyblink = ST_BlinkKey(plr, k % 3);
 
+    if (!card && keyblink)
+    {
+      switch (keyblink)
+      {
         case KEYBLINK_CARD:
           card = (k < 3);
           break;

--- a/src/hu_stuff.c
+++ b/src/hu_stuff.c
@@ -983,28 +983,27 @@ static void HU_widget_build_keys (void)
   // build text string whose characters call out graphic keys
   for (k = 0; k < 6; k++)
   {
-    int card;
+    int card = plr->cards[k];
     const int keyblinkkeys = plr->keyblinkkeys[k%3];
   
-    if (!(card = plr->cards[k]) && keyblinkkeys &&
-        plr->keyblinktics & KEYBLINKMASK)
+    if (!card && keyblinkkeys && plr->keyblinktics & KEYBLINKMASK)
     {
       switch (keyblinkkeys)
       {
         case KEYBLINK_EITHER:
           if ( (plr->keyblinktics & (2*KEYBLINKMASK)) &&
               !(plr->keyblinktics & (4*KEYBLINKMASK)))
-            card = k >= 3;
+            card = (k >= 3);
           else
-            card = k < 3;
+            card = (k < 3);
           break;
 
         case KEYBLINK_CARD:
-          card = k < 3;
+          card = (k < 3);
           break;
 
         case KEYBLINK_SKULL:
-          card = k >= 3;
+          card = (k >= 3);
           break;
 
         case KEYBLINK_BOTH:

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -3240,6 +3240,7 @@ setup_menu_t stat_settings1[] =  // Status Bar and HUD Settings screen
   {"Backpack Shifts Ammo Color", S_YESNO, m_null, M_X, M_SPC, {"hud_backpack_thresholds"}},
   {"Armor Color Matches Type", S_YESNO, m_null, M_X, M_SPC, {"hud_armor_type"}},
   {"Smooth Health/Armor Count", S_YESNO, m_null, M_X, M_SPC, {"smooth_counts"}},
+  {"Blink Missing Keys", S_YESNO, m_null, M_X, M_SPC, {"hud_blink_keys"}},
 
   MI_RESET,
 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -2595,6 +2595,13 @@ default_t defaults[] = {
   },
 
   {
+    "hud_blink_keys",
+    (config_t *) &hud_blink_keys, NULL,
+    {1}, {0,1}, number, ss_none, wad_yes,
+    "1 to make missing keys blink when trying to open locked doors"
+  },
+
+  {
     "st_solidbackground",
     (config_t *) &st_solidbackground, NULL,
     {0}, {0,1}, number, ss_stat, wad_yes,

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -2598,7 +2598,7 @@ default_t defaults[] = {
     "hud_blink_keys",
     (config_t *) &hud_blink_keys, NULL,
     {0}, {0,1}, number, ss_none, wad_yes,
-    "1 to make missing keys blink when trying to open locked doors"
+    "1 to make missing keys blink when trying to trigger linedef actions"
   },
 
   {

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -2597,7 +2597,7 @@ default_t defaults[] = {
   {
     "hud_blink_keys",
     (config_t *) &hud_blink_keys, NULL,
-    {1}, {0,1}, number, ss_none, wad_yes,
+    {0}, {0,1}, number, ss_none, wad_yes,
     "1 to make missing keys blink when trying to open locked doors"
   },
 

--- a/src/p_doors.c
+++ b/src/p_doors.c
@@ -251,7 +251,7 @@ int EV_DoLockedDoor(line_t *line, vldoor_e type, mobj_t *thing)
         {
           doomprintf(p, MESSAGES_NONE, "%s", s_PD_BLUEO);  // Ty 03/27/98 - externalized
           S_StartSound(p->mo,sfx_oof);                  // killough 3/20/98
-          ST_BlinkKeys(p, KEYBLINK_EITHER, KEYBLINK_NONE, KEYBLINK_NONE);
+          ST_SetKeyBlink(p, KEYBLINK_EITHER, KEYBLINK_NONE, KEYBLINK_NONE);
           return 0;
         }
       break;
@@ -262,7 +262,7 @@ int EV_DoLockedDoor(line_t *line, vldoor_e type, mobj_t *thing)
         {
           doomprintf(p, MESSAGES_NONE, "%s", s_PD_REDO); // Ty 03/27/98 - externalized
           S_StartSound(p->mo,sfx_oof);                // killough 3/20/98
-          ST_BlinkKeys(p, KEYBLINK_NONE, KEYBLINK_NONE, KEYBLINK_EITHER);
+          ST_SetKeyBlink(p, KEYBLINK_NONE, KEYBLINK_NONE, KEYBLINK_EITHER);
           return 0;
         }
       break;
@@ -273,7 +273,7 @@ int EV_DoLockedDoor(line_t *line, vldoor_e type, mobj_t *thing)
         {
           doomprintf(p, MESSAGES_NONE, "%s", s_PD_YELLOWO);  // Ty 03/27/98 - externalized
           S_StartSound(p->mo,sfx_oof);                    // killough 3/20/98
-          ST_BlinkKeys(p, KEYBLINK_NONE, KEYBLINK_EITHER, KEYBLINK_NONE);
+          ST_SetKeyBlink(p, KEYBLINK_NONE, KEYBLINK_EITHER, KEYBLINK_NONE);
           return 0;
         }
       break;
@@ -401,7 +401,7 @@ int EV_VerticalDoor(line_t *line, mobj_t *thing)
         {
           doomprintf(player, MESSAGES_NONE, "%s", s_PD_BLUEK);  // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
-          ST_BlinkKeys(player, KEYBLINK_EITHER, KEYBLINK_NONE, KEYBLINK_NONE);
+          ST_SetKeyBlink(player, KEYBLINK_EITHER, KEYBLINK_NONE, KEYBLINK_NONE);
           return 0;
         }
       break;
@@ -414,7 +414,7 @@ int EV_VerticalDoor(line_t *line, mobj_t *thing)
         {
           doomprintf(player, MESSAGES_NONE, "%s", s_PD_YELLOWK);  // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);               // killough 3/20/98
-          ST_BlinkKeys(player, KEYBLINK_NONE, KEYBLINK_EITHER, KEYBLINK_NONE);
+          ST_SetKeyBlink(player, KEYBLINK_NONE, KEYBLINK_EITHER, KEYBLINK_NONE);
           return 0;
         }
       break;
@@ -427,7 +427,7 @@ int EV_VerticalDoor(line_t *line, mobj_t *thing)
         {
           doomprintf(player, MESSAGES_NONE, "%s", s_PD_REDK); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);           // killough 3/20/98
-          ST_BlinkKeys(player, KEYBLINK_NONE, KEYBLINK_NONE, KEYBLINK_EITHER);
+          ST_SetKeyBlink(player, KEYBLINK_NONE, KEYBLINK_NONE, KEYBLINK_EITHER);
           return 0;
         }
       break;

--- a/src/p_doors.c
+++ b/src/p_doors.c
@@ -25,6 +25,7 @@
 #include "r_main.h"
 #include "dstrings.h"
 #include "d_deh.h"  // Ty 03/27/98 - externalized
+#include "st_stuff.h"
 
 ///////////////////////////////////////////////////////////////
 //
@@ -250,6 +251,7 @@ int EV_DoLockedDoor(line_t *line, vldoor_e type, mobj_t *thing)
         {
           doomprintf(p, MESSAGES_NONE, "%s", s_PD_BLUEO);  // Ty 03/27/98 - externalized
           S_StartSound(p->mo,sfx_oof);                  // killough 3/20/98
+          ST_BlinkKeys(p, KEYBLINK_EITHER, KEYBLINK_NONE, KEYBLINK_NONE);
           return 0;
         }
       break;
@@ -260,6 +262,7 @@ int EV_DoLockedDoor(line_t *line, vldoor_e type, mobj_t *thing)
         {
           doomprintf(p, MESSAGES_NONE, "%s", s_PD_REDO); // Ty 03/27/98 - externalized
           S_StartSound(p->mo,sfx_oof);                // killough 3/20/98
+          ST_BlinkKeys(p, KEYBLINK_NONE, KEYBLINK_NONE, KEYBLINK_EITHER);
           return 0;
         }
       break;
@@ -270,6 +273,7 @@ int EV_DoLockedDoor(line_t *line, vldoor_e type, mobj_t *thing)
         {
           doomprintf(p, MESSAGES_NONE, "%s", s_PD_YELLOWO);  // Ty 03/27/98 - externalized
           S_StartSound(p->mo,sfx_oof);                    // killough 3/20/98
+          ST_BlinkKeys(p, KEYBLINK_NONE, KEYBLINK_EITHER, KEYBLINK_NONE);
           return 0;
         }
       break;
@@ -397,6 +401,7 @@ int EV_VerticalDoor(line_t *line, mobj_t *thing)
         {
           doomprintf(player, MESSAGES_NONE, "%s", s_PD_BLUEK);  // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
+          ST_BlinkKeys(player, KEYBLINK_EITHER, KEYBLINK_NONE, KEYBLINK_NONE);
           return 0;
         }
       break;
@@ -409,6 +414,7 @@ int EV_VerticalDoor(line_t *line, mobj_t *thing)
         {
           doomprintf(player, MESSAGES_NONE, "%s", s_PD_YELLOWK);  // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);               // killough 3/20/98
+          ST_BlinkKeys(player, KEYBLINK_NONE, KEYBLINK_EITHER, KEYBLINK_NONE);
           return 0;
         }
       break;
@@ -421,6 +427,7 @@ int EV_VerticalDoor(line_t *line, mobj_t *thing)
         {
           doomprintf(player, MESSAGES_NONE, "%s", s_PD_REDK); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);           // killough 3/20/98
+          ST_BlinkKeys(player, KEYBLINK_NONE, KEYBLINK_NONE, KEYBLINK_EITHER);
           return 0;
         }
       break;

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -1306,6 +1306,37 @@ spawnit:
   {
       mobj->health = 1000 + musid;
   }
+
+  // [crispy] blinking key or skull in the status bar
+  switch (mobj->sprite)
+  {
+    case SPR_BKEY:
+      st_keyorskull[it_bluecard] |= KEYBLINK_CARD;
+      break;
+
+    case SPR_BSKU:
+      st_keyorskull[it_bluecard] |= KEYBLINK_SKULL;
+      break;
+
+    case SPR_RKEY:
+      st_keyorskull[it_redcard] |= KEYBLINK_CARD;
+      break;
+
+    case SPR_RSKU:
+      st_keyorskull[it_redcard] |= KEYBLINK_SKULL;
+      break;
+
+    case SPR_YKEY:
+      st_keyorskull[it_yellowcard] |= KEYBLINK_CARD;
+      break;
+
+    case SPR_YSKU:
+      st_keyorskull[it_yellowcard] |= KEYBLINK_SKULL;
+      break;
+
+    default:
+      break;
+  }
 }
 
 //

--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -37,6 +37,7 @@
 #include "m_misc2.h" // [FG] M_StringJoin()
 #include "m_swap.h"
 #include "nano_bsp.h"
+#include "st_stuff.h"
 
 // [FG] support maps with NODES in uncompressed XNOD/XGLN or compressed ZNOD/ZGLN formats, or DeePBSP format
 #include "p_extnodes.h"
@@ -1648,6 +1649,8 @@ void P_SetupLevel(int episode, int map, int playermask, skill_t skill)
 
   // [crispy] fix long wall wobble
   P_SegLengths(false);
+  // [crispy] blinking key or skull in the status bar
+  memset(st_keyorskull, 0, sizeof(st_keyorskull));
 
   // Note: you don't need to clear player queue slots --
   // a much simpler fix is in g_game.c -- killough 10/98

--- a/src/p_spec.c
+++ b/src/p_spec.c
@@ -49,6 +49,7 @@
 #include "m_swap.h"
 #include "i_video.h" // [FG] uncapped
 #include "m_misc2.h"
+#include "st_stuff.h"
 
 //
 // Animating textures and planes
@@ -802,6 +803,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
         {
           doomprintf(player, MESSAGES_NONE, "%s", s_PD_ANY); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
+          ST_BlinkKeys(player, KEYBLINK_EITHER, KEYBLINK_EITHER, KEYBLINK_EITHER);
           return false;
         }
       break;
@@ -811,6 +813,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
         {
           doomprintf(player, MESSAGES_NONE, "%s", skulliscard? s_PD_REDK : s_PD_REDC); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
+          ST_BlinkKeys(player, KEYBLINK_NONE, KEYBLINK_NONE, skulliscard ? KEYBLINK_EITHER : KEYBLINK_CARD);
           return false;
         }
       break;
@@ -820,6 +823,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
         {
           doomprintf(player, MESSAGES_NONE, "%s", skulliscard? s_PD_BLUEK : s_PD_BLUEC); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
+          ST_BlinkKeys(player, skulliscard ? KEYBLINK_EITHER : KEYBLINK_CARD, KEYBLINK_NONE, KEYBLINK_NONE);
           return false;
         }
       break;
@@ -829,6 +833,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
         {
           doomprintf(player, MESSAGES_NONE, "%s", skulliscard? s_PD_YELLOWK : s_PD_YELLOWC); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
+          ST_BlinkKeys(player, KEYBLINK_NONE, skulliscard ? KEYBLINK_EITHER : KEYBLINK_CARD, KEYBLINK_NONE);
           return false;
         }
       break;
@@ -838,6 +843,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
         {
           doomprintf(player, MESSAGES_NONE, "%s", skulliscard? s_PD_REDK : s_PD_REDS); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
+          ST_BlinkKeys(player, KEYBLINK_NONE, KEYBLINK_NONE, skulliscard ? KEYBLINK_EITHER : KEYBLINK_SKULL);
           return false;
         }
       break;
@@ -847,6 +853,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
         {
           doomprintf(player, MESSAGES_NONE, "%s", skulliscard? s_PD_BLUEK : s_PD_BLUES); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
+          ST_BlinkKeys(player, skulliscard ? KEYBLINK_EITHER : KEYBLINK_SKULL, KEYBLINK_NONE, KEYBLINK_NONE);
           return false;
         }
       break;
@@ -856,6 +863,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
         {
           doomprintf(player, MESSAGES_NONE, "%s", skulliscard? s_PD_YELLOWK : s_PD_YELLOWS); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
+          ST_BlinkKeys(player, KEYBLINK_NONE, skulliscard ? KEYBLINK_EITHER : KEYBLINK_SKULL, KEYBLINK_NONE);
           return false;
         }
       break;
@@ -870,6 +878,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
         {
           doomprintf(player, MESSAGES_NONE, "%s", s_PD_ALL6); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
+          ST_BlinkKeys(player, KEYBLINK_BOTH, KEYBLINK_BOTH, KEYBLINK_BOTH);
           return false;
         }
       if (skulliscard &&
@@ -881,6 +890,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
         {
           doomprintf(player, MESSAGES_NONE, "%s", s_PD_ALL3); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
+          ST_BlinkKeys(player, KEYBLINK_EITHER, KEYBLINK_EITHER, KEYBLINK_EITHER);
           return false;
         }
       break;

--- a/src/p_spec.c
+++ b/src/p_spec.c
@@ -803,7 +803,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
         {
           doomprintf(player, MESSAGES_NONE, "%s", s_PD_ANY); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
-          ST_BlinkKeys(player, KEYBLINK_EITHER, KEYBLINK_EITHER, KEYBLINK_EITHER);
+          ST_SetKeyBlink(player, KEYBLINK_EITHER, KEYBLINK_EITHER, KEYBLINK_EITHER);
           return false;
         }
       break;
@@ -813,7 +813,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
         {
           doomprintf(player, MESSAGES_NONE, "%s", skulliscard? s_PD_REDK : s_PD_REDC); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
-          ST_BlinkKeys(player, KEYBLINK_NONE, KEYBLINK_NONE, skulliscard ? KEYBLINK_EITHER : KEYBLINK_CARD);
+          ST_SetKeyBlink(player, KEYBLINK_NONE, KEYBLINK_NONE, skulliscard ? KEYBLINK_EITHER : KEYBLINK_CARD);
           return false;
         }
       break;
@@ -823,7 +823,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
         {
           doomprintf(player, MESSAGES_NONE, "%s", skulliscard? s_PD_BLUEK : s_PD_BLUEC); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
-          ST_BlinkKeys(player, skulliscard ? KEYBLINK_EITHER : KEYBLINK_CARD, KEYBLINK_NONE, KEYBLINK_NONE);
+          ST_SetKeyBlink(player, skulliscard ? KEYBLINK_EITHER : KEYBLINK_CARD, KEYBLINK_NONE, KEYBLINK_NONE);
           return false;
         }
       break;
@@ -833,7 +833,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
         {
           doomprintf(player, MESSAGES_NONE, "%s", skulliscard? s_PD_YELLOWK : s_PD_YELLOWC); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
-          ST_BlinkKeys(player, KEYBLINK_NONE, skulliscard ? KEYBLINK_EITHER : KEYBLINK_CARD, KEYBLINK_NONE);
+          ST_SetKeyBlink(player, KEYBLINK_NONE, skulliscard ? KEYBLINK_EITHER : KEYBLINK_CARD, KEYBLINK_NONE);
           return false;
         }
       break;
@@ -843,7 +843,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
         {
           doomprintf(player, MESSAGES_NONE, "%s", skulliscard? s_PD_REDK : s_PD_REDS); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
-          ST_BlinkKeys(player, KEYBLINK_NONE, KEYBLINK_NONE, skulliscard ? KEYBLINK_EITHER : KEYBLINK_SKULL);
+          ST_SetKeyBlink(player, KEYBLINK_NONE, KEYBLINK_NONE, skulliscard ? KEYBLINK_EITHER : KEYBLINK_SKULL);
           return false;
         }
       break;
@@ -853,7 +853,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
         {
           doomprintf(player, MESSAGES_NONE, "%s", skulliscard? s_PD_BLUEK : s_PD_BLUES); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
-          ST_BlinkKeys(player, skulliscard ? KEYBLINK_EITHER : KEYBLINK_SKULL, KEYBLINK_NONE, KEYBLINK_NONE);
+          ST_SetKeyBlink(player, skulliscard ? KEYBLINK_EITHER : KEYBLINK_SKULL, KEYBLINK_NONE, KEYBLINK_NONE);
           return false;
         }
       break;
@@ -863,7 +863,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
         {
           doomprintf(player, MESSAGES_NONE, "%s", skulliscard? s_PD_YELLOWK : s_PD_YELLOWS); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
-          ST_BlinkKeys(player, KEYBLINK_NONE, skulliscard ? KEYBLINK_EITHER : KEYBLINK_SKULL, KEYBLINK_NONE);
+          ST_SetKeyBlink(player, KEYBLINK_NONE, skulliscard ? KEYBLINK_EITHER : KEYBLINK_SKULL, KEYBLINK_NONE);
           return false;
         }
       break;
@@ -878,7 +878,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
         {
           doomprintf(player, MESSAGES_NONE, "%s", s_PD_ALL6); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
-          ST_BlinkKeys(player, KEYBLINK_BOTH, KEYBLINK_BOTH, KEYBLINK_BOTH);
+          ST_SetKeyBlink(player, KEYBLINK_BOTH, KEYBLINK_BOTH, KEYBLINK_BOTH);
           return false;
         }
       if (skulliscard &&
@@ -890,7 +890,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
         {
           doomprintf(player, MESSAGES_NONE, "%s", s_PD_ALL3); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
-          ST_BlinkKeys(player, KEYBLINK_EITHER, KEYBLINK_EITHER, KEYBLINK_EITHER);
+          ST_SetKeyBlink(player, KEYBLINK_EITHER, KEYBLINK_EITHER, KEYBLINK_EITHER);
           return false;
         }
       break;

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -303,6 +303,8 @@ static int      st_faceindex = 0;
 
 // holds key-type for each key box on bar
 static int      keyboxes[3];
+// [crispy] blinking key or skull in the status bar
+int             st_keyorskull[3];
 
 // a random number per tick
 static int      st_randomnumber;
@@ -769,11 +771,22 @@ void ST_updateWidgets(void)
           switch (plyr->keyblinkkeys[i])
           {
             case KEYBLINK_EITHER:
-              if ( (plyr->keyblinktics & (2*KEYBLINKMASK)) &&
-                  !(plyr->keyblinktics & (4*KEYBLINKMASK)))
+              if (st_keyorskull[i] == KEYBLINK_SKULL)
+              {
                 keyboxes[i] = i + 3;
-              else
+              }
+              else if (st_keyorskull[i] == KEYBLINK_CARD)
+              {
                 keyboxes[i] = i;
+              }
+              else
+              {
+                if ( (plyr->keyblinktics & (2*KEYBLINKMASK)) &&
+                    !(plyr->keyblinktics & (4*KEYBLINKMASK)))
+                  keyboxes[i] = i + 3;
+                else
+                  keyboxes[i] = i;
+              }
               break;
 
             case KEYBLINK_CARD:

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -685,9 +685,6 @@ void ST_BlinkKeys(player_t* player, int blue, int yellow, int red)
 {
   int i;
   int keys[3] = { blue, yellow, red };
-  
-  if (!STRICTMODE(hud_blink_keys) || st_classicstatusbar)
-    return;
 
   player->keyblinktics = KEYBLINKTICS;
 
@@ -750,7 +747,7 @@ void ST_updateWidgets(void)
   // [crispy] blinking key or skull in the status bar
   if (plyr->keyblinktics)
   {
-    if (st_classicstatusbar || !hud_displayed)
+    if (!STRICTMODE(hud_blink_keys) || st_classicstatusbar || !hud_displayed)
     {
       plyr->keyblinktics = 0;
     }

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -763,16 +763,38 @@ void ST_updateWidgets(void)
         if (!plyr->keyblinkkeys[i])
           continue;
 
-        keyboxes[i] = plyr->keyblinktics & KEYBLINKMASK
-                      ? plyr->keyblinkkeys[i] == KEYBLINK_BOTH
-                        ? i + 6
-                        : (plyr->keyblinkkeys[i] == KEYBLINK_SKULL
-                           || (plyr->keyblinkkeys[i] == KEYBLINK_EITHER
-                               &&  (plyr->keyblinktics & (2*KEYBLINKMASK))
-                               && !(plyr->keyblinktics & (4*KEYBLINKMASK))))
-                          ? i + 3
-                          : i
-                      : -1;
+        if (plyr->keyblinktics & KEYBLINKMASK)
+        {
+          switch (plyr->keyblinkkeys[i])
+          {
+            case KEYBLINK_EITHER:
+              if ( (plyr->keyblinktics & (2*KEYBLINKMASK)) &&
+                  !(plyr->keyblinktics & (4*KEYBLINKMASK)))
+                keyboxes[i] = i + 3;
+              else
+                keyboxes[i] = i;
+              break;
+
+            case KEYBLINK_CARD:
+              keyboxes[i] = i;
+              break;
+
+            case KEYBLINK_SKULL:
+              keyboxes[i] = i + 3;
+              break;
+
+            case KEYBLINK_BOTH:
+              keyboxes[i] = i + 6;
+              break;
+
+            default:
+              break;
+          }
+        }
+        else
+        {
+          keyboxes[i] = -1;
+        }
       }
     }
   }

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -686,6 +686,7 @@ int hud_blink_keys; // [crispy] blinking key or skull in the status bar
 void ST_SetKeyBlink(player_t* player, int blue, int yellow, int red)
 {
   int i;
+  // Init array with args to iterate through
   const int keys[3] = { blue, yellow, red };
 
   player->keyblinktics = KEYBLINKTICS;

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -797,13 +797,11 @@ void ST_updateWidgets(void)
 
       for (i = 0; i < 3; i++)
       {
-        const keyblink_t keyblink = ST_BlinkKey(plyr, i);
-
-        if (!keyblink)
-          continue;
-
-        switch (keyblink)
+        switch (ST_BlinkKey(plyr, i))
         {
+          case KEYBLINK_NONE:
+            continue;
+
           case KEYBLINK_CARD:
             keyboxes[i] = i;
             break;

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -747,7 +747,8 @@ void ST_updateWidgets(void)
   // [crispy] blinking key or skull in the status bar
   if (plyr->keyblinktics)
   {
-    if (!STRICTMODE(hud_blink_keys) || st_classicstatusbar || !hud_displayed)
+    if (!hud_blink_keys ||
+        !(st_classicstatusbar || (hud_displayed && hud_active > 0)))
     {
       plyr->keyblinktics = 0;
     }

--- a/src/st_stuff.h
+++ b/src/st_stuff.h
@@ -76,6 +76,12 @@ extern int sts_always_red;// status numbers do not change colors
 extern int sts_pct_always_gray;// status percents do not change colors
 extern int sts_traditional_keys;  // display keys the traditional way
 
+// [crispy] blinking key or skull in the status bar
+extern int hud_blink_keys;
+#define KEYBLINKMASK 0x8
+#define KEYBLINKTICS (7*KEYBLINKMASK)
+extern void ST_BlinkKeys(player_t* player, int blue, int yellow, int red);
+
 extern int hud_backpack_thresholds; // backpack changes thresholds
 extern int hud_armor_type; // color of armor depends on type
 

--- a/src/st_stuff.h
+++ b/src/st_stuff.h
@@ -80,7 +80,8 @@ extern int sts_traditional_keys;  // display keys the traditional way
 extern int hud_blink_keys;
 #define KEYBLINKMASK 0x8
 #define KEYBLINKTICS (7*KEYBLINKMASK)
-extern void ST_BlinkKeys(player_t* player, int blue, int yellow, int red);
+extern void ST_SetKeyBlink(player_t* player, int blue, int yellow, int red);
+extern int  ST_BlinkKey(player_t* player, int index);
 extern int  st_keyorskull[3];
 
 extern int hud_backpack_thresholds; // backpack changes thresholds

--- a/src/st_stuff.h
+++ b/src/st_stuff.h
@@ -81,6 +81,7 @@ extern int hud_blink_keys;
 #define KEYBLINKMASK 0x8
 #define KEYBLINKTICS (7*KEYBLINKMASK)
 extern void ST_BlinkKeys(player_t* player, int blue, int yellow, int red);
+extern int  st_keyorskull[3];
 
 extern int hud_backpack_thresholds; // backpack changes thresholds
 extern int hud_armor_type; // color of armor depends on type


### PR DESCRIPTION
Resolves #1424.

As this is currently, it doesn't apply to the classic Status Bar. It also is disabled by Strict Mode; I'm not sure if DSDA would actually forbid it, but I'd rather play safe.