### PR TITLE
Activate OPL3 chips on-demand based on voice pressure

### DIFF
--- a/opl/opl.c
+++ b/opl/opl.c
@@ -32,8 +32,6 @@ static opl_driver_t *drivers[] =
 
 static opl_driver_t *driver = NULL;
 
-unsigned int opl_sample_rate = OPL_SAMPLE_RATE;
-
 //
 // Init/shutdown code.
 //
@@ -139,11 +137,6 @@ void OPL_Shutdown(void)
 }
 
 // Set the sample rate used for software OPL emulation.
-
-void OPL_SetSampleRate(unsigned int rate)
-{
-    opl_sample_rate = rate;
-}
 
 void OPL_WritePort(int chip, opl_port_t port, unsigned int value)
 {

--- a/opl/opl.h
+++ b/opl/opl.h
@@ -85,10 +85,6 @@ opl_init_result_t OPL_Init(unsigned int port_base, int num_chips);
 
 void OPL_Shutdown(void);
 
-// Set the sample rate used for software emulation.
-
-void OPL_SetSampleRate(unsigned int rate);
-
 // Write to one of the OPL I/O ports:
 
 void OPL_WritePort(int chip, opl_port_t port, unsigned int value);

--- a/opl/opl_internal.h
+++ b/opl/opl_internal.h
@@ -48,7 +48,5 @@ extern opl_driver_t opl_sdl_driver;
 
 // Sample rate to use when doing software emulation.
 
-extern unsigned int opl_sample_rate;
-
 #endif /* #ifndef OPL_INTERNAL_H */
 

--- a/opl/opl_sdl.c
+++ b/opl/opl_sdl.c
@@ -15,6 +15,8 @@
 //     OPL SDL interface.
 //
 
+#include <stdlib.h>
+
 #include "doomtype.h"
 #include "opl.h"
 #include "opl3.h"
@@ -22,6 +24,9 @@
 #include "opl_queue.h"
 
 #define MAX_SOUND_SLICE_TIME 100 /* ms */
+
+#define OPL_SILENCE_THRESHOLD   36
+#define OPL_CHIP_TIMEOUT        (OPL_SAMPLE_RATE / 2)
 
 typedef struct
 {
@@ -51,6 +56,8 @@ static uint64_t pause_offset;
 // OPL software emulator structure.
 
 static opl3_chip opl_chips[OPL_MAX_CHIPS];
+static uint32_t opl_chip_keys[OPL_MAX_CHIPS];
+static uint32_t opl_chip_timeouts[OPL_MAX_CHIPS];
 static int opl_opl3mode;
 
 // Register number that was written.
@@ -143,16 +150,31 @@ int OPL_FillBuffer(byte *buffer, int buffer_samples)
             Bit32s mix[2] = {0, 0};
             for (int c = 0; c < num_opl_chips; ++c)
             {
-                Bit16s sample[2];
-                OPL3_Generate(&opl_chips[c], sample);
-                mix[0] += sample[0];
-                mix[1] += sample[1];
+                // Reset chip timeout if any channels are active
+                if (opl_chip_keys[c])
+                    opl_chip_timeouts[c] = 0;
+
+                // Run the chip if it hasn't timed out or if it has pending register writes
+                if (opl_chip_timeouts[c] < OPL_CHIP_TIMEOUT || (opl_chips[c].writebuf[opl_chips[c].writebuf_cur].reg & 0x200))
+                {
+                    Bit16s sample[2];
+                    OPL3_Generate(&opl_chips[c], sample);
+                    mix[0] += sample[0];
+                    mix[1] += sample[1];
+
+                    // Reset chip timeout if it breaks the silence threshold
+                    if (MAX(abs(sample[0]), abs(sample[1])) > OPL_SILENCE_THRESHOLD)
+                        opl_chip_timeouts[c] = 0;
+                    else
+                        opl_chip_timeouts[c]++;
+                }
             }
 
             cursor[0] = BETWEEN(-32768, 32767, mix[0]);
             cursor[1] = BETWEEN(-32768, 32767, mix[1]);
             cursor += 2;
         }
+
         //OPL3_GenerateStream(&opl_chip, (Bit16s *)(buffer + filled * 4), nsamples);
         filled += nsamples;
 
@@ -197,6 +219,12 @@ static int OPL_SDL_Init(unsigned int port_base, int num_chips)
     for (int c = 0; c < num_opl_chips; ++c)
         OPL3_Reset(&opl_chips[c], OPL_SAMPLE_RATE);
     opl_opl3mode = 0;
+
+    for (int c = 0; c < OPL_MAX_CHIPS; ++c)
+    {
+        opl_chip_keys[c] = 0;
+        opl_chip_timeouts[c] = OPL_CHIP_TIMEOUT;
+    }
 
     return 1;
 }
@@ -298,6 +326,16 @@ static void WriteRegister(int chip, unsigned int reg_num, unsigned int value)
             break;
 
         default:
+            // Keep track of which channels are keyed-on so we know when the chip is in use
+            if ((reg_num & 0xff) >= 0xb0 && (reg_num & 0xff) <= 0xb8)
+            {
+                uint32_t key_bit = 1 << (((reg_num & 0x100) ? 9 : 0) + (reg_num & 0xf));
+                if (value & (1 << 5))
+                    opl_chip_keys[chip] |= key_bit;
+                else
+                    opl_chip_keys[chip] &= ~key_bit;
+            }
+
             OPL3_WriteRegBuffered(&opl_chips[chip], reg_num, value);
             break;
     }

--- a/opl/opl_sdl.c
+++ b/opl/opl_sdl.c
@@ -25,8 +25,9 @@
 
 #define MAX_SOUND_SLICE_TIME 100 /* ms */
 
-#define OPL_SILENCE_THRESHOLD   36
-#define OPL_CHIP_TIMEOUT        (OPL_SAMPLE_RATE / 2)
+#define OPL_SILENCE_THRESHOLD   36  // Allow for a worst case of +/-1 ripple in all 36 operators.
+#define OPL_CHIP_TIMEOUT        (OPL_SAMPLE_RATE / 2)   // 0.5 seconds of silence with no key-on
+                                                        // should be enough to ensure chip is "off"
 
 typedef struct
 {

--- a/opl/opl_sdl.c
+++ b/opl/opl_sdl.c
@@ -109,42 +109,35 @@ static void AdvanceTime(unsigned int nsamples)
 }
 
 
-// Awaken a dormant OPL chip, or keep an active one active
 // When a chip is re-activated after being idle, we need to bring its
 // internal global timers back into synch with the main chip to avoid
 // possible beating artifacts
 
-static void WakeUpChip (int chip)
+static void ResyncChip (int chip)
 {
-    // If the chip has timed out, we need to resync it
-    if (opl_chip_timeouts[chip] >= OPL_CHIP_TIMEOUT)
+    // Find an active chip to synchronize with; will usually be chip 0
+    int sync = -1;
+    for (int c = 0; c < OPL_MAX_CHIPS; ++c)
     {
-        // Find an active chip to synchronize with; will usually be chip 0
-        int sync = -1;
-        for (int c = 0; c < OPL_MAX_CHIPS; ++c)
+        if (opl_chip_timeouts[c] < OPL_CHIP_TIMEOUT)
         {
-            if (opl_chip_timeouts[c] < OPL_CHIP_TIMEOUT)
-            {
-                sync = c;
-                break;
-            }
-        }
-
-        if (sync >= 0)
-        {
-            // Synchronize the LFOs
-            opl_chips[chip].vibpos = opl_chips[sync].vibpos;
-            opl_chips[chip].tremolopos = opl_chips[sync].tremolopos;
-            opl_chips[chip].timer = opl_chips[sync].timer;
-
-            // Synchronize the envelope clock
-            opl_chips[chip].eg_state = opl_chips[sync].eg_state;
-            opl_chips[chip].eg_timer = opl_chips[sync].eg_timer;
-            opl_chips[chip].eg_timerrem = opl_chips[sync].eg_timerrem;
+            sync = c;
+            break;
         }
     }
 
-    opl_chip_timeouts[chip] = 0;
+    if (sync >= 0)
+    {
+        // Synchronize the LFOs
+        opl_chips[chip].vibpos = opl_chips[sync].vibpos;
+        opl_chips[chip].tremolopos = opl_chips[sync].tremolopos;
+        opl_chips[chip].timer = opl_chips[sync].timer;
+
+        // Synchronize the envelope clock
+        opl_chips[chip].eg_state = opl_chips[sync].eg_state;
+        opl_chips[chip].eg_timer = opl_chips[sync].eg_timer;
+        opl_chips[chip].eg_timerrem = opl_chips[sync].eg_timerrem;
+    }
 }
 
 
@@ -188,13 +181,23 @@ int OPL_FillBuffer(byte *buffer, int buffer_samples)
         Bit16s *cursor = (Bit16s *)(buffer + filled * 4);
         for (int s = 0; s < nsamples; ++s)
         {
-            Bit32s mix[2] = {0, 0};
+            // Check for chip activations before we generate the sample
             for (int c = 0; c < num_opl_chips; ++c)
             {
                 // Reset chip timeout if any channels are active
                 if (opl_chip_keys[c])
-                    WakeUpChip(c);
+                {
+                    // Resync is necessary if the chip was idle
+                    if (opl_chip_timeouts[c] >= OPL_CHIP_TIMEOUT)
+                        ResyncChip(c);
+                    opl_chip_timeouts[c] = 0;
+                }
+            }
 
+            // Generate a sample from each chip and mix them
+            Bit32s mix[2] = {0, 0};
+            for (int c = 0; c < num_opl_chips; ++c)
+            {
                 // Run the chip if it's active or if it has pending register writes
                 if (opl_chip_timeouts[c] < OPL_CHIP_TIMEOUT || (opl_chips[c].writebuf[opl_chips[c].writebuf_cur].reg & 0x200))
                 {
@@ -205,7 +208,7 @@ int OPL_FillBuffer(byte *buffer, int buffer_samples)
 
                     // Reset chip timeout if it breaks the silence threshold
                     if (MAX(abs(sample[0]), abs(sample[1])) > OPL_SILENCE_THRESHOLD)
-                        WakeUpChip(c);
+                        opl_chip_timeouts[c] = 0;
                     else
                         opl_chip_timeouts[c]++;
                 }

--- a/src/i_oplmusic.c
+++ b/src/i_oplmusic.c
@@ -1447,8 +1447,6 @@ static boolean I_OPL_InitStream(int device)
     char *dmxoption;
     opl_init_result_t chip_type;
 
-    OPL_SetSampleRate(OPL_SAMPLE_RATE);
-
     chip_type = OPL_Init(opl_io_port, num_opl_chips);
     if (chip_type == OPL_INIT_NONE)
     {


### PR DESCRIPTION
This turned out to be a little trickier than I thought, but the patch ended up being pretty short after all. In any case, this patch makes 2 modifications to the OPL driver:

First, chips with no active channels that have been outputting silence for at least half a second will be paused until they key-on again.
Second, DMX will attempt to allocate free voices from already active chips until all such voices are used, only then will it draw voices from the next available chip. With only 1 chip active, this is still identical to the vanilla behavior.

In combination, these changes allow the higher chips to go idle when not strictly needed, clawing back a significant amount of CPU time. Only extremely busy sections of a song will activate all of the chips, and they'll quickly fall idle again after the notes clear out.