### PR TITLE
don't discard events in TXT_GetChar

### DIFF
--- a/textscreen/txt_sdl.c
+++ b/textscreen/txt_sdl.c
@@ -586,8 +586,12 @@ signed int TXT_GetChar(void)
                     return 0;
                 }
 
-            default:
+            case SDL_CONTROLLERDEVICEADDED:
+            case SDL_CONTROLLERDEVICEREMOVED:
                 SDL_PushEvent(&ev);
+                break;
+
+            default:
                 break;
         }
     }

--- a/textscreen/txt_sdl.c
+++ b/textscreen/txt_sdl.c
@@ -587,6 +587,7 @@ signed int TXT_GetChar(void)
                 }
 
             default:
+                SDL_PushEvent(&ev);
                 break;
         }
     }


### PR DESCRIPTION
Alternative to #1620 

The problem is the separate SDL initialisation in the textscreen library. I'm not sure which solution is better.