### PR TITLE
disable compatibility menu items according to command line parameters

### DIFF
--- a/src/d_net.c
+++ b/src/d_net.c
@@ -125,10 +125,10 @@ static void LoadGameSettings(net_gamesettings_t *settings)
 
     if (demo_version == 0)
     {
-        demo_version = 109;
+        demo_version = DV_VANILLA;
     }
 
-    if (demo_version == 109)
+    if (demo_version == DV_VANILLA)
     {
         compatibility = true;
     }

--- a/src/doomdef.h
+++ b/src/doomdef.h
@@ -62,6 +62,7 @@ typedef enum {
 
 typedef enum
 {
+    exe_indetermined = -1,
     exe_doom_1_9,    // Doom 1.9: for shareware, registered and commercial
     exe_ultimate,    // Ultimate Doom (retail)
     exe_final,       // Final Doom

--- a/src/doomstat.c
+++ b/src/doomstat.c
@@ -62,7 +62,7 @@ overflow_t overflow[EMU_TOTAL] = {
   { true, false, "donut_overflow"}
 };
 
-int demo_version;           // killough 7/19/98: Boom version of demo
+demo_version_t demo_version;        // killough 7/19/98: Boom version of demo
 
 // v1.1-like pitched sounds
 int pitched_sounds;  // killough 10/98

--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -93,14 +93,26 @@ typedef struct {
 
 extern overflow_t overflow[EMU_TOTAL];
 
-extern int demo_version;           // killough 7/19/98: Version of demo
+typedef enum {
+  DV_NONE    = -1,
+  DV_VANILLA = 109,
+  DV_LONGTIC = 111,
+  DV_BOOM200 = 200,
+  DV_BOOM201 = 201,
+  DV_BOOM    = 202,
+  DV_MBF     = 203,
+  DV_MBF21   = 221,
+  DV_UM      = 255,
+} demo_version_t;
+
+extern demo_version_t demo_version;           // killough 7/19/98: Version of demo
 
 // Only true when playing back an old demo -- used only in "corner cases"
 // which break playback but are otherwise unnoticable or are just desirable:
 
-#define demo_compatibility (demo_version < 200) /* killough 11/98: macroized */
+#define demo_compatibility (demo_version < DV_BOOM200) /* killough 11/98: macroized */
 
-#define mbf21 (demo_version == 221)
+#define mbf21 (demo_version == DV_MBF21)
 
 // killough 7/19/98: whether monsters should fight against each other
 extern int monster_infighting, default_monster_infighting;

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -932,7 +932,7 @@ static void G_DoLoadLevel(void)
 
   playback_levelstarttic = playback_tic;
 
-  if (!demo_compatibility && demo_version < 203)   // killough 9/29/98
+  if (!demo_compatibility && demo_version < DV_MBF)   // killough 9/29/98
     basetic = gametic;
 
   if (wipegamestate == GS_LEVEL)
@@ -1849,22 +1849,19 @@ static void G_DoWorldDone(void)
 
 #define MIN_MAXPLAYERS 32
 
-#define INVALID_DEMO(a, b) \
-   do \
-   { \
-     I_Printf(VB_WARNING, "G_DoPlayDemo: " a, b); \
-     gameaction = ga_nothing; \
-     demoplayback = true; \
-     G_CheckDemoStatus(); \
-     return; \
-   } while(0)
+static void InvalidDemo(void)
+{
+    gameaction = ga_nothing;
+    demoplayback = true;
+    G_CheckDemoStatus();
+}
 
 static void G_DoPlayDemo(void)
 {
   skill_t skill;
   int i, episode, map;
   char basename[9];
-  int demover;
+  demo_version_t demover;
   byte *option_p = NULL;      // killough 11/98
   int lumpnum, lumplength;
 
@@ -1888,19 +1885,25 @@ static void G_DoPlayDemo(void)
   // [FG] ignore too short demo lumps
   if (lumplength < 0xd)
   {
-    INVALID_DEMO("Short demo lump %s.", basename);
+    I_Printf(VB_WARNING, "G_DoPlayDemo: Short demo lump %s.", basename);
+    InvalidDemo();
+    return;
   }
 
   demover = *demo_p++;
 
   // skip UMAPINFO demo header
-  if (demover == 255)
+  if (demover == DV_UM)
   {
     // we check for the PR+UM signature.
     // Eternity Engine also uses 255 demover, with other signatures.
-    if (strncmp((const char *)demo_p, "PR+UM", 5) != 0)
+    if (memcmp(demo_p, "PR+UM", 5))
     {
-      INVALID_DEMO("Extended demo format %d found, but \"PR+UM\" string not found.", demover);
+      I_Printf(VB_WARNING,
+            "Extended demo format %d found, but \"PR+UM\" string not found.",
+            demover);
+      InvalidDemo();
+      return;
     }
 
     demo_p += 6;
@@ -1921,7 +1924,7 @@ static void G_DoPlayDemo(void)
       I_Error("G_DoPlayDemo: Unknown demo format.");
     }
 
-    if (strncmp((const char *)demo_p, "UMAPINFO", 8))
+    if (memcmp(demo_p, "UMAPINFO", 8))
     {
       I_Error("G_DoPlayDemo: Unknown demo format.");
     }
@@ -1944,14 +1947,16 @@ static void G_DoPlayDemo(void)
   // [FG] PrBoom's own demo format starts with demo version 210
   if (demover >= 210 && !mbf21)
   {
-    INVALID_DEMO("Unknown demo format %d.", demover);
+    I_Printf(VB_WARNING, "Unknown demo format %d.", demover);
+    InvalidDemo();
+    return;
   }
 
   longtics = false;
 
-  if (demover < 200)     // Autodetect old demos
+  if (demover < DV_BOOM200)     // Autodetect old demos
     {
-      if (demover == 111)
+      if (demover == DV_LONGTIC)
       {
         longtics = true;
       }
@@ -2024,7 +2029,7 @@ static void G_DoPlayDemo(void)
       consoleplayer = *demo_p++;
 
       // killough 11/98: save option pointer for below
-      if (demover >= 203)
+      if (demover >= DV_MBF)
 	option_p = demo_p;
 
       // killough 3/1/98: Read game options
@@ -2033,7 +2038,7 @@ static void G_DoPlayDemo(void)
       else
         demo_p = G_ReadOptions(demo_p);
 
-      if (demover == 200)        // killough 6/3/98: partially fix v2.00 demos
+      if (demover == DV_BOOM200) // killough 6/3/98: partially fix v2.00 demos
         demo_p += 256-G_GameOptionSize();
     }
 
@@ -2410,7 +2415,7 @@ static void G_DoLoadGame(void)
   }
   else
   {
-    demo_version = 203;
+    demo_version = DV_MBF;
   }
 
   // killough 2/14/98: load compatibility mode
@@ -3165,123 +3170,134 @@ static int G_GetHelpers(void)
   return j ? (j+1 < myargc && myargv[j+1][0] != '-') ? M_ParmArgToInt(j) : 1 : default_dogs;
 }
 
-// [FG] support named complevels on the command line, e.g. "-complevel boom",
+// [FG] support named complevels on the command line, e.g. "-complevel boom"
 
-int G_GetNamedComplevel (const char *arg)
+demo_version_t G_GetNamedComplevel(const char *arg)
 {
-  int i;
-
-  const struct {
-    int level;
-    const char *const name;
-    int exe;
-  } named_complevel[] = {
-    {109, "vanilla", -1},
-    {109, "doom2",   exe_doom_1_9},
-    {109, "1.9",     exe_doom_1_9},
-    {109, "2",       exe_doom_1_9},
-    {109, "ultimate",exe_ultimate},
-    {109, "3",       exe_ultimate},
-    {109, "final",   exe_final},
-    {109, "tnt",     exe_final},
-    {109, "plutonia",exe_final},
-    {109, "4",       exe_final},
-    {202, "boom",    -1},
-    {202, "9",       -1},
-    {203, "mbf",     -1},
-    {203, "11",      -1},
-    {221, "mbf21",   -1},
-    {221, "21",      -1},
-  };
-
-  for (i = 0; i < sizeof(named_complevel)/sizeof(*named_complevel); i++)
-  {
-    if (!strcasecmp(arg, named_complevel[i].name))
+    const struct
     {
-      if (named_complevel[i].exe >= 0)
-        gameversion = named_complevel[i].exe;
+        demo_version_t demover;
+        const char *const name;
+        int exe;
+    } named_complevel[] = {
+        {DV_VANILLA, "vanilla",  exe_indetermined},
+        {DV_VANILLA, "doom2",    exe_doom_1_9    },
+        {DV_VANILLA, "1.9",      exe_doom_1_9    },
+        {DV_VANILLA, "2",        exe_doom_1_9    },
+        {DV_VANILLA, "ultimate", exe_ultimate    },
+        {DV_VANILLA, "3",        exe_ultimate    },
+        {DV_VANILLA, "final",    exe_final       },
+        {DV_VANILLA, "tnt",      exe_final       },
+        {DV_VANILLA, "plutonia", exe_final       },
+        {DV_VANILLA, "4",        exe_final       },
+        {DV_BOOM,    "boom",     exe_indetermined},
+        {DV_BOOM,    "9",        exe_indetermined},
+        {DV_MBF,     "mbf",      exe_indetermined},
+        {DV_MBF,     "11",       exe_indetermined},
+        {DV_MBF21,   "mbf21",    exe_indetermined},
+        {DV_MBF21,   "21",       exe_indetermined},
+    };
 
-      return named_complevel[i].level;
+    for (int i = 0; i < arrlen(named_complevel); i++)
+    {
+        if (!strcasecmp(arg, named_complevel[i].name))
+        {
+            if (named_complevel[i].exe != exe_indetermined)
+            {
+                gameversion = named_complevel[i].exe;
+            }
+
+            return named_complevel[i].demover;
+        }
     }
-  }
 
-  return -1;
+    return DV_NONE;
 }
 
-static int G_GetDefaultComplevel(void)
+static struct
 {
-  switch (default_complevel)
-  {
-    case CL_VANILLA:
-      return 109;
-    case CL_BOOM:
-      return 202;
-    case CL_MBF:
-      return 203;
-    default:
-      return 221;
-  }
+    demo_version_t demover;
+    complevel_t complevel;
+} demover_complevel[] = {
+    {DV_VANILLA, CL_VANILLA},
+    {DV_BOOM,    CL_BOOM   },
+    {DV_MBF,     CL_MBF    },
+    {DV_MBF21,   CL_MBF21  }
+};
+
+static complevel_t GetComplevel(demo_version_t demover)
+{
+    for (int i = 0; i < arrlen(demover_complevel); ++i)
+    {
+        if (demover == demover_complevel[i].demover)
+        {
+            return demover_complevel[i].complevel;
+        }
+    }
+
+    return CL_NONE;
 }
 
-static int G_GetComplevel(int demover)
+static demo_version_t GetDemover(complevel_t complevel)
 {
-  switch (demover)
-  {
-    case 109:
-      return CL_VANILLA;
-    case 202:
-      return CL_BOOM;
-    case 203:
-      return CL_MBF;
-    case 221:
-      return CL_MBF21;
-    default:
-      return CL_NONE;
-  }
+    for (int i = 0; i < arrlen(demover_complevel); ++i)
+    {
+        if (complevel == demover_complevel[i].complevel)
+        {
+            return demover_complevel[i].demover;
+        }
+    }
+
+    return DV_NONE;
 }
 
 const char *G_GetCurrentComplevelName(void)
 {
-  switch (demo_version)
-  {
-    case 109:
-      return gameversions[gameversion].description;
-    case 202:
-      return "Boom";
-    case 203:
-      return "MBF";
-    case 221:
-      return "MBF21";
-    default:
-      return "Unknown";
-  }
+    switch (demo_version)
+    {
+        case DV_VANILLA:
+            return gameversions[gameversion].description;
+        case DV_BOOM:
+            return "Boom";
+        case DV_MBF:
+            return "MBF";
+        case DV_MBF21:
+            return "MBF21";
+        default:
+            return "Unknown";
+    }
 }
 
-static int G_GetWadComplevel(void)
+static demo_version_t GetWadDemover(void)
 {
-  int lumpnum;
+    int lumpnum = W_CheckNumForName("COMPLVL");
 
-  lumpnum = W_CheckNumForName("COMPLVL");
+    if (lumpnum < 0)
+    {
+        return DV_NONE;
+    }
 
-  if (lumpnum >= 0)
-  {
-    int length;
-    char *data = NULL;
-
-    length = W_LumpLength(lumpnum);
-    data = W_CacheLumpNum(lumpnum, PU_CACHE);
+    int length = W_LumpLength(lumpnum);
+    char *data = W_CacheLumpNum(lumpnum, PU_CACHE);
 
     if (length == 7 && !strncasecmp("vanilla", data, 7))
-      return 109;
+    {
+        return DV_VANILLA;
+    }
     else if (length == 4 && !strncasecmp("boom", data, 4))
-      return 202;
+    {
+        return DV_BOOM;
+    }
     else if (length == 3 && !strncasecmp("mbf", data, 3))
-      return 203;
+    {
+        return DV_MBF;
+    }
     else if (length == 5 && !strncasecmp("mbf21", data, 5))
-      return 221;
-  }
+    {
+        return DV_MBF21;
+    }
 
-  return -1;
+    return DV_NONE;
 }
 
 static void G_MBFDefaults(void)
@@ -3408,7 +3424,7 @@ void G_ReloadDefaults(boolean keep_demover)
 
   if (!keep_demover)
   {
-    int level = -1;
+    demo_version_t demover = DV_NONE;
 
     //!
     // @arg <version>
@@ -3423,28 +3439,28 @@ void G_ReloadDefaults(boolean keep_demover)
 
     if (p > 0)
     {
-      level = G_GetNamedComplevel(myargv[p + 1]);
-      if (level < 0)
+      demover = G_GetNamedComplevel(myargv[p + 1]);
+      if (demover == DV_NONE)
       {
         I_Error("Invalid parameter '%s' for -complevel, "
                 "valid values are vanilla, boom, mbf, mbf21.", myargv[p + 1]);
       }
     }
 
-    if (level < 0)
+    if (demover == DV_NONE)
     {
-      level = G_GetWadComplevel();
+      demover = GetWadDemover();
     }
 
-    if (level < 0)
+    if (demover == DV_NONE)
     {
-      demo_version = G_GetDefaultComplevel();
+      demo_version = GetDemover(default_complevel);
       force_complevel = CL_NONE;
     }
     else
     {
-      demo_version = level;
-      force_complevel = G_GetComplevel(demo_version);
+      demo_version = demover;
+      force_complevel = GetComplevel(demo_version);
     }
   }
 
@@ -3505,13 +3521,13 @@ void G_ReloadDefaults(boolean keep_demover)
   // haleyjd
   rngseed = time(NULL);
 
-  if (beta_emulation && demo_version != 203)
+  if (beta_emulation && demo_version != DV_MBF)
     I_Error("G_ReloadDefaults: Beta emulation requires complevel MBF.");
 
-  if ((M_CheckParm("-dog") || M_CheckParm("-dogs")) && demo_version < 203)
+  if ((M_CheckParm("-dog") || M_CheckParm("-dogs")) && demo_version < DV_MBF)
     I_Error("G_ReloadDefaults: Helper dogs require complevel MBF or MBF21.");
 
-  if (demo_version < 203)
+  if (demo_version < DV_MBF)
   {
     monster_infighting = 1;
     monster_backing = 0;
@@ -3524,12 +3540,12 @@ void G_ReloadDefaults(boolean keep_demover)
 
     monkeys = 0;
 
-    if (demo_version == 109)
+    if (demo_version == DV_VANILLA)
     {
       compatibility = true;
       memset(comp, 0xff, sizeof comp);
     }
-    else if (demo_version == 202)
+    else if (demo_version == DV_BOOM)
     {
       memset(comp, 0, sizeof comp);
       G_BoomComp();

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -1990,7 +1990,7 @@ static void G_DoPlayDemo(void)
       // killough 3/6/98: rearrange to fix savegame bugs (moved fastparm,
       // respawnparm, nomonsters flags to G_LoadOptions()/G_SaveOptions())
 
-      if ((skill=demover) >= 100)         // For demos from versions >= 1.4
+      if (demover >= 100)         // For demos from versions >= 1.4
         {
           skill = *demo_p++;
           episode = *demo_p++;
@@ -2003,6 +2003,7 @@ static void G_DoPlayDemo(void)
         }
       else
         {
+          skill = (int)demover;
           episode = *demo_p++;
           map = *demo_p++;
           deathmatch = respawnparm = fastparm =

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -3498,7 +3498,7 @@ void G_ReloadDefaults(boolean keep_demover)
   // Reset MBF compatibility options in strict mode
   if (strictmode)
   {
-    if (demo_version == 203)
+    if (demo_version == DV_MBF)
       G_MBFDefaults();
     else if (mbf21)
       G_MBF21Defaults();
@@ -3744,7 +3744,7 @@ void G_InitNew(skill_t skill, int episode, int map)
 
   M_LoadOptions();     // killough 11/98: read OPTIONS lump from wad
 
-  if (demo_version == 203)
+  if (demo_version == DV_MBF)
     G_MBFComp();
 
   G_DoLoadLevel();
@@ -4030,7 +4030,7 @@ byte *G_ReadOptions(byte *demo_p)
   rngseed += *demo_p++ & 0xff;
 
   // Options new to v2.03
-  if (demo_version >= 203)
+  if (demo_version >= DV_MBF)
     {
       monster_infighting = *demo_p++;   // killough 7/19/98
 
@@ -4065,10 +4065,6 @@ byte *G_ReadOptions(byte *demo_p)
       }
 
       G_MBFComp();
-
-      // Options new to v2.04, etc.
-      if (demo_version >= 204)
-	;
     }
   else  // defaults for versions < 2.02
     {
@@ -4076,7 +4072,7 @@ byte *G_ReadOptions(byte *demo_p)
       for (i=0; i < COMP_TOTAL; i++)
 	comp[i] = compatibility;
 
-      if (demo_version == 202 || demo_version == 201)
+      if (demo_version == DV_BOOM || demo_version == DV_BOOM201)
         G_BoomComp();
 
       monster_infighting = 1;           // killough 7/19/98
@@ -4106,7 +4102,7 @@ void G_BeginRecording(void)
 
   demo_p = demobuffer;
 
-  if (demo_version == 203 || mbf21)
+  if (demo_version == DV_MBF || mbf21)
   {
   *demo_p++ = demo_version;
 
@@ -4142,7 +4138,7 @@ void G_BeginRecording(void)
   for (; i<MIN_MAXPLAYERS; i++)
     *demo_p++ = 0;
   }
-  else if (demo_version == 202)
+  else if (demo_version == DV_BOOM)
   {
     *demo_p++ = demo_version;
 
@@ -4175,11 +4171,11 @@ void G_BeginRecording(void)
     for (; i<MIN_MAXPLAYERS; i++)
       *demo_p++ = 0;
   }
-  else if (demo_version == 109)
+  else if (demo_version == DV_VANILLA)
   {
     if (longtics)
     {
-      *demo_p++ = 111;
+      *demo_p++ = DV_LONGTIC;
     }
     else
     {

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -153,8 +153,7 @@ boolean         padlook = false;
 // killough 4/13/98: Make clock rate adjustable by scale factor
 int             realtic_clock_rate = 100;
 
-complevel_t     default_complevel;
-int             force_demo_version;
+complevel_t     force_complevel, default_complevel;
 
 boolean         pistolstart, default_pistolstart;
 
@@ -3209,7 +3208,7 @@ int G_GetNamedComplevel (const char *arg)
   return -1;
 }
 
-static int G_GetDefaultComplevel()
+static int G_GetDefaultComplevel(void)
 {
   switch (default_complevel)
   {
@@ -3221,6 +3220,23 @@ static int G_GetDefaultComplevel()
       return 203;
     default:
       return 221;
+  }
+}
+
+static int G_GetComplevel(int demover)
+{
+  switch (demover)
+  {
+    case 109:
+      return CL_VANILLA;
+    case 202:
+      return CL_BOOM;
+    case 203:
+      return CL_MBF;
+    case 221:
+      return CL_MBF21;
+    default:
+      return CL_NONE;
   }
 }
 
@@ -3423,12 +3439,12 @@ void G_ReloadDefaults(boolean keep_demover)
     if (level < 0)
     {
       demo_version = G_GetDefaultComplevel();
-      force_demo_version = -1;
+      force_complevel = CL_NONE;
     }
     else
     {
       demo_version = level;
-      force_demo_version = level;
+      force_complevel = G_GetComplevel(demo_version);
     }
   }
 

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -154,7 +154,7 @@ boolean         padlook = false;
 int             realtic_clock_rate = 100;
 
 complevel_t     default_complevel;
-boolean         force_complevel;
+int             force_demo_version;
 
 boolean         pistolstart, default_pistolstart;
 
@@ -3423,11 +3423,12 @@ void G_ReloadDefaults(boolean keep_demover)
     if (level < 0)
     {
       demo_version = G_GetDefaultComplevel();
+      force_demo_version = -1;
     }
     else
     {
       demo_version = level;
-      force_complevel = true;
+      force_demo_version = level;
     }
   }
 

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -84,7 +84,7 @@ typedef enum
 } complevel_t;
 
 extern complevel_t default_complevel;
-extern boolean force_complevel;
+extern int force_demo_version;
 
 extern int realtic_clock_rate;
 

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -18,6 +18,7 @@
 #define __G_GAME__
 
 #include "doomdef.h"
+#include "doomstat.h"
 #include "doomtype.h"
 #include "m_fixed.h"
 
@@ -70,7 +71,7 @@ int G_ValidateMapName(const char *mapname, int *pEpi, int *pMap);
 
 void G_EnableWarp(boolean warp);
 
-int G_GetNamedComplevel (const char *arg);
+demo_version_t G_GetNamedComplevel(const char *arg);
 const char *G_GetCurrentComplevelName(void);
 
 int G_GotoNextLevel(int *pEpi, int *pMap);

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -77,14 +77,14 @@ int G_GotoNextLevel(int *pEpi, int *pMap);
 
 typedef enum
 {
+  CL_NONE = -1,
   CL_VANILLA,
   CL_BOOM,
   CL_MBF,
   CL_MBF21,
 } complevel_t;
 
-extern complevel_t default_complevel;
-extern int force_demo_version;
+extern complevel_t force_complevel, default_complevel;
 
 extern int realtic_clock_rate;
 

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -3144,7 +3144,7 @@ boolean M_ParseOption(const char *p, boolean wad)
         dp->setup_menu = dp_preset->setup_menu;
     }
 
-    if (demo_version < 203 && dp->setup_menu
+    if (demo_version < DV_MBF && dp->setup_menu
         && !(dp->setup_menu->m_flags & S_COSMETIC))
     {
         return 1;

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -321,29 +321,16 @@ static const char **GetStrings(int id);
 
 static boolean ItemDisabled(int flags)
 {
+    complevel_t complevel =
+        force_complevel != CL_NONE ? force_complevel : default_complevel;
+
     if ((flags & S_DISABLE)
-        || (flags & S_STRICT && (default_strictmode || force_strictmode)))
+        || (flags & S_STRICT && (default_strictmode || force_strictmode))
+        || (flags & S_BOOM && complevel < CL_BOOM)
+        || (flags & S_MBF && complevel < CL_MBF)
+        || (flags & S_VANILLA && complevel != CL_VANILLA))
     {
         return true;
-    }
-
-    if (force_demo_version > 0)
-    {
-        if ((flags & S_BOOM && force_demo_version < 202)
-            || (flags & S_MBF && force_demo_version < 203)
-            || (flags & S_VANILLA && force_demo_version != 109))
-        {
-            return true;
-        }
-    }
-    else
-    {
-        if ((flags & S_BOOM && default_complevel < CL_BOOM)
-            || (flags & S_MBF && default_complevel < CL_MBF)
-            || (flags & S_VANILLA && default_complevel != CL_VANILLA))
-        {
-            return true;
-        }
     }
 
     return false;
@@ -1790,7 +1777,7 @@ setup_menu_t comp_settings1[] = {
 
 static void UpdateInterceptsEmuItem(void)
 {
-    DisableItem((force_demo_version == 109 || default_complevel == CL_VANILLA)
+    DisableItem((force_complevel == CL_VANILLA || default_complevel == CL_VANILLA)
                     && overflow[emu_intercepts].enabled,
                 comp_settings1, "blockmapfix");
 }
@@ -3813,7 +3800,7 @@ void MN_SetupResetMenu(void)
     extern boolean deh_set_blood_color;
 
     DisableItem(force_strictmode, comp_settings1, "strictmode");
-    DisableItem(force_demo_version > 0, comp_settings1, "default_complevel");
+    DisableItem(force_complevel != CL_NONE, comp_settings1, "default_complevel");
     DisableItem(M_ParmExists("-pistolstart"), comp_settings1, "pistolstart");
     DisableItem(M_ParmExists("-uncapped") || M_ParmExists("-nouncapped"),
                 gen_settings1, "uncapped");

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -1752,7 +1752,8 @@ static void UpdateInterceptsEmuItem(void);
 setup_menu_t comp_settings1[] = {
 
     {"Default Compatibility Level", S_CHOICE | S_LEVWARN, M_X, M_SPC,
-     {"default_complevel"}, m_null, input_null, str_default_complevel},
+     {"default_complevel"}, m_null, input_null, str_default_complevel,
+     UpdateInterceptsEmuItem},
 
     {"Strict Mode", S_ONOFF | S_LEVWARN, M_X, M_SPC, {"strictmode"}},
 
@@ -1789,7 +1790,8 @@ setup_menu_t comp_settings1[] = {
 
 static void UpdateInterceptsEmuItem(void)
 {
-    DisableItem(demo_compatibility && overflow[emu_intercepts].enabled,
+    DisableItem((force_demo_version == 109 || default_complevel == CL_VANILLA)
+                    && overflow[emu_intercepts].enabled,
                 comp_settings1, "blockmapfix");
 }
 

--- a/src/p_enemy.c
+++ b/src/p_enemy.c
@@ -449,19 +449,19 @@ static boolean P_Move(mobj_t *actor, boolean dropoff) // killough 9/12/98
       // Boom v2.02 and LxDoom return good && (P_Random(pr_trywalk)&3)
       // MBF plays even more games
 
-      if (demo_version < 202)
+      if (demo_version < DV_BOOM)
         return good;
-      if (demo_version < 203)
+      if (demo_version < DV_MBF)
         return good && (compatibility || (P_Random(pr_trywalk)&3)); //jff 8/13/98
       else
-      return good && (demo_version < 203 || comp[comp_doorstuck] ||
+      return good && (demo_version < DV_MBF || comp[comp_doorstuck] ||
 		      (P_Random(pr_opendoor) >= 230) ^ (good & 1));
     }
   else
     actor->flags &= ~MF_INFLOAT;
 
   // killough 11/98: fall more slowly, under gravity, if felldown==true
-  if (!(actor->flags & MF_FLOAT) && (!felldown || demo_version < 203))
+  if (!(actor->flags & MF_FLOAT) && (!felldown || demo_version < DV_MBF))
     actor->z = actor->floorz;
 
   return true;
@@ -687,7 +687,7 @@ static void P_NewChaseDir(mobj_t *actor)
 
   actor->strafecount = 0;
 
-  if (demo_version >= 203)
+  if (demo_version >= DV_MBF)
   {
     if (actor->floorz - actor->dropoffz > FRACUNIT*24 &&
 	actor->z <= actor->floorz && !(actor->flags & (MF_DROPOFF|MF_FLOAT)) &&
@@ -853,7 +853,7 @@ static boolean P_LookForPlayers(mobj_t *actor, boolean allaround)
 
   c = 0;
 
-  stopc = demo_version < 203 && !demo_compatibility && monsters_remember ?
+  stopc = demo_version < DV_MBF && !demo_compatibility && monsters_remember ?
     MAXPLAYERS : 2;       // killough 9/9/98
 
   for (;; actor->lastlook = (actor->lastlook+1)&(MAXPLAYERS-1))
@@ -869,7 +869,7 @@ static boolean P_LookForPlayers(mobj_t *actor, boolean allaround)
         // There are no more desyncs on Donce's demos on horror.wad
 
         // Use last known enemy if no players sighted -- killough 2/15/98:
-        if (demo_version < 203 && !demo_compatibility && monsters_remember)
+        if (demo_version < DV_MBF && !demo_compatibility && monsters_remember)
         {
           if (actor->lastenemy && actor->lastenemy->health > 0)
           {
@@ -897,7 +897,7 @@ static boolean P_LookForPlayers(mobj_t *actor, boolean allaround)
 
       // killough 9/9/98: give monsters a threshold towards getting players
       // (we don't want it to be too easy for a player with dogs :)
-      if (demo_version >= 203 && !comp[comp_pursuit])
+      if (demo_version >= DV_MBF && !comp[comp_pursuit])
 	actor->threshold = 60;
 
       return true;
@@ -927,7 +927,7 @@ static boolean P_LookForMonsters(mobj_t *actor, boolean allaround)
       return true;
     }
 
-  if (demo_version < 203)  // Old demos do not support monster-seeking bots
+  if (demo_version < DV_MBF)  // Old demos do not support monster-seeking bots
     return false;
 
   // Search the threaded list corresponding to this object's potential targets
@@ -1202,7 +1202,7 @@ void A_Chase(mobj_t *actor)
 
   if (!actor->threshold)
   {
-    if (demo_version < 203)
+    if (demo_version < DV_MBF)
       {   // killough 9/9/98: for backward demo compatibility
 	if (netgame && !P_CheckSight(actor, actor->target) &&
 	    P_LookForPlayers(actor, true))
@@ -1758,7 +1758,7 @@ static boolean P_HealCorpse(mobj_t* actor, int radius, statenum_t healstate, sfx
                   corpsehit->health = info->spawnhealth;
 		  P_SetTarget(&corpsehit->target, NULL);  // killough 11/98
 
-		  if (demo_version >= 203)
+		  if (demo_version >= DV_MBF)
 		    {         // kilough 9/9/98
 		      P_SetTarget(&corpsehit->lastenemy, NULL);
 		      corpsehit->flags &= ~MF_JUSTHIT;
@@ -1852,7 +1852,7 @@ void A_VileTarget(mobj_t *actor)
 
   // killough 12/98: fix Vile fog coordinates
   fog = P_SpawnMobj(actor->target->x,
-                    demo_version < 203 ? actor->target->x : actor->target->y,
+                    demo_version < DV_MBF ? actor->target->x : actor->target->y,
                     actor->target->z,MT_FIRE);
 
   P_SetTarget(&actor->tracer, fog);   // killough 11/98
@@ -2021,7 +2021,7 @@ void A_BetaSkullAttack(mobj_t *actor)
 {
   int damage;
 
-  if (demo_version < 203)
+  if (demo_version < DV_MBF)
     return;
 
   if (!actor->target || actor->target->type == MT_SKULL)
@@ -2038,7 +2038,7 @@ void A_BetaSkullAttack(mobj_t *actor)
 
 void A_Stop(mobj_t *actor)
 {
-  if (demo_version < 203)
+  if (demo_version < DV_MBF)
     return;
   actor->momx = actor->momy = actor->momz = 0;
 }
@@ -2204,7 +2204,7 @@ void A_Fall(mobj_t *actor)
 // killough 11/98: kill an object
 void A_Die(mobj_t *actor)
 {
-  if (demo_version < 203)
+  if (demo_version < DV_MBF)
     return;
   P_DamageMobj(actor, NULL, NULL, actor->health);
 }
@@ -2224,7 +2224,7 @@ void A_Explode(mobj_t *thingy)
 
 void A_Detonate(mobj_t *mo)
 {
-  if (demo_version < 203)
+  if (demo_version < DV_MBF)
     return;
   P_RadiusAttack(mo, mo->target, mo->info->damage, mo->info->damage);
 }
@@ -2242,7 +2242,7 @@ void A_Mushroom(mobj_t *actor)
   fixed_t misc1 = actor->state->misc1 ? actor->state->misc1 : FRACUNIT*4;
   fixed_t misc2 = actor->state->misc2 ? actor->state->misc2 : FRACUNIT/2;
 
-  if (demo_version < 203)
+  if (demo_version < DV_MBF)
     return;
   A_Explode(actor);               // make normal explosion
 
@@ -2737,7 +2737,7 @@ void A_KeenDie(mobj_t* mo)
 
 void A_Spawn(mobj_t *mo)
 {
-  if (demo_version < 203)
+  if (demo_version < DV_MBF)
     return;
   if (mo->state->misc1)
     {
@@ -2754,21 +2754,21 @@ void A_Spawn(mobj_t *mo)
 
 void A_Turn(mobj_t *mo)
 {
-  if (demo_version < 203)
+  if (demo_version < DV_MBF)
     return;
   mo->angle += (angle_t)(((uint64_t) mo->state->misc1 << 32) / 360);
 }
 
 void A_Face(mobj_t *mo)
 {
-  if (demo_version < 203)
+  if (demo_version < DV_MBF)
     return;
   mo->angle = (angle_t)(((uint64_t) mo->state->misc1 << 32) / 360);
 }
 
 void A_Scratch(mobj_t *mo)
 {
-  if (demo_version < 203)
+  if (demo_version < DV_MBF)
     return;
   mo->target && (A_FaceTarget(mo), P_CheckMeleeRange(mo)) ?
     mo->state->misc2 ? S_StartSound(mo, mo->state->misc2) : (void) 0,
@@ -2777,7 +2777,7 @@ void A_Scratch(mobj_t *mo)
 
 void A_PlaySound(mobj_t *mo)
 {
-  if (demo_version < 203)
+  if (demo_version < DV_MBF)
     return;
   S_StartSound(mo->state->misc2 ? NULL : mo, mo->state->misc1);
 }
@@ -2796,7 +2796,7 @@ void A_RandomJump(mobj_t *mo)
 
 void A_LineEffect(mobj_t *mo)
 {
-  if (demo_version < 203)
+  if (demo_version < DV_MBF)
     return;
   if (!(mo->intflags & MIF_LINEDONE))                // Unless already used up
     {

--- a/src/p_floor.c
+++ b/src/p_floor.c
@@ -123,7 +123,7 @@ result_e T_MovePlane
           // Moving a floor up
           // jff 02/04/98 keep floor from moving thru ceilings
           // jff 2/22/98 weaken check to demo_compatibility
-          destheight = (demo_compatibility || (demo_version >= 203 && comp[comp_floors]) ||
+          destheight = (demo_compatibility || (demo_version >= DV_MBF && comp[comp_floors]) ||
 			dest<sector->ceilingheight)? // killough 10/98
                           dest : sector->ceilingheight;
           if (sector->floorheight + speed > destheight)
@@ -146,7 +146,7 @@ result_e T_MovePlane
             flag = P_CheckSector(sector,crush); //jff 3/19/98 use faster chk
             if (flag == true)
             {
-              if (demo_compatibility || (demo_version >= 203 && comp[comp_floors])) // killough 10/98
+              if (demo_compatibility || (demo_version >= DV_MBF && comp[comp_floors])) // killough 10/98
                 if (crush == true) //jff 1/25/98 fix floor crusher
                   return crushed;
               sector->floorheight = lastpos;
@@ -834,7 +834,7 @@ int EV_BuildStairs
         if (tsec->floorpic != texture)
           continue;
 
-	if (comp[comp_stairs] || demo_version == 203)
+	if (comp[comp_stairs] || demo_version == DV_MBF)
 	{
 	height += stairsize;  // killough 10/98: intentionally left this way
 	}
@@ -843,7 +843,7 @@ int EV_BuildStairs
         if (P_SectorActive(floor_special,tsec)) //jff 2/22/98
 	  continue;
 
-	if (!comp[comp_stairs] && demo_version != 203)
+	if (!comp[comp_stairs] && demo_version != DV_MBF)
 	{
 	height += stairsize;
 	}
@@ -879,7 +879,7 @@ int EV_BuildStairs
     {
       // cph 2001/09/22 - emulate buggy MBF comp_stairs for demos, with logic
       // reversed since we now have a separate outer loop index.
-      if (demo_version == 203)
+      if (demo_version == DV_MBF)
         ssec = secnum; // Trash outer loop index
       else
       {

--- a/src/p_genlin.c
+++ b/src/p_genlin.c
@@ -754,7 +754,7 @@ manual_stair:
 
 	// jff 6/19/98 prevent double stepsize
 	// killough 10/98: corrected use of demo compatibility flag
-        if (demo_version < 202)
+        if (demo_version < DV_BOOM)
           height += floor->direction * stairsize;
 
         //jff 2/26/98 special lockout condition for retriggering
@@ -763,7 +763,7 @@ manual_stair:
 
 	// jff 6/19/98 increase height AFTER continue        
 	// killough 10/98: corrected use of demo compatibility flag
-        if (demo_version >= 202)
+        if (demo_version >= DV_BOOM)
           height += floor->direction * stairsize;
 
         // jff 2/26/98

--- a/src/p_inter.c
+++ b/src/p_inter.c
@@ -727,7 +727,7 @@ static void P_KillMobj(mobj_t *source, mobj_t *target, method_t mod)
 
             if (playerscount)
             {
-              if (demo_version >= 203)
+              if (demo_version >= DV_MBF)
                 i = P_Random(pr_friends) % playerscount;
               else
                 i = Woof_Random() % playerscount;
@@ -936,7 +936,7 @@ void P_DamageMobjBy(mobj_t *target,mobj_t *inflictor, mobj_t *source, int damage
     }
 
   // killough 9/7/98: keep track of targets so that friends can help friends
-  if (demo_version >= 203)
+  if (demo_version >= DV_MBF)
     {
       // If target is a player, set player's target to source,
       // so that a friend can tell who's hurting a player
@@ -969,7 +969,7 @@ void P_DamageMobjBy(mobj_t *target,mobj_t *inflictor, mobj_t *source, int damage
   if (source && source != target && !(source->flags2 & MF2_DMGIGNORED) &&
       (!target->threshold || target->flags2 & MF2_NOTHRESHOLD) &&
       ((source->flags ^ target->flags) & MF_FRIEND || 
-       monster_infighting || demo_version < 203) &&
+       monster_infighting || demo_version < DV_MBF) &&
       !P_InfightingImmune(target, source))
     {
       // if not intent on another player, chase after this one
@@ -979,7 +979,7 @@ void P_DamageMobjBy(mobj_t *target,mobj_t *inflictor, mobj_t *source, int damage
       // killough 9/9/98: cleaned up, made more consistent:
 
       if (!target->lastenemy || target->lastenemy->health <= 0 ||
-	  (demo_version < 203 ? !target->lastenemy->player :
+	  (demo_version < DV_MBF ? !target->lastenemy->player :
 	   !((target->flags ^ target->lastenemy->flags) & MF_FRIEND) &&
 	   target->target != source)) // remember last enemy - killough
 	P_SetTarget(&target->lastenemy, target->target);

--- a/src/p_map.c
+++ b/src/p_map.c
@@ -149,7 +149,7 @@ int P_GetFriction(const mobj_t *mo, int *frictionfactor)
   // friction value (muddy has precedence over icy).
 
   if (!(mo->flags & (MF_NOCLIP|MF_NOGRAVITY)) 
-      && (demo_version >= 203 || (mo->player && !compatibility)) &&
+      && (demo_version >= DV_MBF || (mo->player && !compatibility)) &&
       variable_friction)
     for (m = mo->touching_sectorlist; m; m = m->m_tnext)
       if ((sec = m->m_sector)->special & FRICTION_MASK &&
@@ -157,7 +157,7 @@ int P_GetFriction(const mobj_t *mo, int *frictionfactor)
 	  (mo->z <= sec->floorheight ||
 	   (sec->heightsec != -1 &&
 	    mo->z <= sectors[sec->heightsec].floorheight &&
-	    demo_version >= 203)))
+	    demo_version >= DV_MBF)))
 	friction = sec->friction, movefactor = sec->movefactor;
   
   if (frictionfactor)
@@ -178,7 +178,7 @@ int P_GetMoveFactor(const mobj_t *mo, int *frictionp)
 
   // Restore original Boom friction code for
   // demo compatibility
-  if (demo_version < 203)
+  if (demo_version < DV_MBF)
   {
     int momentum;
 
@@ -256,7 +256,7 @@ boolean P_TeleportMove(mobj_t *thing, fixed_t x, fixed_t y, boolean boss)
 
   // killough 8/9/98: make telefragging more consistent, preserve compatibility
   telefrag = thing->player || 
-    (comp[comp_telefrag] || demo_version < 203 ? gamemap==30 : boss);
+    (comp[comp_telefrag] || demo_version < DV_MBF ? gamemap==30 : boss);
 
   // kill anything occupying the position
 
@@ -780,7 +780,7 @@ boolean P_CheckPosition(mobj_t *thing, fixed_t x, fixed_t y)
   // Whether object can get out of a sticky situation:
   tmunstuck = thing->player &&          // only players
     thing->player->mo == thing &&       // not voodoo dolls
-    demo_version >= 203;                // not under old demos
+    demo_version >= DV_MBF;             // not under old demos
 
   // The base floor / ceiling is from the subsector
   // that contains the point.
@@ -889,7 +889,7 @@ boolean P_TryMove(mobj_t *thing, fixed_t x, fixed_t y, boolean dropoff)
 			   (tmfloorz-tmdropoffz > 128*FRACUNIT || 
 			    !thing->target || thing->target->z >tmdropoffz)))
 	    {
-	      if (!monkeys || demo_version < 203 ?
+	      if (!monkeys || demo_version < DV_MBF ?
 		  tmfloorz - tmdropoffz > 24*FRACUNIT :
 		  thing->floorz  - tmfloorz > 24*FRACUNIT ||
 		  thing->dropoffz - tmdropoffz > 24*FRACUNIT)
@@ -1151,7 +1151,7 @@ static void P_HitSlideLine(line_t *ld)
 
   // killough 10/98: only bounce if hit hard (prevents wobbling)
 
-  if (demo_version >= 203)
+  if (demo_version >= DV_MBF)
   {
   icyfloor = 
      P_AproxDistance(tmxmove, tmymove) > 4*FRACUNIT &&
@@ -1362,7 +1362,7 @@ void P_SlideMove(mobj_t *mo)
 	    if (!P_TryMove(mo, mo->x + mo->momx, mo->y, true))
 	      // [FG] Compatibility bug in P_SlideMove
 	      // http://prboom.sourceforge.net/mbf-bugs.html
-	      if (demo_version == 201)
+	      if (demo_version == DV_BOOM201)
 		mo->momx = mo->momy = 0;
 
 	  break;
@@ -2132,7 +2132,7 @@ boolean P_CheckSector(sector_t *sector,boolean crunch)
   msecnode_t *n;
 
   // killough 10/98: sometimes use Doom's method
-  if (comp[comp_floors] && (demo_version >= 203 || demo_compatibility))
+  if (comp[comp_floors] && (demo_version >= DV_MBF || demo_compatibility))
     return P_ChangeSector(sector,crunch);
 
   nofit = false;

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -205,7 +205,7 @@ void P_XYMovement (mobj_t* mo)
       // to pass through walls.
 
       if (xmove > MAXMOVE/2 || ymove > MAXMOVE/2 ||  // killough 8/9/98:
-	  ((xmove < -MAXMOVE/2 || ymove < -MAXMOVE/2) && demo_version >= 203))
+	  ((xmove < -MAXMOVE/2 || ymove < -MAXMOVE/2) && demo_version >= DV_MBF))
 	{
 	  ptryx = mo->x + xmove/2;
 	  ptryy = mo->y + ymove/2;
@@ -229,7 +229,7 @@ void P_XYMovement (mobj_t* mo)
 	  // killough 10/98:
 	  // Add ability for objects other than players to bounce on ice
 	  
-	  if (!(mo->flags & MF_MISSILE) && demo_version >= 203 &&
+	  if (!(mo->flags & MF_MISSILE) && demo_version >= DV_MBF &&
 	      (mo->flags & MF_BOUNCES || 
 	       (!player && blockline &&
 		variable_friction && mo->z <= mo->floorz &&
@@ -323,7 +323,7 @@ void P_XYMovement (mobj_t* mo)
   if (mo->momx > -STOPSPEED && mo->momx < STOPSPEED &&
       mo->momy > -STOPSPEED && mo->momy < STOPSPEED &&
       (!player || !(player->cmd.forwardmove | player->cmd.sidemove) ||
-       (player->mo != mo && demo_version >= 203 &&
+       (player->mo != mo && demo_version >= DV_MBF &&
         (comp[comp_voodooscroller] || !(mo->intflags & MIF_SCROLLING)))))
     {
       // if in a walking frame, stop moving
@@ -332,7 +332,7 @@ void P_XYMovement (mobj_t* mo)
       // Don't affect main player when voodoo dolls stop, except in old demos:
 
       if (player && (unsigned)(player->mo->state - states - S_PLAY_RUN1) < 4 
-	  && (player->mo == mo || demo_version < 203))
+	  && (player->mo == mo || demo_version < DV_MBF))
 	P_SetMobjState(player->mo, S_PLAY);
 
       mo->momx = mo->momy = 0;
@@ -357,7 +357,7 @@ void P_XYMovement (mobj_t* mo)
       // Reducing player momentum is no longer needed to reduce
       // bobbing, so ice works much better now.
 
-      if (demo_version < 203)
+      if (demo_version < DV_MBF)
       {
         // phares 9/10/98: reduce bobbing/momentum when on ice & up against wall
 
@@ -767,7 +767,7 @@ void P_MobjThinker (mobj_t* mobj)
 
 	if (mobj->z > mobj->dropoffz &&      // Only objects contacting dropoff
 	    !(mobj->flags & MF_NOGRAVITY) && // Only objects which fall
-	    !comp[comp_falloff] && demo_version >= 203) // Not in old demos
+	    !comp[comp_falloff] && demo_version >= DV_MBF) // Not in old demos
 	  P_ApplyTorque(mobj);               // Apply torque
 	else
 	  mobj->intflags &= ~MIF_FALLING, mobj->gear = 0;  // Reset torque
@@ -832,7 +832,7 @@ mobj_t *P_SpawnMobj(fixed_t x, fixed_t y, fixed_t z, mobjtype_t type)
   mobj->flags2 = info->flags2;
 
   // killough 8/23/98: no friends, bouncers, or touchy things in old demos
-  if (demo_version < 203)
+  if (demo_version < DV_MBF)
     mobj->flags &= ~(MF_BOUNCES | MF_FRIEND | MF_TOUCHY); 
   else
     if (type == MT_PLAYER)         // Except in old demos, players
@@ -952,7 +952,7 @@ void P_RemoveMobj (mobj_t *mobj)
   // if multiple thinkers reference each other indirectly before the
   // end of the current tic.
 
-  if (demo_version >= 203)
+  if (demo_version >= DV_MBF)
     {
       P_SetTarget(&mobj->target,    NULL);
       P_SetTarget(&mobj->tracer,    NULL);
@@ -1169,7 +1169,7 @@ void P_SpawnMapThing (mapthing_t* mthing)
   // then simply ignore all upper bits.
 
   if (demo_compatibility || 
-      (demo_version >= 203 && mthing->options & MTF_RESERVED))
+      (demo_version >= DV_MBF && mthing->options & MTF_RESERVED))
     mthing->options &= MTF_EASY|MTF_NORMAL|MTF_HARD|MTF_AMBUSH|MTF_NOTSINGLE;
 
   // count deathmatch start positions
@@ -1294,7 +1294,7 @@ spawnit:
 
   if (!(mobj->flags & MF_FRIEND) &&
       mthing->options & MTF_FRIEND && 
-      demo_version>=203)
+      demo_version >= DV_MBF)
     {
       mobj->flags |= MF_FRIEND;            // killough 10/98:
       P_UpdateThinker(&mobj->thinker);     // transfer friendliness flag
@@ -1432,7 +1432,7 @@ boolean P_CheckMissileSpawn (mobj_t* th)
   th->z += th->momz>>1;
 
   // killough 8/12/98: for non-missile objects (e.g. grenades)
-  if (!(th->flags & MF_MISSILE) && demo_version >= 203)
+  if (!(th->flags & MF_MISSILE) && demo_version >= DV_MBF)
     return true;
 
   // killough 3/15/98: no dropoff (really = don't care for missiles)
@@ -1506,7 +1506,7 @@ mobj_t* P_SpawnPlayerMissile(mobj_t* source,mobjtype_t type)
   if (!beta_emulation || autoaim)
     {
       // killough 8/2/98: prefer autoaiming at enemies
-      int mask = demo_version < 203 ? 0 : MF_FRIEND;
+      int mask = demo_version < DV_MBF ? 0 : MF_FRIEND;
       if (direct_vertical_aiming)
       {
         slope = source->player->slope;

--- a/src/p_plats.c
+++ b/src/p_plats.c
@@ -127,7 +127,7 @@ void T_PlatRaise(plat_t* plat)
         //killough 1/31/98: relax compatibility to demo_compatibility
 
         // remove the plat if its a pure raise type
-        if (demo_version<203 ? !demo_compatibility : !comp[comp_floors])
+        if (demo_version < DV_MBF ? !demo_compatibility : !comp[comp_floors])
         {
           switch(plat->type)
           {

--- a/src/p_pspr.c
+++ b/src/p_pspr.c
@@ -169,7 +169,7 @@ static void P_BringUpWeapon(player_t *player)
   player->pendingweapon = wp_nochange;
 
   // killough 12/98: prevent pistol from starting visibly at bottom of screen:
-  player->psprites[ps_weapon].sy = demo_version >= 203 ? 
+  player->psprites[ps_weapon].sy = demo_version >= DV_MBF ? 
     WEAPONBOTTOM+FRACUNIT*2 : WEAPONBOTTOM;
 
   P_SetPsprite(player, ps_weapon, newstate);
@@ -630,7 +630,7 @@ static void A_FireSomething(player_t* player,int adder)
 
   // killough 3/27/98: prevent recoil in no-clipping mode
   if (!(player->mo->flags & MF_NOCLIP))
-    if (weapon_recoil && (demo_version >= 203 || !compatibility))
+    if (weapon_recoil && (demo_version >= DV_MBF || !compatibility))
       P_Thrust(player, ANG180 + player->mo->angle,
                2048*recoil_values[player->readyweapon].thrust);          // phares
 }
@@ -672,7 +672,7 @@ void A_Punch(player_t *player, pspdef_t *psp)
   range = (mbf21 ? player->mo->info->meleerange : MELEERANGE);
 
   // killough 8/2/98: make autoaiming prefer enemies
-  if (demo_version<203 ||
+  if (demo_version < DV_MBF ||
       (slope = P_AimLineAttack(player->mo, angle, range, MF_FRIEND),
        !linetarget))
     slope = P_AimLineAttack(player->mo, angle, range, 0);
@@ -709,7 +709,7 @@ void A_Saw(player_t *player, pspdef_t *psp)
   range = (mbf21 ? player->mo->info->meleerange : MELEERANGE) + 1;
 
   // killough 8/2/98: make autoaiming prefer enemies
-  if (demo_version<203 ||
+  if (demo_version < DV_MBF ||
       (slope = P_AimLineAttack(player->mo, angle, range, MF_FRIEND),
        !linetarget))
     slope = P_AimLineAttack(player->mo, angle, range, 0);
@@ -871,7 +871,7 @@ static void P_BulletSlope(mobj_t *mo)
   angle_t an = mo->angle;    // see which target is to be aimed at
 
   // killough 8/2/98: make autoaiming prefer enemies
-  int mask = demo_version < 203 ? 0 : MF_FRIEND;
+  int mask = demo_version < DV_MBF ? 0 : MF_FRIEND;
 
   if (direct_vertical_aiming)
   {
@@ -1039,7 +1039,7 @@ void A_BFGSpray(mobj_t *mo)
       // mo->target is the originator (player) of the missile
 
       // killough 8/2/98: make autoaiming prefer enemies
-      if (demo_version < 203 || 
+      if (demo_version < DV_MBF || 
 	  (P_AimLineAttack(mo->target, an, 16*64*FRACUNIT, MF_FRIEND), 
 	   !linetarget))
 	P_AimLineAttack(mo->target, an, 16*64*FRACUNIT, 0);

--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -1399,7 +1399,7 @@ void P_RemoveSlimeTrails(void)                // killough 10/98
 		    v->r_y = (fixed_t)((dy2 * y0 + dx2 * y1 + dxy * (x0 - x1)) / s);
 
 		    // [FG] override actual vertex coordinates except in compatibility mode
-		    if (demo_version >= 203)
+		    if (demo_version >= DV_MBF)
 		    {
 		      v->x = v->r_x;
 		      v->y = v->r_y;

--- a/src/p_sight.c
+++ b/src/p_sight.c
@@ -260,7 +260,7 @@ static boolean P_CheckSight_MBF(mobj_t *t1, mobj_t *t2)
   // killough 11/98: shortcut for melee situations
   // [FG] Compatibility bug in P_CheckSight
   // http://prboom.sourceforge.net/mbf-bugs.html
-  if (t1->subsector == t2->subsector && demo_version >= 203)     // same subsector? obviously visible
+  if (t1->subsector == t2->subsector && demo_version >= DV_MBF)     // same subsector? obviously visible
     return true;
 
   // An unobstructed LOS is possible.

--- a/src/p_spec.c
+++ b/src/p_spec.c
@@ -898,7 +898,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
            !(player->cards[it_bluecard] | player->cards[it_blueskull]) ||
            // [FG] 3-key door works with only 2 keys
            // http://prboom.sourceforge.net/mbf-bugs.html
-           !(player->cards[it_yellowcard] | (demo_version == 203 ? !player->cards[it_yellowskull] : player->cards[it_yellowskull]))))
+           !(player->cards[it_yellowcard] | (demo_version == DV_MBF ? !player->cards[it_yellowskull] : player->cards[it_yellowskull]))))
         {
           doomprintf(player, MESSAGES_NONE, "%s", s_PD_ALL3); // Ty 03/27/98 - externalized
           S_StartSound(player->mo,sfx_oof);             // killough 3/20/98
@@ -3059,7 +3059,7 @@ static void P_SpawnFriction(void)
         else
           movefactor = ((friction - 0xDB34)*(0xA))/0x80;
 
-        if (demo_version >= 203)
+        if (demo_version >= DV_MBF)
           { // killough 8/28/98: prevent odd situations
             if (friction > FRACUNIT)
               friction = FRACUNIT;
@@ -3082,7 +3082,7 @@ static void P_SpawnFriction(void)
             // at level startup, and then uses this friction value.
 
             // Boom's friction code for demo compatibility
-            if (!demo_compatibility && demo_version < 203)
+            if (!demo_compatibility && demo_version < DV_MBF)
               Add_Friction(friction,movefactor,s);
 
             sectors[s].friction = friction;
@@ -3180,7 +3180,7 @@ pusher_t* tmpusher; // pusher structure for blockmap searches
 
 boolean PIT_PushThing(mobj_t* thing)
 {
-  if (demo_version < 203  ?     // killough 10/98: made more general
+  if (demo_version < DV_MBF  ?     // killough 10/98: made more general
       thing->player && !(thing->flags & (MF_NOCLIP | MF_NOGRAVITY)) :
       (sentient(thing) || thing->flags & MF_SHOOTABLE) &&
       !(thing->flags & MF_NOCLIP))
@@ -3202,7 +3202,7 @@ boolean PIT_PushThing(mobj_t* thing)
       // to stay close to source, grow increasingly hard as you
       // get closer, as expected. Still, it doesn't consider z :(
 
-      if (speed > 0 && demo_version >= 203)
+      if (speed > 0 && demo_version >= DV_MBF)
         {
           int x = (thing->x-sx) >> FRACBITS;
           int y = (thing->y-sy) >> FRACBITS;

--- a/src/p_user.c
+++ b/src/p_user.c
@@ -93,7 +93,7 @@ void P_Thrust(player_t* player,angle_t angle,fixed_t move)
 
 void P_Bob(player_t *player, angle_t angle, fixed_t move)
 {
-  if (demo_version < 203)
+  if (demo_version < DV_MBF)
     return;
 
   player->momx += FixedMul(move,finecosine[angle >>= ANGLETOFINESHIFT]);
@@ -125,14 +125,14 @@ void P_CalcHeight (player_t* player)
 
   // [FG] MBF player bobbing rewrite causes demo sync problems
   // http://prboom.sourceforge.net/mbf-bugs.html
-  player->bob = (demo_version >= 203 && player_bobbing) ?
+  player->bob = (demo_version >= DV_MBF && player_bobbing) ?
       (FixedMul(player->momx,player->momx)
       + FixedMul(player->momy,player->momy))>>2 :
       (demo_compatibility || player_bobbing) ?
       (FixedMul (player->mo->momx, player->mo->momx)
       + FixedMul (player->mo->momy,player->mo->momy))>>2 : 0;
 
-  if ((demo_version == 202 || demo_version == 203) &&
+  if ((demo_version == DV_BOOM || demo_version == DV_MBF) &&
       player->mo->friction > ORIG_FRICTION) // ice?
   {
     if (player->bob > (MAXBOB>>2))
@@ -227,7 +227,7 @@ void P_MovePlayer (player_t* player)
   // ice, because the player still "works just as hard" to move, while the
   // thrust applied to the movement varies with 'movefactor'.
 
-  if ((!demo_compatibility && demo_version < 203) ||
+  if ((!demo_compatibility && demo_version < DV_MBF) ||
       cmd->forwardmove | cmd->sidemove) // killough 10/98
     {
       if (onground || mo->flags & MF_BOUNCES) // killough 8/9/98

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -720,7 +720,7 @@ void R_AddSprites(sector_t* sec, int lightlevel)
   // Well, now it will be done.
   sec->validcount = validcount;
 
-  if (demo_version <= 202)
+  if (demo_version <= DV_BOOM)
     lightlevel = sec->lightlevel;
 
   lightnum = (lightlevel >> LIGHTSEGSHIFT)+extralight;

--- a/src/wi_stuff.c
+++ b/src/wi_stuff.c
@@ -1733,7 +1733,7 @@ static void WI_updateStats(void)
           // killough 2/22/98: Make secrets = 100% if maxsecret = 0:
           // [FG] Intermission screen secrets desync
           // http://prboom.sourceforge.net/mbf-bugs.html
-          if ((!wbs->maxsecret && demo_version < 203) ||
+          if ((!wbs->maxsecret && demo_version < DV_MBF) ||
               cnt_secret[0] >= (wbs->maxsecret ? 
                                 (plrs[me].ssecret * 100) / wbs->maxsecret : 100))
             {
@@ -1767,10 +1767,10 @@ static void WI_updateStats(void)
 
                 // This check affects demo compatibility with PrBoom+
                 if ((cnt_time >= plrs[me].stime / TICRATE) &&
-                    (demo_version < 203 || cnt_total_time >= wbs->totaltimes / TICRATE)
+                    (demo_version < DV_MBF || cnt_total_time >= wbs->totaltimes / TICRATE)
                    )
                   {
-                    if (demo_version < 203)
+                    if (demo_version < DV_MBF)
                       cnt_total_time = wbs->totaltimes / TICRATE;
                     S_StartSound(0, sfx_barexp);
                     sp_state++;


### PR DESCRIPTION
* Only disable "Improved Hit Detection" if "Emulate INTERCEPTS overflow" enabled

Fix [[doomworld]](https://www.doomworld.com/forum/topic/112333-this-is-woof-1430-mar-15-2024/?do=findComment&comment=2779896)