### PR TITLE
Improve fpslimit/uncapped logic

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -48,8 +48,8 @@ boolean dynamic_resolution;
 
 boolean use_vsync;  // killough 2/8/98: controls whether vsync is called
 boolean use_aspect;
-boolean uncapped, default_uncapped; // [FG] uncapped rendering frame rate
-int fpslimit; // when uncapped, limit framerate to this value
+boolean uncapped; // [FG] uncapped rendering frame rate
+int fpslimit, default_fpslimit; // when uncapped, limit framerate to this value
 boolean fullscreen;
 boolean exclusive_fullscreen;
 aspect_ratio_mode_t widescreen, default_widescreen; // widescreen mode
@@ -1318,9 +1318,11 @@ static void I_InitVideoParms(void)
 
     I_ResetInvalidDisplayIndex();
     widescreen = default_widescreen;
-    uncapped = default_uncapped;
     grabmouse = default_grabmouse;
-    I_ResetTargetRefresh();
+
+    if (default_fpslimit < TICRATE)
+        default_fpslimit = 0;
+    fpslimit = default_fpslimit;
 
     //!
     // @category video
@@ -1329,7 +1331,7 @@ static void I_InitVideoParms(void)
     //
 
     if (M_CheckParm("-uncapped"))
-        uncapped = true;
+        fpslimit = 0;
 
     //!
     // @category video
@@ -1338,7 +1340,10 @@ static void I_InitVideoParms(void)
     //
 
     else if (M_CheckParm("-nouncapped"))
-        uncapped = false;
+        fpslimit = TICRATE;
+
+    uncapped = (fpslimit != TICRATE);
+    I_ResetTargetRefresh();
 
     if (M_CheckParm("-grabmouse"))
         grabmouse = true;
@@ -1404,8 +1409,6 @@ static void I_InitVideoParms(void)
     {
         fullscreen = true;
     }
-
-    M_ResetSetupMenuVideo();
 }
 
 static void I_InitGraphicsMode(void)

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -79,11 +79,11 @@ extern int current_video_height;
 extern boolean dynamic_resolution;
 
 extern boolean use_aspect;
-extern boolean uncapped, default_uncapped; // [FG] uncapped rendering frame rate
+extern boolean uncapped; // [FG] uncapped rendering frame rate
 
 extern boolean fullscreen;
 extern boolean exclusive_fullscreen;
-extern int fpslimit; // when uncapped, limit framerate to this value
+extern int fpslimit, default_fpslimit; // when uncapped, limit framerate to this value
 extern int fps;
 extern boolean vga_porch_flash; // emulate VGA "porch" behaviour
 extern aspect_ratio_mode_t widescreen, default_widescreen; // widescreen mode

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -3765,7 +3765,6 @@ enum {
   gen1_exclusive_fullscreen,
   gen1_gap2,
 
-  gen1_uncapped,
   gen1_fpslimit,
   gen1_vsync,
   gen1_gap3,
@@ -3938,12 +3937,6 @@ static void M_SetMidiPlayer(void)
   S_RestartMusic();
 }
 
-static void M_ToggleUncapped(void)
-{
-  DISABLE_ITEM(!uncapped, gen_settings1[gen1_fpslimit]);
-  I_ResetTargetRefresh();
-}
-
 static void M_ToggleFullScreen(void)
 {
   toggle_fullscreen = true;
@@ -3956,8 +3949,10 @@ static void M_ToggleExclusiveFullScreen(void)
 
 static void M_CoerceFPSLimit(void)
 {
-  if (fpslimit < TICRATE)
-    fpslimit = 0;
+  if (default_fpslimit < TICRATE)
+    default_fpslimit = 0;
+  fpslimit = default_fpslimit;
+  uncapped = (fpslimit != TICRATE);
   I_ResetTargetRefresh();
 }
 
@@ -4003,9 +3998,6 @@ setup_menu_t gen_settings1[] = { // General Settings screen1
    {"exclusive_fullscreen"}, 0, M_ToggleExclusiveFullScreen},
 
   {"", S_SKIP, m_null, M_X, M_SPC},
-
-  {"Uncapped Framerate", S_YESNO, m_null, M_X, M_SPC,
-   {"uncapped"}, 0, M_ToggleUncapped},
 
   {"Framerate Limit", S_NUM, m_null, M_X, M_SPC,
    {"fpslimit"}, 0, M_CoerceFPSLimit},
@@ -7137,7 +7129,7 @@ void M_ResetSetupMenu(void)
 
   if (M_ParmExists("-uncapped") || M_ParmExists("-nouncapped"))
   {
-    gen_settings1[gen1_uncapped].m_flags |= S_DISABLE;
+    gen_settings1[gen1_fpslimit].m_flags |= S_DISABLE;
   }
 
   if (deh_set_blood_color)
@@ -7150,15 +7142,9 @@ void M_ResetSetupMenu(void)
     gen_settings5[gen5_brightmaps].m_flags |= S_DISABLE;
   }
 
-  M_CoerceFPSLimit();
   M_UpdateCrosshairItems();
   M_UpdateCenteredWeaponItem();
   M_UpdateAdvancedSoundItems();
-}
-
-void M_ResetSetupMenuVideo(void)
-{
-  M_ToggleUncapped();
 }
 
 //

--- a/src/m_menu.h
+++ b/src/m_menu.h
@@ -64,8 +64,6 @@ void M_ResetMenu(void);      // killough 11/98: reset main menu ordering
 
 void M_ResetSetupMenu(void);
 
-void M_ResetSetupMenuVideo(void);
-
 void M_ResetTimeScale(void);
 
 void M_DrawCredits(void);    // killough 11/98

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -189,18 +189,10 @@ default_t defaults[] = {
     "1 to enable wait for vsync to avoid display tearing"
   },
 
-  // [FG] uncapped rendering frame rate
-  {
-    "uncapped",
-    (config_t *) &default_uncapped, (config_t *) &uncapped,
-    {1}, {0, 1}, number, ss_gen, wad_no,
-    "1 to enable uncapped rendering frame rate"
-  },
-
   // framerate limit
   {
     "fpslimit",
-    (config_t *) &fpslimit, NULL,
+    (config_t *) &default_fpslimit, NULL,
     {0}, {0, 500}, number, ss_gen, wad_no,
     "framerate limit in frames per second (< 35 = disable)"
   },


### PR DESCRIPTION
The "Uncapped Framerate" and "Framerate Limit" options seem inconsistent and redundant. This is an attempt to address that with some logical changes. This is a detailed summary but it's simple in practice.

- Remove redundant "Uncapped Framerate" option:
    - "Uncapped Framerate: Yes" is just "Framerate Limit: 0" (already the previously established default). Other values only matter to power users.
    - "Uncapped Framerate: No" is just "Framerate Limit: 35".
- Internally, `uncapped` is retained as a convenience variable equivalent to `(fpslimit != TICRATE)` so the changes required by this PR are minimal.
- Command-line parameter behavior:
    - `-uncapped` uses an uncapped framerate (unlimited fps) regardless of the `fpslimit` value.
    - `-nouncapped` uses a capped framerate (35 fps) regardless of the `fpslimit` value.
    - The "Framerate Limit" menu option is disabled for the current session if either parameter is used.
    - The saved `fpslimit` value is not altered if either parameter is used.
    - The next time the game is launched without either parameter, the previously saved `fpslimit` value will be used.