### PR TITLE
Blit directly to texture

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -665,9 +665,16 @@ void I_StartFrame(void)
 
 static void UpdateRender(void)
 {
+    void *pixels;
+    int pitch;
+
+    SDL_LockTexture(texture, &blit_rect, &pixels, &pitch);
+
+    argbbuffer->pixels = pixels;
+    argbbuffer->pitch = pitch;
+
     SDL_LowerBlit(screenbuffer, &blit_rect, argbbuffer, &blit_rect);
-    SDL_UpdateTexture(texture, &blit_rect, argbbuffer->pixels,
-                      argbbuffer->pitch);
+    SDL_UnlockTexture(texture);
 
     if (letterboxed)
     {
@@ -1814,16 +1821,9 @@ static void CreateSurfaces(int w, int h)
     }
 
     // [FG] create intermediate ARGB frame buffer
-    {
-        uint32_t rmask, gmask, bmask, amask;
-        int bpp;
 
-        SDL_PixelFormatEnumToMasks(SDL_PIXELFORMAT_ARGB8888, &bpp,
-                                   &rmask, &gmask, &bmask, &amask);
-        argbbuffer =
-            SDL_CreateRGBSurface(0, w, h, bpp, rmask, gmask, bmask, amask);
-        SDL_FillRect(argbbuffer, NULL, 0);
-    }
+    argbbuffer = SDL_CreateRGBSurfaceWithFormatFrom(
+        NULL, w, h, 8, 0, SDL_PIXELFORMAT_ARGB8888);
 
     I_SetPalette(W_CacheLumpName("PLAYPAL", PU_CACHE));
 

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -665,15 +665,11 @@ void I_StartFrame(void)
 
 static void UpdateRender(void)
 {
-    void *pixels;
-    int pitch;
-
-    SDL_LockTexture(texture, &blit_rect, &pixels, &pitch);
-
-    argbbuffer->pixels = pixels;
-    argbbuffer->pitch = pitch;
+    SDL_LockTexture(texture, &blit_rect, &argbbuffer->pixels,
+        &argbbuffer->pitch);
 
     SDL_LowerBlit(screenbuffer, &blit_rect, argbbuffer, &blit_rect);
+
     SDL_UnlockTexture(texture);
 
     if (letterboxed)


### PR DESCRIPTION
This avoids some memcpy'ing in the direct3d backend and gives a nice fps bump for me at higher res settings

| scale | before | after |
|--------|--------|--------|
| 2x| 1000 | 1170|
| 3x| 450| 580|
| 4x| 220  | 340| 

opengl backend performance seems unaffected