### PR TITLE
Add custom gamepad mapping

### DIFF
--- a/src/i_gamepad.c
+++ b/src/i_gamepad.c
@@ -30,6 +30,7 @@
 #define REMAP(x, min, max) (((x) - (min)) / ((max) - (min)))
 
 boolean joy_enable;
+const char *joy_mapping = "";
 static int joy_layout;
 static int joy_sensitivity_forward;
 static int joy_sensitivity_strafe;
@@ -392,6 +393,8 @@ void I_ResetController(void)
 void I_BindGamepadVariables(void)
 {
     BIND_BOOL(joy_enable, true, "Allow game controller");
+    M_BindStr("joy_mapping", &joy_mapping, "", wad_no,
+        "Game controller mapping string");
     BIND_NUM_GENERAL(joy_layout, LAYOUT_DEFAULT, 0, NUM_LAYOUTS - 1,
         "Analog stick layout (0 = Default; 1 = Swap; 2 = Legacy; 3 = Legacy Swap)");
     BIND_NUM(joy_sensitivity_forward, 50, 0, 100, "Forward axis sensitivity");

--- a/src/i_gamepad.h
+++ b/src/i_gamepad.h
@@ -22,6 +22,7 @@
 #include "doomtype.h"
 
 extern boolean joy_enable;                  // Enable game controller.
+extern const char *joy_mapping;             // Game controller mapping string.
 extern boolean joy_invert_forward;          // Invert forward axis.
 extern boolean joy_invert_strafe;           // Invert strafe axis.
 extern boolean joy_invert_turn;             // Invert turn axis.

--- a/src/i_input.c
+++ b/src/i_input.c
@@ -250,6 +250,23 @@ void I_InitController(void)
     I_AtExit(I_ShutdownController, true);
 }
 
+static void UpdateControllerMapping(void)
+{
+    if (joy_mapping[0] == '\0')
+    {
+        return;
+    }
+
+    if (SDL_GameControllerAddMapping(joy_mapping) == -1)
+    {
+        I_Printf(VB_WARNING, "Failed to add game controller mapping");
+    }
+    else
+    {
+        I_Printf(VB_INFO, "Updated game controller mapping");
+    }
+}
+
 void I_OpenController(int which)
 {
     if (controller)
@@ -281,6 +298,7 @@ void I_OpenController(int which)
 
     if (controller)
     {
+        UpdateControllerMapping();
         EnableControllerEvents();
     }
 }

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -688,7 +688,7 @@ void M_LoadDefaults(void)
 
     if ((f = M_fopen(defaultfile, "r")))
     {
-        char s[256];
+        char s[1024];
 
         while (fgets(s, sizeof s, f))
         {


### PR DESCRIPTION
This is an experiment to work around cases where controller mappings haven't been added to [SDL's database](https://github.com/libsdl-org/SDL/blob/SDL2/src/joystick/SDL_gamecontrollerdb.h) yet. For example, ChopBlock223 has a [unique controller](https://www.doomworld.com/forum/post/2776883) without a mapping. There is a [test app](https://github.com/libsdl-org/SDL/blob/SDL2/test/controllermap.c) that can be used to create a mapping string which can be provided to the SDL devs, but it may take a long time until it shows up in a new release.

I compiled the test app here: [controllermap-win64.zip](https://github.com/user-attachments/files/15782573/controllermap-win64.zip)

It prompts the user to press every controller input:

![1](https://github.com/fabiangreffrath/woof/assets/56656010/ac6b25d5-103b-4d75-9831-b0c466684c2e)

Then it outputs a controller mapping string at the end:

![2](https://github.com/fabiangreffrath/woof/assets/56656010/09aaef71-8f57-490e-8338-6d681b93cb0c)

Which can be copied to woof.cfg:

![3](https://github.com/fabiangreffrath/woof/assets/56656010/6dc5abed-0881-4cec-857a-622efd371358)

If this initial experiment works okay, it can be developed further to be more streamlined so that the test app is not needed. I was thinking of a sub-menu in Woof that does the same thing as the test app, one level deeper than General > Gamepad, if that's possible. But the details can be worked out later.