### PR TITLE
Display "off" when mouse acceleration is disabled

### DIFF
--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -2100,7 +2100,9 @@ static const char **M_GetMouseAccelStrings(void)
     static const char *strings[MOUSE_ACCEL_STRINGS_SIZE];
     char buf[8];
 
-    for (int i = 0; i < MOUSE_ACCEL_STRINGS_SIZE; ++i)
+    strings[0] = M_StringDuplicate("Off");
+
+    for (int i = 1; i < MOUSE_ACCEL_STRINGS_SIZE; ++i)
     {
         int val = i + 10;
         M_snprintf(buf, sizeof(buf), "%1d.%1d", val / 10, val % 10);


### PR DESCRIPTION
In the menus, mouse acceleration at "1.0" shows "Off" instead. It seems this was confusing some users.