### PR TITLE
Fix some weapon-switching issues

### DIFF
--- a/src/p_pspr.c
+++ b/src/p_pspr.c
@@ -80,8 +80,6 @@ void A_Recoil(player_t* player)
 
 static void P_SetPsprite(player_t *player, int position, statenum_t stnum)
 {
-  P_SetPspritePtr(player, &player->psprites[position], stnum);
-
   if (position == ps_weapon)
   {
     const weaponinfo_t wp = weaponinfo[player->readyweapon];
@@ -91,6 +89,8 @@ static void P_SetPsprite(player_t *player, int position, statenum_t stnum)
     else if (stnum == wp.downstate)
       player->switching = weapswitch_lowering;
   }
+
+  P_SetPspritePtr(player, &player->psprites[position], stnum);
 }
 
 //


### PR DESCRIPTION
The first bug in question has to do with the _Weapon Alignment_ setting not taking effect when firing a weapon right after raising it (i.e. holding down Fire while switching weapons). I'll try to explain why it happens:

```c
// Assume that we're currently in the raising animation

P_MovePsprites(player);
{
  P_SetPsprite(player, i, psp->state->nextstate);
  {
    P_SetPspritePtr(player, &player->psprites[position], stnum);
    {
      // stnum is the raising state, which calls A_Raise()
      A_Raise(player, psp);
      {
        // The weapon has been raised all the way,
        //  so change to the ready state.

        newstate = weaponinfo[player->readyweapon].readystate;

        P_SetPsprite(player, ps_weapon, newstate);
        {
          P_SetPspritePtr(player, &player->psprites[position], stnum);
          {
            // stnum is the ready state, which calls A_WeaponReady()
            A_WeaponReady(player, psp);
            {
              player->switching = weapswitch_none; // Notice that this is set here
            }
          }
        }
      }
    }

    if (stnum == wp.upstate) // Condition met
      // The line below is executed *after* the A_WeaponReady() call,
      // so it overrides its change to player->switching
      player->switching = weapswitch_raising;
  }
}
```

I hope that's understandable. Anyways, the obvious solution IMO is to set `switching` in `P_SetPsprite()` _before_ the actual state change, so any potential modifications to `switching` during said state change are maintained properly. Admittedly, though, I'm not sure if this could be introducing some new issues of its own.

The fix for that issue also seems to fix the other bug, whereby `switching` is set in `P_SetPsprite()` without accounting for the possibility of `upstate == readystate` (that might sound weird, but I just so happened to do that in a mod of mine to achieve instantaneous weapon raising, which works in MBF), causing _Weapon Alignment_ and _Weapon Bob_ to not take effect at all. Although it seems to be fixed by this PR, it could probably use some revisiting in the future.