### PR TITLE
add a compact widget showing only health, armor and ammo information

### DIFF
--- a/base/all-all/woofhud.lmp
+++ b/base/all-all/woofhud.lmp
@@ -1,5 +1,6 @@
 hud 0
 rate topleft
+compact bottomleft
 monsec topleft
 sttime topleft
 coord topright

--- a/docs/woofhud.md
+++ b/docs/woofhud.md
@@ -4,7 +4,7 @@ Woof! supports the WOOFHUD lump to customize the appearance of the extended Boom
 
 ## Description
 
-The Boom HUD shows information about the player's health, armor, weapons, ammo and keys using different widgets, i.e. lines of text and symbols. It is usually made visible by hitting the <kbd>F5</kbd> key, and repeatedly hitting the <kbd>F5</kbd> key toggles through three different modes: the "minimal" mode which only shows the most basic information by default, the "compact" mode which shows all information in the lower left corner of the screen and the "distributed" mode which shows information spread across the corners of the screen.
+The Boom HUD shows information about the player's health, armor, weapons, ammo and keys using different widgets, i.e. lines of text and symbols. It is usually made visible by hitting the <kbd>F5</kbd> key, and repeatedly hitting the <kbd>F5</kbd> key toggles through three different modes: the "minimal" mode which shows only the most basic information, the "compact" mode which shows all information in the lower left corner of the screen and the "distributed" mode which shows information spread across the corners of the screen.
 
 The WOOFHUD lump can be used to modify the positions of these widgets for each mode.
 This lump may either get embedded into a PWAD, or provided by the user on the command line or through the autoload feature.
@@ -104,7 +104,7 @@ fps 224 16
 
 The "title" widget is only visible if the Automap is enabled. The "monsec", "sttime" and "coord" widgets are only visible if they are explicitly enabled in the Options menu (separately for Automap and HUD). The "fps" widget is only visible if the SHOWFPS cheat is enabled.
 
-The "compact" widget is a minimal widget showing health, armor and ammo information only. It is enabled by default in the minimal Boom HUD mode.
+The "compact" widget is a minimal widget showing only health, armor and ammo information. It is enabled by default in the minimal Boom HUD mode.
 
 A centered widget does not allow for any other left or right aligned widget on the same line.
 

--- a/docs/woofhud.md
+++ b/docs/woofhud.md
@@ -4,7 +4,7 @@ Woof! supports the WOOFHUD lump to customize the appearance of the extended Boom
 
 ## Description
 
-The Boom HUD shows information about the player's health, armor, weapons, ammo and keys using different widgets, i.e. lines of text and symbols. It is usually made visible by hitting the <kbd>F5</kbd> key, and repeatedly hitting the <kbd>F5</kbd> key toggles through three different modes: the "minimal" mode which does not show any information by default, the "compact" mode which shows all information in the lower left corner of the screen and the "distributed" mode which shows information spread across the corners of the screen.
+The Boom HUD shows information about the player's health, armor, weapons, ammo and keys using different widgets, i.e. lines of text and symbols. It is usually made visible by hitting the <kbd>F5</kbd> key, and repeatedly hitting the <kbd>F5</kbd> key toggles through three different modes: the "minimal" mode which only shows the most basic information by default, the "compact" mode which shows all information in the lower left corner of the screen and the "distributed" mode which shows information spread across the corners of the screen.
 
 The WOOFHUD lump can be used to modify the positions of these widgets for each mode.
 This lump may either get embedded into a PWAD, or provided by the user on the command line or through the autoload feature.
@@ -29,6 +29,7 @@ Possible values for the HUD widget names:
  * "coord" or "coords"
  * "fps" or "rate"
  * "cmd" or "commands"
+ * "compact"
 
 Possible values for the widget position keywords:
 
@@ -49,6 +50,7 @@ The following example represents the current default alignments of the Boom HUD 
 
 ```
 hud 0
+compact bottomleft
 rate topleft
 monsec topleft
 sttime topleft
@@ -101,6 +103,8 @@ fps 224 16
 ## Remarks
 
 The "title" widget is only visible if the Automap is enabled. The "monsec", "sttime" and "coord" widgets are only visible if they are explicitly enabled in the Options menu (separately for Automap and HUD). The "fps" widget is only visible if the SHOWFPS cheat is enabled.
+
+The "compact" widget is a minimal widget showing health, armor and ammo information only. It is enabled by default in the minimal Boom HUD mode.
 
 A centered widget does not allow for any other left or right aligned widget on the same line.
 

--- a/docs/woofhud.md
+++ b/docs/woofhud.md
@@ -50,8 +50,8 @@ The following example represents the current default alignments of the Boom HUD 
 
 ```
 hud 0
-compact bottomleft
 rate topleft
+compact bottomleft
 monsec topleft
 sttime topleft
 coord topright

--- a/src/hu_stuff.c
+++ b/src/hu_stuff.c
@@ -924,11 +924,11 @@ static void HU_widget_build_compact (void)
   if (hud_widget_layout)
   {
     M_snprintf(hud_compactstr, sizeof(hud_compactstr),
-    "\x1b%cHEL\t%d", '0'+cr_health, st_health);
+    "\x1b%cHEL\t\x1b%c%d", '0'+CR_GRAY, '0'+cr_health, st_health);
     HUlib_add_string_to_cur_line(&w_compact, hud_compactstr);
 
     M_snprintf(hud_compactstr, sizeof(hud_compactstr),
-    "\x1b%cARM\t%d", '0'+cr_armor, st_armor);
+    "\x1b%cARM\t\x1b%c%d", '0'+CR_GRAY, '0'+cr_armor, st_armor);
     HUlib_add_string_to_cur_line(&w_compact, hud_compactstr);
 
     if (noammo)
@@ -942,7 +942,7 @@ static void HU_widget_build_compact (void)
       const crange_idx_e cr_ammo = CRByAmmo(ammo, fullammo, ammopct);
 
       M_snprintf(hud_compactstr, sizeof(hud_compactstr),
-      "\x1b%cAMM\t%d/%d", '0'+cr_ammo, ammo, fullammo);
+      "\x1b%cAMM\t\x1b%c%d/%d", '0'+CR_GRAY, '0'+cr_ammo, ammo, fullammo);
     }
     HUlib_add_string_to_cur_line(&w_compact, hud_compactstr);
   }
@@ -962,10 +962,10 @@ static void HU_widget_build_compact (void)
       const crange_idx_e cr_ammo = CRByAmmo(ammo, fullammo, ammopct);
 
       M_snprintf(hud_compactstr, sizeof(hud_compactstr),
-      "\x1b%cHEL %d \x1b%cARM %d \x1b%cAMM %d/%d",
-      '0'+cr_health, st_health,
-      '0'+cr_armor, st_armor,
-      '0'+cr_ammo, ammo, fullammo);
+      "\x1b%cHEL \x1b%c%d \x1b%cARM \x1b%c%d \x1b%cAMM \x1b%c%d/%d",
+      '0'+CR_GRAY, '0'+cr_health, st_health,
+      '0'+CR_GRAY, '0'+cr_armor, st_armor,
+      '0'+CR_GRAY, '0'+cr_ammo, ammo, fullammo);
     }
     HUlib_add_string_to_cur_line(&w_compact, hud_compactstr);
   }

--- a/src/hu_stuff.c
+++ b/src/hu_stuff.c
@@ -1779,18 +1779,13 @@ void HU_Ticker(void)
     }
     else
     {
-      if (hud_active > 0)
-      {
-        HU_cond_build_widget(&w_weapon, true);
-        HU_cond_build_widget(&w_armor, true);
-        HU_cond_build_widget(&w_health, true);
-        HU_cond_build_widget(&w_ammo, true);
-        HU_cond_build_widget(&w_keys, true);
-      }
-      else
-      {
-        HU_cond_build_widget(&w_compact, true);
-      }
+      HU_cond_build_widget(&w_weapon, true);
+      HU_cond_build_widget(&w_armor, true);
+      HU_cond_build_widget(&w_health, true);
+      HU_cond_build_widget(&w_ammo, true);
+      HU_cond_build_widget(&w_keys, true);
+
+      HU_cond_build_widget(&w_compact, true);
     }
   }
 

--- a/src/hu_stuff.c
+++ b/src/hu_stuff.c
@@ -924,11 +924,11 @@ static void HU_widget_build_compact (void)
   if (hud_widget_layout)
   {
     M_snprintf(hud_compactstr, sizeof(hud_compactstr),
-    "\x1b%cHEL\t\x1b%c%d", '0'+CR_GRAY, '0'+cr_health, st_health);
+    "\x1b%cHEL\t\x1b%c%3d", '0'+CR_GRAY, '0'+cr_health, st_health);
     HUlib_add_string_to_cur_line(&w_compact, hud_compactstr);
 
     M_snprintf(hud_compactstr, sizeof(hud_compactstr),
-    "\x1b%cARM\t\x1b%c%d", '0'+CR_GRAY, '0'+cr_armor, st_armor);
+    "\x1b%cARM\t\x1b%c%3d", '0'+CR_GRAY, '0'+cr_armor, st_armor);
     HUlib_add_string_to_cur_line(&w_compact, hud_compactstr);
 
     if (noammo)
@@ -942,7 +942,7 @@ static void HU_widget_build_compact (void)
       const crange_idx_e cr_ammo = CRByAmmo(ammo, fullammo, ammopct);
 
       M_snprintf(hud_compactstr, sizeof(hud_compactstr),
-      "\x1b%cAMM\t\x1b%c%d/%d", '0'+CR_GRAY, '0'+cr_ammo, ammo, fullammo);
+      "\x1b%cAMM\t\x1b%c%3d/%3d", '0'+CR_GRAY, '0'+cr_ammo, ammo, fullammo);
     }
     HUlib_add_string_to_cur_line(&w_compact, hud_compactstr);
   }
@@ -951,7 +951,7 @@ static void HU_widget_build_compact (void)
     if (noammo)
     {
       M_snprintf(hud_compactstr, sizeof(hud_compactstr),
-      "\x1b%cHEL %d \x1b%cARM %d \x1b%cAMM N/A",
+      "\x1b%cHEL %3d \x1b%cARM %3d \x1b%cAMM N/A",
       '0'+cr_health, st_health,
       '0'+cr_armor, st_armor,
       '0'+CR_GRAY);
@@ -962,7 +962,7 @@ static void HU_widget_build_compact (void)
       const crange_idx_e cr_ammo = CRByAmmo(ammo, fullammo, ammopct);
 
       M_snprintf(hud_compactstr, sizeof(hud_compactstr),
-      "\x1b%cHEL \x1b%c%d \x1b%cARM \x1b%c%d \x1b%cAMM \x1b%c%d/%d",
+      "\x1b%cHEL \x1b%c%3d \x1b%cARM \x1b%c%3d \x1b%cAMM \x1b%c%3d/%3d",
       '0'+CR_GRAY, '0'+cr_health, st_health,
       '0'+CR_GRAY, '0'+cr_armor, st_armor,
       '0'+CR_GRAY, '0'+cr_ammo, ammo, fullammo);


### PR DESCRIPTION
I couldn't get it done with the existing widgets, so I created a new one which displays only the most basic information (health, armor, ammo) in one line. Fixes #1396 