### PR TITLE
fix crash with S_FUNC item instructions, simplify

### DIFF
--- a/src/mn_internal.h
+++ b/src/mn_internal.h
@@ -187,7 +187,6 @@ typedef struct setup_menu_s
 
     union // killough 11/98: The first field is a union of several types
     {
-        void *var;             // generic variable
         char *name;            // name
         struct default_s *def; // default[] table entry
     } var;

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -137,8 +137,9 @@ static void DisableItem(boolean condition, setup_menu_t *menu, const char *item)
     {
         if (!(menu->m_flags & (S_SKIP | S_RESET)))
         {
-            if (!strcasecmp(menu->var.name, item)
-                || !strcasecmp(menu->var.def->name, item))
+            if (((menu->m_flags & S_HASDEFPTR)
+                 && !strcasecmp(menu->var.def->name, item))
+                || !strcasecmp(menu->m_text, item))
             {
                 if (condition)
                 {
@@ -1133,7 +1134,7 @@ static void DrawInstructions()
 
     if (flags & S_FUNC)
     {
-        if (!strcmp(item->var.name, "gyro_calibrate"))
+        if (!strcasecmp(item->m_text, "Calibrate"))
         {
             s = "Place gamepad on a flat surface";
         }
@@ -2655,7 +2656,7 @@ static setup_menu_t gen_gyro[] = {
     MI_GAP,
 
     {"Calibrate", S_FUNC, CNTR_X, M_SPC,
-      {"gyro_calibrate"}, m_null, input_null, str_empty,
+      {NULL}, m_null, input_null, str_empty,
       I_UpdateGyroCalibrationState},
 
     MI_END
@@ -2673,7 +2674,7 @@ static void UpdateGyroItems(void)
     DisableItem(condition, gen_gyro, "gyro_look_speed");
     DisableItem(condition, gen_gyro, "gyro_acceleration");
     DisableItem(condition, gen_gyro, "gyro_smooth_threshold");
-    DisableItem(condition, gen_gyro, "gyro_calibrate");
+    DisableItem(condition, gen_gyro, "Calibrate");
 }
 
 void MN_UpdateAllGamepadItems(void)


### PR DESCRIPTION
Fix #1857 

I think we can implement `S_FUNC` if we need at least two of them.

ASAN report:
<details>

```
=================================================================
==8612==ERROR: AddressSanitizer: access-violation on unknown address 0xffffffffffffffff (pc 0x7ff91ebca0e2 bp 0x01b2b6380000 sp 0x00196b76f6f0 T0)
==8612==The signal is caused by a READ memory access.
    #0 0x7ff91ebca0e1 in MN_GetPixelWidth C:\develop\woof\src\mn_setup.c:3278
    #1 0x7ff91ebc759a in DrawInstructions C:\develop\woof\src\mn_setup.c:1247
    #2 0x7ff91ebc9f4e in MN_DrawWeapons C:\develop\woof\src\mn_setup.c:1545
    #3 0x7ff91ebc305f in M_Drawer C:\develop\woof\src\mn_menu.c:3102
    #4 0x7ff91eb72b82 in D_Display C:\develop\woof\src\d_main.c:432
    #5 0x7ff91eb742c7 in D_DoomMain C:\develop\woof\src\d_main.c:2734
    #6 0x7ff91eba0683 in Woof_Main C:\develop\woof\src\i_main.c:70
    #7 0x7ff794f1651f in main_getcmdline C:\develop\vcpkg\buildtrees\sdl2\src\ase-2.30.5-4439cd0809.clean\src\main\windows\SDL_windows_main.c:80
    #8 0x7ff794f1381b in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #9 0x7ff94f417373 in BaseThreadInitThunk+0x13 (C:\Windows\System32\KERNEL32.DLL+0x180017373)
    #10 0x7ff95101cc90 in RtlUserThreadStart+0x20 (C:\Windows\SYSTEM32\ntdll.dll+0x18004cc90)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: access-violation C:\develop\woof\src\mn_setup.c:3278 in MN_GetPixelWidth
==8612==ABORTING
```
</details>