### PR TITLE
fix setup menu highlight when using non-menu key

### DIFF
--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -3353,6 +3353,11 @@ boolean MN_SetupResponder(menu_action_t action, int ch)
 
     setup_menu_t *current_item = current_menu + set_item_on;
 
+    if (menu_input != mouse_mode)
+    {
+       current_item->m_flags |= S_HILITE;
+    }
+
     // phares 4/19/98:
     // Catch the response to the 'reset to default?' verification
     // screen


### PR DESCRIPTION
Fix #1795 

This is not much different from #1803, but in my opinion it is more correct.