### PR TITLE
Use native texture format

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -989,6 +989,7 @@ void I_SetPalette(byte *palette)
         colors[i].r = gamma[*palette++];
         colors[i].g = gamma[*palette++];
         colors[i].b = gamma[*palette++];
+        colors[i].a = 0xffu;
     }
 
     SDL_SetPaletteColors(screenbuffer->format->palette, colors, 0, 256);

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1372,7 +1372,7 @@ static void CreateUpscaledTexture(boolean force)
     // screen.
 
     texture_upscaled = SDL_CreateTexture(
-        renderer, SDL_GetWindowPixelFormat(screen), SDL_TEXTUREACCESS_TARGET,
+        renderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_TARGET,
         w_upscale * screen_width, h_upscale * screen_height);
 
     SDL_SetTextureScaleMode(texture_upscaled, SDL_ScaleModeLinear);
@@ -1750,7 +1750,7 @@ static void CreateSurfaces(int w, int h)
         uint32_t rmask, gmask, bmask, amask;
         int bpp;
 
-        SDL_PixelFormatEnumToMasks(SDL_GetWindowPixelFormat(screen), &bpp,
+        SDL_PixelFormatEnumToMasks(SDL_PIXELFORMAT_ARGB8888, &bpp,
                                    &rmask, &gmask, &bmask, &amask);
         argbbuffer =
             SDL_CreateRGBSurface(0, w, h, bpp, rmask, gmask, bmask, amask);
@@ -1766,7 +1766,7 @@ static void CreateSurfaces(int w, int h)
         SDL_DestroyTexture(texture);
     }
 
-    texture = SDL_CreateTexture(renderer, SDL_GetWindowPixelFormat(screen),
+    texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_ARGB8888,
                                 SDL_TEXTUREACCESS_STREAMING, w, h);
 
     SDL_SetTextureScaleMode(texture, SDL_ScaleModeNearest);


### PR DESCRIPTION
Using the `ARGB8888` format prevents a call to `Blit4to4MaskAlpha` by `SDL_UpdateTexture`. which improves fps by about 10% for me on the `direct3d` renderer [*]:

| scale | before | after |
|--------|--------|--------|
| 2x| 980 | 1100|
| 3x| 440 | 500|
| 4x| 230  | 250| 

[*] The `opengl` and `direct3d11` renderers also support the previous `RGB888` format so they aren't affected by this change.

These are the supported/native texture formats for the various backends:

`direct3d`

> SDL_PIXELFORMAT_ARGB8888
> SDL_PIXELFORMAT_YV12
> SDL_PIXELFORMAT_IYUV

`direct3d11`

> SDL_PIXELFORMAT_ARGB8888
> SDL_PIXELFORMAT_RGB888
> SDL_PIXELFORMAT_YV12
> SDL_PIXELFORMAT_IYUV
> SDL_PIXELFORMAT_NV12
> SDL_PIXELFORMAT_NV21

`opengl`

> SDL_PIXELFORMAT_ARGB8888
> SDL_PIXELFORMAT_ABGR8888
> SDL_PIXELFORMAT_RGB888
> SDL_PIXELFORMAT_BGR888
> SDL_PIXELFORMAT_YV12
> SDL_PIXELFORMAT_IYUV
> SDL_PIXELFORMAT_NV12
> SDL_PIXELFORMAT_NV21