### PR TITLE
Prevent mouse motion when returning from message prompts

### DIFF
--- a/src/g_game.c
+++ b/src/g_game.c
@@ -820,6 +820,7 @@ void G_ClearInput(void)
   ClearLocalView();
   G_ClearCarry();
   memset(&basecmd, 0, sizeof(basecmd));
+  I_ResetRelativeMouseState();
 }
 
 //

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -220,6 +220,8 @@ void I_ShowMouseCursor(boolean toggle)
 
 void I_ResetRelativeMouseState(void)
 {
+    SDL_PumpEvents();
+    SDL_FlushEvent(SDL_MOUSEMOTION);
     SDL_GetRelativeMouseState(NULL, NULL);
 }
 
@@ -1782,8 +1784,6 @@ void I_InitGraphics(void)
     ResetLogicalSize();
 
     // clear out events waiting at the start and center the mouse
-    SDL_PumpEvents();
-    SDL_FlushEvent(SDL_MOUSEMOTION);
     I_ResetRelativeMouseState();
 }
 

--- a/src/mn_menu.c
+++ b/src/mn_menu.c
@@ -2726,6 +2726,7 @@ boolean M_Responder(event_t *ev)
             messageRoutine(ch);
         }
 
+        G_ClearInput();
         menuactive = false;
         M_StartSound(sfx_swtchx);
         return true;

--- a/src/mn_menu.c
+++ b/src/mn_menu.c
@@ -1900,7 +1900,6 @@ void MN_ClearMenus(void)
     //     sendpause = true;
 
     G_ClearInput();
-    I_ResetRelativeMouseState();
 }
 
 void MN_Back(void)


### PR DESCRIPTION
For example, when the end or quit game prompts are up, move the mouse but press escape.