### PR TITLE
Fix freelook toggles

### DIFF
--- a/src/g_game.c
+++ b/src/g_game.c
@@ -909,7 +909,7 @@ static void G_DoLoadLevel(void)
 
   P_SetupLevel (gameepisode, gamemap, 0, gameskill);
 
-  MN_UpdateFreeLook();
+  MN_UpdateFreeLook(!mouselook && !padlook);
   HU_UpdateTurnFormat();
 
   // [Woof!] Do not reset chosen player view across levels in multiplayer
@@ -3474,7 +3474,6 @@ void G_ReloadDefaults(boolean keep_demover)
   }
 
   G_UpdateSideMove();
-  P_UpdateDirectVerticalAiming();
 
   pistolstart = default_pistolstart;
 

--- a/src/mn_menu.c
+++ b/src/mn_menu.c
@@ -2085,14 +2085,15 @@ static boolean ShortcutResponder(const event_t *ev)
             // Gamepad free look toggle only affects gamepad.
             padlook = !padlook;
             togglemsg("Gamepad Free Look %s", padlook ? "On" : "Off");
+            MN_UpdatePadLook();
         }
         else
         {
             // Keyboard or mouse free look toggle only affects mouse.
             mouselook = !mouselook;
             togglemsg("Free Look %s", mouselook ? "On" : "Off");
+            MN_UpdateMouseLook();
         }
-        MN_UpdateFreeLook();
         // return true; // [FG] don't let toggles eat keys
     }
 

--- a/src/mn_menu.h
+++ b/src/mn_menu.h
@@ -58,7 +58,9 @@ void MN_StartControlPanel(void);
 void MN_ForcedLoadGame(const char *msg); // killough 5/15/98: forced loadgames
 void MN_Trans(void);     // killough 11/98: reset translucency
 void MN_SetupResetMenu(void);
-void MN_UpdateFreeLook(void);
+void MN_UpdateFreeLook(boolean condition);
+void MN_UpdateMouseLook(void);
+void MN_UpdatePadLook(void);
 void MN_UpdateAdvancedSoundItems(boolean toggle);
 void MN_ResetTimeScale(void);
 void MN_DrawCredits(void); // killough 11/98

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -1756,7 +1756,8 @@ setup_menu_t comp_settings1[] = {
     {"Compatibility-breaking Features", S_SKIP | S_TITLE, M_X, M_SPC},
 
     {"Direct Vertical Aiming", S_ONOFF | S_STRICT, M_X, M_SPC,
-     {"direct_vertical_aiming"}},
+     {"direct_vertical_aiming"}, m_null, input_null, str_empty,
+     P_UpdateDirectVerticalAiming},
 
     {"Auto Strafe 50", S_ONOFF | S_STRICT, M_X, M_SPC,
      {"autostrafe50"}, m_null, input_null, str_empty, G_UpdateSideMove},
@@ -2148,11 +2149,11 @@ static const char **GetResamplerStrings(void)
     return strings;
 }
 
-void MN_UpdateFreeLook(void)
+void MN_UpdateFreeLook(boolean condition)
 {
     P_UpdateDirectVerticalAiming();
 
-    if (!mouselook && !padlook)
+    if (condition)
     {
         for (int i = 0; i < MAXPLAYERS; ++i)
         {
@@ -2162,6 +2163,16 @@ void MN_UpdateFreeLook(void)
             }
         }
     }
+}
+
+void MN_UpdateMouseLook(void)
+{
+    MN_UpdateFreeLook(!mouselook);
+}
+
+void MN_UpdatePadLook(void)
+{
+    MN_UpdateFreeLook(!padlook);
 }
 
 #define MOUSE_ACCEL_STRINGS_SIZE (40 + 1)
@@ -2189,7 +2200,7 @@ static setup_menu_t gen_settings3[] = {
     {"Double-Click to \"Use\"", S_ONOFF, CNTR_X, M_SPC, {"dclick_use"}},
 
     {"Free Look", S_ONOFF, CNTR_X, M_SPC, {"mouselook"}, m_null, input_null,
-     str_empty, MN_UpdateFreeLook},
+     str_empty, MN_UpdateMouseLook},
 
     // [FG] invert vertical axis
     {"Invert Look", S_ONOFF, CNTR_X, M_SPC,
@@ -2240,7 +2251,7 @@ static setup_menu_t gen_settings4[] = {
      str_layout, I_ResetController},
 
     {"Free Look", S_ONOFF, CNTR_X, M_SPC, {"padlook"}, m_null, input_null,
-     str_empty, MN_UpdateFreeLook},
+     str_empty, MN_UpdatePadLook},
 
     {"Invert Look", S_ONOFF, CNTR_X, M_SPC, {"joy_invert_look"},
      m_null, input_null, str_empty, G_UpdateControllerVariables},


### PR DESCRIPTION
- When loading a level (e.g. loading a save game), the view will center if both `mouselook` and `padlook` are "off".
- When toggling `mouselook` or `padlook` to "off", with key bindings or the menu items, the view will always center regardless of the value of the other `*look` setting.
- Always call `P_UpdateDirectVerticalAiming` if any of `mouselook`, `padlook`, or `direct_vertical_aiming` are changed.

References:
- https://github.com/fabiangreffrath/woof/commit/481b8de46dc76823fe0d420a40cccd8039f1f3ed#r144922599
- https://github.com/fabiangreffrath/woof/issues/1614