### PR TITLE
Use _div64 intrinsic if available

### DIFF
--- a/src/m_fixed.h
+++ b/src/m_fixed.h
@@ -24,6 +24,14 @@
 #include <stdlib.h> // abs()
 #include <stdint.h> // int64_t
 
+// VS 2019 and later provide a [64]/[32] intrinsic
+#if defined(_MSC_VER) && _MSC_VER >= 1920 && (defined(_M_X64) || defined(_M_IX86))
+  #include <immintrin.h>
+  #define DIV64(a,b) (_div64((a),(b),NULL))
+#else
+  #define DIV64(a,b) ((fixed_t)((a)/(b)))
+#endif
+
 //
 // Fixed point, 32bit as 16.16.
 //
@@ -57,7 +65,7 @@ inline static fixed_t FixedDiv(fixed_t a, fixed_t b)
 {
   // [FG] avoid 31-bit shift (from Chocolate Doom)
   return (abs(a)>>14) >= abs(b) ? ((a^b) < 0 ? INT_MIN : INT_MAX) :
-    (fixed_t)(((int64_t) a << FRACBITS) / b);
+    DIV64((int64_t) a << FRACBITS, b);
 }
 
 #endif


### PR DESCRIPTION
Following the theme of #1769, use the [_div64](https://learn.microsoft.com/en-us/cpp/intrinsics/div64?view=msvc-170) intrinsic to  have FixedDiv perform a 32-bit operand divide like the original Doom. This is available since VS 2019 and is worth about a 1% faster tic (*) and a 1.3x+ speedup when using voxels.

(*) Intel CPUs newer than Coffee Lake have a hardware divider and won't see any benefit from this PR

|| fps before [realtics] | fps after [realtics]|
|--------|--------|--------|
| [av20](https://dsdarchive.com/files/demos/av/28588/av20-1357.zip) | 2981 [345] | 2999 [343] |
| [su03](https://dsdarchive.com/files/demos/sunder/56326/su03-935.zip) | 1259 [565] | 1270 [560] |
| [coma](https://dsdarchive.com/files/demos/comatose/59073/comatose01p040.zip) | 141 [405] | 142 [401] |

with voxels:

|| fps before [realtics] | fps after [realtics]|
|--------|--------|--------|
| av20 | 1495 [688] | 1941 [530] |
| su03 | 289 [2465] | 400 [1799] |

Testing was done with `-nosound -noblit` and voxel tests with `-fastdemo` to speed things up a bit.