### PR TITLE
save/load menu improvements in mouse mode

### DIFF
--- a/src/mn_menu.c
+++ b/src/mn_menu.c
@@ -867,7 +867,10 @@ static void M_DrawLoad(void)
 
     int index = (menu_input == mouse_mode ? highlight_item : itemOn);
 
-    M_DrawBorderedSnapshot(index);
+    if (index < load_page)
+    {
+        M_DrawBorderedSnapshot(index);
+    }
 
     M_DrawSaveLoadBottomLine();
 }
@@ -1092,7 +1095,12 @@ static void M_DrawSave(void)
         WriteText(LoadDef.x + i, LoadDef.y + LINEHEIGHT * saveSlot, "_");
     }
 
-    M_DrawBorderedSnapshot(itemOn);
+    int index = (menu_input == mouse_mode ? highlight_item : itemOn);
+
+    if (index < load_page)
+    {
+        M_DrawBorderedSnapshot(index);
+    }
 
     M_DrawSaveLoadBottomLine();
 }
@@ -2455,15 +2463,21 @@ static boolean MouseResponder(void)
 
     menuitem_t *current_item = &currentMenu->menuitems[highlight_item];
 
+    mrect_t *rect = &current_item->rect;
+
     if (current_item->flags & MF_PAGE)
     {
         if (M_InputActivated(input_menu_enter))
         {
-            if (savepage == savepage_max)
+            int dot = mouse_state_x - video.deltaw * 2 - rect->x;
+            if (dot >= rect->w / 2)
             {
-                savepage = -1;
+                SaveLoadResponder(MENU_RIGHT, 0);
             }
-            SaveLoadResponder(MENU_RIGHT, 0);
+            else
+            {
+                SaveLoadResponder(MENU_LEFT, 0);
+            }
             return true;
         }
         return false;
@@ -2474,7 +2488,7 @@ static boolean MouseResponder(void)
         current_item++;
     }
 
-    mrect_t *rect = &current_item->rect;
+    rect = &current_item->rect;
 
     if (M_InputActivated(input_menu_enter))
     {


### PR DESCRIPTION
* Don't show snapshot for page item.

* Switch pages left/right depending on mouse cursor position.

There was a comment on DW about this, but I can't find it anymore. 