### PR TITLE
clear out SDL events to center mouse

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1722,6 +1722,11 @@ void I_InitGraphics(void)
         I_Error("Failed to initialize video: %s", SDL_GetError());
     }
 
+    // clear out any events waiting at the start and center the mouse
+    SDL_Event dummy;
+    while (SDL_PollEvent(&dummy))
+        ;
+
     I_AtExit(I_ShutdownGraphics, true);
 
     I_InitVideoParms();

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1730,10 +1730,9 @@ void I_InitGraphics(void)
     CreateSurfaces(video.pitch, video.height);
     ResetLogicalSize();
 
-    // clear out any events waiting at the start and center the mouse
-    SDL_Event dummy;
-    while (SDL_PollEvent(&dummy))
-        ;
+    // clear out events waiting at the start and center the mouse
+    SDL_PumpEvents();
+    SDL_FlushEvent(SDL_MOUSEMOTION);
     I_ResetRelativeMouseState();
 }
 

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1722,11 +1722,6 @@ void I_InitGraphics(void)
         I_Error("Failed to initialize video: %s", SDL_GetError());
     }
 
-    // clear out any events waiting at the start and center the mouse
-    SDL_Event dummy;
-    while (SDL_PollEvent(&dummy))
-        ;
-
     I_AtExit(I_ShutdownGraphics, true);
 
     I_InitVideoParms();
@@ -1734,6 +1729,12 @@ void I_InitGraphics(void)
     ResetResolution(CurrentResolutionHeight(), true);
     CreateSurfaces(video.pitch, video.height);
     ResetLogicalSize();
+
+    // clear out any events waiting at the start and center the mouse
+    SDL_Event dummy;
+    while (SDL_PollEvent(&dummy))
+        ;
+    I_ResetRelativeMouseState();
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
Fix #1594 

Taken from Chocolate Doom.