### PR TITLE
Using "-strict" always disables related menu items

### DIFF
--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -319,6 +319,7 @@ extern  int       playback_skiptics;
 extern  boolean   frozen_mode;
 
 extern  boolean   strictmode, default_strictmode;
+extern  boolean   force_strictmode;
 
 #define STRICTMODE(x) (strictmode ? 0 : (x))
 

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -159,6 +159,7 @@ boolean         force_complevel;
 boolean         pistolstart, default_pistolstart;
 
 boolean         strictmode, default_strictmode;
+boolean         force_strictmode;
 boolean         critical;
 
 // [crispy] store last cmd to track joins
@@ -3436,7 +3437,10 @@ void G_ReloadDefaults(boolean keep_demover)
   //
 
   if (M_CheckParm("-strict"))
+  {
     strictmode = true;
+    force_strictmode = true;
+  }
 
   G_UpdateSideMove();
   P_UpdateDirectVerticalAiming();

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -318,7 +318,8 @@ static const char **GetStrings(int id);
 
 static boolean ItemDisabled(int flags)
 {
-    if ((flags & S_DISABLE) || (flags & S_STRICT && default_strictmode)
+    if ((flags & S_DISABLE)
+        || (flags & S_STRICT && (default_strictmode || force_strictmode))
         || (flags & S_BOOM && default_complevel < CL_BOOM)
         || (flags & S_MBF && default_complevel < CL_MBF)
         || (flags & S_VANILLA && default_complevel != CL_VANILLA))
@@ -3777,7 +3778,7 @@ void MN_SetupResetMenu(void)
 {
     extern boolean deh_set_blood_color;
 
-    DisableItem(M_ParmExists("-strict"), comp_settings1, "strictmode");
+    DisableItem(force_strictmode, comp_settings1, "strictmode");
     DisableItem(force_complevel, comp_settings1, "default_complevel");
     DisableItem(M_ParmExists("-pistolstart"), comp_settings1, "pistolstart");
     DisableItem(M_ParmExists("-uncapped") || M_ParmExists("-nouncapped"),


### PR DESCRIPTION
Without this, it's possible to accidentally change settings when using `-strict` but with the config set to `strictmode 0`.