### PR TITLE
Pump events while waiting in fps limiter

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -829,6 +829,7 @@ void I_FinishUpdate(void)
     if (use_limiter)
     {
         uint64_t target_time = 1000000ull / targetrefresh;
+        uint64_t last_pump = 0;
 
         while (true)
         {
@@ -841,7 +842,14 @@ void I_FinishUpdate(void)
                 break;
             }
 
-            if (target_time - elapsed_time > 1000)
+            uint64_t remaining_time = target_time - elapsed_time;
+
+            if (remaining_time > 200 && current_time - last_pump > 200)
+            {
+                last_pump = current_time;
+                SDL_PumpEvents();
+            }
+            else if (remaining_time > 1000)
             {
                 I_SleepUS(500);
             }


### PR DESCRIPTION
Might as well chew through some input processing while waiting with nothing better to do. This will reduce the amount of work the final `SDL_PumpEvents` call has to do after we exit the delay loop.