### PR TITLE
Ignore game controller events until needed

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -65,6 +65,7 @@
 #include "d_quit.h"
 #include "r_bmaps.h"
 #include "p_inter.h" // maxhealthbonus
+#include "i_input.h"
 
 #include "dsdhacked.h"
 
@@ -2743,7 +2744,7 @@ void D_DoomMain(void)
 
   I_Printf(VB_INFO, "I_Init: Setting up machine state.");
   I_InitTimer();
-  I_InitJoystick();
+  I_InitController();
   I_InitSound();
   I_InitMusic();
 

--- a/src/i_input.h
+++ b/src/i_input.h
@@ -20,6 +20,7 @@
 #include "SDL.h"
 
 boolean I_UseController(void);
+void I_InitController(void);
 void I_OpenController(int which);
 void I_CloseController(int which);
 

--- a/src/i_system.c
+++ b/src/i_system.c
@@ -36,27 +36,6 @@ ticcmd_t *I_BaseTiccmd(void)
   return &emptycmd;
 }
 
-static void I_ShutdownJoystick(void)
-{
-    SDL_QuitSubSystem(SDL_INIT_GAMECONTROLLER);
-}
-
-void I_InitJoystick(void)
-{
-    if (SDL_Init(SDL_INIT_GAMECONTROLLER) < 0)
-    {
-        I_Printf(VB_WARNING, "I_InitJoystick: Failed to initialize game controller: %s",
-                SDL_GetError());
-        return;
-    }
-
-    SDL_GameControllerEventState(SDL_ENABLE);
-
-    I_Printf(VB_INFO, "I_InitJoystick: Initialize game controller.");
-
-    I_AtExit(I_ShutdownJoystick, true);
-}
-
 //
 // I_Error
 //

--- a/src/i_system.h
+++ b/src/i_system.h
@@ -23,9 +23,6 @@
 #include "d_ticcmd.h"
 #include "i_timer.h"
 
-// Called by DoomMain.
-void I_InitJoystick(void);
-
 //
 // Called by D_DoomLoop,
 // called before processing any tics in a frame


### PR DESCRIPTION
- If `joy_enable` is `false` don't initialize the game controller subsystem.
- If `joy_enable` is `true` initialize the subsystem but ignore event processing until a controller is actually connected.
- Ignore unsupported events to prevent them from being added to the SDL queue (e.g. PS4 controller gyroscope and touchpad events).