### PR TITLE
Add speedometer widget, `speed` cheat

### DIFF
--- a/base/all-all/woofhud.lmp
+++ b/base/all-all/woofhud.lmp
@@ -6,6 +6,7 @@ sttime topleft
 coord topright
 fps topright
 cmd bottomright
+speed bottomcenter
 
 hud 1
 rate topleft
@@ -19,6 +20,7 @@ sttime bottomleft
 coord topright
 fps topright
 cmd bottomright
+speed bottomcenter
 
 hud 2
 rate topleft
@@ -32,3 +34,4 @@ sttime bottomleft
 coord topright
 fps topright
 cmd bottomright
+speed bottomcenter

--- a/docs/cheats.md
+++ b/docs/cheats.md
@@ -100,6 +100,9 @@ Toggle printing the FPS in the upper right corner.
 `RATE`  
 Toggle the display of rendering stats, including frame rate and the current number of segs, visplanes, and sprites.
 
+`SPEED`
+Toggle the speedometer. Repeating the cheat cycles through different units: map units per second, kilometers per hour, and miles per hour.
+
 ## Beta cheats
 
 These cheats only work in MBF `-beta` emulation mode.

--- a/docs/woofhud.md
+++ b/docs/woofhud.md
@@ -30,6 +30,7 @@ Possible values for the HUD widget names:
  * "fps" or "rate"
  * "cmd" or "commands"
  * "compact"
+ * "speed"
 
 Possible values for the widget position keywords:
 
@@ -57,6 +58,7 @@ sttime topleft
 coord topright
 fps topright
 cmd bottomright
+speed bottomcenter
 
 hud 1
 rate topleft
@@ -70,6 +72,7 @@ sttime bottomleft
 coord topright
 fps topright
 cmd bottomright
+speed bottomcenter
 
 hud 2
 rate topleft
@@ -83,6 +86,7 @@ sttime bottomleft
 coord topright
 fps topright
 cmd bottomright
+speed bottomcenter
 ```
 
 An alternative approach to the distributed HUD, using absolute screen coordinates, could look like this:
@@ -103,6 +107,8 @@ fps 224 16
 ## Remarks
 
 The "title" widget is only visible if the Automap is enabled. The "monsec", "sttime" and "coord" widgets are only visible if they are explicitly enabled in the Options menu (separately for Automap and HUD). The "fps" widget is only visible if the SHOWFPS cheat is enabled.
+
+The "speed" widget is only visible if the SPEED cheat is enabled. Repeating the cheat cycles through different units.
 
 The "compact" widget is a minimal widget showing only health, armor and ammo information. It is enabled by default in the minimal Boom HUD mode.
 

--- a/src/hu_stuff.h
+++ b/src/hu_stuff.h
@@ -101,6 +101,8 @@ void HU_BindHUDVariables(void);
 
 byte* HU_ColorByHealth(int health, int maxhealth, boolean invul);
 
+extern int speedometer;
+
 #endif
 
 //----------------------------------------------------------------------------

--- a/src/m_cheat.c
+++ b/src/m_cheat.c
@@ -30,6 +30,7 @@
 #include "doomdef.h"
 #include "doomstat.h"
 #include "g_game.h"
+#include "hu_stuff.h"
 #include "info.h"
 #include "m_cheat.h"
 #include "m_fixed.h"
@@ -107,6 +108,7 @@ static void cheat_reveal_item();
 static void cheat_autoaim();      // killough 7/19/98
 static void cheat_tst();
 static void cheat_showfps(); // [FG] FPS counter widget
+static void cheat_speed();
 
 //-----------------------------------------------------------------------------
 //
@@ -324,6 +326,9 @@ struct cheat_s cheat[] = {
   {"showfps",    NULL,                always,
    {cheat_showfps} },
 
+  {"speed",      NULL,                always,
+   {cheat_speed} },
+
   {NULL}                 // end-of-list marker
 };
 
@@ -333,6 +338,11 @@ struct cheat_s cheat[] = {
 static void cheat_showfps()
 {
   plyr->cheats ^= CF_SHOWFPS;
+}
+
+static void cheat_speed()
+{
+  speedometer = STRICTMODE((speedometer + 1) % 4);
 }
 
 // killough 7/19/98: Autoaiming optional in beta emulation mode


### PR DESCRIPTION
Added by request. No menu option, just a cheat.