### PR TITLE
Disable SDL render batching by default

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1787,6 +1787,7 @@ void I_InitGraphics(void)
     {
         I_Error("Failed to initialize video: %s", SDL_GetError());
     }
+    SDL_SetHint("SDL_HINT_RENDER_BATCHING", "0");
 
     I_AtExit(I_ShutdownGraphics, true);
 


### PR DESCRIPTION
Disabling render batching cuts latency roughly in half with the default renderer backend. With that in mind, and given how little Woof does with the GPU, a potential small reduction in efficiency doesn't seem to merit leaving this enabled.

For those that want it, it can still be forced on via the `SDL_HINT_RENDER_BATCHING=1` environment variable.