### PR TITLE
ability to set max resolution in config, option to change display resolution

### DIFF
--- a/src/i_video.h
+++ b/src/i_video.h
@@ -71,9 +71,10 @@ extern boolean drs_skip_frame;
 extern boolean use_vsync; // killough 2/8/98: controls whether vsync is called
 extern boolean disk_icon; // killough 10/98
 
+extern int max_video_width, max_video_height;
 extern int current_video_height, default_current_video_height;
 
-#  define DRS_MIN_HEIGHT 400
+#define DRS_MIN_HEIGHT 400
 extern boolean dynamic_resolution;
 
 extern boolean use_aspect;
@@ -82,6 +83,7 @@ extern boolean uncapped,
 
 extern boolean fullscreen;
 extern boolean exclusive_fullscreen;
+extern boolean change_display_resolution;
 extern int fpslimit; // when uncapped, limit framerate to this value
 extern int fps;
 extern boolean vga_porch_flash; // emulate VGA "porch" behaviour

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -215,6 +215,27 @@ default_t defaults[] = {
     "current video display index"
   },
 
+  {
+    "max_video_width",
+    (config_t *) &max_video_width, NULL,
+    {0}, {SCREENWIDTH, UL}, number, ss_none, wad_no,
+    "maximum horizontal resolution (native by default)"
+  },
+
+  {
+    "max_video_height",
+    (config_t *) &max_video_height, NULL,
+    {0}, {SCREENHEIGHT, UL}, number, ss_none, wad_no,
+    "maximum vertical resolution (native by default)"
+  },
+
+  {
+    "change_display_resolution",
+    (config_t *) &change_display_resolution, NULL,
+    {0}, {0, 1}, number, ss_none, wad_no,
+    "1 to change display resolution with exclusive fullscreen (make sense only with CRT)"
+  },
+
   // window position
   {
     "window_position_x",


### PR DESCRIPTION
Feature request: [[doomworld]](https://www.doomworld.com/forum/topic/112333-this-is-woof-1430-mar-15-2024/?do=findComment&comment=2791884)

To change the display resolution, the user needs to set max video height/width, enable the option in config and set exclusive fullscreen. I deliberately made it complicated, but maybe it's too much.