### PR TITLE
Add quickstart cache

### DIFF
--- a/src/g_game.c
+++ b/src/g_game.c
@@ -420,7 +420,6 @@ static boolean ApplyQuickstartMouseCache(int *mousex)
     }
     *mousex = result;
     quickstart_queued = false;
-    I_Printf(VB_DEBUG, "ApplyQuickstartMouseCache");
     return true;
   }
   else


### PR DESCRIPTION
Requested by El Juancho on the speedrunner discord. This is adapted from DSDA-Doom. When recording a demo and the map is reloaded, cached mouse input from a circular buffer can be applied prior to the screen wipe. Similar behavior is already present in the vanilla game, but it's usually inconsistent for different source ports and computer specs. So it seems that this is considered a convenience feature and not TAS.