### PR TITLE
More fps limiter tweaks

### DIFF
--- a/cmake/WoofSettings.cmake
+++ b/cmake/WoofSettings.cmake
@@ -29,6 +29,11 @@ function(_checked_add_link_option FLAG)
     endif()
 endfunction()
 
+if(MSVC)
+    # Disable function-level linking
+    _checked_add_compile_option(/Gy-)
+endif()
+
 # Parameters we want to check for on all compilers.
 #
 # Note that we want to check for these, even on MSVC, because some compilers

--- a/src/doomtype.h
+++ b/src/doomtype.h
@@ -95,10 +95,13 @@ typedef byte lighttable_t;
 
 #if defined(__GNUC__) || defined(__clang__)
  #define NORETURN __attribute__((noreturn))
+ #define NOINLINE __attribute__((noinline))
 #elif defined (_MSC_VER)
  #define NORETURN __declspec(noreturn)
+ #define NOINLINE __declspec(noinline)
 #else
  #define NORETURN
+ #define NOINLINE
 #endif
 
 // The packed attribute forces structures to be packed into the minimum

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -817,7 +817,7 @@ void I_FinishUpdate(void)
 
     if (use_limiter)
     {
-        I_WaitUntil(1000000ull / targetrefresh);
+        I_WaitUntil(1000000u / targetrefresh);
     }
     else
     {

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -731,10 +731,16 @@ static void I_ResetTargetRefresh(void);
  #define I_CpuPause()
 #endif
 
+#ifdef _MSC_VER
+#pragma optimize("s", on) // Don't unroll the wait loop
+#endif
 NOINLINE static void I_WaitUntil(uint64_t target_time)
 {   //
     // No code here - this loop is sensitive to instruction alignment
     //
+#ifdef __GNUC__
+#pragma GCC unroll 0
+#endif
     while (true)
     {
         const uint64_t current_time = I_GetTimeUS();
@@ -758,6 +764,9 @@ NOINLINE static void I_WaitUntil(uint64_t target_time)
         }
     }
 }
+#ifdef _MSC_VER
+#pragma optimize("", on) // Restore previous settings
+#endif
 
 void I_FinishUpdate(void)
 {

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -725,7 +725,7 @@ static void I_ResetTargetRefresh(void);
  #define I_CpuPause()
 #endif
 
-static void I_WaitUntil(uint64_t target_time)
+NOINLINE static void I_WaitUntil(uint64_t target_time)
 {
     while (true)
     {

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -732,7 +732,9 @@ static void I_ResetTargetRefresh(void);
 #endif
 
 NOINLINE static void I_WaitUntil(uint64_t target_time)
-{
+{   //
+    // No code here - this loop is sensitive to instruction alignment
+    //
     while (true)
     {
         const uint64_t current_time = I_GetTimeUS();

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -729,9 +729,8 @@ NOINLINE static void I_WaitUntil(uint64_t target_time)
 {
     while (true)
     {
-        uint64_t current_time = I_GetTimeUS();
-        uint64_t elapsed_time = current_time - frametime_start;
-        uint64_t remaining_time = 0;
+        const uint64_t current_time = I_GetTimeUS();
+        const uint64_t elapsed_time = current_time - frametime_start;
 
         I_CpuPause();
 
@@ -741,9 +740,7 @@ NOINLINE static void I_WaitUntil(uint64_t target_time)
             break;
         }
 
-        remaining_time = target_time - elapsed_time;
-
-        if (remaining_time > 1000)
+        if (target_time - elapsed_time > 1000)
         {
             I_SleepUS(500);
         }

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -85,7 +85,7 @@ boolean toggle_exclusive_fullscreen;
 static boolean use_vsync; // killough 2/8/98: controls whether vsync is called
 boolean correct_aspect_ratio;
 static int fpslimit; // when uncapped, limit framerate to this value
-static boolean fpslimit_busywait;
+static boolean cpu_priority;
 static boolean fullscreen;
 static boolean exclusive_fullscreen;
 static boolean change_display_resolution;
@@ -228,6 +228,11 @@ void I_ResetRelativeMouseState(void)
 
 static void UpdatePriority(void)
 {
+    if (!cpu_priority)
+    {
+        return;
+    }
+
     const boolean active = (screenvisible && window_focused);
 #if defined(_WIN32)
     SetPriorityClass(GetCurrentProcess(), active ? ABOVE_NORMAL_PRIORITY_CLASS
@@ -728,7 +733,6 @@ static void I_ResetTargetRefresh(void);
 
 NOINLINE static void I_WaitUntil(uint64_t target_time)
 {
-    const boolean busy_wait = fpslimit_busywait;
     while (true)
     {
         const uint64_t current_time = I_GetTimeUS();
@@ -746,7 +750,7 @@ NOINLINE static void I_WaitUntil(uint64_t target_time)
         {
             I_SleepUS(500);
         }
-        else if (!busy_wait)
+        else
         {
             I_Sleep(0); // yield
         }
@@ -1822,8 +1826,8 @@ void I_BindVideoVariables(void)
         "Uncapped rendering frame rate");
     BIND_NUM_GENERAL(fpslimit, 0, 0, 500,
         "Framerate limit in frames per second (< 35 = Disable)");
-    BIND_BOOL(fpslimit_busywait, true,
-        "Use more CPU to stay closer to limit (may increase input latency)");
+    BIND_BOOL(cpu_priority, true,
+        "Run at higher priority (may increase input latency)");
     M_BindNum("widescreen", &default_widescreen, &widescreen, RATIO_AUTO, 0,
               NUM_RATIOS - 1, ss_gen, wad_no,
               "Widescreen (0 = Off; 1 = Auto; 2 = 16:10; 3 = 16:9; 4 = 21:9)");

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -739,7 +739,7 @@ NOINLINE static void I_WaitUntil(uint64_t target_time)
     // No code here - this loop is sensitive to instruction alignment
     //
 #ifdef __GNUC__
-#pragma GCC unroll 0
+#pragma GCC unroll 1
 #endif
     while (true)
     {

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -85,6 +85,7 @@ boolean toggle_exclusive_fullscreen;
 static boolean use_vsync; // killough 2/8/98: controls whether vsync is called
 boolean correct_aspect_ratio;
 static int fpslimit; // when uncapped, limit framerate to this value
+static boolean fpslimit_busywait;
 static boolean fullscreen;
 static boolean exclusive_fullscreen;
 static boolean change_display_resolution;
@@ -727,6 +728,7 @@ static void I_ResetTargetRefresh(void);
 
 NOINLINE static void I_WaitUntil(uint64_t target_time)
 {
+    const boolean busy_wait = fpslimit_busywait;
     while (true)
     {
         const uint64_t current_time = I_GetTimeUS();
@@ -744,7 +746,7 @@ NOINLINE static void I_WaitUntil(uint64_t target_time)
         {
             I_SleepUS(500);
         }
-        else
+        else if (!busy_wait)
         {
             I_Sleep(0); // yield
         }
@@ -1820,6 +1822,8 @@ void I_BindVideoVariables(void)
         "Uncapped rendering frame rate");
     BIND_NUM_GENERAL(fpslimit, 0, 0, 500,
         "Framerate limit in frames per second (< 35 = Disable)");
+    BIND_BOOL(fpslimit_busywait, true,
+        "Use more CPU to stay closer to limit (may increase input latency)");
     M_BindNum("widescreen", &default_widescreen, &widescreen, RATIO_AUTO, 0,
               NUM_RATIOS - 1, ss_gen, wad_no,
               "Widescreen (0 = Off; 1 = Auto; 2 = 16:10; 3 = 16:9; 4 = 21:9)");

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -786,7 +786,8 @@ void I_FinishUpdate(void)
         // Update FPS counter every second
         if (time >= 1000000)
         {
-            fps = ((uint64_t)frame_counter * 1000000) / time;
+            float secs = time * 1e-6f;
+            fps = (frame_counter / secs) + 0.5f;
             frame_counter = 0;
             last_time = frametime_start;
         }


### PR DESCRIPTION
This branch modifies the frame limiter, improving latency, CPU usage, and accuracy at the cost of occasional higher frame time spikes (due to yielding the current thread). Given that someone using the in-game limiter is probably interested in the lowest possible latency, I think this may be a worthwhile compromise. In combination with #1733 the changes in this branch provide great latency results for me.  And [c50582c](https://github.com/fabiangreffrath/woof/pull/1728/commits/c50582c0004ece3c8ea27e1cc5fd2add5d9f8e2c) fixes the flaky, unpredictable performance that I've been seeing in general.

![Screenshot 2024-06-08 070832](https://github.com/fabiangreffrath/woof/assets/108626604/d1b0af05-a31d-4b1e-8e3d-98d3a3e7f7be)
