### PR TITLE
Scale pitch before clamping range

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -2456,6 +2456,7 @@ void D_DoomMain(void)
   G_UpdateSideMove();
   G_UpdateAngleFunctions();
   G_UpdateLocalViewFunction();
+  G_UpdateControllerVariables();
   G_UpdateMouseVariables();
   R_UpdateViewAngleFunction();
 

--- a/src/g_input.c
+++ b/src/g_input.c
@@ -178,6 +178,11 @@ void G_UpdateControllerVariables(void)
 {
     joy_scale_angle = angleturn[1] * direction[joy_invert_turn];
     joy_scale_pitch = angleturn[1] * direction[joy_invert_look] * FRACUNIT;
+
+    if (correct_aspect_ratio)
+    {
+        joy_scale_pitch /= 1.2;
+    }
 }
 
 void G_UpdateDeltaTics(void)
@@ -303,6 +308,11 @@ void G_UpdateMouseVariables(void)
     {
         mouse_sens_pitch = ((double)(mouse_sensitivity_y_look + 5) * 8 / 10
                             * direction[mouse_y_invert] * FRACUNIT);
+
+        if (correct_aspect_ratio)
+        {
+            mouse_sens_pitch /= 1.2;
+        }
     }
 
     if (mouse_sensitivity_strafe)

--- a/src/g_input.c
+++ b/src/g_input.c
@@ -171,6 +171,14 @@ int G_CarryVert(double vert)
 
 static const int direction[] = {1, -1};
 static double deltatics;
+static double joy_scale_angle;
+static double joy_scale_pitch;
+
+void G_UpdateControllerVariables(void)
+{
+    joy_scale_angle = angleturn[1] * direction[joy_invert_turn];
+    joy_scale_pitch = angleturn[1] * direction[joy_invert_look] * FRACUNIT;
+}
 
 void G_UpdateDeltaTics(void)
 {
@@ -200,14 +208,12 @@ void G_UpdateDeltaTics(void)
 
 double G_CalcControllerAngle(void)
 {
-    return (angleturn[1] * axes[AXIS_TURN] * direction[joy_invert_turn]
-            * deltatics);
+    return (axes[AXIS_TURN] * joy_scale_angle * deltatics);
 }
 
 double G_CalcControllerPitch(void)
 {
-    return (angleturn[1] * axes[AXIS_LOOK] * direction[joy_invert_look]
-            * deltatics * FRACUNIT);
+    return (axes[AXIS_LOOK] * joy_scale_pitch * deltatics);
 }
 
 int G_CalcControllerSideTurn(int speed)

--- a/src/g_input.h
+++ b/src/g_input.h
@@ -35,6 +35,7 @@ int G_CarryVert(double vert);
 
 // Gamepad
 
+void G_UpdateControllerVariables(void);
 void G_UpdateDeltaTics(void);
 double G_CalcControllerAngle(void);
 double G_CalcControllerPitch(void);

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -83,7 +83,7 @@ boolean toggle_fullscreen;
 boolean toggle_exclusive_fullscreen;
 
 static boolean use_vsync; // killough 2/8/98: controls whether vsync is called
-static boolean correct_aspect_ratio;
+boolean correct_aspect_ratio;
 static int fpslimit; // when uncapped, limit framerate to this value
 static boolean fullscreen;
 static boolean exclusive_fullscreen;

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -77,6 +77,7 @@ extern boolean resetneeded;
 extern boolean setrefreshneeded;
 extern boolean toggle_fullscreen;
 extern boolean toggle_exclusive_fullscreen;
+extern boolean correct_aspect_ratio;
 extern boolean screenvisible;
 
 extern int gamma2;

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -2189,7 +2189,8 @@ static setup_menu_t gen_settings4[] = {
     {"Free Look", S_ONOFF, CNTR_X, M_SPC, {"padlook"}, m_null, input_null,
      str_empty, MN_UpdateFreeLook},
 
-    {"Invert Look", S_ONOFF, CNTR_X, M_SPC, {"joy_invert_look"}},
+    {"Invert Look", S_ONOFF, CNTR_X, M_SPC, {"joy_invert_look"},
+     m_null, input_null, str_empty, G_UpdateControllerVariables},
 
     MI_GAP,
 

--- a/src/p_user.c
+++ b/src/p_user.c
@@ -45,16 +45,7 @@
 static fixed_t PlayerSlope(player_t *player)
 {
   const fixed_t pitch = player->pitch;
-
-  if (pitch)
-  {
-    const fixed_t slope = -finetangent[(ANG90 - pitch) >> ANGLETOFINESHIFT];
-    return (fixed_t)((int64_t)slope * SCREENHEIGHT / ACTUALHEIGHT);
-  }
-  else
-  {
-    return 0;
-  }
+  return pitch ? -finetangent[(ANG90 - pitch) >> ANGLETOFINESHIFT] : 0;
 }
 
 // Index of the special effects (INVUL inverse) map.

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -497,7 +497,6 @@ static void R_SetupFreelook(void)
   if (viewpitch)
   {
     dy = FixedMul(projection, -finetangent[(ANG90 - viewpitch) >> ANGLETOFINESHIFT]);
-    dy = (fixed_t)((int64_t)dy * SCREENHEIGHT / ACTUALHEIGHT);
   }
   else
   {


### PR DESCRIPTION
Before this PR, the free look range was less than it should have been because the values were clamped first and then adjusted for aspect ratio after:

p_user:
https://github.com/fabiangreffrath/woof/blob/f219f7231d6f74351ca6c40685a15d732cf10741/src/p_user.c#L263
https://github.com/fabiangreffrath/woof/blob/f219f7231d6f74351ca6c40685a15d732cf10741/src/p_user.c#L51-L52
r_main:
https://github.com/fabiangreffrath/woof/blob/f219f7231d6f74351ca6c40685a15d732cf10741/src/r_main.c#L786
https://github.com/fabiangreffrath/woof/blob/f219f7231d6f74351ca6c40685a15d732cf10741/src/r_main.c#L499-L500

Now the pitch has aspect ratio correction applied before clamping by scaling the mouse and gamepad input directly. Also, this is only done if `correct_aspect_ratio` is enabled.

Example wad (use fov 90 and stretched skies): [skytest.zip](https://github.com/user-attachments/files/15510234/skytest.zip)
