### PR TITLE
reset `tmthing` pointer in `cheat_spechits` function

### DIFF
--- a/src/m_cheat.c
+++ b/src/m_cheat.c
@@ -810,6 +810,8 @@ static void cheat_spechits()
     plyr->cards[i] = true;
   }
 
+  P_MapStart();
+
   for (i = 0; i < numlines; i++)
   {
     if (lines[i].special)
@@ -938,6 +940,8 @@ static void cheat_spechits()
     dummy.tag = 666;
     speciallines += EV_DoDoor(&dummy, doorOpen);
   }
+
+  P_MapEnd();
 
   displaymsg("%d Special Action%s Triggered", speciallines, speciallines == 1 ? "" : "s");
 }


### PR DESCRIPTION
Fix SPECHITS cheat in Resurge.wad MAP15. Bug report: [[doomworld]](https://www.doomworld.com/forum/topic/112333-this-is-woof-1450-apr-30-2024/?do=findComment&comment=2812929)