### PR TITLE
Limit auto aspect ratio to 21:9

### DIFF
--- a/src/i_video.h
+++ b/src/i_video.h
@@ -26,7 +26,7 @@
 #define FOV_DEFAULT 90
 #define FOV_MIN 60
 #define FOV_MAX 120
-#define ASPECT_RATIO_MAX 3.6 // Up to 32:9 ultrawide.
+#define ASPECT_RATIO_MAX 2.4 // Up to 21:9. TODO: Support up to 3.6 (32:9).
 
 typedef enum
 {


### PR DESCRIPTION
This was left in by mistake when the rest of the experimental 32:9 code was removed. Maybe in the future we can support it. For now, let's avoid any issues it may cause.