### PR TITLE
Prevent unintentional death use reload

### DIFF
--- a/src/g_game.c
+++ b/src/g_game.c
@@ -655,7 +655,8 @@ static boolean FilterDeathUseAction(void)
             case death_use_nothing:
                 return true;
             case death_use_reload:
-                if (!demoplayback && !demorecording && !netgame)
+                if (!demoplayback && !demorecording && !netgame
+                    && !activate_death_use_reload)
                 {
                     activate_death_use_reload = true;
                 }
@@ -952,6 +953,7 @@ void G_ClearInput(void)
   I_ResetRelativeMouseState();
   I_ResetAllRumbleChannels();
   WS_Reset();
+  activate_death_use_reload = false;
 }
 
 //

--- a/src/p_user.c
+++ b/src/p_user.c
@@ -320,8 +320,6 @@ void P_DeathThink (player_t* player)
 
   if (activate_death_use_reload)
   {
-    activate_death_use_reload = false;
-
     if (savegameslot >= 0)
     {
       char *file = G_SaveGameName(savegameslot);


### PR DESCRIPTION
Fixes this bug:
When dying and pressing use, `FilterDeathUseAction` can still run again, setting `activate_death_use_reload` to true before the player is reborn. This is never cleared, so when dying a second time, the death use is immediately activated even though nothing was pressed.