### PR TITLE
Fix potential overflow in FixedDiv, re-add gcc asm implementation

### DIFF
--- a/src/m_fixed.h
+++ b/src/m_fixed.h
@@ -30,6 +30,20 @@
 
   #define div64_32(a, b) _div64((a), (b), NULL)
 
+#elif defined(__GNUC__) && defined(__x86_64__)
+
+  inline static int32_t div64_32(int64_t a, int32_t b)
+  {
+      if (__builtin_constant_p(b))
+      {
+          return a / b;
+      }
+      int32_t lo = a;
+      int32_t hi = a >> 32;
+      asm("idivl %[divisor]" : "+a" (lo), "+d" (hi) : [divisor] "rm" (b));
+      return lo;
+  }
+
 #else
 
   #define div64_32(a, b) ((fixed_t)((a) / (b)))

--- a/src/m_fixed.h
+++ b/src/m_fixed.h
@@ -82,7 +82,7 @@ inline static int64_t FixedMul64(int64_t a, int64_t b)
 inline static fixed_t FixedDiv(fixed_t a, fixed_t b)
 {
     // [FG] avoid 31-bit shift (from Chocolate Doom)
-    if ((abs(a) >> 14) >= abs(b))
+    if (((unsigned)abs(a) >> 14) >= (unsigned)abs(b))
     {
         return (a ^ b) < 0 ? INT_MIN : INT_MAX;
     }

--- a/src/m_fixed.h
+++ b/src/m_fixed.h
@@ -40,7 +40,7 @@
       }
       int32_t lo = a;
       int32_t hi = a >> 32;
-      asm("idivl %[divisor]" : "+a" (lo), "+d" (hi) : [divisor] "rm" (b));
+      asm("idivl %[divisor]" : "+a" (lo), "+d" (hi) : [divisor] "r" (b));
       return lo;
   }
 


### PR DESCRIPTION
If the first argument of `FixedDiv`  is `INT_MIN` its overflow check is effectively bypassed because `abs(INT_MIN)==INT_MIN`. This is the only possible explanation I can see for #1816, even though neither @rfomin nor myself have been able to reproduce this crash.

Using an unsigned comparison here fixes the problem and _seems_ like it shouldn't affect demo compatibility - this bug has never been reported in game (see discussion [here](https://forum.zdoom.org/viewtopic.php?t=12794&p=262045)) so it seems impossible to get `INT_MIN` as either arg in the course of normal play or else someone would have noticed by now. Modern ports technically already broke compatibility here anyway - in vanilla an overflow will result in a crash, while an implementation using an int64 divide will silently return an incorrect truncated result instead.