### PR TITLE
Menu changes

### DIFF
--- a/src/doomdef.h
+++ b/src/doomdef.h
@@ -197,6 +197,7 @@ typedef enum {
   ss_enem,
   ss_gen,       // killough 10/98
   ss_comp,      // killough 10/98
+  ss_midi,
   ss_eq,
   ss_padadv,
   ss_gyro,

--- a/src/i_flmusic.c
+++ b/src/i_flmusic.c
@@ -477,8 +477,8 @@ static void I_FL_BindVariables(void)
     "../share/" PROJECT_SHORTNAME "/soundfonts",
 #endif
     wad_no, "FluidSynth soundfont directories");
-    BIND_BOOL(mus_chorus, false, "FluidSynth chorus");
-    BIND_BOOL(mus_reverb, false, "FluidSynth reverb");
+    BIND_BOOL_MIDI(mus_chorus, false, "FluidSynth chorus");
+    BIND_BOOL_MIDI(mus_reverb, false, "FluidSynth reverb");
 }
 
 stream_module_t stream_fl_module =

--- a/src/i_flmusic.c
+++ b/src/i_flmusic.c
@@ -441,7 +441,7 @@ static const char **I_FL_DeviceList(void)
 
     if (W_CheckNumForName("SNDFONT") >= 0)
     {
-        array_push(devices, "FluidSynth (SNDFONT)");
+        array_push(devices, "FluidSynth: SNDFONT");
         return devices;
     }
 
@@ -454,7 +454,7 @@ static const char **I_FL_DeviceList(void)
         {
             name[NAME_MAX_LENGTH] = '\0';
         }
-        array_push(devices, M_StringJoin("FluidSynth (", name, ")"));
+        array_push(devices, M_StringJoin("FluidSynth: ", name));
         free(name);
     }
 

--- a/src/i_midimusic.c
+++ b/src/i_midimusic.c
@@ -1487,15 +1487,15 @@ static const char **I_MID_DeviceList(void)
 
 static void I_MID_BindVariables(void)
 {
-    BIND_NUM(midi_complevel, COMP_STANDARD, 0, COMP_NUM - 1,
+    BIND_NUM_MIDI(midi_complevel, COMP_STANDARD, 0, COMP_NUM - 1,
         "Native MIDI compatibility level (0 = Vanilla; 1 = Standard; 2 = Full)");
-    BIND_NUM(midi_reset_type, RESET_TYPE_GM, 0, RESET_NUM - 1,
+    BIND_NUM_MIDI(midi_reset_type, RESET_TYPE_GM, 0, RESET_NUM - 1,
         "Reset type for native MIDI (0 = No SysEx; 1 = GM; 2 = GS; 3 = XG)");
     BIND_NUM(midi_reset_delay, -1, -1, 2000,
         "Delay after reset for native MIDI (-1 = Auto; 0 = None; 1-2000 = Milliseconds)");
-    BIND_BOOL(midi_ctf, true,
+    BIND_BOOL_MIDI(midi_ctf, true,
         "Fix invalid instruments by emulating SC-55 capital tone fallback");
-    BIND_NUM(midi_gain, 100, 0, 100,
+    BIND_NUM_MIDI(midi_gain, 100, 0, 100,
         "Fine tune native MIDI output level (default 100%)");
 }
 

--- a/src/i_midimusic.c
+++ b/src/i_midimusic.c
@@ -64,6 +64,7 @@ static int midi_complevel = COMP_STANDARD;
 static int midi_reset_type = RESET_TYPE_GM;
 static int midi_reset_delay = -1;
 static boolean midi_ctf = true;
+static int midi_gain = 100;
 
 static const byte gm_system_on[] =
 {
@@ -1320,25 +1321,32 @@ static boolean I_MID_InitMusic(int device)
     return true;
 }
 
+static void UpdateVolumeFactor(int volume)
+{
+    volume_factor = sqrtf(volume / 15.0f) * midi_gain / 100.0f;
+}
+
 static void I_MID_SetMusicVolume(int volume)
 {
     static int last_volume = -1;
+    static int last_midi_gain = -1;
 
-    if (last_volume == volume)
+    if (last_volume == volume && midi_gain == last_midi_gain)
     {
         // Ignore holding key down in volume menu.
         return;
     }
     last_volume = volume;
+    last_midi_gain = midi_gain;
 
     if (!SDL_AtomicGet(&player_thread_running))
     {
-        volume_factor = sqrtf((float)volume / 15.0f);
+        UpdateVolumeFactor(volume);
         return;
     }
 
     SDL_LockMutex(music_lock);
-    volume_factor = sqrtf((float)volume / 15.0f);
+    UpdateVolumeFactor(volume);
     UpdateVolume();
     SDL_UnlockMutex(music_lock);
 }
@@ -1487,6 +1495,8 @@ static void I_MID_BindVariables(void)
         "Delay after reset for native MIDI (-1 = Auto; 0 = None; 1-2000 = Milliseconds)");
     BIND_BOOL(midi_ctf, true,
         "Fix invalid instruments by emulating SC-55 capital tone fallback");
+    BIND_NUM(midi_gain, 100, 0, 100,
+        "Fine tune native MIDI output level (default 100%)");
 }
 
 music_module_t music_mid_module =

--- a/src/i_oalmusic.c
+++ b/src/i_oalmusic.c
@@ -460,10 +460,10 @@ static const char **I_OAL_DeviceList(void)
 
 static void I_OAL_BindVariables(void)
 {
-    BIND_NUM(opl_gain, 200, 100, 1000,
+    BIND_NUM_MIDI(opl_gain, 200, 100, 1000,
         "Fine tune OPL emulation output level (default 200%)");
 #if defined (HAVE_FLUIDSYNTH)
-    BIND_NUM(mus_gain, 100, 10, 1000,
+    BIND_NUM_MIDI(mus_gain, 100, 10, 1000,
         "Fine tune FluidSynth output level (default 100%)");
 #endif
     for (int i = 0; i < arrlen(midi_modules); ++i)

--- a/src/i_oplmusic.c
+++ b/src/i_oplmusic.c
@@ -1687,9 +1687,9 @@ static const char **I_OPL_DeviceList(void)
 
 static void I_OPL_BindVariables(void)
 {
-    BIND_NUM(num_opl_chips, 1, 1, OPL_MAX_CHIPS,
+    BIND_NUM_MIDI(num_opl_chips, 1, 1, OPL_MAX_CHIPS,
         "[OPL3 Emulation] Number of chips to emulate (1-6)");
-    BIND_BOOL(opl_stereo_correct, false,
+    BIND_BOOL_MIDI(opl_stereo_correct, false,
         "[OPL3 Emulation] Use MIDI-correct stereo channel polarity");
 }
 

--- a/src/m_config.h
+++ b/src/m_config.h
@@ -42,6 +42,9 @@ void M_BindNum(const char *name, void *location, void *current,
 #define BIND_NUM_GENERAL(name, v, a, b, help) \
     M_BindNum(#name, &name, NULL, (v), (a), (b), ss_gen, wad_no, help)
 
+#define BIND_NUM_MIDI(name, v, a, b, help) \
+    M_BindNum(#name, &name, NULL, (v), (a), (b), ss_midi, wad_no, help)
+
 void M_BindBool(const char *name, boolean *location, boolean *current,
                 boolean default_val, ss_types screen, wad_allowed_t wad,
                 const char *help);
@@ -51,6 +54,9 @@ void M_BindBool(const char *name, boolean *location, boolean *current,
 
 #define BIND_BOOL_GENERAL(name, v, help) \
     M_BindBool(#name, &name, NULL, (v), ss_gen, wad_no, help)
+
+#define BIND_BOOL_MIDI(name, v, help) \
+    M_BindBool(#name, &name, NULL, (v), ss_midi, wad_no, help)
 
 void M_BindStr(char *name, const char **location, char *default_val,
                wad_allowed_t wad, const char *help);

--- a/src/mn_internal.h
+++ b/src/mn_internal.h
@@ -95,9 +95,10 @@ void MN_DrawStatusHUD(void);
 void MN_DrawAutoMap(void);
 void MN_DrawWeapons(void);
 void MN_DrawEnemy(void);
+void MN_DrawMidi(void);
+void MN_DrawEqualizer(void);
 void MN_DrawPadAdv(void);
 void MN_DrawGyro(void);
-void MN_DrawEqualizer(void);
 
 /////////////////////////////
 //

--- a/src/mn_menu.c
+++ b/src/mn_menu.c
@@ -1867,6 +1867,14 @@ static menu_t CompatDef = // killough 10/98
     0
 };
 
+static menu_t MidiDef = {
+    generic_setup_end,  // numitems
+    &SetupDef,          // prevMenu
+    Generic_Setup,      // menuitems
+    MN_DrawMidi,        // routine
+    34, 5,              // x, y (skull drawn here)
+};
+
 static menu_t EqualizerDef = {
     generic_setup_end,  // numitems
     &SetupDef,          // prevMenu
@@ -1894,8 +1902,9 @@ static menu_t GyroDef = {
 void MN_SetNextMenuAlt(ss_types type)
 {
     static menu_t *setup_defs[] = {
-        &KeybndDef,  &WeaponDef, &StatusHUDDef, &AutoMapDef, &EnemyDef,
-        &GeneralDef, &CompatDef, &EqualizerDef, &PadAdvDef,  &GyroDef,
+        &KeybndDef,    &WeaponDef,  &StatusHUDDef, &AutoMapDef,
+        &EnemyDef,     &GeneralDef, &CompatDef,    &MidiDef,
+        &EqualizerDef, &PadAdvDef,  &GyroDef,
     };
 
     SetNextMenu(setup_defs[type]);

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -2847,19 +2847,13 @@ static void MN_Gyro(void);
 
 static setup_menu_t gen_settings4[] = {
 
-    {"Advanced Options", S_FUNC, CNTR_X, M_SPC, .action = MN_PadAdv},
-
-    {"Gyro Options", S_FUNC, CNTR_X, M_SPC, .action = MN_Gyro},
-
-    MI_GAP_EX(6),
-
     {"Free Look", S_ONOFF, CNTR_X, M_SPC, {"padlook"},
      .action = MN_UpdatePadLook},
 
     {"Invert Look", S_ONOFF, CNTR_X, M_SPC, {"joy_invert_look"},
      .action = I_ResetGamepad},
 
-    MI_GAP_EX(6),
+    MI_GAP_EX(4),
 
     {"Turn Speed", S_THERMO | S_THRM_SIZE11, CNTR_X, M_THRM_SPC,
      {"joy_turn_speed"}, .action = I_ResetGamepad},
@@ -2867,7 +2861,7 @@ static setup_menu_t gen_settings4[] = {
     {"Look Speed", S_THERMO | S_THRM_SIZE11, CNTR_X, M_THRM_SPC,
      {"joy_look_speed"}, .action = I_ResetGamepad},
 
-    MI_GAP_EX(6),
+    MI_GAP_EX(4),
 
     {"Movement Deadzone", S_THERMO | S_PCT, CNTR_X, M_THRM_SPC,
      {"joy_movement_inner_deadzone"}, .action = I_ResetGamepad},
@@ -2875,10 +2869,16 @@ static setup_menu_t gen_settings4[] = {
     {"Camera Deadzone", S_THERMO | S_PCT, CNTR_X, M_THRM_SPC,
      {"joy_camera_inner_deadzone"}, .action = I_ResetGamepad},
 
-    MI_GAP_EX(6),
+    MI_GAP_EX(4),
 
     {"Rumble", S_THERMO, CNTR_X, M_THRM_SPC, {"joy_rumble"},
      .strings_id = str_rumble, .action = UpdateRumble},
+
+    MI_GAP,
+
+    {"Advanced Options", S_FUNC, CNTR_X, M_SPC, .action = MN_PadAdv},
+
+    {"Gyro Options", S_FUNC, CNTR_X, M_SPC, .action = MN_Gyro},
 
     MI_END
 };

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -133,8 +133,8 @@ static boolean default_reset;
 #define MI_GAP \
     {NULL, S_SKIP, 0, M_SPC}
 
-#define MI_GAP_HALF \
-    {NULL, S_SKIP, 0, M_SPC / 2}
+#define MI_GAP_EX(y) \
+    {NULL, S_SKIP, 0, (y)}
 
 static void DisableItem(boolean condition, setup_menu_t *menu, const char *item)
 {
@@ -1665,19 +1665,19 @@ static setup_menu_t weap_settings2[] = {
      .strings_id = str_weapon_slots_selection,
      .action = UpdateWeaponSlotSelection},
 
-    MI_GAP_HALF,
+    MI_GAP_EX(4),
     MI_WEAPON_SLOT(0, "weapon_slots_1_1"),
     MI_WEAPON_SLOT(1, "weapon_slots_1_2"),
     MI_WEAPON_SLOT(2, "weapon_slots_1_3"),
-    MI_GAP_HALF,
+    MI_GAP_EX(4),
     MI_WEAPON_SLOT(3, "weapon_slots_2_1"),
     MI_WEAPON_SLOT(4, "weapon_slots_2_2"),
     MI_WEAPON_SLOT(5, "weapon_slots_2_3"),
-    MI_GAP_HALF,
+    MI_GAP_EX(4),
     MI_WEAPON_SLOT(6, "weapon_slots_3_1"),
     MI_WEAPON_SLOT(7, "weapon_slots_3_2"),
     MI_WEAPON_SLOT(8, "weapon_slots_3_3"),
-    MI_GAP_HALF,
+    MI_GAP_EX(4),
     MI_WEAPON_SLOT(9, "weapon_slots_4_1"),
     MI_WEAPON_SLOT(10, "weapon_slots_4_2"),
     MI_WEAPON_SLOT(11, "weapon_slots_4_3"),
@@ -2558,12 +2558,12 @@ static setup_menu_t eq_settings1[] = {
     {"Preset", S_CHOICE, CNTR_X, M_SPC_EQ, {"snd_equalizer"},
      .strings_id = str_equalizer_preset, .action = I_OAL_EqualizerPreset},
 
-    MI_GAP_HALF,
+    MI_GAP_EX(4),
 
     {"Preamp dB", S_THERMO, CNTR_X, M_THRM_SPC_EQ,
      {"snd_eq_preamp"}, .action = I_OAL_EqualizerPreset},
 
-    MI_GAP_HALF,
+    MI_GAP_EX(4),
 
     {"Low Gain dB", S_THERMO, CNTR_X, M_THRM_SPC_EQ,
      {"snd_eq_low_gain"}, .action = I_OAL_EqualizerPreset},
@@ -2577,7 +2577,7 @@ static setup_menu_t eq_settings1[] = {
     {"High Gain dB", S_THERMO, CNTR_X, M_THRM_SPC_EQ,
      {"snd_eq_high_gain"}, .action = I_OAL_EqualizerPreset},
 
-    MI_GAP_HALF,
+    MI_GAP_EX(4),
 
     {"Low Cutoff Hz", S_THERMO, CNTR_X, M_THRM_SPC_EQ,
      {"snd_eq_low_cutoff"}, .action = I_OAL_EqualizerPreset},
@@ -2755,15 +2755,13 @@ static const char *curve_strings[] = {
 static void MN_PadAdv(void);
 static void MN_Gyro(void);
 
-#define MI_GAP_GAMEPAD {NULL, S_SKIP, 0, 6}
-
 static setup_menu_t gen_settings4[] = {
 
     {"Advanced Options", S_FUNC, CNTR_X, M_SPC, .action = MN_PadAdv},
 
     {"Gyro Options", S_FUNC, CNTR_X, M_SPC, .action = MN_Gyro},
 
-    MI_GAP_GAMEPAD,
+    MI_GAP_EX(6),
 
     {"Free Look", S_ONOFF, CNTR_X, M_SPC, {"padlook"},
      .action = MN_UpdatePadLook},
@@ -2771,7 +2769,7 @@ static setup_menu_t gen_settings4[] = {
     {"Invert Look", S_ONOFF, CNTR_X, M_SPC, {"joy_invert_look"},
      .action = I_ResetGamepad},
 
-    MI_GAP_GAMEPAD,
+    MI_GAP_EX(6),
 
     {"Turn Speed", S_THERMO | S_THRM_SIZE11, CNTR_X, M_THRM_SPC,
      {"joy_turn_speed"}, .action = I_ResetGamepad},
@@ -2779,7 +2777,7 @@ static setup_menu_t gen_settings4[] = {
     {"Look Speed", S_THERMO | S_THRM_SIZE11, CNTR_X, M_THRM_SPC,
      {"joy_look_speed"}, .action = I_ResetGamepad},
 
-    MI_GAP_GAMEPAD,
+    MI_GAP_EX(6),
 
     {"Movement Deadzone", S_THERMO | S_PCT, CNTR_X, M_THRM_SPC,
      {"joy_movement_inner_deadzone"}, .action = I_ResetGamepad},
@@ -2787,7 +2785,7 @@ static setup_menu_t gen_settings4[] = {
     {"Camera Deadzone", S_THERMO | S_PCT, CNTR_X, M_THRM_SPC,
      {"joy_camera_inner_deadzone"}, .action = I_ResetGamepad},
 
-    MI_GAP_GAMEPAD,
+    MI_GAP_EX(6),
 
     {"Rumble", S_THERMO, CNTR_X, M_THRM_SPC, {"joy_rumble"},
      .strings_id = str_rumble, .action = UpdateRumble},

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -2439,7 +2439,7 @@ static setup_menu_t gen_settings1[] = {
     {"Exclusive Fullscreen", S_ONOFF, CNTR_X, M_SPC, {"exclusive_fullscreen"},
      .action = ToggleExclusiveFullScreen},
 
-    MI_GAP,
+    MI_GAP_EX(6),
 
     {"Uncapped FPS", S_ONOFF, CNTR_X, M_SPC, {"uncapped"},
      .action = UpdateFPSLimit},
@@ -2450,7 +2450,7 @@ static setup_menu_t gen_settings1[] = {
     {"VSync", S_ONOFF, CNTR_X, M_SPC, {"use_vsync"},
      .action = I_ToggleVsync},
 
-    MI_GAP,
+    MI_GAP_EX(5),
 
     {"FOV", S_THERMO | S_THRM_SIZE11, CNTR_X, M_THRM_SPC, {"fov"},
      .action = UpdateFOV},

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -756,6 +756,11 @@ static void WrapSettingString(setup_menu_t *s, int x, int y, int color)
             DrawMenuStringBuffer(flags, x, y, color, &menu_buffer[index]);
             y += M_SPC;
             s->lines++;
+
+            if (s->lines > 1)
+            {
+                break;
+            }
         }
         else
         {


### PR DESCRIPTION
<details><summary>details</summary>

Fixed spacing (I give up on redoing the video menu):

![woof0000](https://github.com/user-attachments/assets/2a610aa5-b966-4a05-bcdf-b33f665c71aa)

Added MIDI options to audio tab:

![woof0001](https://github.com/user-attachments/assets/dd28308c-9143-421f-b44f-d167736352db)

MIDI options include the most commonly asked items (ability to adjust gain for each backend, reverb/chorus for FluidSynth) and other advanced settings:

![woof0002](https://github.com/user-attachments/assets/7257f4b6-51e8-4236-a44f-eaa7a70afa9d)

Adjusted gamepad menu for consistency:

![woof0003](https://github.com/user-attachments/assets/b77b7ae3-6ecd-499d-9a6b-0909508fa2d0)

</details>