### PR TITLE
remove "garbage pixels" fix to avoid crashes on some resolutions

### DIFF
--- a/src/r_main.c
+++ b/src/r_main.c
@@ -602,12 +602,6 @@ void R_ExecuteSetViewSize (void)
   pspritescale = FixedDiv(viewwidth_nonwide, SCREENWIDTH);       // killough 11/98
   pspriteiscale = FixedDiv(SCREENWIDTH, viewwidth_nonwide);      // killough 11/98
 
-  // [FG] make sure that the product of the weapon sprite scale factor
-  //      and its reciprocal is always at least FRACUNIT to
-  //      fix garbage lines at the top of weapon sprites
-  while (FixedMul(pspriteiscale, pspritescale) < FRACUNIT)
-    pspriteiscale++;
-
   if (custom_fov == FOV_DEFAULT)
   {
     skyiscale = FixedDiv(SCREENWIDTH, viewwidth_nonwide);

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -602,6 +602,12 @@ void R_ExecuteSetViewSize (void)
   pspritescale = FixedDiv(viewwidth_nonwide, SCREENWIDTH);       // killough 11/98
   pspriteiscale = FixedDiv(SCREENWIDTH, viewwidth_nonwide);      // killough 11/98
 
+  // [FG] make sure that the product of the weapon sprite scale factor
+  //      and its reciprocal is always at least FRACUNIT to
+  //      fix garbage lines at the top of weapon sprites
+  while (FixedMul(pspriteiscale, pspritescale) < FRACUNIT)
+    pspriteiscale++;
+
   if (custom_fov == FOV_DEFAULT)
   {
     skyiscale = FixedDiv(SCREENWIDTH, viewwidth_nonwide);

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -465,10 +465,10 @@ void R_DrawVisSprite(vissprite_t *vis, int x1, int x2)
     {
       texturecolumn = frac>>FRACBITS;
 
-#ifdef RANGECHECK
-      if (texturecolumn < 0 || texturecolumn >= SHORT(patch->width))
-        I_Error ("R_DrawSpriteRange: bad texturecolumn");
-#endif
+      if (texturecolumn < 0)
+        continue;
+      else if (texturecolumn >= SHORT(patch->width))
+        break;
 
       column = (column_t *)((byte *) patch +
                             LONG(patch->columnofs[texturecolumn]));


### PR DESCRIPTION
I recorded a demo with an "R_DrawSpriteRange: bad texturecolumn" crash with Pirate Doom II (reported here: [[doomworld]](https://www.doomworld.com/forum/topic/112333-this-is-woof-1430-mar-15-2024/?do=findComment&comment=2791283)) [dem2.zip](https://github.com/fabiangreffrath/woof/files/15046479/dem2.zip)
How to reproduce - set native resolution to 1366x768, turn off dynamic resolution. Interesting that demo crashes in different places depending on build type (debug ASan, release with debug info).