### PR TITLE
Ignore mouse motion events

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1781,6 +1781,9 @@ void I_InitGraphics(void)
     CreateSurfaces(video.pitch, video.height);
     ResetLogicalSize();
 
+    // Mouse motion is based on SDL_GetRelativeMouseState() values only.
+    SDL_EventState(SDL_MOUSEMOTION, SDL_IGNORE);
+
     // clear out events waiting at the start and center the mouse
     I_ResetRelativeMouseState();
 }


### PR DESCRIPTION
We only use `SDL_GetMouseState()` and `SDL_GetRelativeMouseState()`. so `SDL_MOUSEMOTION` events were already being ignored. This also prevents them from getting added to queue, so they aren't processed by `SDL_PollEvent()`.
- https://github.com/libsdl-org/SDL/blob/SDL2/src/events/SDL_mouse.c#L599-L606
- https://github.com/libsdl-org/SDL/blob/SDL2/src/events/SDL_mouse.c#L650-L674
- https://github.com/libsdl-org/SDL/blob/SDL2/src/events/SDL_mouse.c#L997-L1023
