### PR TITLE
Add doomu.wad alias for Ultimate Doom

### DIFF
--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -35,6 +35,8 @@ static const iwad_t iwads[] = {
     {"doom.wad",      doom,       indetermined, "DOOM"                           },
     {"doom.wad",      doom,       registered,   "DOOM Registered"                },
     {"doom.wad",      doom,       retail,       "The Ultimate DOOM"              },
+    // "doomu.wad" alias to allow retail wad to coexist with registered in the same folder
+    {"doomu.wad",     doom,       retail,       "The Ultimate DOOM"              },
     {"doom1.wad",     doom,       shareware,    "DOOM Shareware"                 },
     {"doom2f.wad",    doom2,      commercial,   "DOOM II: L'Enfer sur Terre"     },
     {"freedoom2.wad", doom2,      commercial,   "Freedoom: Phase 2"              },


### PR DESCRIPTION
Currently, the Doom Registered and Ultimate Doom IWADs are identified by the same "doom.wad" name. If the name is different, some things won't work, such as the doom-all autoload (which includes the default brightmaps). Because they must have the same name, it's impossible to have both in the same directory, and regardless it can make it harder to tell them apart.

This PR adds support for the "doomu.wad" alias which ZDoom also supports.