### PR TITLE
restore original fix for "garbage lines at the top of weapon sprites"

### DIFF
--- a/src/r_main.c
+++ b/src/r_main.c
@@ -586,7 +586,7 @@ void R_ExecuteSetViewSize (void)
 
   // psprite scales
   pspritescale = FixedDiv(viewwidth_nonwide, SCREENWIDTH);       // killough 11/98
-  pspriteiscale = FixedDiv(SCREENWIDTH, viewwidth_nonwide) + 1;  // killough 11/98
+  pspriteiscale = FixedDiv(SCREENWIDTH, viewwidth_nonwide);      // killough 11/98
 
   skyiscale = FixedDiv(160 << FRACBITS, focallength);
 

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -588,6 +588,12 @@ void R_ExecuteSetViewSize (void)
   pspritescale = FixedDiv(viewwidth_nonwide, SCREENWIDTH);       // killough 11/98
   pspriteiscale = FixedDiv(SCREENWIDTH, viewwidth_nonwide);      // killough 11/98
 
+  // [FG] make sure that the product of the weapon sprite scale factor
+  //      and its reciprocal is always at least FRACUNIT to
+  //      fix garbage lines at the top of weapon sprites
+  while (FixedMul(pspriteiscale, pspritescale) < FRACUNIT)
+    pspriteiscale++;
+
   skyiscale = FixedDiv(160 << FRACBITS, focallength);
 
   for (i=0 ; i<viewwidth ; i++)


### PR DESCRIPTION
This reverts commit 6cccb751849b83d0f5e12b9c85f139f085d62db1.

People on DW don't seem to like it (amazing how they notice the tiniest things).