### PR TITLE
fix sound origin for huge levels (taken from PrBoom+)

### DIFF
--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -1297,10 +1297,10 @@ int P_GroupLines (void)
       sector->lines -= sector->linecount;
 
       // set the degenmobj_t to the middle of the bounding box
-      sector->soundorg.x = (sector->blockbox[BOXRIGHT] + 
-			    sector->blockbox[BOXLEFT])/2;
-      sector->soundorg.y = (sector->blockbox[BOXTOP] + 
-			    sector->blockbox[BOXBOTTOM])/2;
+      sector->soundorg.x =
+          sector->blockbox[BOXRIGHT] / 2 + sector->blockbox[BOXLEFT] / 2;
+      sector->soundorg.y =
+          sector->blockbox[BOXTOP] / 2 + sector->blockbox[BOXBOTTOM] / 2;
 
       sector->soundorg.thinker.function.p1 = (actionf_p1)P_DegenMobjThinker;
 


### PR DESCRIPTION
Fixes an issue reported in [[doomworld]](https://www.doomworld.com/forum/topic/112333-this-is-woof-1450-apr-30-2024/?do=findComment&comment=2827653)