### PR TITLE
Remember cursor position on Sound Volume menu

### DIFF
--- a/src/mn_menu.c
+++ b/src/mn_menu.c
@@ -2164,7 +2164,7 @@ static boolean ShortcutResponder(const event_t *ev)
     {
         MN_StartControlPanel();
         currentMenu = &SoundDef;
-        itemOn = sfx_vol;
+        itemOn = currentMenu->lastOn;
         M_StartSound(sfx_swtchn);
         return true;
     }


### PR DESCRIPTION
Traditionally, Doom remember cursor position in all menus, but Sound Volume (`F4`) doesn't follow the suite. Steps to reproduce:

- Open Sound Volume menu (`F4`).
- Set cursor to Music Volume.
- Close menu (`ESC`) and open it again.
- Cursor will be placed on SFX Volume.

Not a big problem in practice, unless you'll need to fine-tune music volume. Probably even not worth to add a `[Woof!]` comment, this is a tiny change. At your discretion.