### PR TITLE
Improve frame limiter behavior on older CPUs

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -714,6 +714,17 @@ static unsigned int disk_to_draw, disk_to_restore;
 static void CreateUpscaledTexture(boolean force);
 static void I_ResetTargetRefresh(void);
 
+//
+// I_CpuPause
+//  Avoids a performance penalty on exit from busy-wait loops. This should be
+//  called on every iteration of the loop and positioned near the loop exit.
+//
+#if SDL_VERSION_ATLEAST(2, 24, 0)
+ #define I_CpuPause() SDL_CPUPauseInstruction()
+#else
+ #define I_CpuPause()
+#endif
+
 void I_FinishUpdate(void)
 {
     if (noblit)
@@ -786,6 +797,8 @@ void I_FinishUpdate(void)
             uint64_t current_time = I_GetTimeUS();
             uint64_t elapsed_time = current_time - frametime_start;
             uint64_t remaining_time = 0;
+
+            I_CpuPause();
 
             if (elapsed_time >= target_time)
             {


### PR DESCRIPTION
Adding a [pause ](https://www.felixcloutier.com/x86/pause) instruction in the busy-wait loop of the frame limiter improves behavior on older CPUs such as mine (Nehalem). This resolves an input latency issue I was seeing when setting the limiter to certain values relative to the unlimited framerate.