### PR TITLE
Add auto save feature

### DIFF
--- a/src/d_event.h
+++ b/src/d_event.h
@@ -78,6 +78,7 @@ typedef enum
   ga_worlddone,
   ga_screenshot,
   ga_reloadlevel,
+  ga_saveautosave,
 } gameaction_t;
 
 

--- a/src/d_event.h
+++ b/src/d_event.h
@@ -78,6 +78,7 @@ typedef enum
   ga_worlddone,
   ga_screenshot,
   ga_reloadlevel,
+  ga_loadautosave,
   ga_saveautosave,
 } gameaction_t;
 

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -4813,7 +4813,7 @@ void G_BindGameVariables(void)
     "Maximum number of player corpses (< 0 = No limit)");
   BIND_NUM_GENERAL(death_use_action, 0, 0, 2,
     "Use-button action upon death (0 = Default; 1 = Load save; 2 = Nothing)");
-  BIND_BOOL_GENERAL(autosave, false,
+  BIND_BOOL_GENERAL(autosave, true,
     "Auto save at the beginning of a map, after completing the previous one.");
 }
 

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -212,6 +212,8 @@ boolean joybuttons[NUM_GAMEPAD_BUTTONS];
 int   savegameslot = -1;
 char  savedescription[32];
 
+static boolean autosave;
+
 //jff 3/24/98 declare startskill external, define defaultskill here
 int default_skill;               //note 1-based
 
@@ -4674,6 +4676,8 @@ void G_BindGameVariables(void)
     "Maximum number of player corpses (< 0 = No limit)");
   BIND_NUM_GENERAL(death_use_action, 0, 0, 2,
     "Use-button action upon death (0 = Default; 1 = Load save; 2 = Nothing)");
+  BIND_BOOL_GENERAL(autosave, false,
+    "Auto save at the beginning of a map, after completing the previous one.");
 }
 
 void G_BindEnemVariables(void)

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -48,6 +48,7 @@ void G_DeferedInitNew(skill_t skill, int episode, int map);
 void G_DeferedPlayDemo(char *demo);
 void G_LoadGame(char *name, int slot, boolean is_command); // killough 5/15/98
 void G_ForcedLoadGame(void);           // killough 5/15/98: forced loadgames
+void G_SaveAutoSave(char *description);
 void G_SaveGame(int slot, char *description); // Called by M_Responder.
 void G_RecordDemo(char *name);              // Only called by startup code.
 void G_BeginRecording(void);
@@ -58,6 +59,7 @@ void G_WorldDone(void);
 void G_Ticker(void);
 void G_ScreenShot(void);
 void G_ReloadDefaults(boolean keep_demover); // killough 3/1/98: loads game defaults
+char *G_AutoSaveName(void);
 char *G_SaveGameName(int); // killough 3/22/98: sets savegame filename
 char *G_MBFSaveGameName(int); // MBF savegame filename
 void G_SetFastParms(int);        // killough 4/10/98: sets -fast parameters

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -46,10 +46,14 @@ void G_DeathMatchSpawnPlayer(int playernum);
 void G_InitNew(skill_t skill, int episode, int map);
 void G_DeferedInitNew(skill_t skill, int episode, int map);
 void G_DeferedPlayDemo(char *demo);
+void G_LoadAutoSave(char *name);
 void G_LoadGame(char *name, int slot, boolean is_command); // killough 5/15/98
+void G_ForcedLoadAutoSave(void);
 void G_ForcedLoadGame(void);           // killough 5/15/98: forced loadgames
 void G_SaveAutoSave(char *description);
 void G_SaveGame(int slot, char *description); // Called by M_Responder.
+boolean G_AutoSaveEnabled(void);
+boolean G_LoadAutoSaveDeathUse(void);
 void G_RecordDemo(char *name);              // Only called by startup code.
 void G_BeginRecording(void);
 void G_PlayDemo(char *name);

--- a/src/mn_menu.c
+++ b/src/mn_menu.c
@@ -1138,7 +1138,7 @@ void MN_SetQuickSaveSlot(int slot)
 }
 
 // [FG] generate a default save slot name when the user saves to an empty slot
-static void SetDefaultSaveName(int slot)
+static void SetDefaultSaveName(char *name, const char *append)
 {
     char *maplump = MAPNAME(gameepisode, gamemap);
     int maplumpnum = W_CheckNumForName(maplump);
@@ -1158,16 +1158,31 @@ static void SetDefaultSaveName(int slot)
             *ext = '\0';
         }
 
-        M_snprintf(savegamestrings[slot], SAVESTRINGSIZE, "%s (%s)", maplump,
-                   wadname);
+        if (append)
+        {
+            M_snprintf(name, SAVESTRINGSIZE, "%s (%s) (%s)", maplump, wadname,
+                       append);
+        }
+        else
+        {
+            M_snprintf(name, SAVESTRINGSIZE, "%s (%s)", maplump, wadname);
+        }
+
         free(wadname);
     }
     else
     {
-        M_snprintf(savegamestrings[slot], SAVESTRINGSIZE, "%s", maplump);
+        if (append)
+        {
+            M_snprintf(name, SAVESTRINGSIZE, "%s (%s)", maplump, append);
+        }
+        else
+        {
+            M_snprintf(name, SAVESTRINGSIZE, "%s", maplump);
+        }
     }
 
-    M_StringToUpper(savegamestrings[slot]);
+    M_StringToUpper(name);
 }
 
 // [FG] override savegame name if it already starts with a map identifier
@@ -1195,7 +1210,7 @@ static boolean GamepadSave(int choice)
         // Immediately save game using a default name.
         saveSlot = choice;
         savegamestrings[choice][0] = 0;
-        SetDefaultSaveName(choice);
+        SetDefaultSaveName(savegamestrings[choice], NULL);
         M_DoSave(choice);
         LoadDef.lastOn = choice;
         return true;
@@ -1224,7 +1239,7 @@ static void M_SaveSelect(int choice)
         || MN_StartsWithMapIdentifier(savegamestrings[choice]))
     {
         savegamestrings[choice][0] = 0;
-        SetDefaultSaveName(choice);
+        SetDefaultSaveName(savegamestrings[choice], NULL);
     }
     saveCharIndex = strlen(savegamestrings[choice]);
 
@@ -1449,7 +1464,7 @@ static void M_QuickSaveResponse(int ch)
     {
         if (MN_StartsWithMapIdentifier(savegamestrings[quickSaveSlot]))
         {
-            SetDefaultSaveName(quickSaveSlot);
+            SetDefaultSaveName(savegamestrings[quickSaveSlot], NULL);
         }
         M_DoSave(quickSaveSlot);
         M_StartSound(sfx_swtchx);

--- a/src/mn_menu.c
+++ b/src/mn_menu.c
@@ -1215,6 +1215,14 @@ static void M_ReadSaveString(char *name, int menu_slot, int save_slot,
     SetLoadSlotStatus(menu_slot, 1);
 }
 
+static void UpdateRectX(menu_t *menu, int x)
+{
+    for (int i = 0; i < menu->numitems; i++)
+    {
+        menu->menuitems[i].rect.x = x;
+    }
+}
+
 //
 // M_ReadSaveStrings
 //  read the strings from the savegame files
@@ -1223,8 +1231,11 @@ static void M_ReadSaveStrings(void)
 {
     // [FG] shift savegame descriptions a bit to the right
     //      to make room for the snapshots on the left
-    SaveDef.x = LoadDef.x = LoadAutoSaveDef.x =
-        M_X_LOADSAVE + MIN(M_LOADSAVE_WIDTH / 2, video.deltaw);
+    const int x = M_X_LOADSAVE + MIN(M_LOADSAVE_WIDTH / 2, video.deltaw);
+    SaveDef.x = LoadDef.x = LoadAutoSaveDef.x = x;
+    UpdateRectX(&SaveDef, x);
+    UpdateRectX(&LoadDef, x);
+    UpdateRectX(&LoadAutoSaveDef, x);
 
     // [FG] fit the snapshots into the resulting space
     snapshot_width = MIN((video.deltaw + SaveDef.x + 2 * SKULLXOFF) & ~7,

--- a/src/mn_menu.c
+++ b/src/mn_menu.c
@@ -947,6 +947,16 @@ static void M_LoadSelect(int choice)
 // killough 5/15/98: add forced loadgames
 //
 
+static void M_VerifyForcedLoadAutoSave(int ch)
+{
+    if (ch == 'y')
+    {
+        G_ForcedLoadAutoSave();
+    }
+    free(messageString);
+    MN_ClearMenus();
+}
+
 static void M_VerifyForcedLoadGame(int ch)
 {
     if (ch == 'y')
@@ -955,6 +965,11 @@ static void M_VerifyForcedLoadGame(int ch)
     }
     free(messageString); // free the message strdup()'ed below
     MN_ClearMenus();
+}
+
+void MN_ForcedLoadAutoSave(const char *msg)
+{
+    M_StartMessage(strdup(msg), M_VerifyForcedLoadAutoSave, true);
 }
 
 void MN_ForcedLoadGame(const char *msg)

--- a/src/mn_menu.c
+++ b/src/mn_menu.c
@@ -1203,6 +1203,13 @@ boolean MN_StartsWithMapIdentifier(char *str)
     return false;
 }
 
+void M_SaveAutoSave(void)
+{
+    char autosave_string[SAVESTRINGSIZE];
+    SetDefaultSaveName(autosave_string, "Auto");
+    G_SaveAutoSave(autosave_string);
+}
+
 static boolean GamepadSave(int choice)
 {
     if (menu_input == pad_mode)

--- a/src/mn_menu.h
+++ b/src/mn_menu.h
@@ -88,6 +88,8 @@ extern int savepage;
 
 extern const char *default_skill_strings[];
 
+void M_ResetAutoSave(void);
+
 void MN_SetQuickSaveSlot(int slot);
 
 void M_SaveAutoSave(void);

--- a/src/mn_menu.h
+++ b/src/mn_menu.h
@@ -57,6 +57,7 @@ void M_Init(void);
 
 void MN_StartControlPanel(void);
 
+void MN_ForcedLoadAutoSave(const char *msg);
 void MN_ForcedLoadGame(const char *msg); // killough 5/15/98: forced loadgames
 void MN_Trans(void);     // killough 11/98: reset translucency
 void MN_SetupResetMenu(void);

--- a/src/mn_menu.h
+++ b/src/mn_menu.h
@@ -89,6 +89,8 @@ extern const char *default_skill_strings[];
 
 void MN_SetQuickSaveSlot(int slot);
 
+void M_SaveAutoSave(void);
+
 void MN_InitMenuStrings(void);
 
 boolean MN_StartsWithMapIdentifier(char *str);

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -3300,7 +3300,8 @@ static setup_menu_t gen_settings6[] = {
     {"On death action", S_CHOICE, OFF_CNTR_X, M_SPC, {"death_use_action"},
      .strings_id = str_death_use_action},
 
-    {"Auto save", S_ONOFF, OFF_CNTR_X, M_SPC, {"autosave"}},
+    {"Auto save", S_ONOFF, OFF_CNTR_X, M_SPC, {"autosave"},
+     .action = M_ResetAutoSave},
 
     {"Organize save files", S_ONOFF | S_PRGWARN, OFF_CNTR_X, M_SPC,
      {"organize_savefiles"}},

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -3289,16 +3289,18 @@ static setup_menu_t gen_settings6[] = {
     {"Screen wipe effect", S_CHOICE | S_STRICT, OFF_CNTR_X, M_SPC,
      {"screen_melt"}, .strings_id = str_screen_melt},
 
-    {"On death action", S_CHOICE, OFF_CNTR_X, M_SPC, {"death_use_action"},
-     .strings_id = str_death_use_action},
-
-    {"Demo progress bar", S_ONOFF, OFF_CNTR_X, M_SPC, {"demobar"}},
-
     {"Screen flashes", S_ONOFF | S_STRICT, OFF_CNTR_X, M_SPC,
      {"palette_changes"}},
 
     {"Invulnerability effect", S_CHOICE | S_STRICT, OFF_CNTR_X, M_SPC,
      {"invul_mode"}, .strings_id = str_invul_mode, .action = R_InvulMode},
+
+    {"Demo progress bar", S_ONOFF, OFF_CNTR_X, M_SPC, {"demobar"}},
+
+    {"On death action", S_CHOICE, OFF_CNTR_X, M_SPC, {"death_use_action"},
+     .strings_id = str_death_use_action},
+
+    {"Auto save", S_ONOFF, OFF_CNTR_X, M_SPC, {"autosave"}},
 
     {"Organize save files", S_ONOFF | S_PRGWARN, OFF_CNTR_X, M_SPC,
      {"organize_savefiles"}},

--- a/src/p_user.c
+++ b/src/p_user.c
@@ -322,14 +322,19 @@ void P_DeathThink (player_t* player)
   {
     activate_death_use_reload = 1;
 
-    if (savegameslot >= 0)
+    if (!G_AutoSaveEnabled() || !G_LoadAutoSaveDeathUse())
     {
-      char *file = G_SaveGameName(savegameslot);
-      G_LoadGame(file, savegameslot, false);
-      free(file);
+      if (savegameslot >= 0)
+      {
+        char *file = G_SaveGameName(savegameslot);
+        G_LoadGame(file, savegameslot, false);
+        free(file);
+      }
+      else
+      {
+        player->playerstate = PST_REBORN;
+      }
     }
-    else
-      player->playerstate = PST_REBORN;
   }
 }
 


### PR DESCRIPTION
<details><summary>details</summary>

Simple behavior:
- Auto save at the beginning of a map, after completing the previous one
- Menu item under General > Misc
- Off by default
- Disabled for demos and multiplayer

Example of completing a map, the next one loads, then the game auto saves (note the `game saved.` in the upper left corner):

https://github.com/user-attachments/assets/1b258933-bd79-4def-a652-57c10d5e1fd5

Notice that the save description is the default one with `(Auto)` appended.

If `On Death Action` is set to `Last Save`, the auto save will be loaded if it's more recent than the regular save in the player's current save slot. That's usually the case when the player forgets to save on the current level, and that's where this feature is most helpful. Example:

https://github.com/user-attachments/assets/66973db2-8741-4704-b19b-b1e36cdad1d1

The first save slot on the first save page is reserved for auto saving. The auto save is kept separate from `woofsav0.dsg` in a dedicated file named `autosave.dsg`. Toggling the "Auto Save" menu item toggles which one is shown.

https://github.com/user-attachments/assets/2372dc6f-1d65-4194-a705-1e4c73e8e6a9

The auto save slot is enabled when using the regular load menu, but disabled for the regular save menu. This is so the player doesn't try to save to that slot only for the save to be replaced by the auto save later.

Quick saving and quick loading can't select the auto save slot either, so that those keys can continue to function independently.

</details>