### PR TITLE
Add "FOV Affects Skies" toggle

### DIFF
--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -2213,6 +2213,12 @@ static setup_menu_t gen_settings4[] = {
     MI_END
 };
 
+static void InitPlanes(void)
+{
+    R_InitPlanes();
+    setsizeneeded = true;
+}
+
 static void SmoothLight(void)
 {
     setsmoothlight = true;
@@ -2243,7 +2249,10 @@ static setup_menu_t gen_settings5[] = {
      m_null, input_null, str_empty, R_InitSkyMap},
 
     {"Linear Sky Scrolling", S_ONOFF, M_X, M_SPC, {"linearsky"},
-     m_null, input_null, str_empty, R_InitPlanes},
+     m_null, input_null, str_empty, InitPlanes},
+
+    {"FOV Affects Skies", S_ONOFF, M_X, M_SPC, {"fovsky"},
+     m_null, input_null, str_empty, InitPlanes},
 
     {"Swirling Flats", S_ONOFF, M_X, M_SPC, {"r_swirl"}},
 

--- a/src/r_draw.c
+++ b/src/r_draw.c
@@ -314,7 +314,7 @@ void R_DrawSkyColumn(void)
   dest = ylookup[dc_yl] + columnofs[dc_x];
 
   fracstep = dc_iscale; 
-  frac = dc_texturemid + (dc_yl - centery) * fracstep;
+  frac = dc_texturemid + (dc_yl - centery + skyoffsety) * fracstep;
 
   {
     const byte *source = dc_source;

--- a/src/r_main.h
+++ b/src/r_main.h
@@ -49,6 +49,9 @@ extern int      linecount;
 extern int      loopcount;
 extern fixed_t  viewheightfrac; // [FG] sprite clipping optimizations
 
+extern boolean fovsky;
+extern int skyoffsety;
+
 //
 // Rendering stats
 //

--- a/src/r_plane.c
+++ b/src/r_plane.c
@@ -108,7 +108,8 @@ static angle_t *xtoskyangle;
 //
 void R_InitPlanes (void)
 {
-  xtoskyangle = linearsky ? linearskyangle : xtoviewangle;
+  xtoskyangle = linearsky ? linearskyangle
+                          : (fovsky ? xtoviewangle : defaultskyangle);
 }
 
 void R_InitPlanesRes(void)
@@ -141,7 +142,8 @@ void R_InitPlanesRes(void)
 
   openings = Z_Calloc(1, video.width * video.height * sizeof(*openings), PU_STATIC, NULL);
 
-  xtoskyangle = linearsky ? linearskyangle : xtoviewangle;
+  xtoskyangle = linearsky ? linearskyangle
+                          : (fovsky ? xtoviewangle : defaultskyangle);
 }
 
 void R_InitVisplanesRes(void)

--- a/src/r_state.h
+++ b/src/r_state.h
@@ -118,6 +118,9 @@ extern angle_t          rw_normalangle;
 // [FG] linear horizontal sky scrolling
 extern angle_t          *linearskyangle;
 
+// Default sky scrolling.
+extern angle_t          *defaultskyangle;
+
 // angle to line origin
 extern int              rw_angle1;
 

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -120,11 +120,13 @@ void R_InitSpritesRes(void)
 {
   if (xtoviewangle) Z_Free(xtoviewangle);
   if (linearskyangle) Z_Free(linearskyangle);
+  if (defaultskyangle) Z_Free(defaultskyangle);
   if (negonearray) Z_Free(negonearray);
   if (screenheightarray) Z_Free(screenheightarray);
 
   xtoviewangle = Z_Calloc(1, (video.width + 1) * sizeof(*xtoviewangle), PU_STATIC, NULL);
   linearskyangle = Z_Calloc(1, (video.width + 1) * sizeof(*linearskyangle), PU_STATIC, NULL);
+  defaultskyangle = Z_Calloc(1, (video.width + 1) * sizeof(*defaultskyangle), PU_STATIC, NULL);
   negonearray = Z_Calloc(1, video.width * sizeof(*negonearray), PU_STATIC, NULL);
   screenheightarray = Z_Calloc(1, video.width * sizeof(*screenheightarray), PU_STATIC, NULL);
 


### PR DESCRIPTION
[Doomworld post](https://www.doomworld.com/forum/post/2801996) describing request.
[Previous discussion](https://github.com/fabiangreffrath/woof/pull/1474#issuecomment-1945319647) where we originally wanted this.

The menu item is a placeholder for quick testing only, unless we want to keep it.

There are pros and cons to various sky settings:

https://github.com/fabiangreffrath/woof/assets/56656010/78fe2a14-e200-4554-b36e-b61d7cb834ff



