### PR TITLE
automap: draw 1S lines last

### DIFF
--- a/src/am_map.c
+++ b/src/am_map.c
@@ -1697,8 +1697,8 @@ static void AM_drawWalls(void)
             )
           )
         {
-          am_line_t al = {l, mapcolor_secr}; // line bounding secret sector
-          array_push(lines_1S, al);
+          // line bounding secret sector
+          array_push(lines_1S, ((am_line_t){l, mapcolor_secr}));
         }
         else if (mapcolor_revsecr &&
             (
@@ -1707,13 +1707,13 @@ static void AM_drawWalls(void)
             )
           )
         {
-          am_line_t al = {l, mapcolor_revsecr}; // line bounding revealed secret sector
-          array_push(lines_1S, al);
+          // line bounding revealed secret sector
+          array_push(lines_1S, ((am_line_t){l, mapcolor_revsecr}));
         }
         else                               //jff 2/16/98 fixed bug
         {
-          am_line_t al = {l, mapcolor_wall}; // special was cleared
-          array_push(lines_1S, al);
+          // special was cleared
+          array_push(lines_1S, ((am_line_t){l, mapcolor_wall}));
         }
       }
       else

--- a/src/am_map.c
+++ b/src/am_map.c
@@ -1597,6 +1597,9 @@ static int AM_DoorColor(int type)
 // jff 4/3/98 changed mapcolor_xxxx=-1 to disable drawing line completely
 //
 
+#define M_ARRAY_INIT_CAPACITY 500
+#include "m_array.h"
+
 typedef struct
 {
   mline_t l;
@@ -1604,8 +1607,6 @@ typedef struct
 } am_line_t;
 
 static am_line_t *lines_1S = NULL;
-
-#include "m_array.h"
 
 static void AM_drawWalls(void)
 {
@@ -1688,7 +1689,6 @@ static void AM_drawWalls(void)
 
       if (!lines[i].backsector)
       {
-        am_line_t al;
         // jff 1/10/98 add new color for 1S secret sector boundary
         if (mapcolor_secr && //jff 4/3/98 0 is disable
             (
@@ -1697,10 +1697,8 @@ static void AM_drawWalls(void)
             )
           )
         {
-          al.l = l;
-          al.color = mapcolor_secr;
+          am_line_t al = {l, mapcolor_secr}; // line bounding secret sector
           array_push(lines_1S, al);
-          //AM_drawMline(&l, mapcolor_secr); // line bounding secret sector
         }
         else if (mapcolor_revsecr &&
             (
@@ -1709,17 +1707,13 @@ static void AM_drawWalls(void)
             )
           )
         {
-          al.l = l;
-          al.color = mapcolor_revsecr;
+          am_line_t al = {l, mapcolor_revsecr}; // line bounding revealed secret sector
           array_push(lines_1S, al);
-          //AM_drawMline(&l, mapcolor_revsecr); // line bounding revealed secret sector
         }
         else                               //jff 2/16/98 fixed bug
         {
-          al.l = l;
-          al.color = mapcolor_wall;
+          am_line_t al = {l, mapcolor_wall}; // special was cleared
           array_push(lines_1S, al);
-          //AM_drawMline(&l, mapcolor_wall); // special was cleared
         }
       }
       else

--- a/src/am_map.c
+++ b/src/am_map.c
@@ -1596,6 +1596,17 @@ static int AM_DoorColor(int type)
 // jff 4/3/98 changed mapcolor_xxxx=0 as control to disable feature
 // jff 4/3/98 changed mapcolor_xxxx=-1 to disable drawing line completely
 //
+
+typedef struct
+{
+  mline_t l;
+  int color;
+} am_line_t;
+
+static am_line_t *lines_1S = NULL;
+
+#include "m_array.h"
+
 static void AM_drawWalls(void)
 {
   int i;
@@ -1677,6 +1688,7 @@ static void AM_drawWalls(void)
 
       if (!lines[i].backsector)
       {
+        am_line_t al;
         // jff 1/10/98 add new color for 1S secret sector boundary
         if (mapcolor_secr && //jff 4/3/98 0 is disable
             (
@@ -1684,16 +1696,31 @@ static void AM_drawWalls(void)
              P_IsSecret(lines[i].frontsector)
             )
           )
-          AM_drawMline(&l, mapcolor_secr); // line bounding secret sector
+        {
+          al.l = l;
+          al.color = mapcolor_secr;
+          array_push(lines_1S, al);
+          //AM_drawMline(&l, mapcolor_secr); // line bounding secret sector
+        }
         else if (mapcolor_revsecr &&
             (
              P_WasSecret(lines[i].frontsector) &&
              !P_IsSecret(lines[i].frontsector)
             )
           )
-          AM_drawMline(&l, mapcolor_revsecr); // line bounding revealed secret sector
+        {
+          al.l = l;
+          al.color = mapcolor_revsecr;
+          array_push(lines_1S, al);
+          //AM_drawMline(&l, mapcolor_revsecr); // line bounding revealed secret sector
+        }
         else                               //jff 2/16/98 fixed bug
-          AM_drawMline(&l, mapcolor_wall); // special was cleared
+        {
+          al.l = l;
+          al.color = mapcolor_wall;
+          array_push(lines_1S, al);
+          //AM_drawMline(&l, mapcolor_wall); // special was cleared
+        }
       }
       else
       {
@@ -1784,6 +1811,12 @@ static void AM_drawWalls(void)
       }
     }
   }
+
+  for (int i = 0; i < array_size(lines_1S); ++i)
+  {
+    AM_drawMline(&lines_1S[i].l, lines_1S[i].color);
+  }
+  array_clear(lines_1S);
 }
 
 //


### PR DESCRIPTION
Fix #1665 

This is a quick implementation to show the idea, maybe there is a more efficient way to do this.

MAP01 with Ribbiks OPTIONS lump:
Before:
![woof0001](https://github.com/fabiangreffrath/woof/assets/5077629/fc111a70-c62f-409b-8b32-b7369e8e69f6)
After:
![woof0002](https://github.com/fabiangreffrath/woof/assets/5077629/841bff10-56d6-4ba9-b3a3-e77e18d855a4)

Thanks to @JNechaevsky 