### PR TITLE
Fix skies being shifted down a few pixels compared to Woof 12.0.2

### DIFF
--- a/src/r_main.c
+++ b/src/r_main.c
@@ -274,7 +274,7 @@ static fixed_t centerxfrac_nonwide;
 static void R_InitTextureMapping(void)
 {
   register int i,x;
-  fixed_t slopefrac;
+  fixed_t slopefrac, limit;
   angle_t fov;
   double linearskyfactor;
 
@@ -285,13 +285,20 @@ static void R_InitTextureMapping(void)
   // Calc focallength
   //  so FIELDOFVIEW angles covers SCREENWIDTH.
 
-  if (custom_fov == FOV_DEFAULT && centerxfrac == centerxfrac_nonwide)
+  if (custom_fov == FOV_DEFAULT)
   {
     fov = FIELDOFVIEW;
     slopefrac = finetangent[FINEANGLES / 4 + fov / 2];
     focallength = FixedDiv(centerxfrac_nonwide, slopefrac);
     lightfocallength = centerxfrac_nonwide;
     projection = centerxfrac_nonwide;
+    limit = FRACUNIT * 2;
+
+    if (centerxfrac != centerxfrac_nonwide)
+    {
+      fov = atan((double)centerxfrac / centerxfrac_nonwide) * FINEANGLES / M_PI;
+      slopefrac = finetangent[FINEANGLES / 4 + fov / 2];
+    }
   }
   else
   {
@@ -307,15 +314,16 @@ static void R_InitTextureMapping(void)
     slopefrac = finetangent[FINEANGLES / 4 + fov / 2];
     focallength = FixedDiv(centerxfrac, slopefrac);
     projection = centerxfrac / slope;
+    limit = slopefrac;
   }
 
   for (i=0 ; i<FINEANGLES/2 ; i++)
     {
       int t;
-      if (finetangent[i] > slopefrac)
+      if (finetangent[i] > limit)
         t = -1;
       else
-        if (finetangent[i] < -slopefrac)
+        if (finetangent[i] < -limit)
           t = viewwidth+1;
       else
         {

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -293,7 +293,6 @@ static void R_InitTextureMapping(void)
     lightfocallength = centerxfrac_nonwide;
     projection = centerxfrac_nonwide;
     limit = FRACUNIT * 2;
-    skyiscale = FixedDiv(SCREENWIDTH, viewwidth_nonwide);
 
     if (centerxfrac != centerxfrac_nonwide)
     {
@@ -316,7 +315,6 @@ static void R_InitTextureMapping(void)
     focallength = FixedDiv(centerxfrac, slopefrac);
     projection = centerxfrac / slope;
     limit = slopefrac;
-    skyiscale = (slope * 160.0 / FIXED2DOUBLE(centerxfrac)) * FRACUNIT;
   }
 
   for (i=0 ; i<FINEANGLES/2 ; i++)
@@ -617,6 +615,8 @@ void R_ExecuteSetViewSize (void)
   //      fix garbage lines at the top of weapon sprites
   while (FixedMul(pspriteiscale, pspritescale) < FRACUNIT)
     pspriteiscale++;
+
+  skyiscale = FixedDiv(160 << FRACBITS, focallength);
 
   for (i=0 ; i<viewwidth ; i++)
     {

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -274,7 +274,7 @@ static fixed_t centerxfrac_nonwide;
 static void R_InitTextureMapping(void)
 {
   register int i,x;
-  fixed_t slopefrac, limit;
+  fixed_t slopefrac;
   angle_t fov;
   double linearskyfactor;
 
@@ -285,20 +285,13 @@ static void R_InitTextureMapping(void)
   // Calc focallength
   //  so FIELDOFVIEW angles covers SCREENWIDTH.
 
-  if (custom_fov == FOV_DEFAULT)
+  if (custom_fov == FOV_DEFAULT && centerxfrac == centerxfrac_nonwide)
   {
     fov = FIELDOFVIEW;
     slopefrac = finetangent[FINEANGLES / 4 + fov / 2];
     focallength = FixedDiv(centerxfrac_nonwide, slopefrac);
     lightfocallength = centerxfrac_nonwide;
     projection = centerxfrac_nonwide;
-    limit = FRACUNIT * 2;
-
-    if (centerxfrac != centerxfrac_nonwide)
-    {
-      fov = atan((double)centerxfrac / centerxfrac_nonwide) * FINEANGLES / M_PI;
-      slopefrac = finetangent[FINEANGLES / 4 + fov / 2];
-    }
   }
   else
   {
@@ -314,16 +307,15 @@ static void R_InitTextureMapping(void)
     slopefrac = finetangent[FINEANGLES / 4 + fov / 2];
     focallength = FixedDiv(centerxfrac, slopefrac);
     projection = centerxfrac / slope;
-    limit = slopefrac;
   }
 
   for (i=0 ; i<FINEANGLES/2 ; i++)
     {
       int t;
-      if (finetangent[i] > limit)
+      if (finetangent[i] > slopefrac)
         t = -1;
       else
-        if (finetangent[i] < -limit)
+        if (finetangent[i] < -slopefrac)
           t = viewwidth+1;
       else
         {

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -293,6 +293,7 @@ static void R_InitTextureMapping(void)
     lightfocallength = centerxfrac_nonwide;
     projection = centerxfrac_nonwide;
     limit = FRACUNIT * 2;
+    skyiscale = FixedDiv(SCREENWIDTH, viewwidth_nonwide);
 
     if (centerxfrac != centerxfrac_nonwide)
     {
@@ -315,6 +316,7 @@ static void R_InitTextureMapping(void)
     focallength = FixedDiv(centerxfrac, slopefrac);
     projection = centerxfrac / slope;
     limit = slopefrac;
+    skyiscale = (slope * 160.0 / FIXED2DOUBLE(centerxfrac)) * FRACUNIT;
   }
 
   for (i=0 ; i<FINEANGLES/2 ; i++)
@@ -615,8 +617,6 @@ void R_ExecuteSetViewSize (void)
   //      fix garbage lines at the top of weapon sprites
   while (FixedMul(pspriteiscale, pspritescale) < FRACUNIT)
     pspriteiscale++;
-
-  skyiscale = FixedDiv(160 << FRACBITS, focallength);
 
   for (i=0 ; i<viewwidth ; i++)
     {

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -608,7 +608,14 @@ void R_ExecuteSetViewSize (void)
   while (FixedMul(pspriteiscale, pspritescale) < FRACUNIT)
     pspriteiscale++;
 
-  skyiscale = FixedDiv(160 << FRACBITS, focallength);
+  if (custom_fov == FOV_DEFAULT)
+  {
+    skyiscale = FixedDiv(SCREENWIDTH, viewwidth_nonwide);
+  }
+  else
+  {
+    skyiscale = tan(custom_fov * M_PI / 360.0) * SCREENWIDTH / viewwidth_nonwide * FRACUNIT;
+  }
 
   for (i=0 ; i<viewwidth ; i++)
     {


### PR DESCRIPTION
Edit: See comment further down.

<details><summary>old information</summary>

1. Partially fixes walls being drawn slightly differently: https://github.com/fabiangreffrath/woof/pull/1605#issuecomment-2006087424
2. Fixes skies being shifted down a few pixels.

For (1), there are still occasional wall columns that vary slightly. I don't know the cause but it doesn't seem critical at the moment. Here's a zip file with screenshots and a save: [woofsav3_shots.zip](https://github.com/fabiangreffrath/woof/files/14662641/woofsav3_shots.zip). Look at the wall in the middle left.

For this PR, I ran a modified version of the HOM test (https://github.com/fabiangreffrath/woof/pull/1525#issuecomment-1958035286) with the entire range of FOVs and it was fine: [hom_with_fov.patch](https://github.com/fabiangreffrath/woof/files/14662642/hom_with_fov.patch).

</details>
