### PR TITLE
umapinfo: proper fix levelpic for fullscreen patches 

### DIFF
--- a/src/wi_stuff.c
+++ b/src/wi_stuff.c
@@ -798,7 +798,8 @@ static void WI_drawEL(void)
   {
     patch_t* lpic = V_CachePatchName(wbs->nextmapinfo->levelpic, PU_CACHE);
 
-    y += (5 * SHORT(lpic->height)) / 4;
+    if (SHORT(lpic->height) < SCREENHEIGHT)
+      y += (5 * SHORT(lpic->height)) / 4;
 
     V_DrawPatch((SCREENWIDTH - SHORT(lpic->width))/2, y, lpic);
   }

--- a/src/wi_stuff.c
+++ b/src/wi_stuff.c
@@ -798,8 +798,7 @@ static void WI_drawEL(void)
   {
     patch_t* lpic = V_CachePatchName(wbs->nextmapinfo->levelpic, PU_CACHE);
 
-    if (SHORT(lnames[wbs->next]->height) < SCREENHEIGHT)
-      y += (5 * SHORT(lpic->height)) / 4;
+    y += (5 * SHORT(lpic->height)) / 4;
 
     V_DrawPatch((SCREENWIDTH - SHORT(lpic->width))/2, y, lpic);
   }


### PR DESCRIPTION
This reverts commit 0880d6f52c14c013188cfbe0ffda55d6af2c6093.

Fix https://github.com/fabiangreffrath/woof/issues/1917