### PR TITLE
Don't apply threshold to raw mouse input

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -2735,6 +2735,7 @@ void D_DoomMain(void)
 
   G_UpdateSideMove();
   G_UpdateCarryAngle();
+  I_UpdateAccelerateMouse();
 
   MN_ResetTimeScale();
 

--- a/src/i_input.h
+++ b/src/i_input.h
@@ -26,7 +26,8 @@ void I_InitController(void);
 void I_OpenController(int which);
 void I_CloseController(int which);
 
-double I_AccelerateMouse(int val);
+double (*I_AccelerateMouse)(int val);
+void I_UpdateAccelerateMouse(void);
 void I_ReadMouse(void);
 void I_UpdateJoystick(boolean axis_buttons);
 void I_UpdateJoystickMenu(void);

--- a/src/i_input.h
+++ b/src/i_input.h
@@ -26,7 +26,7 @@ void I_InitController(void);
 void I_OpenController(int which);
 void I_CloseController(int which);
 
-double (*I_AccelerateMouse)(int val);
+extern double (*I_AccelerateMouse)(int val);
 void I_UpdateAccelerateMouse(void);
 void I_ReadMouse(void);
 void I_UpdateJoystick(boolean axis_buttons);

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -23,6 +23,7 @@
 #include "hu_lib.h"
 #include "hu_stuff.h"
 #include "i_gamepad.h"
+#include "i_input.h"
 #include "i_sound.h"
 #include "i_timer.h"
 #include "i_video.h"
@@ -2141,7 +2142,7 @@ static setup_menu_t gen_settings3[] = {
     MI_GAP,
 
     {"Mouse acceleration", S_THERMO, CNTR_X, M_THRM_SPC, {"mouse_acceleration"},
-     m_null, input_null, str_mouse_accel},
+     m_null, input_null, str_mouse_accel, I_UpdateAccelerateMouse},
 
     MI_END
 };


### PR DESCRIPTION
Using the latest master (not this PR), start from a default woof.cfg and disable vsync and lower the resolution scale so the framerate goes to hundreds or thousands of fps. Then move the mouse and notice that it's sluggish. This is due to the "threshold" value inherited from Chocolate Doom which is supposed to emulate a DOS PS/2 mouse driver (vanilla Doom has no mouse acceleration or threshold). Threshold works as intended with capped fps, but not at higher fps because the mouse is sampled so quickly that the delta mouse counts from SDL are rarely able to exceed 10 (default threshold). Mouse input is fine with threshold or acceleration disabled, or if interpolated input is used instead (raw_input 0).

Now for this PR. Here we disable threshold for raw mouse input. The mouse response is nearly identical:

![untitled](https://github.com/fabiangreffrath/woof/assets/56656010/ef3724fd-1027-457a-8315-4581b132ac00)

That bend in the blue line is caused by threshold. Other source ports that use fast mouse polling look like the red line as well and don't use mouse acceleration or threshold.