### PR TITLE
Bring back 32:9 aspect ratio

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1197,6 +1197,10 @@ static double CurrentAspectRatio(void)
             w = 21;
             h = 9;
             break;
+        case RATIO_32_9:
+            w = 32;
+            h = 9;
+            break;
         default:
             w = 16;
             h = 9;
@@ -1864,7 +1868,7 @@ void I_BindVideoVariables(void)
         "Framerate limit in frames per second (< 35 = Disable)");
     M_BindNum("widescreen", &default_widescreen, &widescreen, RATIO_AUTO, 0,
               NUM_RATIOS - 1, ss_gen, wad_no,
-              "Widescreen (0 = Off; 1 = Auto; 2 = 16:10; 3 = 16:9; 4 = 21:9)");
+              "Widescreen (0 = Off; 1 = Auto; 2 = 16:10; 3 = 16:9; 4 = 21:9; 5 = 32:9)");
     M_BindNum("fov", &custom_fov, NULL, FOV_DEFAULT, FOV_MIN, FOV_MAX, ss_gen,
               wad_no, "Field of view in degrees");
     BIND_NUM_GENERAL(gamma2, 9, 0, 17, "Custom gamma level (0 = -4; 9 = 0; 17 = 4)");

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -26,7 +26,7 @@
 #define FOV_DEFAULT      90
 #define FOV_MIN          60
 #define FOV_MAX          120
-#define ASPECT_RATIO_MAX 2.4  // Up to 21:9. TODO: Support up to 3.6 (32:9).
+#define ASPECT_RATIO_MAX 3.6 // Up to 32:9 aspect ratio.
 #define ASPECT_RATIO_MIN (4.0 / 3.0)
 
 typedef enum
@@ -36,6 +36,7 @@ typedef enum
     RATIO_16_10,
     RATIO_16_9,
     RATIO_21_9,
+    RATIO_32_9,
     NUM_RATIOS
 } aspect_ratio_mode_t;
 

--- a/src/m_fixed.h
+++ b/src/m_fixed.h
@@ -44,6 +44,11 @@ inline static fixed_t FixedMul(fixed_t a, fixed_t b)
   return (fixed_t)((int64_t) a*b >> FRACBITS);
 }
 
+inline static int64_t FixedMul64(int64_t a, int64_t b)
+{
+  return (a * b >> FRACBITS);
+}
+
 //
 // Fixed Point Division
 //

--- a/src/mn_menu.c
+++ b/src/mn_menu.c
@@ -763,7 +763,7 @@ static void M_DrawBorderedSnapshot(int n)
     const char *txt = "n/a";
 
     const int snapshot_x =
-        MAX((video.deltaw + SaveDef.x + SKULLXOFF - snapshot_width) / 2, 8);
+        MAX(video.deltaw + SaveDef.x + SKULLXOFF - snapshot_width - 8, 8);
     const int snapshot_y =
         LoadDef.y
         + MAX((load_end * LINEHEIGHT - snapshot_height) * n / load_end, 0);

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -1929,7 +1929,7 @@ static void ResetVideoHeight(void)
 }
 
 static const char *widescreen_strings[] = {"Off", "Auto", "16:10", "16:9",
-                                           "21:9"};
+                                           "21:9", "32:9"};
 
 static void ResetVideo(void)
 {

--- a/src/r_draw.c
+++ b/src/r_draw.c
@@ -927,8 +927,8 @@ void R_DrawViewBorder(void)
 
     // copy sides
     R_VideoErase(0, scaledviewy, scaledviewx, scaledviewheight);
-    R_VideoErase(scaledviewx + scaledviewwidth, scaledviewy, scaledviewx,
-                 scaledviewheight);
+    int side = scaledviewx + scaledviewwidth;
+    R_VideoErase(side, scaledviewy, video.unscaledw - side, scaledviewheight);
 
     // copy bottom
     R_VideoErase(0, scaledviewy + scaledviewheight, video.unscaledw,

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -74,6 +74,7 @@ boolean raw_input;
 fixed_t  viewcos, viewsin;
 player_t *viewplayer;
 fixed_t  viewheightfrac; // [FG] sprite clipping optimizations
+int max_project_slope = 4;
 
 static fixed_t focallength, lightfocallength;
 
@@ -270,6 +271,26 @@ static int scaledviewwidth_nonwide, viewwidth_nonwide;
 static fixed_t centerxfrac_nonwide;
 
 //
+// CalcMaxProjectSlope
+// Calculate the minimum divider needed to provide at least 45 degrees of FOV
+// padding. For fast rejection during sprite/voxel projection.
+//
+
+static void CalcMaxProjectSlope(int fov)
+{
+  max_project_slope = 16;
+
+  for (int i = 1; i < 16; i++)
+  {
+    if (atan(i) * FINEANGLES / M_PI - fov >= FINEANGLES / 8)
+    {
+      max_project_slope = i;
+      break;
+    }
+  }
+}
+
+//
 // R_InitTextureMapping
 //
 // killough 5/2/98: reformatted
@@ -359,6 +380,7 @@ static void R_InitTextureMapping(void)
   clipangle = xtoviewangle[0];
 
   vx_clipangle = clipangle - ((fov << ANGLETOFINESHIFT) - ANG90);
+  CalcMaxProjectSlope(fov);
 }
 
 //

--- a/src/r_main.h
+++ b/src/r_main.h
@@ -48,6 +48,7 @@ extern int      validcount;
 extern int      linecount;
 extern int      loopcount;
 extern fixed_t  viewheightfrac; // [FG] sprite clipping optimizations
+extern int      max_project_slope;
 
 //
 // Rendering stats

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -554,7 +554,7 @@ static void R_ProjectSprite (mobj_t* thing)
   tx = -(gyt+gxt);
 
   // too far off the side?
-  if (abs(tx)>((int64_t) tz<<2))
+  if (abs(tx) / max_project_slope > tz)
     return;
 
   xscale = FixedDiv(projection, tz);
@@ -600,14 +600,14 @@ static void R_ProjectSprite (mobj_t* thing)
   // calculate edges of the shape
   // [crispy] fix sprite offsets for mirrored sprites
   tx -= flip ? spritewidth[lump] - spriteoffset[lump] : spriteoffset[lump];
-  x1 = (centerxfrac + FixedMul(tx,xscale)) >>FRACBITS;
+  x1 = (centerxfrac + FixedMul64(tx,xscale)) >>FRACBITS;
 
     // off the right side?
   if (x1 > viewwidth)
     return;
 
   tx +=  spritewidth[lump];
-  x2 = ((centerxfrac + FixedMul(tx,xscale)) >> FRACBITS) - 1;
+  x2 = ((centerxfrac + FixedMul64(tx,xscale)) >> FRACBITS) - 1;
 
     // off the left side
   if (x2 < 0)

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -549,8 +549,6 @@ static void R_ProjectSprite (mobj_t* thing)
   if (tz < MINZ || tz > MAXZ)
     return;
 
-  xscale = FixedDiv(projection, tz);
-
   gxt = -FixedMul(tr_x,viewsin);
   gyt = FixedMul(tr_y,viewcos);
   tx = -(gyt+gxt);
@@ -558,6 +556,8 @@ static void R_ProjectSprite (mobj_t* thing)
   // too far off the side?
   if (abs(tx)>((int64_t) tz<<2))
     return;
+
+  xscale = FixedDiv(projection, tz);
 
     // decide which patch to use for sprite relative to player
   if ((unsigned) thing->sprite >= num_sprites)

--- a/src/r_voxel.c
+++ b/src/r_voxel.c
@@ -564,7 +564,7 @@ boolean VX_ProjectVoxel (mobj_t * thing)
 	else
 	{
 		// too far off the side?  if so, ignore it
-		if (ty > (64 * FRACUNIT) && abs(tx) / 4 > ty)
+		if (ty > (64 * FRACUNIT) && abs(tx) / max_project_slope > ty)
 			return true;
 
 		xscale = FixedDiv (projection, ty);

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -219,7 +219,7 @@ void V_InitColorTranslation(void)
 
 video_t video;
 
-#define WIDE_SCREENWIDTH 864 // corresponds to 3.6 aspect ratio
+#define WIDE_SCREENWIDTH 864 // Up to 32:9 aspect ratio (3.6).
 
 static int x1lookup[WIDE_SCREENWIDTH + 1];
 static int y1lookup[SCREENHEIGHT + 1];


### PR DESCRIPTION
The last time we tried this there were two issues:
1. HOMs on right side depending on resolution and FOV.
2. Sprites/voxels at edges missing at high FOV.

(1) needs to be checked with the rendering changes since then.
(2) is fixed by this PR, thanks to suggestions by @JNechaevsky.

I may also use this PR to experiment with techniques to reduce edge distortion at high FOV values.