### PR TITLE
Use more accurate light index

### DIFF
--- a/src/r_main.c
+++ b/src/r_main.c
@@ -290,7 +290,7 @@ static void R_InitTextureMapping(void)
     fov = FIELDOFVIEW;
     slopefrac = finetangent[FINEANGLES / 4 + fov / 2];
     focallength = FixedDiv(centerxfrac_nonwide, slopefrac);
-    lightfocallength = focallength;
+    lightfocallength = centerxfrac_nonwide;
     projection = centerxfrac_nonwide;
 
     if (centerxfrac != centerxfrac_nonwide)


### PR DESCRIPTION
This is barely noticeable (quick check: right column on map01) but it is more accurate and matches Crispy Doom.