### PR TITLE
don't disable menu items during demo playback

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -387,7 +387,7 @@ void D_Display (void)
     }
 
   // draw pause pic
-  if (paused && !options_active)
+  if (paused)
     {
       int x = scaledviewx;
       int y = 4;

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -387,7 +387,7 @@ void D_Display (void)
     }
 
   // draw pause pic
-  if (paused)
+  if (paused && !options_active)
     {
       int x = scaledviewx;
       int y = 4;

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -131,7 +131,7 @@ boolean         padlook = false;
 // killough 4/13/98: Make clock rate adjustable by scale factor
 int             realtic_clock_rate = 100;
 
-int             default_complevel;
+complevel_t     default_complevel;
 boolean         force_complevel;
 
 boolean         pistolstart, default_pistolstart;
@@ -3063,11 +3063,11 @@ static int G_GetDefaultComplevel()
 {
   switch (default_complevel)
   {
-    case 0:
+    case CL_VANILLA:
       return 109;
-    case 1:
+    case CL_BOOM:
       return 202;
-    case 2:
+    case CL_MBF:
       return 203;
     default:
       return 221;

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -70,7 +70,15 @@ void G_EnableWarp(boolean warp);
 int G_GetNamedComplevel (const char *arg);
 const char *G_GetCurrentComplevelName(void);
 
-extern int  default_complevel;
+typedef enum
+{
+  CL_VANILLA,
+  CL_BOOM,
+  CL_MBF,
+  CL_MBF21,
+} complevel_t;
+
+extern complevel_t default_complevel;
 extern boolean force_complevel;
 
 // killough 5/2/98: moved from m_misc.c:

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -120,7 +120,7 @@ boolean inhelpscreens; // indicates we are in or just left a help screen
 
 boolean menuactive;    // The menus are up
 
-static boolean optionsactive;
+boolean options_active;
 
 backdrop_t menu_backdrop;
 
@@ -386,7 +386,8 @@ static void M_DrawMainMenu(void)
   // [crispy] force status bar refresh
   inhelpscreens = true;
 
-  optionsactive = false;
+  options_active = false;
+  paused = 0;
 
   V_DrawPatchDirect (94,2,W_CacheLumpName("M_DOOM",PU_CACHE));
 }
@@ -1882,7 +1883,8 @@ static void M_DrawSetup(void)
 
 static void M_Setup(int choice)
 {
-  optionsactive = true;
+  options_active = true;
+  paused = 2;
 
   M_SetupNextMenu(&SetupDef);
 }
@@ -1972,16 +1974,15 @@ static void M_DrawMenuStringEx(int flags, int x, int y, int color);
 
 static boolean ItemDisabled(int flags)
 {
-  if ((flags & S_DISABLE) ||
-      (flags & S_STRICT && strictmode) ||
-      (flags & S_CRITICAL && critical) ||
-      (flags & S_BOOM && demo_version < 202) ||
-      (flags & S_MBF && demo_version < 203))
-  {
-    return true;
-  }
+    if ((flags & S_DISABLE) ||
+        (flags & S_STRICT && default_strictmode) ||
+        (flags & S_BOOM && default_complevel < CL_BOOM) ||
+        (flags & S_MBF && default_complevel < CL_MBF))
+    {
+        return true;
+    }
 
-  return false;
+    return false;
 }
 
 static boolean ItemSelected(setup_menu_t *s)
@@ -3638,12 +3639,6 @@ static const char *default_complevel_strings[] = {
   "Vanilla", "Boom", "MBF", "MBF21"
 };
 
-static void M_UpdateCriticalItems(void)
-{
-  DISABLE_ITEM(demo_compatibility && overflow[emu_intercepts].enabled,
-               comp_settings1[comp1_blockmapfix]);
-}
-
 setup_menu_t comp_settings1[] =  // Compatibility Settings screen #1
 {
   {"Compatibility", S_SKIP|S_TITLE, m_null, M_X, M_Y},
@@ -3657,21 +3652,21 @@ setup_menu_t comp_settings1[] =  // Compatibility Settings screen #1
 
   {"Compatibility-breaking Features", S_SKIP|S_TITLE, m_null, M_X, M_SPC},
 
-  {"Direct Vertical Aiming", S_YESNO|S_STRICT|S_CRITICAL, m_null, M_X, M_SPC,
+  {"Direct Vertical Aiming", S_YESNO|S_STRICT, m_null, M_X, M_SPC,
    {"direct_vertical_aiming"}},
 
-  {"Auto Strafe 50", S_YESNO|S_STRICT|S_CRITICAL, m_null, M_X, M_SPC,
+  {"Auto Strafe 50", S_YESNO|S_STRICT, m_null, M_X, M_SPC,
    {"autostrafe50"}, 0, G_UpdateSideMove},
 
-  {"Pistol Start", S_YESNO|S_STRICT|S_CRITICAL, m_null, M_X, M_SPC,
+  {"Pistol Start", S_YESNO|S_STRICT, m_null, M_X, M_SPC,
    {"pistolstart"}},
 
   {"", S_SKIP, m_null, M_X, M_SPC},
 
-  {"Improved Hit Detection", S_YESNO|S_STRICT|S_CRITICAL, m_null, M_X, M_SPC,
-   {"blockmapfix"}},
+  {"Improved Hit Detection", S_YESNO|S_STRICT|S_BOOM, m_null, M_X,
+   M_SPC, {"blockmapfix"}},
 
-  {"Walk Under Solid Hanging Bodies", S_YESNO|S_STRICT|S_CRITICAL, m_null, M_X,
+  {"Walk Under Solid Hanging Bodies", S_YESNO|S_STRICT, m_null, M_X,
    M_SPC, {"hangsolid"}},
 
 
@@ -6628,7 +6623,7 @@ void M_StartControlPanel (void)
 
 boolean M_MenuIsShaded(void)
 {
-  return optionsactive && menu_backdrop == MENU_BG_DARK;
+  return options_active && menu_backdrop == MENU_BG_DARK;
 }
 
 void M_Drawer (void)
@@ -6773,7 +6768,8 @@ void M_Drawer (void)
 static void M_ClearMenus(void)
 {
   menuactive = 0;
-  optionsactive = false;
+  options_active = false;
+  paused = 0;
   print_warning_about_changes = 0;     // killough 8/15/98
   default_verify = 0;                  // killough 10/98
 
@@ -7165,12 +7161,9 @@ void M_ResetSetupMenu(void)
     gen_settings5[gen5_brightmaps].m_flags |= S_DISABLE;
   }
 
-  DISABLE_ITEM(!comp[comp_vile], enem_settings1[enem1_ghost]);
-
   M_CoerceFPSLimit();
   M_UpdateCrosshairItems();
   M_UpdateCenteredWeaponItem();
-  M_UpdateCriticalItems();
   M_UpdateAdvancedSoundItems();
 }
 

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -120,7 +120,7 @@ boolean inhelpscreens; // indicates we are in or just left a help screen
 
 boolean menuactive;    // The menus are up
 
-boolean options_active;
+static boolean options_active;
 
 backdrop_t menu_backdrop;
 
@@ -387,7 +387,6 @@ static void M_DrawMainMenu(void)
   inhelpscreens = true;
 
   options_active = false;
-  paused = 0;
 
   V_DrawPatchDirect (94,2,W_CacheLumpName("M_DOOM",PU_CACHE));
 }
@@ -1884,7 +1883,6 @@ static void M_DrawSetup(void)
 static void M_Setup(int choice)
 {
   options_active = true;
-  paused = 2;
 
   M_SetupNextMenu(&SetupDef);
 }
@@ -6770,7 +6768,6 @@ static void M_ClearMenus(void)
 {
   menuactive = 0;
   options_active = false;
-  paused = 0;
   print_warning_about_changes = 0;     // killough 8/15/98
   default_verify = 0;                  // killough 10/98
 

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -1977,7 +1977,8 @@ static boolean ItemDisabled(int flags)
     if ((flags & S_DISABLE) ||
         (flags & S_STRICT && default_strictmode) ||
         (flags & S_BOOM && default_complevel < CL_BOOM) ||
-        (flags & S_MBF && default_complevel < CL_MBF))
+        (flags & S_MBF && default_complevel < CL_MBF) ||
+        (flags & S_VANILLA && default_complevel != CL_VANILLA))
     {
         return true;
     }
@@ -3549,7 +3550,7 @@ setup_menu_t enem_settings1[] =  // Enemy Settings screen
    {"flipcorpses"}},
 
   // [crispy] resurrected pools of gore ("ghost monsters") are translucent
-  {"Translucent Ghost Monsters", S_YESNO|S_STRICT, m_null, M_X, M_SPC,
+  {"Translucent Ghost Monsters", S_YESNO|S_STRICT|S_VANILLA, m_null, M_X, M_SPC,
    {"ghost_monsters"}},
 
   // [FG] spectre drawing mode

--- a/src/m_menu.h
+++ b/src/m_menu.h
@@ -72,8 +72,6 @@ void M_DrawCredits(void);    // killough 11/98
 
 void M_SetMenuFontSpacing(void);
 
-extern boolean options_active;
-
 /////////////////////////////
 //
 // The following #defines are for the m_flags field of each item on every

--- a/src/m_menu.h
+++ b/src/m_menu.h
@@ -72,6 +72,8 @@ void M_DrawCredits(void);    // killough 11/98
 
 void M_SetMenuFontSpacing(void);
 
+extern boolean options_active;
+
 /////////////////////////////
 //
 // The following #defines are for the m_flags field of each item on every
@@ -101,7 +103,6 @@ void M_SetMenuFontSpacing(void);
 #define S_NEXT_LINE    0x00200000 // Two lines menu items
 #define S_STRICT       0x00400000 // Disable in strict mode
 #define S_BOOM         0x00800000 // Disable if complevel < boom
-#define S_CRITICAL     0x01000000 // Disable when recording/playing a demo and in netgame
 #define S_ACTION       0x02000000 // Run function call only when change is complete
 #define S_THRM_SIZE11  0x04000000 // Thermo bar size 11
 #define S_ONOFF        0x08000000 // Alias for S_YESNO

--- a/src/m_menu.h
+++ b/src/m_menu.h
@@ -103,6 +103,7 @@ extern boolean options_active;
 #define S_NEXT_LINE    0x00200000 // Two lines menu items
 #define S_STRICT       0x00400000 // Disable in strict mode
 #define S_BOOM         0x00800000 // Disable if complevel < boom
+#define S_VANILLA      0x01000000 // Disable if complevel != vanilla
 #define S_ACTION       0x02000000 // Run function call only when change is complete
 #define S_THRM_SIZE11  0x04000000 // Thermo bar size 11
 #define S_ONOFF        0x08000000 // Alias for S_YESNO

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -1121,7 +1121,7 @@ default_t defaults[] = {
   {
     "default_complevel",
     (config_t *) &default_complevel, NULL,
-    {3}, {0,3}, number, ss_comp, wad_no,
+    {CL_MBF21}, {CL_VANILLA, CL_MBF21}, number, ss_comp, wad_no,
     "0 Vanilla, 1 Boom, 2 MBF, 3 MBF21"
   },
 


### PR DESCRIPTION
* Show disabled items immediately when complevel/strict mode is changed

* Remove S_CRITICAL

Fix #1439 