### PR TITLE
Restore resampler menu option

### DIFF
--- a/src/i_oalsound.h
+++ b/src/i_oalsound.h
@@ -35,6 +35,8 @@ void I_OAL_ShutdownSound(void);
 
 void I_OAL_ShutdownModule(void);
 
+void I_OAL_SetResampler(void);
+
 void I_OAL_ResetSource2D(int channel);
 
 void I_OAL_ResetSource3D(int channel, boolean point_source);
@@ -45,6 +47,8 @@ void I_OAL_UpdateSourceParams(int channel, const ALfloat *position,
 void I_OAL_UpdateListenerParams(const ALfloat *position,
                                 const ALfloat *velocity,
                                 const ALfloat *orientation);
+
+const char **I_OAL_GetResamplerStrings(void);
 
 boolean I_OAL_InitSound(void);
 

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -73,7 +73,7 @@ void I_ShutdownSound(void);
 //
 
 extern int forceFlipPan;
-extern char *snd_resampler;
+extern int snd_resampler;
 extern boolean snd_limiter;
 extern int snd_module;
 extern boolean snd_hrtf;

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -437,8 +437,8 @@ default_t defaults[] = {
   {
     "snd_resampler",
     (config_t *) &snd_resampler, NULL,
-    {.s = "Linear"}, {0}, string, ss_none, wad_no,
-    "Sound resampler"
+    {1}, {0, UL}, number, ss_gen, wad_no,
+    "Sound resampler (0 = Nearest, 1 = Linear, ...)"
   },
 
   {

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -24,6 +24,7 @@
 #include "hu_stuff.h"
 #include "i_gamepad.h"
 #include "i_input.h"
+#include "i_oalsound.h"
 #include "i_sound.h"
 #include "i_timer.h"
 #include "i_video.h"
@@ -304,6 +305,7 @@ enum
 
     str_gamma,
     str_sound_module,
+    str_resampler,
 
     str_mouse_accel,
 
@@ -2082,6 +2084,10 @@ static setup_menu_t gen_settings2[] = {
     // [FG] play sounds in full length
     {"Disable Sound Cutoffs", S_ONOFF, M_X, M_SPC, {"full_sounds"}},
 
+    {"Resampler", S_CHOICE | S_NEXT_LINE, M_X, M_SPC, {"snd_resampler"}, m_null,
+     input_null, str_resampler, I_OAL_SetResampler},
+
+    MI_GAP,
     MI_GAP,
 
     // [FG] music backend
@@ -2090,6 +2096,13 @@ static setup_menu_t gen_settings2[] = {
 
     MI_END
 };
+
+static const char **GetResamplerStrings(void)
+{
+    const char **strings = I_OAL_GetResamplerStrings();
+    DisableItem(!strings, gen_settings2, "snd_resampler");
+    return strings;
+}
 
 void MN_UpdateFreeLook(void)
 {
@@ -3789,6 +3802,7 @@ static const char **selectstrings[] = {
     NULL, // str_midi_player
     gamma_strings,
     sound_module_strings,
+    NULL, // str_resampler
     NULL, // str_mouse_accel
     default_skill_strings,
     default_complevel_strings,
@@ -3845,6 +3859,7 @@ void MN_InitMenuStrings(void)
     UpdateHUDModeStrings();
     selectstrings[str_resolution_scale] = GetResolutionScaleStrings();
     selectstrings[str_mouse_accel] = GetMouseAccelStrings();
+    selectstrings[str_resampler] = GetResamplerStrings();
 }
 
 void MN_SetupResetMenu(void)


### PR DESCRIPTION
Any suggestions for handling the long names better? A few of them are going to change in a future OpenAL Soft release, which means we shouldn't check for exact strings to replace (refs: https://github.com/kcat/openal-soft/commit/3ad68aa979de387fa05efad0a081a064c382580b and https://github.com/kcat/openal-soft/commit/fdd16434c663b68fbddd6fe2c97a9e0c66b1f15e).

![woof0003](https://github.com/fabiangreffrath/woof/assets/56656010/6496a98b-68ad-4b72-acbc-7d61fe00907b)

```
 Using 'Nearest' resampler.
 Using 'Linear' resampler.
 Using 'Cubic' resampler.
 Using '11th order Sinc (fast)' resampler.
 Using '11th order Sinc' resampler.
 Using '23rd order Sinc (fast)' resampler.
 Using '23rd order Sinc' resampler.
```