### PR TITLE
fix ASAN report

### DIFF
--- a/src/net_query.c
+++ b/src/net_query.c
@@ -324,6 +324,7 @@ static void NET_Query_ParseResponse(net_addr_t *addr, net_packet_t *packet,
         // Create new target.
 
         target = GetTargetForAddr(addr, true);
+        broadcast_target = GetTargetForAddr(NULL, false);
         target->state = QUERY_TARGET_QUERIED;
         target->query_time = broadcast_target->query_time;
     }


### PR DESCRIPTION
`GetTargetForAddr` can invalidate pointers since it uses `realloc`. Get element from array again.

Same issue in Chocolate Doom.