### PR TITLE
Do not reset chosen player view while multiplayer or demo playback

### DIFF
--- a/src/g_game.c
+++ b/src/g_game.c
@@ -872,7 +872,6 @@ void G_ClearInput(void)
 static void G_DoLoadLevel(void)
 {
   int i;
-  static boolean displayplayer_set = false;
 
   // Set the sky map.
   // First thing, we have a dummy sky texture name,
@@ -961,12 +960,11 @@ static void G_DoLoadLevel(void)
   }
 
   P_SetupLevel (gameepisode, gamemap, 0, gameskill);
-  // [Woof!] Do not reset chosen player view across levels in multiplayer.
-  // However, reset must be done in case of starting new game from demo playback.
-  if (!displayplayer_set || !netgame)
+  // [Woof!] Do not reset chosen player view across levels in multiplayer
+  // demo playback. However, it must be reset when starting a new game.
+  if (usergame)
   {
     displayplayer = consoleplayer;    // view the guy you are playing
-    displayplayer_set = true;
   }
   // [Alaux] Update smooth count values
   st_health = players[displayplayer].health;

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -961,7 +961,8 @@ static void G_DoLoadLevel(void)
   }
 
   P_SetupLevel (gameepisode, gamemap, 0, gameskill);
-  // [Woof!] Do not reset chosen player view while multiplayer.
+  // [Woof!] Do not reset chosen player view across levels in multiplayer.
+  // However, reset must be done in case of starting new game from demo playback.
   if (!displayplayer_set || !netgame)
   {
     displayplayer = consoleplayer;    // view the guy you are playing

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -961,8 +961,8 @@ static void G_DoLoadLevel(void)
   }
 
   P_SetupLevel (gameepisode, gamemap, 0, gameskill);
-  // [Woof!] Do not reset chosen player view while multiplayer or demo playback.
-  if (!displayplayer_set)
+  // [Woof!] Do not reset chosen player view while multiplayer.
+  if (!displayplayer_set || !netgame)
   {
     displayplayer = consoleplayer;    // view the guy you are playing
     displayplayer_set = true;

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -872,6 +872,7 @@ void G_ClearInput(void)
 static void G_DoLoadLevel(void)
 {
   int i;
+  static boolean displayplayer_set = false;
 
   // Set the sky map.
   // First thing, we have a dummy sky texture name,
@@ -960,7 +961,12 @@ static void G_DoLoadLevel(void)
   }
 
   P_SetupLevel (gameepisode, gamemap, 0, gameskill);
-  displayplayer = consoleplayer;    // view the guy you are playing
+  // [Woof!] Do not reset chosen player view while multiplayer or demo playback.
+  if (!displayplayer_set)
+  {
+    displayplayer = consoleplayer;    // view the guy you are playing
+    displayplayer_set = true;
+  }
   // [Alaux] Update smooth count values
   st_health = players[displayplayer].health;
   st_armor  = players[displayplayer].armorpoints;


### PR DESCRIPTION
This is primary useful for multiplayer demos: user no longer need to press `F12` to choose desired player on level changing over and over again. 

**Edit:** initial approach rewritten to better one, so now it's just keeping chosen player view across levels in multiplayer demo playback. Three player demos for Doom 2 were used for testing: [30uv2245.zip](https://dsdarchive.com/files/demos/doom2/26845/30uv2245.zip)