### PR TITLE
FPS limiter tweaks

### DIFF
--- a/src/i_timer.c
+++ b/src/i_timer.c
@@ -148,7 +148,14 @@ void I_InitTimer(void)
 
 #ifdef _WIN32
     // Create an unnamed waitable timer.
+#  ifdef CREATE_WAITABLE_TIMER_HIGH_RESOLUTION
+    hTimer = CreateWaitableTimerEx(NULL, NULL,
+                                   CREATE_WAITABLE_TIMER_MANUAL_RESET
+                                   | CREATE_WAITABLE_TIMER_HIGH_RESOLUTION,
+                                   TIMER_ALL_ACCESS);
+#  else
     hTimer = CreateWaitableTimer(NULL, TRUE, NULL);
+#  endif
     if (hTimer == NULL)
     {
         I_Error("I_InitTimer: CreateWaitableTimer failed");

--- a/src/i_timer.c
+++ b/src/i_timer.c
@@ -148,14 +148,16 @@ void I_InitTimer(void)
 
 #ifdef _WIN32
     // Create an unnamed waitable timer.
-#  ifdef CREATE_WAITABLE_TIMER_HIGH_RESOLUTION
     hTimer = CreateWaitableTimerEx(NULL, NULL,
                                    CREATE_WAITABLE_TIMER_MANUAL_RESET
                                    | CREATE_WAITABLE_TIMER_HIGH_RESOLUTION,
                                    TIMER_ALL_ACCESS);
-#  else
-    hTimer = CreateWaitableTimer(NULL, TRUE, NULL);
-#  endif
+
+    if (hTimer == NULL)
+    {
+        hTimer = CreateWaitableTimer(NULL, TRUE, NULL);
+    }
+
     if (hTimer == NULL)
     {
         I_Error("I_InitTimer: CreateWaitableTimer failed");

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -714,17 +714,6 @@ static unsigned int disk_to_draw, disk_to_restore;
 static void CreateUpscaledTexture(boolean force);
 static void I_ResetTargetRefresh(void);
 
-//
-// I_CpuPause
-//  Avoids a performance penalty on exit from busy-wait loops. This should be
-//  called on every iteration of the loop and positioned near the loop exit.
-//
-#if SDL_VERSION_ATLEAST(2, 24, 0)
- #define I_CpuPause() SDL_CPUPauseInstruction()
-#else
- #define I_CpuPause()
-#endif
-
 void I_FinishUpdate(void)
 {
     if (noblit)
@@ -796,9 +785,6 @@ void I_FinishUpdate(void)
         {
             uint64_t current_time = I_GetTimeUS();
             uint64_t elapsed_time = current_time - frametime_start;
-            uint64_t remaining_time = 0;
-
-            I_CpuPause();
 
             if (elapsed_time >= target_time)
             {
@@ -806,11 +792,9 @@ void I_FinishUpdate(void)
                 break;
             }
 
-            remaining_time = target_time - elapsed_time;
-
-            if (remaining_time > 1000)
+            if (target_time - elapsed_time > 1000)
             {
-                I_Sleep((remaining_time - 1000) / 1000);
+                I_SleepUS(500);
             }
         }
     }


### PR DESCRIPTION
* Remove I_CpuPause().

* Change limiter sleep loop.

I tested this with direct3d9 backend, resolution scale 100%, vsync off, frame limiter 200. With CapFrameX I've got a slightly better frame pacing with about the same CPU load. @ceski-1 I am interested in your results.