### PR TITLE
Give strafe priority with capped or lerped input

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -196,9 +196,13 @@ void D_PostEvent(event_t *ev)
   {
     case ev_mouse:
     case ev_joystick:
-      G_MovementResponder(ev);
-      G_PrepTiccmd();
-      break;
+      if (uncapped && raw_input)
+      {
+        G_MovementResponder(ev);
+        G_PrepTiccmd();
+        break;
+      }
+      // Fall through.
 
     default:
       events[eventhead++] = *ev;

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -1065,10 +1065,7 @@ static boolean G_StrictModeSkipEvent(event_t *ev)
     case ev_joystick:
         if (first_event)
         {
-          *axes_data[AXIS_LEFTX] = ev->data1;
-          *axes_data[AXIS_LEFTY] = ev->data2;
-          *axes_data[AXIS_RIGHTX] = ev->data3;
-          *axes_data[AXIS_RIGHTY] = ev->data4;
+          I_UpdateAxesData(ev);
           I_CalcControllerAxes();
           if (axes[AXIS_STRAFE] || axes[AXIS_FORWARD] || axes[AXIS_TURN] ||
               axes[AXIS_LOOK])
@@ -1102,10 +1099,7 @@ boolean G_MovementResponder(event_t *ev)
       return true;
 
     case ev_joystick:
-      *axes_data[AXIS_LEFTX] = ev->data1;
-      *axes_data[AXIS_LEFTY] = ev->data2;
-      *axes_data[AXIS_RIGHTX] = ev->data3;
-      *axes_data[AXIS_RIGHTY] = ev->data4;
+      I_UpdateAxesData(ev);
       return true;
 
     default:

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -594,6 +594,11 @@ void G_BuildTiccmd(ticcmd_t* cmd)
 
   G_DemoSkipTics();
 
+  if (!uncapped || !raw_input)
+  {
+    G_PrepTiccmd();
+  }
+
   memcpy(cmd, &basecmd, sizeof(*cmd));
   memset(&basecmd, 0, sizeof(basecmd));
 

--- a/src/i_gamepad.c
+++ b/src/i_gamepad.c
@@ -18,6 +18,7 @@
 
 #include <math.h>
 
+#include "d_event.h"
 #include "doomkeys.h"
 #include "doomtype.h"
 #include "g_game.h"
@@ -51,7 +52,7 @@ boolean joy_invert_strafe;
 boolean joy_invert_turn;
 boolean joy_invert_look;
 
-int *axes_data[NUM_AXES];
+static int *axes_data[NUM_AXES]; // Pointers to ev_joystick event data.
 float axes[NUM_AXES];
 int trigger_threshold;
 
@@ -282,6 +283,14 @@ void I_CalcControllerAxes(void)
         camera.x.data = 0;
         camera.y.data = 0;
     }
+}
+
+void I_UpdateAxesData(const event_t *ev)
+{
+    *axes_data[AXIS_LEFTX] = ev->data1;
+    *axes_data[AXIS_LEFTY] = ev->data2;
+    *axes_data[AXIS_RIGHTX] = ev->data3;
+    *axes_data[AXIS_RIGHTY] = ev->data4;
 }
 
 void I_ResetControllerAxes(void)

--- a/src/i_gamepad.h
+++ b/src/i_gamepad.h
@@ -17,6 +17,7 @@
 #ifndef __I_GAMEPAD__
 #define __I_GAMEPAD__
 
+#include "d_event.h"
 #include "doomkeys.h"
 #include "doomtype.h"
 
@@ -44,11 +45,11 @@ extern boolean joy_invert_strafe;           // Invert strafe axis.
 extern boolean joy_invert_turn;             // Invert turn axis.
 extern boolean joy_invert_look;             // Invert look axis.
 
-extern int *axes_data[NUM_AXES];    // Pointers to ev_joystick event data.
 extern float axes[NUM_AXES];        // Calculated controller values.
 extern int trigger_threshold;       // Trigger threshold (axis resolution).
 
 void I_CalcControllerAxes(void);
+void I_UpdateAxesData(const struct event_s *ev);
 void I_ResetControllerAxes(void);
 void I_ResetControllerLevel(void);
 void I_ResetController(void);


### PR DESCRIPTION
This ensures that SR50 engages on the same tic that the strafe key combo is pressed, regardless of mouse/gamepad turning input. This matches vanilla and Woof 12 behavior. When using uncapped fps and raw input, the behavior is unchanged: mouse/gamepad turning input is given priority since it updates every frame. I think this should satisfy every player's preference.