### PR TITLE
Disable mouse acceleration by default

### DIFF
--- a/src/g_input.c
+++ b/src/g_input.c
@@ -360,15 +360,15 @@ double G_CalcMouseVert(int mousey)
 
 void G_BindMouseVariables(void)
 {
-    BIND_NUM_GENERAL(mouse_sensitivity, 5, 0, UL,
+    BIND_NUM_GENERAL(mouse_sensitivity, 15, 0, UL,
         "Horizontal mouse sensitivity for turning");
-    BIND_NUM_GENERAL(mouse_sensitivity_y, 5, 0, UL,
+    BIND_NUM_GENERAL(mouse_sensitivity_y, 15, 0, UL,
         "Vertical mouse sensitivity for moving");
-    BIND_NUM_GENERAL(mouse_sensitivity_strafe, 5, 0, UL,
+    BIND_NUM_GENERAL(mouse_sensitivity_strafe, 15, 0, UL,
         "Horizontal mouse sensitivity for strafing");
-    BIND_NUM_GENERAL(mouse_sensitivity_y_look, 5, 0, UL,
+    BIND_NUM_GENERAL(mouse_sensitivity_y_look, 15, 0, UL,
         "Vertical mouse sensitivity for looking");
-    BIND_NUM_GENERAL(mouse_acceleration, 10, 0, 40,
+    BIND_NUM_GENERAL(mouse_acceleration, 0, 0, 40,
         "Mouse acceleration (0 = 1.0; 40 = 5.0)");
     BIND_NUM(mouse_acceleration_threshold, 10, 0, 32,
         "Mouse acceleration threshold");


### PR DESCRIPTION
Default mouse sensitivities increased to equivalent values so everything will feel exactly the same as before:

Scaling:
```
accel  = (mouse_acceleration + 10) / 10
turn   = accel * (mouse_sensitivity        + 5) * 8 / 10
look   = accel * (mouse_sensitivity_y_look + 5) * 8 / 10
move   = accel * (mouse_sensitivity_y      + 5) / 10
strafe = accel * (mouse_sensitivity_strafe + 5) * 2 / 10
```

Before:
```
turn   = 2 * (5 + 5) * 8 / 10   = 16
look   = 2 * (5 + 5) * 8 / 10   = 16
move   = 2 * (5 + 5) / 10       = 2
strafe = 2 * (5 + 5) * 2 / 10   = 4
```

After:
```
turn   = 1 * (15 + 5) * 8 / 10  = 16
look   = 1 * (15 + 5) * 8 / 10  = 16
move   = 1 * (15 + 5) / 10      = 2
strafe = 1 * (15 + 5) * 2 / 10  = 4
```