### PR TITLE
fix init. with invalid video_display setting (again)

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1365,6 +1365,7 @@ static void I_InitVideoParms(void)
     int p, tmp_scalefactor;
     SDL_DisplayMode mode;
 
+    I_ResetInvalidDisplayIndex();
     if (SDL_GetCurrentDisplayMode(video_display, &mode))
     {
         I_Error("Error getting display mode: %s", SDL_GetError());
@@ -1387,7 +1388,6 @@ static void I_InitVideoParms(void)
     // SDL may report native refresh rate as zero.
     native_refresh_rate = mode.refresh_rate;
 
-    I_ResetInvalidDisplayIndex();
     widescreen = default_widescreen;
     uncapped = default_uncapped;
     grabmouse = default_grabmouse;


### PR DESCRIPTION
commit d38fd80fed89 ("fix 21:9 aspect ratio, tweak DRS parameters", released in Woof 14.0.0) added some code that uses `video_display` before it is checked by `I_ResetInvalidDisplayIndex`, which causes Woof! to exit with an error if it has an invalid value (e.g. as a result of unplugging monitors).

Fix it by moving `I_ResetInvalidDisplayIndex` to an earlier point.

