### PR TITLE
revert changes to centery calculation in R_SetupFreelook

### DIFF
--- a/src/r_main.c
+++ b/src/r_main.c
@@ -501,8 +501,8 @@ static void R_SetupFreelook(void)
     dy = 0;
   }
 
-  centeryfrac = (viewheight << FRACBITS) / 2 + dy;
-  centery = centeryfrac >> FRACBITS;
+  centery = viewheight / 2 + (dy >> FRACBITS);
+  centeryfrac = centery << FRACBITS;
 
   for (i = 0; i < viewheight; i++)
   {


### PR DESCRIPTION
I don't understand why, but it fixes the garbage pixels reported in the DW [thread](https://www.doomworld.com/forum/topic/112333-this-is-woof-1420-mar-05-2024/?do=findComment&comment=2778129).