### PR TITLE
Unconditionally skip first/last 16 bytes of DMX sound data

### DIFF
--- a/src/i_oalsound.c
+++ b/src/i_oalsound.c
@@ -580,36 +580,6 @@ boolean I_OAL_AllowReinitSound(void)
     return (alcIsExtensionPresent(oal->device, "ALC_SOFT_HRTF") == ALC_TRUE);
 }
 
-//
-// IsPaddedSound
-//
-// DMX sounds use 16 bytes of padding before and after the real sound. The
-// padding bytes are equal to the first or last real byte, respectively.
-// Reference: https://www.doomworld.com/forum/post/949486
-//
-static boolean IsPaddedSound(const byte *data, int size)
-{
-    const int sound_end = size - DMXPADSIZE;
-    int i;
-
-    for (i = 0; i < DMXPADSIZE; i++)
-    {
-        // Check padding before sound.
-        if (data[i] != data[DMXPADSIZE])
-        {
-            return false;
-        }
-
-        // Check padding after sound.
-        if (data[sound_end + i] != data[sound_end - 1])
-        {
-            return false;
-        }
-    }
-
-    return true;
-}
-
 static void FadeInOutMono8(byte *data, ALsizei size, ALsizei freq)
 {
     const int fadelen = freq * FADETIME / 1000000;
@@ -686,19 +656,18 @@ boolean I_OAL_CacheSound(sfxinfo_t *sfx)
 
             sampledata = lumpdata + DMXHDRSIZE;
 
-            if (IsPaddedSound(sampledata, size))
-            {
-                // Ignore DMX padding.
-                sampledata += DMXPADSIZE;
-                size -= DMXPADSIZE * 2;
-            }
+            // DMX skips the first and last 16 bytes of data. Custom sounds may
+            // be created with tools that aren't aware of this, which means part
+            // of the waveform is cut off. We compensate for this by fading in
+            // or out sounds that start or end at a non-zero amplitude to
+            // prevent clicking.
+            // Reference: https://www.doomworld.com/forum/post/949486
+            sampledata += DMXPADSIZE;
+            size -= DMXPADSIZE * 2;
+            FadeInOutMono8(sampledata, size, freq);
 
             // All Doom sounds are 8-bit
             format = AL_FORMAT_MONO8;
-
-            // Fade in sounds that start at a non-zero amplitude to prevent
-            // clicking.
-            FadeInOutMono8(sampledata, size, freq);
         }
         else
         {


### PR DESCRIPTION
Chocolate Doom [always skips](https://github.com/chocolate-doom/chocolate-doom/blob/2ea764fed6a266e291cf37375f52bc92260f686c/src/i_sdlsound.c#L768) the first 16 and last 16 bytes from every sound file. This is vanilla Doom behavior.

PrBoom+ [incorrectly skips](https://github.com/coelckers/prboom-plus/blob/969515162c5aebea4ad7a125ee178dcad3d576ad/prboom2/src/SDL/i_sound.c#L410) just the last 8 bytes from every sound file. The reasoning for this is not clear.

Chex Quest was likely created with tools that [weren't aware of DMX padding](https://github.com/Doom-Utils/deutex/blob/ef1c06a62cc0eff82ecea984f58fbbe41d8a593d/src/sound.c#L177). So there are non-zero starting/ending amplitudes that the authors never heard. There are wads with custom sounds that have the same issue. Since the tools used for these sounds didn't add the 32 bytes of dummy data, that means a small part of the actual waveform is cut off with Chocolate, PrBoom+, Woof (with this PR), and any port based on them.

To compensate, we apply an inaudible fade-in and fade-out ([pending](https://github.com/fabiangreffrath/woof/pull/1731)) to sounds that start or end at a non-zero amplitude to prevent clicking. As [previously discovered](https://github.com/fabiangreffrath/woof/pull/1220), even the vanilla Doom sounds need this anyway, so this is an acceptable solution.