### PR TITLE
Remove 64-bit integer divides from performance sensitive code

### DIFF
--- a/cmake/WoofSettings.cmake
+++ b/cmake/WoofSettings.cmake
@@ -29,6 +29,12 @@ function(_checked_add_link_option FLAG)
     endif()
 endfunction()
 
+if(MSVC)
+    _checked_add_compile_option(/fp:fast)
+else()
+    _checked_add_compile_option(-ffast-math)
+endif()
+
 # Parameters we want to check for on all compilers.
 #
 # Note that we want to check for these, even on MSVC, because some compilers

--- a/src/g_input.c
+++ b/src/g_input.c
@@ -189,13 +189,13 @@ void G_UpdateDeltaTics(void)
 {
     if (uncapped && raw_input)
     {
-        static uint64_t last_time;
-        const uint64_t current_time = I_GetTimeUS();
+        static double last_time;
+        const double current_time = I_GetTimeUS();
 
         if (input_ready)
         {
-            const uint64_t delta_time = current_time - last_time;
-            deltatics = (double)delta_time * TICRATE / 1000000.0;
+            const double delta_time = current_time - last_time;
+            deltatics = delta_time * TICRATE * 1e-6;
             deltatics = BETWEEN(0.0, 1.0, deltatics);
         }
         else

--- a/src/i_midimusic.c
+++ b/src/i_midimusic.c
@@ -147,19 +147,19 @@ typedef struct
     midi_track_t *track;
 } midi_position_t;
 
-static uint64_t start_time, pause_time;
+static double start_time, pause_time;
 
-static uint64_t TicksToUS(uint32_t ticks)
+static double TicksToUS(uint32_t ticks)
 {
-    return (uint64_t)ticks * us_per_beat / ticks_per_beat;
+    return (double)ticks * us_per_beat / ticks_per_beat;
 }
 
-static void RestartTimer(uint64_t offset)
+static void RestartTimer(double offset)
 {
-    if (pause_time)
+    if (pause_time != 0.)
     {
         start_time += (I_GetTimeUS() - pause_time);
-        pause_time = 0;
+        pause_time = 0.;
     }
     else
     {
@@ -172,7 +172,7 @@ static void PauseTimer(void)
     pause_time = I_GetTimeUS();
 }
 
-static uint64_t CurrentTime(void)
+static double CurrentTime(void)
 {
     return I_GetTimeUS() - start_time;
 }

--- a/src/i_timer.c
+++ b/src/i_timer.c
@@ -36,6 +36,7 @@ HANDLE hTimer = NULL;
 static uint64_t basecounter = 0;
 static uint64_t basecounter_scaled = 0;
 static uint64_t basefreq = 0;
+static double baseperiod_ms = 0.;
 static double baseperiod_us = 0.;
 
 static int MSToTic(uint32_t time)
@@ -57,7 +58,7 @@ int I_GetTimeMS(void)
         basecounter = counter;
     }
 
-    return ((counter - basecounter) * 1000ull) / basefreq;
+    return (int64_t)(counter - basecounter) * baseperiod_ms;
 }
 
 double I_GetTimeUS(void)
@@ -92,7 +93,7 @@ static uint32_t GetTimeMS_Scaled(void)
         basecounter_scaled = counter;
     }
 
-    return ((counter - basecounter_scaled) * 1000ull) / basefreq;
+    return (int64_t)(counter - basecounter_scaled) * baseperiod_ms;
 }
 
 int I_GetTime_RealTime(void)
@@ -161,6 +162,7 @@ void I_InitTimer(void)
     I_AtExit(I_ShutdownTimer, true);
 
     basefreq = SDL_GetPerformanceFrequency();
+    baseperiod_ms = 1e3 / basefreq;
     baseperiod_us = 1e6 / basefreq;
 
     I_GetTime = I_GetTime_Scaled;

--- a/src/i_timer.h
+++ b/src/i_timer.h
@@ -32,7 +32,7 @@ extern int (*I_GetFracTime)(void);
 // [FG] Same as I_GetTime, but returns time in milliseconds
 int I_GetTimeMS(void);
 
-uint64_t I_GetTimeUS(void);
+double I_GetTimeUS(void);
 
 void I_SetTimeScale(int scale);
 
@@ -44,7 +44,7 @@ void I_EnableWarp(boolean warp);
 // Pause for a specified number of ms
 void I_Sleep(int ms);
 
-void I_SleepUS(uint64_t us);
+void I_SleepUS(int us);
 
 // Initialize timer
 void I_InitTimer(void);


### PR DESCRIPTION
These are pretty bad from a performance standpoint, see table below (from Agner Fog's instruction latency tables for Nehalem). Just use doubles for high-precision timekeeping instead, and use multiplication instead of division where we can.

| operation | instruction | cycles | uops |
|--------|--------|--------|--------|
| uint64 divide | div | 28-90 | 40 |
| int64 divide | idiv | 37-100 | 60 |

compare to:

| operation | instruction | cycles | uops |
|--------|--------|--------|--------|
| fp64 divide | divsd | 7-22 | 1 |
| int32 divide | idiv | 17-28 | 7 |

and:

| operation | instruction | cycles | uops |
|--------|--------|--------|--------|
| int64 to double | cvtsi2sd | 6 |  2 |
| double to int64 | cvtsd2si | 5 | 1 |
| int32 multiply | imul | 3 | 1 |
| fp64 multiply | mulsd | 5 |1 |