### PR TITLE
Initialize video before gamepad

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -2713,7 +2713,6 @@ void D_DoomMain(void)
 
   I_Printf(VB_INFO, "I_Init: Setting up machine state.");
   I_InitTimer();
-  I_InitController();
   I_InitSound();
   I_InitMusic();
 
@@ -2895,6 +2894,7 @@ void D_DoomMain(void)
 
   // [FG] init graphics (video.widedelta) before HUD widgets
   I_InitGraphics();
+  I_InitController();
 
   MN_InitMenuStrings();
 


### PR DESCRIPTION
Related [Doomworld issue](https://www.doomworld.com/forum/post/2783201). This bug has been around for at least two years I think? Not many people using controllers in multiplayer I guess.