### PR TITLE
tweaks to audio menus

### DIFF
--- a/src/i_midimusic.c
+++ b/src/i_midimusic.c
@@ -1321,9 +1321,12 @@ static boolean I_MID_InitMusic(int device)
     return true;
 }
 
+// MIDI CC#7 volume formula (GM Level 1 Developer Guidelines, page 9).
+#define MIDI_DB_TO_GAIN(db) powf(10.0f, (db) / 40.0f)
+
 static void UpdateVolumeFactor(int volume)
 {
-    volume_factor = sqrtf(volume / 15.0f) * midi_gain / 100.0f;
+    volume_factor = volume / 15.0f * MIDI_DB_TO_GAIN(midi_gain);
 }
 
 static void I_MID_SetMusicVolume(int volume)
@@ -1500,8 +1503,7 @@ static void I_MID_BindVariables(void)
         "Delay after reset for native MIDI (-1 = Auto; 0 = None; 1-2000 = Milliseconds)");
     BIND_BOOL_MIDI(midi_ctf, true,
         "Fix invalid instruments by emulating SC-55 capital tone fallback");
-    BIND_NUM_MIDI(midi_gain, 100, 0, 100,
-        "Fine tune native MIDI output level (default 100%)");
+    BIND_NUM_MIDI(midi_gain, 0, -20, 0, "Native MIDI gain [dB]");
 }
 
 music_module_t music_mid_module =

--- a/src/i_midimusic.c
+++ b/src/i_midimusic.c
@@ -1485,9 +1485,9 @@ static const char **I_MID_DeviceList(void)
     return midi_devices;
 }
 
-static miditype_t I_MID_MidiType(void)
+static midiplayertype_t I_MID_MidiPlayerType(void)
 {
-    return midi_native;
+    return midiplayer_native;
 }
 
 static void I_MID_BindVariables(void)
@@ -1517,5 +1517,5 @@ music_module_t music_mid_module =
     I_MID_UnRegisterSong,
     I_MID_DeviceList,
     I_MID_BindVariables,
-    I_MID_MidiType,
+    I_MID_MidiPlayerType,
 };

--- a/src/i_midimusic.c
+++ b/src/i_midimusic.c
@@ -1485,6 +1485,11 @@ static const char **I_MID_DeviceList(void)
     return midi_devices;
 }
 
+static miditype_t I_MID_MidiType(void)
+{
+    return midi_native;
+}
+
 static void I_MID_BindVariables(void)
 {
     BIND_NUM_MIDI(midi_complevel, COMP_STANDARD, 0, COMP_NUM - 1,
@@ -1512,4 +1517,5 @@ music_module_t music_mid_module =
     I_MID_UnRegisterSong,
     I_MID_DeviceList,
     I_MID_BindVariables,
+    I_MID_MidiType,
 };

--- a/src/i_oalcommon.h
+++ b/src/i_oalcommon.h
@@ -22,6 +22,8 @@
 #include "al.h"
 #include "alc.h"
 
+#include <math.h>
+
 #include "doomtype.h"
 
 // C doesn't allow casting between function and non-function pointer types, so
@@ -35,6 +37,8 @@
 #endif
 
 #define ALFUNC(T, ptr) (ptr = FUNCTION_CAST(T, alGetProcAddress(#ptr)))
+
+#define DB_TO_GAIN(db) powf(10.0f, (db) / 20.0f)
 
 typedef struct oal_system_s
 {

--- a/src/i_oalequalizer.c
+++ b/src/i_oalequalizer.c
@@ -20,8 +20,6 @@
 #include "alc.h"
 #include "alext.h"
 
-#include <math.h>
-
 #include "i_oalcommon.h"
 #include "i_oalequalizer.h"
 #include "i_sound.h"
@@ -233,7 +231,6 @@ void I_OAL_SetEqualizer(void)
     // Gains vary from 0.251 up to 3.981, which means from -12dB attenuation
     // up to +12dB amplification, i.e. 20*log10(gain).
 
-    #define DB_TO_GAIN(db) powf(10.0f, (db) / 20.0f)
     #define EQ_GAIN(db) ((ALfloat)BETWEEN(0.251f, 3.981f, DB_TO_GAIN(db)))
     #define LP_GAIN(db) ((ALfloat)BETWEEN(0.063f, 1.0f, DB_TO_GAIN(db)))
     #define OCTAVE(x) ((ALfloat)BETWEEN(0.01f, 1.0f, (x) / 100.0f))

--- a/src/i_oalmusic.c
+++ b/src/i_oalmusic.c
@@ -458,7 +458,7 @@ static const char **I_OAL_DeviceList(void)
     return devices;
 }
 
-miditype_t I_OAL_MidiType(void)
+static miditype_t I_OAL_MidiType(void)
 {
 #ifdef HAVE_FLUIDSYNTH
     if (active_module == &stream_fl_module)
@@ -500,4 +500,5 @@ music_module_t music_oal_module =
     I_OAL_UnRegisterSong,
     I_OAL_DeviceList,
     I_OAL_BindVariables,
+    I_OAL_MidiType,
 };

--- a/src/i_oalmusic.c
+++ b/src/i_oalmusic.c
@@ -458,19 +458,19 @@ static const char **I_OAL_DeviceList(void)
     return devices;
 }
 
-static miditype_t I_OAL_MidiType(void)
+static midiplayertype_t I_OAL_MidiPlayerType(void)
 {
 #ifdef HAVE_FLUIDSYNTH
     if (active_module == &stream_fl_module)
     {
-        return midi_fluidsynth;
+        return midiplayer_fluidsynth;
     }
 #endif
     if (active_module == &stream_opl_module)
     {
-        return midi_opl;
+        return midiplayer_opl;
     }
-    return midi_none;
+    return midiplayer_none;
 }
 
 static void I_OAL_BindVariables(void)
@@ -500,5 +500,5 @@ music_module_t music_oal_module =
     I_OAL_UnRegisterSong,
     I_OAL_DeviceList,
     I_OAL_BindVariables,
-    I_OAL_MidiType,
+    I_OAL_MidiPlayerType,
 };

--- a/src/i_oalmusic.c
+++ b/src/i_oalmusic.c
@@ -458,6 +458,19 @@ static const char **I_OAL_DeviceList(void)
     return devices;
 }
 
+miditype_t I_OAL_MidiType(void)
+{
+    if (active_module == &stream_fl_module)
+    {
+        return midi_fluidsynth;
+    }
+    else if (active_module == &stream_opl_module)
+    {
+        return midi_opl;
+    }
+    return midi_none;
+}
+
 static void I_OAL_BindVariables(void)
 {
     BIND_NUM_MIDI(opl_gain, 200, 100, 1000,

--- a/src/i_oalmusic.c
+++ b/src/i_oalmusic.c
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 
 #include "doomtype.h"
+#include "i_oalcommon.h"
 #include "i_oalstream.h"
 #include "i_printf.h"
 #include "i_sound.h"
@@ -308,12 +309,12 @@ static void I_OAL_SetMusicVolume(int volume)
 
     if (active_module == &stream_opl_module)
     {
-        gain *= (ALfloat)opl_gain / 100.0f;
+        gain *= (ALfloat)DB_TO_GAIN(opl_gain);
     }
 #if defined(HAVE_FLUIDSYNTH)
     else if (active_module == &stream_fl_module)
     {
-        gain *= (ALfloat)mus_gain / 100.0f;
+        gain *= (ALfloat)DB_TO_GAIN(mus_gain);
     }
 #endif
 
@@ -475,11 +476,9 @@ static midiplayertype_t I_OAL_MidiPlayerType(void)
 
 static void I_OAL_BindVariables(void)
 {
-    BIND_NUM_MIDI(opl_gain, 200, 100, 1000,
-        "Fine tune OPL emulation output level (default 200%)");
+    BIND_NUM_MIDI(opl_gain, 0, -20, 20, "OPL emulation gain [dB]");
 #if defined (HAVE_FLUIDSYNTH)
-    BIND_NUM_MIDI(mus_gain, 100, 10, 1000,
-        "Fine tune FluidSynth output level (default 100%)");
+    BIND_NUM_MIDI(mus_gain, 0, -20, 20, "FluidSynth gain [dB]");
 #endif
     for (int i = 0; i < arrlen(midi_modules); ++i)
     {

--- a/src/i_oalmusic.c
+++ b/src/i_oalmusic.c
@@ -460,11 +460,13 @@ static const char **I_OAL_DeviceList(void)
 
 miditype_t I_OAL_MidiType(void)
 {
+#ifdef HAVE_FLUIDSYNTH
     if (active_module == &stream_fl_module)
     {
         return midi_fluidsynth;
     }
-    else if (active_module == &stream_opl_module)
+#endif
+    if (active_module == &stream_opl_module)
     {
         return midi_opl;
     }

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -525,14 +525,9 @@ void I_SetSoundModule(void)
 
 miditype_t I_MidiType(void)
 {
-    if (active_module == &music_mid_module)
+    if (active_module)
     {
-        return midi_native;
-    }
-    else if (active_module == &music_oal_module)
-    {
-        extern miditype_t I_OAL_MidiType(void);
-        return I_OAL_MidiType();
+        return active_module->I_MidiType();
     }
     return midi_none;
 }
@@ -759,6 +754,6 @@ void I_BindSoundVariables(void)
               "MIDI Player string");
     for (int i = 0; i < arrlen(music_modules); ++i)
     {
-        music_modules[i]->BindVariables();
+        music_modules[i]->I_BindVariables();
     }
 }

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -525,9 +525,9 @@ void I_SetSoundModule(void)
 
 miditype_t I_MidiType(void)
 {
-    if (active_module)
+    if (midi_module)
     {
-        return active_module->I_MidiType();
+        return midi_module->I_MidiType();
     }
     return midi_none;
 }

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -523,13 +523,13 @@ void I_SetSoundModule(void)
     MN_UpdateAdvancedSoundItems(snd_module != SND_MODULE_3D);
 }
 
-miditype_t I_MidiType(void)
+midiplayertype_t I_MidiPlayerType(void)
 {
     if (active_module)
     {
-        return active_module->I_MidiType();
+        return active_module->I_MidiPlayerType();
     }
-    return midi_none;
+    return midiplayer_none;
 }
 
 void I_SetMidiPlayer(void)

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -525,9 +525,9 @@ void I_SetSoundModule(void)
 
 miditype_t I_MidiType(void)
 {
-    if (midi_module)
+    if (active_module)
     {
-        return midi_module->I_MidiType();
+        return active_module->I_MidiType();
     }
     return midi_none;
 }

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -523,6 +523,20 @@ void I_SetSoundModule(void)
     MN_UpdateAdvancedSoundItems(snd_module != SND_MODULE_3D);
 }
 
+miditype_t I_MidiType(void)
+{
+    if (active_module == &music_mid_module)
+    {
+        return midi_native;
+    }
+    else if (active_module == &music_oal_module)
+    {
+        extern miditype_t I_OAL_MidiType(void);
+        return I_OAL_MidiType();
+    }
+    return midi_none;
+}
+
 void I_SetMidiPlayer(void)
 {
     if (nomusicparm)

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -143,6 +143,16 @@ int I_SoundID(int handle);
 //  MUSIC I/O
 //
 
+typedef enum
+{
+    midi_none,
+    midi_native,
+    midi_fluidsynth,
+    midi_opl,
+} miditype_t;
+
+miditype_t I_MidiType(void);
+
 typedef struct
 {
     boolean (*I_InitMusic)(int device);
@@ -155,7 +165,8 @@ typedef struct
     void (*I_StopSong)(void *handle);
     void (*I_UnRegisterSong)(void *handle);
     const char **(*I_DeviceList)(void);
-    void (*BindVariables)(void);
+    void (*I_BindVariables)(void);
+    miditype_t (*I_MidiType)(void);
 } music_module_t;
 
 extern music_module_t music_oal_module;
@@ -197,16 +208,6 @@ boolean IsMid(byte *mem, int len);
 boolean IsMus(byte *mem, int len);
 
 void I_BindSoundVariables(void);
-
-typedef enum
-{
-    midi_none,
-    midi_native,
-    midi_fluidsynth,
-    midi_opl,
-} miditype_t;
-
-miditype_t I_MidiType(void);
 
 #endif
 

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -198,6 +198,16 @@ boolean IsMus(byte *mem, int len);
 
 void I_BindSoundVariables(void);
 
+typedef enum
+{
+    midi_none,
+    midi_native,
+    midi_fluidsynth,
+    midi_opl,
+} miditype_t;
+
+miditype_t I_MidiType(void);
+
 #endif
 
 //----------------------------------------------------------------------------

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -145,13 +145,13 @@ int I_SoundID(int handle);
 
 typedef enum
 {
-    midi_none,
-    midi_native,
-    midi_fluidsynth,
-    midi_opl,
-} miditype_t;
+    midiplayer_none,
+    midiplayer_native,
+    midiplayer_fluidsynth,
+    midiplayer_opl,
+} midiplayertype_t;
 
-miditype_t I_MidiType(void);
+midiplayertype_t I_MidiPlayerType(void);
 
 typedef struct
 {
@@ -166,7 +166,7 @@ typedef struct
     void (*I_UnRegisterSong)(void *handle);
     const char **(*I_DeviceList)(void);
     void (*I_BindVariables)(void);
-    miditype_t (*I_MidiType)(void);
+    midiplayertype_t (*I_MidiPlayerType)(void);
 } music_module_t;
 
 extern music_module_t music_oal_module;

--- a/src/mn_internal.h
+++ b/src/mn_internal.h
@@ -204,6 +204,7 @@ typedef struct setup_menu_s
     mrect_t rect;
     int lines;            // number of lines for rect, always > 0
     const char *desc;     // overrides default description
+    const char *append;   // string to append to value
 } setup_menu_t;
 
 // phares 4/21/98: Moved from m_misc.c so m_menu.c could see it.

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -2604,7 +2604,7 @@ static const char *midi_reset_type_strings[] = {
 static setup_menu_t midi_settings1[] = {
 
     {"Native MIDI Gain", S_THERMO, CNTR_X, M_THRM_SPC,
-     {"midi_gain"}, .action = UpdateMusicVolume, .append = {"dB"}},
+     {"midi_gain"}, .action = UpdateMusicVolume, .append = "dB"},
 
     {"Native MIDI Reset", S_CHOICE | S_ACTION, CNTR_X, M_SPC,
      {"midi_reset_type"}, .strings_id = str_midi_reset_type,
@@ -2621,7 +2621,7 @@ static setup_menu_t midi_settings1[] = {
 
 #if defined (HAVE_FLUIDSYNTH)
     {"FluidSynth Gain", S_THERMO, CNTR_X, M_THRM_SPC, {"mus_gain"},
-     .action = UpdateMusicVolume, .append = {"dB"}},
+     .action = UpdateMusicVolume, .append = "dB"},
 
     {"FluidSynth Reverb", S_ONOFF, CNTR_X, M_SPC, {"mus_reverb"},
      .action = SetMidiPlayerFluidSynth},
@@ -2633,7 +2633,7 @@ static setup_menu_t midi_settings1[] = {
 #endif
 
     {"OPL3 Gain", S_THERMO, CNTR_X, M_THRM_SPC, {"opl_gain"},
-     .action = UpdateMusicVolume, .append = {"dB"}},
+     .action = UpdateMusicVolume, .append = "dB"},
 
     {"OPL3 Number of Chips", S_THERMO | S_THRM_SIZE4 | S_ACTION, CNTR_X,
      M_THRM_SPC, {"num_opl_chips"}, .action = SetMidiPlayerOpl},
@@ -2682,35 +2682,35 @@ static setup_menu_t eq_settings1[] = {
     MI_GAP_EX(4),
 
     {"Preamp", S_THERMO, CNTR_X, M_THRM_SPC,
-     {"snd_eq_preamp"}, .action = I_OAL_EqualizerPreset, .append = {"dB"}},
+     {"snd_eq_preamp"}, .action = I_OAL_EqualizerPreset, .append = "dB"},
 
     MI_GAP_EX(4),
 
     {"Low Gain", S_THERMO, CNTR_X, M_THRM_SPC,
-     {"snd_eq_low_gain"}, .action = I_OAL_EqualizerPreset, .append = {"dB"}},
+     {"snd_eq_low_gain"}, .action = I_OAL_EqualizerPreset, .append = "dB"},
 
     {"Mid 1 Gain", S_THERMO, CNTR_X, M_THRM_SPC,
-     {"snd_eq_mid1_gain"}, .action = I_OAL_EqualizerPreset, .append = {"dB"}},
+     {"snd_eq_mid1_gain"}, .action = I_OAL_EqualizerPreset, .append = "dB"},
 
     {"Mid 2 Gain", S_THERMO, CNTR_X, M_THRM_SPC,
-     {"snd_eq_mid2_gain"}, .action = I_OAL_EqualizerPreset, .append = {"dB"}},
+     {"snd_eq_mid2_gain"}, .action = I_OAL_EqualizerPreset, .append = "dB"},
 
     {"High Gain", S_THERMO, CNTR_X, M_THRM_SPC,
-     {"snd_eq_high_gain"}, .action = I_OAL_EqualizerPreset, .append = {"dB"}},
+     {"snd_eq_high_gain"}, .action = I_OAL_EqualizerPreset, .append = "dB"},
 
     MI_GAP_EX(4),
 
     {"Low Cutoff", S_NUM, CNTR_X, M_SPC,
-     {"snd_eq_low_cutoff"}, .action = I_OAL_EqualizerPreset, .append = {"Hz"}},
+     {"snd_eq_low_cutoff"}, .action = I_OAL_EqualizerPreset, .append = "Hz"},
 
     {"Mid 1 Center", S_NUM, CNTR_X, M_SPC,
-     {"snd_eq_mid1_center"}, .action = I_OAL_EqualizerPreset, .append = {"Hz"}},
+     {"snd_eq_mid1_center"}, .action = I_OAL_EqualizerPreset, .append = "Hz"},
 
     {"Mid 2 Center", S_NUM, CNTR_X, M_SPC,
-     {"snd_eq_mid2_center"}, .action = I_OAL_EqualizerPreset, .append = {"Hz"}},
+     {"snd_eq_mid2_center"}, .action = I_OAL_EqualizerPreset, .append = "Hz"},
 
     {"High Cutoff", S_NUM, CNTR_X, M_SPC,
-     {"snd_eq_high_cutoff"}, .action = I_OAL_EqualizerPreset, .append = {"Hz"}},
+     {"snd_eq_high_cutoff"}, .action = I_OAL_EqualizerPreset, .append = "Hz"},
 
     MI_END
 };

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -2593,42 +2593,42 @@ static const char *midi_reset_type_strings[] = {
 
 static setup_menu_t midi_settings1[] = {
 
-    {"Native MIDI Gain", S_NUM | S_PCT, M_X, M_SPC,
+    {"Native MIDI Gain", S_NUM | S_PCT, CNTR_X, M_SPC,
      {"midi_gain"}, .action = UpdateMusicVolume},
 
-    {"Native MIDI Reset", S_CHOICE | S_ACTION, M_X, M_SPC,
+    {"Native MIDI Reset", S_CHOICE | S_ACTION, CNTR_X, M_SPC,
      {"midi_reset_type"}, .strings_id = str_midi_reset_type,
      .action = SetMidiPlayerNative},
 
-    {"Compatibility Level", S_CHOICE | S_ACTION, M_X, M_SPC,
+    {"Compatibility Level", S_CHOICE | S_ACTION, CNTR_X, M_SPC,
      {"midi_complevel"}, .strings_id = str_midi_complevel,
      .action = SetMidiPlayerNative},
 
-    {"SC-55 CTF Emulation", S_ONOFF, M_X, M_SPC, {"midi_ctf"},
+    {"SC-55 CTF Emulation", S_ONOFF, CNTR_X, M_SPC, {"midi_ctf"},
      .action = SetMidiPlayerNative},
 
     MI_GAP,
 
 #if defined (HAVE_FLUIDSYNTH)
-    {"FluidSynth Gain", S_NUM | S_PCT, M_X, M_SPC, {"mus_gain"},
+    {"FluidSynth Gain", S_NUM | S_PCT, CNTR_X, M_SPC, {"mus_gain"},
      .action = UpdateMusicVolume},
 
-    {"FluidSynth Reverb", S_ONOFF, M_X, M_SPC, {"mus_reverb"},
+    {"FluidSynth Reverb", S_ONOFF, CNTR_X, M_SPC, {"mus_reverb"},
      .action = SetMidiPlayerFluidSynth},
 
-    {"FluidSynth Chorus", S_ONOFF, M_X, M_SPC, {"mus_chorus"},
+    {"FluidSynth Chorus", S_ONOFF, CNTR_X, M_SPC, {"mus_chorus"},
      .action = SetMidiPlayerFluidSynth},
 
     MI_GAP,
 #endif
 
-    {"OPL3 Gain", S_NUM | S_PCT, M_X, M_SPC, {"opl_gain"},
+    {"OPL3 Gain", S_NUM | S_PCT, CNTR_X, M_SPC, {"opl_gain"},
      .action = UpdateMusicVolume},
 
-    {"OPL3 Number of Chips", S_THERMO | S_THRM_SIZE4 | S_ACTION, M_X_THRM4,
+    {"OPL3 Number of Chips", S_THERMO | S_THRM_SIZE4 | S_ACTION, CNTR_X,
      M_THRM_SPC, {"num_opl_chips"}, .action = SetMidiPlayerOpl},
 
-    {"OPL3 Reverse Stereo", S_ONOFF, M_X, M_SPC,
+    {"OPL3 Reverse Stereo", S_ONOFF, CNTR_X, M_SPC,
      {"opl_stereo_correct"}, .action = SetMidiPlayerOpl},
 
     MI_END
@@ -2674,35 +2674,35 @@ static setup_menu_t eq_settings1[] = {
 
     MI_GAP_EX(4),
 
-    {"Preamp dB", S_THERMO, M_X_THRM8, M_THRM_SPC,
+    {"Preamp dB", S_THERMO, CNTR_X, M_THRM_SPC,
      {"snd_eq_preamp"}, .action = I_OAL_EqualizerPreset},
 
     MI_GAP_EX(4),
 
-    {"Low Gain dB", S_THERMO, M_X_THRM8, M_THRM_SPC,
+    {"Low Gain dB", S_THERMO, CNTR_X, M_THRM_SPC,
      {"snd_eq_low_gain"}, .action = I_OAL_EqualizerPreset},
 
-    {"Mid 1 Gain dB", S_THERMO, M_X_THRM8, M_THRM_SPC,
+    {"Mid 1 Gain dB", S_THERMO, CNTR_X, M_THRM_SPC,
      {"snd_eq_mid1_gain"}, .action = I_OAL_EqualizerPreset},
 
-    {"Mid 2 Gain dB", S_THERMO, M_X_THRM8, M_THRM_SPC,
+    {"Mid 2 Gain dB", S_THERMO, CNTR_X, M_THRM_SPC,
      {"snd_eq_mid2_gain"}, .action = I_OAL_EqualizerPreset},
 
-    {"High Gain dB", S_THERMO, M_X_THRM8, M_THRM_SPC,
+    {"High Gain dB", S_THERMO, CNTR_X, M_THRM_SPC,
      {"snd_eq_high_gain"}, .action = I_OAL_EqualizerPreset},
 
     MI_GAP_EX(4),
 
-    {"Low Cutoff Hz", S_NUM, M_X, M_SPC,
+    {"Low Cutoff Hz", S_NUM, CNTR_X, M_SPC,
      {"snd_eq_low_cutoff"}, .action = I_OAL_EqualizerPreset},
 
-    {"Mid 1 Center Hz", S_NUM, M_X, M_SPC,
+    {"Mid 1 Center Hz", S_NUM, CNTR_X, M_SPC,
      {"snd_eq_mid1_center"}, .action = I_OAL_EqualizerPreset},
 
-    {"Mid 2 Center Hz", S_NUM, M_X, M_SPC,
+    {"Mid 2 Center Hz", S_NUM, CNTR_X, M_SPC,
      {"snd_eq_mid2_center"}, .action = I_OAL_EqualizerPreset},
 
-    {"High Cutoff Hz", S_NUM, M_X, M_SPC,
+    {"High Cutoff Hz", S_NUM, CNTR_X, M_SPC,
      {"snd_eq_high_cutoff"}, .action = I_OAL_EqualizerPreset},
 
     MI_END

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -2509,6 +2509,30 @@ static void SetMidiPlayer(void)
     S_RestartMusic();
 }
 
+static void SetMidiPlayerNative(void)
+{
+    if (I_MidiType() == midi_native)
+    {
+        SetMidiPlayer();
+    }
+}
+
+static void SetMidiPlayerOpl(void)
+{
+    if (I_MidiType() == midi_opl)
+    {
+        SetMidiPlayer();
+    }
+}
+
+static void SetMidiPlayerFluidSynth(void)
+{
+    if (I_MidiType() == midi_fluidsynth)
+    {
+        SetMidiPlayer();
+    }
+}
+
 static void MN_Midi(void);
 static void MN_Equalizer(void);
 
@@ -2567,78 +2591,62 @@ static const char *midi_reset_type_strings[] = {
     "No SysEx", "General MIDI", "Roland GS", "Yamaha XG"
 };
 
-static setup_menu_t midi_settings_native[] = {
+static setup_menu_t midi_settings1[] = {
 
     {"Native MIDI Gain", S_NUM | S_PCT, CNTR_X, M_SPC,
      {"midi_gain"}, .action = UpdateMusicVolume},
 
     {"Native MIDI Reset", S_CHOICE | S_ACTION, CNTR_X, M_SPC,
      {"midi_reset_type"}, .strings_id = str_midi_reset_type,
-     .action = SetMidiPlayer},
+     .action = SetMidiPlayerNative},
 
     {"Compatibility Level", S_CHOICE | S_ACTION, CNTR_X, M_SPC,
      {"midi_complevel"}, .strings_id = str_midi_complevel,
-     .action = SetMidiPlayer},
+     .action = SetMidiPlayerNative},
 
     {"SC-55 CTF Emulation", S_ONOFF, CNTR_X, M_SPC, {"midi_ctf"},
-     .action = SetMidiPlayer},
+     .action = SetMidiPlayerNative},
 
-    MI_END
-};
+    MI_GAP,
 
-static setup_menu_t midi_settings_fluidsynth[] = {
-
+#if defined (HAVE_FLUIDSYNTH)
     {"FluidSynth Gain", S_NUM | S_PCT, CNTR_X, M_SPC, {"mus_gain"},
      .action = UpdateMusicVolume},
 
     {"FluidSynth Reverb", S_ONOFF, CNTR_X, M_SPC, {"mus_reverb"},
-     .action = SetMidiPlayer},
+     .action = SetMidiPlayerFluidSynth},
 
     {"FluidSynth Chorus", S_ONOFF, CNTR_X, M_SPC, {"mus_chorus"},
-     .action = SetMidiPlayer},
+     .action = SetMidiPlayerFluidSynth},
 
-    MI_END
-};
-
-static setup_menu_t midi_settings_opl[] = {
+    MI_GAP,
+#endif
 
     {"OPL3 Gain", S_NUM | S_PCT, CNTR_X, M_SPC, {"opl_gain"},
      .action = UpdateMusicVolume},
 
     {"OPL3 Number of Chips", S_THERMO | S_THRM_SIZE4 | S_ACTION, CNTR_X,
-     M_THRM_SPC, {"num_opl_chips"}, .action = SetMidiPlayer},
+     M_THRM_SPC, {"num_opl_chips"}, .action = SetMidiPlayerOpl},
 
     {"OPL3 Reverse Stereo", S_ONOFF, CNTR_X, M_SPC,
-     {"opl_stereo_correct"}, .action = SetMidiPlayer},
+     {"opl_stereo_correct"}, .action = SetMidiPlayerOpl},
 
     MI_END
 };
 
-static setup_menu_t *midi_settings[] = {
-    midi_settings_native,
-    midi_settings_fluidsynth,
-    midi_settings_opl,
-    NULL
-};
+static setup_menu_t *midi_settings[] = {midi_settings1, NULL};
 
 static setup_tab_t midi_tabs[] = {{"MIDI"}, {NULL}};
 
 static void MN_Midi(void)
 {
-    int index = 0;
-    miditype_t type = I_MidiType();
-    if (type > midi_none)
-    {
-        index = type - 1;
-    }
-
     SetItemOn(set_item_on);
     SetPageIndex(current_page);
 
     MN_SetNextMenuAlt(ss_midi);
     setup_screen = ss_midi;
-    current_page = 0;
-    current_menu = midi_settings[index];
+    current_page = GetPageIndex(midi_settings);
+    current_menu = midi_settings[current_page];
     current_tabs = midi_tabs;
     SetupMenuSecondary();
 }

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -2657,11 +2657,8 @@ static const char *equalizer_preset_strings[] = {
     "Off", "Classical", "Rock", "Vocal", "Custom"
 };
 
-#define M_THRM_SPC_EQ (M_THRM_HEIGHT - 1)
-#define M_SPC_EQ 8
-
 static setup_menu_t eq_settings1[] = {
-    {"Preset", S_CHOICE, CNTR_X, M_SPC_EQ, {"snd_equalizer"},
+    {"Preset", S_CHOICE, CNTR_X, M_SPC, {"snd_equalizer"},
      .strings_id = str_equalizer_preset, .action = I_OAL_EqualizerPreset},
 
     MI_GAP_EX(4),

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -2674,35 +2674,35 @@ static setup_menu_t eq_settings1[] = {
 
     MI_GAP_EX(4),
 
-    {"Preamp dB", S_THERMO, CNTR_X, M_THRM_SPC_EQ,
+    {"Preamp dB", S_THERMO, M_X_THRM8, M_THRM_SPC,
      {"snd_eq_preamp"}, .action = I_OAL_EqualizerPreset},
 
     MI_GAP_EX(4),
 
-    {"Low Gain dB", S_THERMO, CNTR_X, M_THRM_SPC_EQ,
+    {"Low Gain dB", S_THERMO, M_X_THRM8, M_THRM_SPC,
      {"snd_eq_low_gain"}, .action = I_OAL_EqualizerPreset},
 
-    {"Mid 1 Gain dB", S_THERMO, CNTR_X, M_THRM_SPC_EQ,
+    {"Mid 1 Gain dB", S_THERMO, M_X_THRM8, M_THRM_SPC,
      {"snd_eq_mid1_gain"}, .action = I_OAL_EqualizerPreset},
 
-    {"Mid 2 Gain dB", S_THERMO, CNTR_X, M_THRM_SPC_EQ,
+    {"Mid 2 Gain dB", S_THERMO, M_X_THRM8, M_THRM_SPC,
      {"snd_eq_mid2_gain"}, .action = I_OAL_EqualizerPreset},
 
-    {"High Gain dB", S_THERMO, CNTR_X, M_THRM_SPC_EQ,
+    {"High Gain dB", S_THERMO, M_X_THRM8, M_THRM_SPC,
      {"snd_eq_high_gain"}, .action = I_OAL_EqualizerPreset},
 
     MI_GAP_EX(4),
 
-    {"Low Cutoff Hz", S_THERMO, CNTR_X, M_THRM_SPC_EQ,
+    {"Low Cutoff Hz", S_NUM, M_X, M_SPC,
      {"snd_eq_low_cutoff"}, .action = I_OAL_EqualizerPreset},
 
-    {"Mid 1 Center Hz", S_THERMO, CNTR_X, M_THRM_SPC_EQ,
+    {"Mid 1 Center Hz", S_NUM, M_X, M_SPC,
      {"snd_eq_mid1_center"}, .action = I_OAL_EqualizerPreset},
 
-    {"Mid 2 Center Hz", S_THERMO, CNTR_X, M_THRM_SPC_EQ,
+    {"Mid 2 Center Hz", S_NUM, M_X, M_SPC,
      {"snd_eq_mid2_center"}, .action = I_OAL_EqualizerPreset},
 
-    {"High Cutoff Hz", S_THERMO, CNTR_X, M_THRM_SPC_EQ,
+    {"High Cutoff Hz", S_NUM, M_X, M_SPC,
      {"snd_eq_high_cutoff"}, .action = I_OAL_EqualizerPreset},
 
     MI_END

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -2511,7 +2511,7 @@ static void SetMidiPlayer(void)
 
 static void SetMidiPlayerNative(void)
 {
-    if (I_MidiType() == midi_native)
+    if (I_MidiPlayerType() == midiplayer_native)
     {
         SetMidiPlayer();
     }
@@ -2519,7 +2519,7 @@ static void SetMidiPlayerNative(void)
 
 static void SetMidiPlayerOpl(void)
 {
-    if (I_MidiType() == midi_opl)
+    if (I_MidiPlayerType() == midiplayer_opl)
     {
         SetMidiPlayer();
     }
@@ -2527,7 +2527,7 @@ static void SetMidiPlayerOpl(void)
 
 static void SetMidiPlayerFluidSynth(void)
 {
-    if (I_MidiType() == midi_fluidsynth)
+    if (I_MidiPlayerType() == midiplayer_fluidsynth)
     {
         SetMidiPlayer();
     }

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -2509,30 +2509,6 @@ static void SetMidiPlayer(void)
     S_RestartMusic();
 }
 
-static void SetMidiPlayerNative(void)
-{
-    if (I_MidiType() == midi_native)
-    {
-        SetMidiPlayer();
-    }
-}
-
-static void SetMidiPlayerOpl(void)
-{
-    if (I_MidiType() == midi_opl)
-    {
-        SetMidiPlayer();
-    }
-}
-
-static void SetMidiPlayerFluidSynth(void)
-{
-    if (I_MidiType() == midi_fluidsynth)
-    {
-        SetMidiPlayer();
-    }
-}
-
 static void MN_Midi(void);
 static void MN_Equalizer(void);
 
@@ -2591,62 +2567,78 @@ static const char *midi_reset_type_strings[] = {
     "No SysEx", "General MIDI", "Roland GS", "Yamaha XG"
 };
 
-static setup_menu_t midi_settings1[] = {
+static setup_menu_t midi_settings_native[] = {
 
     {"Native MIDI Gain", S_NUM | S_PCT, CNTR_X, M_SPC,
      {"midi_gain"}, .action = UpdateMusicVolume},
 
     {"Native MIDI Reset", S_CHOICE | S_ACTION, CNTR_X, M_SPC,
      {"midi_reset_type"}, .strings_id = str_midi_reset_type,
-     .action = SetMidiPlayerNative},
+     .action = SetMidiPlayer},
 
     {"Compatibility Level", S_CHOICE | S_ACTION, CNTR_X, M_SPC,
      {"midi_complevel"}, .strings_id = str_midi_complevel,
-     .action = SetMidiPlayerNative},
+     .action = SetMidiPlayer},
 
     {"SC-55 CTF Emulation", S_ONOFF, CNTR_X, M_SPC, {"midi_ctf"},
-     .action = SetMidiPlayerNative},
+     .action = SetMidiPlayer},
 
-    MI_GAP,
+    MI_END
+};
 
-#if defined (HAVE_FLUIDSYNTH)
+static setup_menu_t midi_settings_fluidsynth[] = {
+
     {"FluidSynth Gain", S_NUM | S_PCT, CNTR_X, M_SPC, {"mus_gain"},
      .action = UpdateMusicVolume},
 
     {"FluidSynth Reverb", S_ONOFF, CNTR_X, M_SPC, {"mus_reverb"},
-     .action = SetMidiPlayerFluidSynth},
+     .action = SetMidiPlayer},
 
     {"FluidSynth Chorus", S_ONOFF, CNTR_X, M_SPC, {"mus_chorus"},
-     .action = SetMidiPlayerFluidSynth},
+     .action = SetMidiPlayer},
 
-    MI_GAP,
-#endif
+    MI_END
+};
+
+static setup_menu_t midi_settings_opl[] = {
 
     {"OPL3 Gain", S_NUM | S_PCT, CNTR_X, M_SPC, {"opl_gain"},
      .action = UpdateMusicVolume},
 
     {"OPL3 Number of Chips", S_THERMO | S_THRM_SIZE4 | S_ACTION, CNTR_X,
-     M_THRM_SPC, {"num_opl_chips"}, .action = SetMidiPlayerOpl},
+     M_THRM_SPC, {"num_opl_chips"}, .action = SetMidiPlayer},
 
     {"OPL3 Reverse Stereo", S_ONOFF, CNTR_X, M_SPC,
-     {"opl_stereo_correct"}, .action = SetMidiPlayerOpl},
+     {"opl_stereo_correct"}, .action = SetMidiPlayer},
 
     MI_END
 };
 
-static setup_menu_t *midi_settings[] = {midi_settings1, NULL};
+static setup_menu_t *midi_settings[] = {
+    midi_settings_native,
+    midi_settings_fluidsynth,
+    midi_settings_opl,
+    NULL
+};
 
 static setup_tab_t midi_tabs[] = {{"MIDI"}, {NULL}};
 
 static void MN_Midi(void)
 {
+    int index = 0;
+    miditype_t type = I_MidiType();
+    if (type > midi_none)
+    {
+        index = type - 1;
+    }
+
     SetItemOn(set_item_on);
     SetPageIndex(current_page);
 
     MN_SetNextMenuAlt(ss_midi);
     setup_screen = ss_midi;
-    current_page = GetPageIndex(midi_settings);
-    current_menu = midi_settings[current_page];
+    current_page = 0;
+    current_menu = midi_settings[index];
     current_tabs = midi_tabs;
     SetupMenuSecondary();
 }

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -2509,6 +2509,30 @@ static void SetMidiPlayer(void)
     S_RestartMusic();
 }
 
+static void SetMidiPlayerNative(void)
+{
+    if (I_MidiType() == midi_native)
+    {
+        SetMidiPlayer();
+    }
+}
+
+static void SetMidiPlayerOpl(void)
+{
+    if (I_MidiType() == midi_opl)
+    {
+        SetMidiPlayer();
+    }
+}
+
+static void SetMidiPlayerFluidSynth(void)
+{
+    if (I_MidiType() == midi_fluidsynth)
+    {
+        SetMidiPlayer();
+    }
+}
+
 static void MN_Midi(void);
 static void MN_Equalizer(void);
 
@@ -2569,43 +2593,43 @@ static const char *midi_reset_type_strings[] = {
 
 static setup_menu_t midi_settings1[] = {
 
-    {"Native MIDI Gain", S_THERMO | S_PCT, CNTR_X, M_THRM_SPC,
+    {"Native MIDI Gain", S_NUM | S_PCT, M_X, M_SPC,
      {"midi_gain"}, .action = UpdateMusicVolume},
 
-    {"Native MIDI Reset", S_CHOICE | S_ACTION, CNTR_X, M_SPC,
+    {"Native MIDI Reset", S_CHOICE | S_ACTION, M_X, M_SPC,
      {"midi_reset_type"}, .strings_id = str_midi_reset_type,
-     .action = SetMidiPlayer},
+     .action = SetMidiPlayerNative},
 
-    {"Compatibility Level", S_CHOICE | S_ACTION, CNTR_X, M_SPC,
+    {"Compatibility Level", S_CHOICE | S_ACTION, M_X, M_SPC,
      {"midi_complevel"}, .strings_id = str_midi_complevel,
-     .action = SetMidiPlayer},
+     .action = SetMidiPlayerNative},
 
-    {"SC-55 CTF Emulation", S_ONOFF, CNTR_X, M_SPC, {"midi_ctf"},
-     .action = SetMidiPlayer},
+    {"SC-55 CTF Emulation", S_ONOFF, M_X, M_SPC, {"midi_ctf"},
+     .action = SetMidiPlayerNative},
 
     MI_GAP,
 
 #if defined (HAVE_FLUIDSYNTH)
-    {"FluidSynth Gain", S_THERMO | S_PCT, CNTR_X, M_THRM_SPC, {"mus_gain"},
+    {"FluidSynth Gain", S_NUM | S_PCT, M_X, M_SPC, {"mus_gain"},
      .action = UpdateMusicVolume},
 
-    {"FluidSynth Reverb", S_ONOFF, CNTR_X, M_SPC, {"mus_reverb"},
-     .action = SetMidiPlayer},
+    {"FluidSynth Reverb", S_ONOFF, M_X, M_SPC, {"mus_reverb"},
+     .action = SetMidiPlayerFluidSynth},
 
-    {"FluidSynth Chorus", S_ONOFF, CNTR_X, M_SPC, {"mus_chorus"},
-     .action = SetMidiPlayer},
+    {"FluidSynth Chorus", S_ONOFF, M_X, M_SPC, {"mus_chorus"},
+     .action = SetMidiPlayerFluidSynth},
 
     MI_GAP,
 #endif
 
-    {"OPL3 Gain", S_THERMO | S_PCT, CNTR_X, M_THRM_SPC, {"opl_gain"},
+    {"OPL3 Gain", S_NUM | S_PCT, M_X, M_SPC, {"opl_gain"},
      .action = UpdateMusicVolume},
 
-    {"OPL3 Number of Chips", S_THERMO | S_THRM_SIZE4 | S_ACTION, CNTR_X,
-     M_THRM_SPC, {"num_opl_chips"}, .action = SetMidiPlayer},
+    {"OPL3 Number of Chips", S_THERMO | S_THRM_SIZE4 | S_ACTION, M_X_THRM4,
+     M_THRM_SPC, {"num_opl_chips"}, .action = SetMidiPlayerOpl},
 
-    {"OPL3 Reverse Stereo", S_ONOFF, CNTR_X, M_SPC,
-     {"opl_stereo_correct"}, .action = SetMidiPlayer},
+    {"OPL3 Reverse Stereo", S_ONOFF, M_X, M_SPC,
+     {"opl_stereo_correct"}, .action = SetMidiPlayerOpl},
 
     MI_END
 };

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -823,6 +823,11 @@ static void DrawSetting(setup_menu_t *s, int accum_y)
             M_snprintf(menu_buffer, sizeof(menu_buffer), "%d%%",
                        s->var.def->location->i);
         }
+        else if (s->append)
+        {
+            M_snprintf(menu_buffer, sizeof(menu_buffer), "%d %s",
+                       s->var.def->location->i, s->append);
+        }
         else
         {
             M_snprintf(menu_buffer, sizeof(menu_buffer), "%d",
@@ -989,6 +994,11 @@ static void DrawSetting(setup_menu_t *s, int accum_y)
         else if (flags & S_PCT)
         {
             M_snprintf(menu_buffer, sizeof(menu_buffer), "%d%%", value);
+        }
+        else if (s->append)
+        {
+            M_snprintf(menu_buffer, sizeof(menu_buffer), "%d %s", value,
+                       s->append);
         }
         else
         {
@@ -2593,8 +2603,8 @@ static const char *midi_reset_type_strings[] = {
 
 static setup_menu_t midi_settings1[] = {
 
-    {"Native MIDI Gain", S_NUM | S_PCT, CNTR_X, M_SPC,
-     {"midi_gain"}, .action = UpdateMusicVolume},
+    {"Native MIDI Gain", S_THERMO, CNTR_X, M_THRM_SPC,
+     {"midi_gain"}, .action = UpdateMusicVolume, .append = {"dB"}},
 
     {"Native MIDI Reset", S_CHOICE | S_ACTION, CNTR_X, M_SPC,
      {"midi_reset_type"}, .strings_id = str_midi_reset_type,
@@ -2610,8 +2620,8 @@ static setup_menu_t midi_settings1[] = {
     MI_GAP,
 
 #if defined (HAVE_FLUIDSYNTH)
-    {"FluidSynth Gain", S_NUM | S_PCT, CNTR_X, M_SPC, {"mus_gain"},
-     .action = UpdateMusicVolume},
+    {"FluidSynth Gain", S_THERMO, CNTR_X, M_THRM_SPC, {"mus_gain"},
+     .action = UpdateMusicVolume, .append = {"dB"}},
 
     {"FluidSynth Reverb", S_ONOFF, CNTR_X, M_SPC, {"mus_reverb"},
      .action = SetMidiPlayerFluidSynth},
@@ -2622,8 +2632,8 @@ static setup_menu_t midi_settings1[] = {
     MI_GAP,
 #endif
 
-    {"OPL3 Gain", S_NUM | S_PCT, CNTR_X, M_SPC, {"opl_gain"},
-     .action = UpdateMusicVolume},
+    {"OPL3 Gain", S_THERMO, CNTR_X, M_THRM_SPC, {"opl_gain"},
+     .action = UpdateMusicVolume, .append = {"dB"}},
 
     {"OPL3 Number of Chips", S_THERMO | S_THRM_SIZE4 | S_ACTION, CNTR_X,
      M_THRM_SPC, {"num_opl_chips"}, .action = SetMidiPlayerOpl},
@@ -2671,36 +2681,36 @@ static setup_menu_t eq_settings1[] = {
 
     MI_GAP_EX(4),
 
-    {"Preamp dB", S_THERMO, CNTR_X, M_THRM_SPC,
-     {"snd_eq_preamp"}, .action = I_OAL_EqualizerPreset},
+    {"Preamp", S_THERMO, CNTR_X, M_THRM_SPC,
+     {"snd_eq_preamp"}, .action = I_OAL_EqualizerPreset, .append = {"dB"}},
 
     MI_GAP_EX(4),
 
-    {"Low Gain dB", S_THERMO, CNTR_X, M_THRM_SPC,
-     {"snd_eq_low_gain"}, .action = I_OAL_EqualizerPreset},
+    {"Low Gain", S_THERMO, CNTR_X, M_THRM_SPC,
+     {"snd_eq_low_gain"}, .action = I_OAL_EqualizerPreset, .append = {"dB"}},
 
-    {"Mid 1 Gain dB", S_THERMO, CNTR_X, M_THRM_SPC,
-     {"snd_eq_mid1_gain"}, .action = I_OAL_EqualizerPreset},
+    {"Mid 1 Gain", S_THERMO, CNTR_X, M_THRM_SPC,
+     {"snd_eq_mid1_gain"}, .action = I_OAL_EqualizerPreset, .append = {"dB"}},
 
-    {"Mid 2 Gain dB", S_THERMO, CNTR_X, M_THRM_SPC,
-     {"snd_eq_mid2_gain"}, .action = I_OAL_EqualizerPreset},
+    {"Mid 2 Gain", S_THERMO, CNTR_X, M_THRM_SPC,
+     {"snd_eq_mid2_gain"}, .action = I_OAL_EqualizerPreset, .append = {"dB"}},
 
-    {"High Gain dB", S_THERMO, CNTR_X, M_THRM_SPC,
-     {"snd_eq_high_gain"}, .action = I_OAL_EqualizerPreset},
+    {"High Gain", S_THERMO, CNTR_X, M_THRM_SPC,
+     {"snd_eq_high_gain"}, .action = I_OAL_EqualizerPreset, .append = {"dB"}},
 
     MI_GAP_EX(4),
 
-    {"Low Cutoff Hz", S_NUM, CNTR_X, M_SPC,
-     {"snd_eq_low_cutoff"}, .action = I_OAL_EqualizerPreset},
+    {"Low Cutoff", S_NUM, CNTR_X, M_SPC,
+     {"snd_eq_low_cutoff"}, .action = I_OAL_EqualizerPreset, .append = {"Hz"}},
 
-    {"Mid 1 Center Hz", S_NUM, CNTR_X, M_SPC,
-     {"snd_eq_mid1_center"}, .action = I_OAL_EqualizerPreset},
+    {"Mid 1 Center", S_NUM, CNTR_X, M_SPC,
+     {"snd_eq_mid1_center"}, .action = I_OAL_EqualizerPreset, .append = {"Hz"}},
 
-    {"Mid 2 Center Hz", S_NUM, CNTR_X, M_SPC,
-     {"snd_eq_mid2_center"}, .action = I_OAL_EqualizerPreset},
+    {"Mid 2 Center", S_NUM, CNTR_X, M_SPC,
+     {"snd_eq_mid2_center"}, .action = I_OAL_EqualizerPreset, .append = {"Hz"}},
 
-    {"High Cutoff Hz", S_NUM, CNTR_X, M_SPC,
-     {"snd_eq_high_cutoff"}, .action = I_OAL_EqualizerPreset},
+    {"High Cutoff", S_NUM, CNTR_X, M_SPC,
+     {"snd_eq_high_cutoff"}, .action = I_OAL_EqualizerPreset, .append = {"Hz"}},
 
     MI_END
 };

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -4024,36 +4024,36 @@ static boolean ChangeEntry(menu_action_t action, int ch)
         {
             if (gather_count) // Any input?
             {
-                int value;
-
                 gather_buffer[gather_count] = 0;
-                value = atoi(gather_buffer); // Integer value
 
-                if ((def->limit.min != UL && value < def->limit.min)
-                    || (def->limit.max != UL && value > def->limit.max))
+                int value = atoi(gather_buffer); // Integer value
+
+                int min = def->limit.min;
+                int max = def->limit.max;
+
+                if ((min != UL && value < min) || (max != UL && value > max))
                 {
                     warn_about_changes(S_BADVAL);
+                    value = BETWEEN(min, max, value);
                 }
-                else
+
+                def->location->i = value;
+
+                // killough 8/9/98: fix numeric vars
+                // killough 8/15/98: add warning message
+
+                if (flags & (S_LEVWARN | S_PRGWARN))
                 {
-                    def->location->i = value;
+                    warn_about_changes(flags);
+                }
+                else if (def->current)
+                {
+                    def->current->i = value;
+                }
 
-                    // killough 8/9/98: fix numeric vars
-                    // killough 8/15/98: add warning message
-
-                    if (flags & (S_LEVWARN | S_PRGWARN))
-                    {
-                        warn_about_changes(flags);
-                    }
-                    else if (def->current)
-                    {
-                        def->current->i = value;
-                    }
-
-                    if (current_item->action) // killough 10/98
-                    {
-                        current_item->action();
-                    }
+                if (current_item->action) // killough 10/98
+                {
+                    current_item->action();
                 }
             }
             SelectDone(current_item); // phares 4/17/98


### PR DESCRIPTION
* Do not restart the MIDI player if the current option does not match it.

* Don't use thermo bars for big numbers.

The large thermos are unusable with keyboard/gamepad controls. I think it's not necessary to make a custom thermos for these options (like for "resolution scale"), so just `S_NUM` is sufficient.