### PR TITLE
use SDL_GetWindowSize instead of SDL_GetRendererOutputSize

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1435,6 +1435,7 @@ static void I_InitGraphicsMode(void)
 
     // [FG] window flags
     flags |= SDL_WINDOW_RESIZABLE;
+    flags |= SDL_WINDOW_ALLOW_HIGHDPI;
 
     w = window_width;
     h = window_height;

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1435,7 +1435,6 @@ static void I_InitGraphicsMode(void)
 
     // [FG] window flags
     flags |= SDL_WINDOW_RESIZABLE;
-    flags |= SDL_WINDOW_ALLOW_HIGHDPI;
 
     w = window_width;
     h = window_height;

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -475,7 +475,7 @@ void I_StartTic (void)
 
         SDL_GetMouseState(&x, &y);
 
-        SDL_GetRendererOutputSize(renderer, &w, &h);
+        SDL_GetWindowSize(screen, &w, &h);
 
         SDL_Rect rect;
         SDL_RenderGetViewport(renderer, &rect);


### PR DESCRIPTION
What if we just remove `SDL_WINDOW_ALLOW_HIGHDPI` flag, will it fix mouse on macOS? On Windows with custom scaling there is no differece.