### PR TITLE
xmp: context is created at open, deleted at close

### DIFF
--- a/src/i_xmp.c
+++ b/src/i_xmp.c
@@ -60,22 +60,17 @@ static void PrintError(int e)
 
 static boolean I_XMP_InitStream(int device)
 {
-    context = xmp_create_context();
-
-    if (!context)
-    {
-        I_Printf(VB_ERROR, "XMP: Failed to create context.");
-        return false;
-    }
-
     return true;
 }
 
 static boolean I_XMP_OpenStream(void *data, ALsizei size, ALenum *format,
                                 ALsizei *freq, ALsizei *frame_size)
 {
+    context = xmp_create_context();
+
     if (!context)
     {
+        I_Printf(VB_ERROR, "XMP: Failed to create context.");
         return false;
     }
 
@@ -86,6 +81,7 @@ static boolean I_XMP_OpenStream(void *data, ALsizei size, ALenum *format,
     {
         PrintError(err);
         xmp_free_context(context);
+        context = NULL;
         return false;
     }
 
@@ -130,17 +126,12 @@ static void I_XMP_CloseStream(void)
     xmp_stop_module(context);
     xmp_end_player(context);
     xmp_release_module(context);
+    xmp_free_context(context);
+    context = NULL;
 }
 
 static void I_XMP_ShutdownStream(void)
 {
-    if (!context)
-    {
-        return;
-    }
-
-    xmp_free_context(context);
-    context = NULL;
 }
 
 static const char **I_XMP_DeviceList(int *current_device)


### PR DESCRIPTION
This fixes a bug where XMP crashes at the first invocation after attempting to load an incompatible music format. In addition, this ensures that the subsystem remains functional for subsequent usage after a failed load attempt.

I found this issue when attempting to load mp3 music lumps. My libsoundfile is an older version that lacks mp3 support. After libsoundfile fails to load the lump, Woof attempts to load the lump with libxmp and it too fails. After this, the next time the XMP module is invoked there's a segfault due to a use-after-free condition with the XMP `context` pointer. 