### PR TITLE
Don't use predefined resampler names

### DIFF
--- a/src/i_oalsound.c
+++ b/src/i_oalsound.c
@@ -235,7 +235,13 @@ static void SetResampler(ALuint *sources)
     }
     if (i == num_resamplers)
     {
-        I_Printf(VB_WARNING, " Failed to find resampler: '%s'.", snd_resampler);
+        I_Printf(VB_WARNING, " Failed to find resampler: '%s'. Valid choices:",
+                 snd_resampler);
+        for (i = 0; i < num_resamplers; i++)
+        {
+            I_Printf(VB_WARNING, "  %s",
+                     alGetStringiSOFT(AL_RESAMPLER_NAME_SOFT, i));
+        }
         return;
     }
 

--- a/src/i_oalsound.c
+++ b/src/i_oalsound.c
@@ -57,15 +57,13 @@
 #  define FUNCTION_CAST(T, ptr) (T)(ptr)
 #endif
 
-int snd_resampler;
+char *snd_resampler;
 boolean snd_limiter;
 boolean snd_hrtf;
 int snd_absorption;
 int snd_doppler;
 
 boolean oal_use_doppler;
-
-static const char *oal_resamplers[] = {"Nearest", "Linear", "Cubic"};
 
 typedef struct oal_system_s
 {
@@ -199,7 +197,6 @@ void I_OAL_ShutdownSound(void)
 
 static void SetResampler(ALuint *sources)
 {
-    const char *resampler_name = oal_resamplers[snd_resampler];
     LPALGETSTRINGISOFT alGetStringiSOFT = NULL;
     ALint i, num_resamplers, def_resampler;
 
@@ -229,7 +226,7 @@ static void SetResampler(ALuint *sources)
 
     for (i = 0; i < num_resamplers; i++)
     {
-        if (!strcasecmp(resampler_name,
+        if (!strcasecmp(snd_resampler,
                         alGetStringiSOFT(AL_RESAMPLER_NAME_SOFT, i)))
         {
             def_resampler = i;
@@ -238,8 +235,7 @@ static void SetResampler(ALuint *sources)
     }
     if (i == num_resamplers)
     {
-        I_Printf(VB_WARNING, " Failed to find resampler: '%s'.",
-                 resampler_name);
+        I_Printf(VB_WARNING, " Failed to find resampler: '%s'.", snd_resampler);
         return;
     }
 

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -73,7 +73,7 @@ void I_ShutdownSound(void);
 //
 
 extern int forceFlipPan;
-extern int snd_resampler;
+extern char *snd_resampler;
 extern boolean snd_limiter;
 extern int snd_module;
 extern boolean snd_hrtf;

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -419,8 +419,8 @@ default_t defaults[] = {
   {
     "snd_resampler",
     (config_t *) &snd_resampler, NULL,
-    {1}, {0, 2}, number, ss_gen, wad_no,
-    "OpenAL resampler (0 = Nearest, 1 = Linear, 2 = Cubic)"
+    {.s = "Linear"}, {0}, string, ss_none, wad_no,
+    "Sound resampler"
   },
 
   {


### PR DESCRIPTION
The resampler names defined by OpenAL Soft will change in a future release, breaking our current configuration.

References:
- https://github.com/kcat/openal-soft/commit/3ad68aa979de387fa05efad0a081a064c382580b
- https://github.com/kcat/openal-soft/commit/fdd16434c663b68fbddd6fe2c97a9e0c66b1f15e
- https://openal-soft.org/openal-extensions/SOFT_source_resampler.txt