### PR TITLE
Use `DV_MBF` instead of literal in `A_RandomJump()`

### DIFF
--- a/src/p_enemy.c
+++ b/src/p_enemy.c
@@ -2784,7 +2784,7 @@ void A_PlaySound(mobj_t *mo)
 
 void A_RandomJump(mobj_t *mo)
 {
-  if (demo_version < 203)
+  if (demo_version < DV_MBF)
     return;
   if (P_Random(pr_randomjump) < mo->state->misc2)
     P_SetMobjState(mo, mo->state->misc1);


### PR DESCRIPTION
I think you missed this one. Seems odd, though, so I'm making a PR instead of committing directly.

EDIT: I edited the file in GitHub itself, and I just realized that it created a branch in Woof's repo instead of Nugget's. Hope you don't mind.