### PR TITLE
Apply deadzone to gamepad for strict mode check

### DIFF
--- a/src/g_game.c
+++ b/src/g_game.c
@@ -1052,11 +1052,28 @@ static boolean G_StrictModeSkipEvent(event_t *ev)
 
     case ev_joyb_down:
     case ev_joyb_up:
-    case ev_joystick:
-        if (first_event && (ev->data1 || ev->data2 || ev->data3 || ev->data4))
+        if (first_event)
         {
           first_event = false;
           enable_controller = true;
+        }
+        return !enable_controller;
+
+    case ev_joystick:
+        if (first_event)
+        {
+          *axes_data[AXIS_LEFTX] = ev->data1;
+          *axes_data[AXIS_LEFTY] = ev->data2;
+          *axes_data[AXIS_RIGHTX] = ev->data3;
+          *axes_data[AXIS_RIGHTY] = ev->data4;
+          I_CalcControllerAxes();
+          if (axes[AXIS_STRAFE] || axes[AXIS_FORWARD] || axes[AXIS_TURN] ||
+              axes[AXIS_LOOK])
+          {
+            first_event = false;
+            enable_controller = true;
+          }
+          return true; // Already "ate" the event above.
         }
         return !enable_controller;
 


### PR DESCRIPTION
[SDL tries to ignore jitter](https://github.com/libsdl-org/SDL/blob/05f670961708925f95fb799d469aecaf216b1d46/src/joystick/SDL_joystick.c#L1933) for the initial input but some controllers have poor analog sticks. [Related Doomworld issue](https://www.doomworld.com/forum/topic/112333-this-is-woof-1410-feb-29-2024/?do=findComment&comment=2773686).