### PR TITLE
Improve simultaneous mouse and gamepad input

### DIFF
--- a/src/g_game.c
+++ b/src/g_game.c
@@ -1180,7 +1180,7 @@ static boolean G_StrictModeSkipEvent(event_t *ev)
             first_event = false;
             enable_controller = true;
           }
-          return true; // Already "ate" the event above.
+          I_ResetControllerLevel();
         }
         return !enable_controller;
 

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -529,9 +529,8 @@ void G_PrepTiccmd(void)
 
   // Gamepad
 
-  if (I_UseController())
+  if (I_UseController() && I_CalcControllerAxes())
   {
-    I_CalcControllerAxes();
     D_UpdateDeltaTics();
 
     if (axes[AXIS_TURN] && !strafe)

--- a/src/i_gamepad.c
+++ b/src/i_gamepad.c
@@ -261,8 +261,10 @@ static void CalcRadial(axes_t *ax, float *xaxis, float *yaxis)
 static void (*CalcMovement)(axes_t *ax, float *xaxis, float *yaxis);
 static void (*CalcCamera)(axes_t *ax, float *xaxis, float *yaxis);
 
-void I_CalcControllerAxes(void)
+boolean I_CalcControllerAxes(void)
 {
+    boolean camera_update = false;
+
     if (movement.x.data || movement.y.data)
     {
         CalcMovement(&movement, &axes[AXIS_STRAFE], &axes[AXIS_FORWARD]);
@@ -282,7 +284,11 @@ void I_CalcControllerAxes(void)
 
         camera.x.data = 0;
         camera.y.data = 0;
+
+        camera_update = true;
     }
+
+    return camera_update;
 }
 
 void I_UpdateAxesData(const event_t *ev)

--- a/src/i_gamepad.h
+++ b/src/i_gamepad.h
@@ -48,7 +48,7 @@ extern boolean joy_invert_look;             // Invert look axis.
 extern float axes[NUM_AXES];        // Calculated controller values.
 extern int trigger_threshold;       // Trigger threshold (axis resolution).
 
-void I_CalcControllerAxes(void);
+boolean I_CalcControllerAxes(void);
 void I_UpdateAxesData(const struct event_s *ev);
 void I_ResetControllerAxes(void);
 void I_ResetControllerLevel(void);


### PR DESCRIPTION
This applies to e.g. a gamepad with a gyro that emulates a mouse while using uncapped fps and raw input. Simultaneous input with capped fps or interpolated input is not affected. [Doomworld post](https://www.doomworld.com/forum/post/2776176).