### PR TITLE
Tweak description of `change_display_resolution` CVAR

### DIFF
--- a/src/m_config.c
+++ b/src/m_config.c
@@ -234,7 +234,7 @@ default_t defaults[] = {
     "change_display_resolution",
     (config_t *) &change_display_resolution, NULL,
     {0}, {0, 1}, number, ss_none, wad_no,
-    "1 to change display resolution with exclusive fullscreen (make sense only with CRT)"
+    "1 to change display resolution with exclusive fullscreen (only useful for CRTs)"
   },
 
   // window position


### PR DESCRIPTION
What do you think?

While we're on it, and to make this PR more worthwhile, I'd like to say that the rest of descriptions could probably use a revision; some start with uppercase (e.g. "Widescreen [...]") and some with lowercase (e.g. "vertical resolution [...]"); some indicate the default value despite the fact that the prefix showing the possible values already does it (e.g. the `menu_backdrop` description), and some don't.

If you'd like, we could settle on those points and I could revise the descriptions myself.