### PR TITLE
Add config key to toggle sound limiter

### DIFF
--- a/src/i_oalsound.c
+++ b/src/i_oalsound.c
@@ -403,7 +403,6 @@ static void PrintDeviceInfo(ALCdevice *device)
 static void GetAttribs(ALCint **attribs)
 {
     const boolean use_3d = (snd_module == SND_MODULE_3D);
-    int i = 0;
 
     if (alcIsExtensionPresent(oal->device, "ALC_SOFT_HRTF") == ALC_TRUE)
     {

--- a/src/i_oalsound.c
+++ b/src/i_oalsound.c
@@ -40,7 +40,7 @@
 #define OAL_MAP_UNITS_PER_METER (128.0f / 3.0f)
 #define OAL_SOURCE_RADIUS       32.0f
 #define OAL_DEFAULT_PITCH       1.0f
-#define OAL_NUM_ATTRIBS         5
+#define OAL_NUM_ATTRIBS         7
 
 #define DMXHDRSIZE              8
 #define DMXPADSIZE              16
@@ -58,6 +58,7 @@
 #endif
 
 int snd_resampler;
+boolean snd_limiter;
 boolean snd_hrtf;
 int snd_absorption;
 int snd_doppler;
@@ -420,6 +421,13 @@ static void GetAttribs(ALCint *attribs)
                               : ALC_STEREO_BASIC_SOFT;
     }
 #endif
+
+    if (alcIsExtensionPresent(oal->device, "ALC_SOFT_output_limiter")
+        == ALC_TRUE)
+    {
+        attribs[i++] = ALC_OUTPUT_LIMITER_SOFT;
+        attribs[i++] = snd_limiter ? ALC_TRUE : ALC_FALSE;
+    }
 }
 
 boolean I_OAL_InitSound(void)

--- a/src/i_oalsound.c
+++ b/src/i_oalsound.c
@@ -29,6 +29,7 @@
 #include "i_printf.h"
 #include "i_sndfile.h"
 #include "i_sound.h"
+#include "m_array.h"
 #include "m_fixed.h"
 #include "sounds.h"
 #include "w_wad.h"
@@ -40,7 +41,6 @@
 #define OAL_MAP_UNITS_PER_METER (128.0f / 3.0f)
 #define OAL_SOURCE_RADIUS       32.0f
 #define OAL_DEFAULT_PITCH       1.0f
-#define OAL_NUM_ATTRIBS         7
 
 #define DMXHDRSIZE              8
 #define DMXPADSIZE              16
@@ -400,39 +400,41 @@ static void PrintDeviceInfo(ALCdevice *device)
     I_Printf(VB_INFO, " Using '%s' @ %d Hz.", name, srate);
 }
 
-static void GetAttribs(ALCint *attribs)
+static void GetAttribs(ALCint **attribs)
 {
     const boolean use_3d = (snd_module == SND_MODULE_3D);
     int i = 0;
 
-    memset(attribs, 0, sizeof(*attribs) * OAL_NUM_ATTRIBS);
-
     if (alcIsExtensionPresent(oal->device, "ALC_SOFT_HRTF") == ALC_TRUE)
     {
-        attribs[i++] = ALC_HRTF_SOFT;
-        attribs[i++] = use_3d ? (snd_hrtf ? ALC_TRUE : ALC_FALSE) : ALC_FALSE;
+        array_push(*attribs, ALC_HRTF_SOFT);
+        array_push(*attribs, (use_3d && snd_hrtf) ? ALC_TRUE : ALC_FALSE);
     }
 
 #ifdef ALC_OUTPUT_MODE_SOFT
     if (alcIsExtensionPresent(oal->device, "ALC_SOFT_output_mode") == ALC_TRUE)
     {
-        attribs[i++] = ALC_OUTPUT_MODE_SOFT;
-        attribs[i++] = use_3d ? (snd_hrtf ? ALC_STEREO_HRTF_SOFT : ALC_ANY_SOFT)
-                              : ALC_STEREO_BASIC_SOFT;
+        array_push(*attribs, ALC_OUTPUT_MODE_SOFT);
+        array_push(*attribs,
+                   use_3d ? (snd_hrtf ? ALC_STEREO_HRTF_SOFT : ALC_ANY_SOFT)
+                          : ALC_STEREO_BASIC_SOFT);
     }
 #endif
 
     if (alcIsExtensionPresent(oal->device, "ALC_SOFT_output_limiter")
         == ALC_TRUE)
     {
-        attribs[i++] = ALC_OUTPUT_LIMITER_SOFT;
-        attribs[i++] = snd_limiter ? ALC_TRUE : ALC_FALSE;
+        array_push(*attribs, ALC_OUTPUT_LIMITER_SOFT);
+        array_push(*attribs, snd_limiter ? ALC_TRUE : ALC_FALSE);
     }
+
+    // Attribute list must be zero terminated.
+    array_push(*attribs, 0);
 }
 
 boolean I_OAL_InitSound(void)
 {
-    ALCint attribs[OAL_NUM_ATTRIBS];
+    ALCint *attribs = NULL;
 
     if (oal)
     {
@@ -449,8 +451,9 @@ boolean I_OAL_InitSound(void)
         return false;
     }
 
-    GetAttribs(attribs);
+    GetAttribs(&attribs);
     oal->context = alcCreateContext(oal->device, attribs);
+    array_free(attribs);
     if (!oal->context || !alcMakeContextCurrent(oal->context))
     {
         I_Printf(VB_ERROR, "I_OAL_InitSound: Error creating context.");
@@ -484,7 +487,8 @@ boolean I_OAL_InitSound(void)
 boolean I_OAL_ReinitSound(void)
 {
     LPALCRESETDEVICESOFT alcResetDeviceSOFT = NULL;
-    ALCint attribs[OAL_NUM_ATTRIBS];
+    ALCint *attribs = NULL;
+    ALCboolean result;
 
     if (!oal)
     {
@@ -507,9 +511,10 @@ boolean I_OAL_ReinitSound(void)
         return false;
     }
 
-    GetAttribs(attribs);
-
-    if (alcResetDeviceSOFT(oal->device, attribs) != ALC_TRUE)
+    GetAttribs(&attribs);
+    result = alcResetDeviceSOFT(oal->device, attribs);
+    array_free(attribs);
+    if (result != ALC_TRUE)
     {
         I_Printf(VB_ERROR, "I_OAL_ReinitSound: Error resetting device.");
         I_OAL_ShutdownSound();

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -74,6 +74,7 @@ void I_ShutdownSound(void);
 
 extern int forceFlipPan;
 extern int snd_resampler;
+extern boolean snd_limiter;
 extern int snd_module;
 extern boolean snd_hrtf;
 extern int snd_absorption;

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -424,6 +424,13 @@ default_t defaults[] = {
   },
 
   {
+    "snd_limiter",
+    (config_t *) &snd_limiter, NULL,
+    {0}, {0, 1}, number, ss_none, wad_no,
+    "1 to enable sound output limiter"
+  },
+
+  {
     "snd_module",
     (config_t *) &snd_module, NULL,
     {SND_MODULE_MBF}, {0, NUM_SND_MODULES - 1}, number, ss_gen, wad_no,


### PR DESCRIPTION
Requested by Shepardus on the speedrunner discord. Windows already has a built-in limiter via WASAPI, which is what OpenAL Soft uses for output by default. So this seems to only benefit odd configurations in Windows or Linux. No idea about macOS. I need to test this on a few configurations first.