### PR TITLE
delay for one millisecond only

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -750,7 +750,9 @@ void I_FinishUpdate(void)
             remaining_time = target_time - elapsed_time;
 
             if (remaining_time > 1000)
-                I_Sleep((remaining_time - 1000) / 1000);
+            {
+                I_Sleep(1);
+            }
         }
     }
     else


### PR DESCRIPTION
This makes it almost the same as the limiter in TryRunTics. Also, interesting note: https://wiki.libsdl.org/SDL2/SDL_Delay#remarks