### PR TITLE
Make light levels independent of screen size

### DIFF
--- a/src/r_main.c
+++ b/src/r_main.c
@@ -626,7 +626,7 @@ void R_ExecuteSetViewSize (void)
 
       for (j=0 ; j<MAXLIGHTSCALE ; j++)
         {                                       // killough 11/98:
-          int t, level = startmap - j*NONWIDEWIDTH/scaledviewwidth_nonwide/DISTMAP;
+          int t, level = startmap - j / DISTMAP;
 
           if (level < 0)
             level = 0;


### PR DESCRIPTION
Fixes https://github.com/fabiangreffrath/woof/issues/1551

This is from PrBoom+. I don't fully understand why this seems to fix the issue.