### PR TITLE
Add config option to stretch output slightly to fit screen

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -787,6 +787,14 @@ static void I_ResetTargetRefresh(void);
 
 void I_FinishUpdate(void)
 {
+    // nocheckin
+    boolean ff = (players[0].cheats & CF_GODMODE) != 0;
+    if (ff != full_frame)
+    {
+        full_frame = ff;
+        UpdateViewport();
+    }
+
     if (NOBLIT)
     {
         return;
@@ -1420,6 +1428,9 @@ static void UpdateViewport(void)
 {
     int w, h;
 
+     // nocheckin
+    boolean prevmargins = has_margins;
+
     if (full_frame
         && SDL_GetRendererOutputSize(renderer, &w, &h) == 0
         && fabs((double)w / h - CurrentAspectRatio()) < .002)
@@ -1438,6 +1449,10 @@ static void UpdateViewport(void)
     {
         UpdateMarginState();
     }
+
+    // nocheckin
+    if (has_margins != prevmargins)
+        I_Printf(VB_ALWAYS, "has_margins=%d", has_margins);
 }
 
 static void ResetLogicalSize(void)
@@ -1901,6 +1916,9 @@ void I_ShutdownGraphics(void)
 
 void I_InitGraphics(void)
 {
+    // nocheckin
+    full_frame ? players[0].cheats |= CF_GODMODE : 0;
+
     if (SDL_Init(SDL_INIT_VIDEO) < 0)
     {
         I_Error("Failed to initialize video: %s", SDL_GetError());

--- a/src/m_cheat.c
+++ b/src/m_cheat.c
@@ -318,6 +318,9 @@ struct cheat_s cheat[] = {
 
   {"tst",        NULL,                not_net | not_demo | beta_only,
    {cheat_tst} },
+// nocheckin
+  { "t",         NULL,                always,
+   {cheat_tst} },
 
   {"nc",         NULL,                not_net | not_demo | beta_only,
    {cheat_noclip} },


### PR DESCRIPTION
Tentatively named `full_frame`. Added `t` temporary cheat to toggle on/off for testing.

This is mainly for 16:9 (and 32:9) which otherwise ends up with thin black bars at the edges of the screen - see comment here:

https://github.com/fabiangreffrath/woof/blob/794af9df85e32a2f7f617068ea6cb16d130bfcbc/src/i_video.c#L1246-L1249

What this PR does is check If the output resolution matches the desired aspect ratio within some tolerance, and if so allow the horizontal and vertical scale differ slightly so that the window will render edge-to-edge. (feature might better be named "strict aspect ratio" or "maintain aspect ratio" and have its sense inverted, but that seemed easy to confuse with the existing `correct_aspect_ratio`).

 I can see this being useful for people worried about OLED burn-in, but mainly I wanted this in order to enable omitting the backbuffer clear which is a small performance win (5-10% lower GPU busy time on my 1080ti according to Special K).