### PR TITLE
Video fixes

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1824,6 +1824,8 @@ void D_DoomMain(void)
 
   I_AtExitPrio(I_ErrorMsg,  true,  "I_ErrorMsg",  exit_priority_verylast);
 
+  I_UpdatePriority(true);
+
 #if defined(_WIN32)
   // [FG] compose a proper command line from loose file paths passed as
   // arguments to allow for loading WADs and DEHACKED patches by drag-and-drop

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -225,9 +225,8 @@ void I_ResetRelativeMouseState(void)
     SDL_GetRelativeMouseState(NULL, NULL);
 }
 
-static void UpdatePriority(void)
+void I_UpdatePriority(boolean active)
 {
-    const boolean active = (screenvisible && window_focused);
 #if defined(_WIN32)
     SetPriorityClass(GetCurrentProcess(), active ? ABOVE_NORMAL_PRIORITY_CLASS
                                                  : NORMAL_PRIORITY_CLASS);
@@ -276,13 +275,11 @@ static void HandleWindowEvent(SDL_WindowEvent *event)
 
         case SDL_WINDOWEVENT_MINIMIZED:
             screenvisible = false;
-            UpdatePriority();
             break;
 
         case SDL_WINDOWEVENT_MAXIMIZED:
         case SDL_WINDOWEVENT_RESTORED:
             screenvisible = true;
-            UpdatePriority();
             break;
 
         // Update the value of window_focused when we get a focus event
@@ -294,13 +291,13 @@ static void HandleWindowEvent(SDL_WindowEvent *event)
         case SDL_WINDOWEVENT_FOCUS_GAINED:
             window_focused = true;
             FocusGained();
-            UpdatePriority();
+            I_UpdatePriority(true);
             break;
 
         case SDL_WINDOWEVENT_FOCUS_LOST:
             window_focused = false;
             FocusLost();
-            UpdatePriority();
+            I_UpdatePriority(false);
             break;
 
         // We want to save the user's preferred monitor to use for running the

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1684,6 +1684,9 @@ static void I_InitGraphicsMode(void)
 #endif
     }
 
+    SDL_PumpEvents();
+    SDL_FlushEvent(SDL_WINDOWEVENT);
+
     UpdateLimiter();
 }
 

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -93,6 +93,8 @@ void I_InitWindowIcon(void);
 void I_ShowMouseCursor(boolean toggle);
 void I_ResetRelativeMouseState(void);
 
+void I_UpdatePriority(boolean active);
+
 void I_BindVideoVariables(void);
 
 #endif


### PR DESCRIPTION
The alt+tab fix works for all Windows render drivers. It doesn't seem necessary for Linux and just makes switching back and forth slower there (OpenGL + Arch tested). Fixes https://github.com/fabiangreffrath/woof/issues/1752

OpenGL exclusive fullscreen didn't work right in Windows. It would just start minimized. Looking at the SDL behavior on launch, it fires off a bunch of window events during window/render creation that confuses the logic we have in Woof. There's no point in parsing those initial window events, so they're now flushed, which fixes the issue.

Since the initial events are flushed, the priority is just raised explicitly on launch. Some of the other calls were redundant, so they were removed.