### PR TITLE
Implement option to correct automap aspect ratio

### DIFF
--- a/src/am_map.c
+++ b/src/am_map.c
@@ -299,7 +299,7 @@ static mpoint_t mapcenter;
 static angle_t mapangle;
 
 // [Woof!] automap aspect ratio correction
-boolean correctautomapaspect = false;
+boolean automapsquareaspect = false;
 static void AM_aspectCorrectPoint(mpoint_t *pt);
 
 enum
@@ -1515,7 +1515,7 @@ static void AM_drawGrid(int color)
     // [crispy] moved here
     ml.a.y = m_y;
     ml.b.y = m_y+m_h;
-    if (automaprotate || correctautomapaspect)
+    if (automaprotate || automapsquareaspect)
     {
       ml.a.y -= m_w / 2;
       ml.b.y += m_w / 2;
@@ -1525,7 +1525,7 @@ static void AM_drawGrid(int color)
       AM_rotatePoint(&ml.a);
       AM_rotatePoint(&ml.b);
     }
-    if (correctautomapaspect)
+    if (automapsquareaspect)
     {
         AM_aspectCorrectPoint(&ml.a);
         AM_aspectCorrectPoint(&ml.b);
@@ -1535,7 +1535,7 @@ static void AM_drawGrid(int color)
 
   // Figure out start of horizontal gridlines
   start = m_y;
-  if (automaprotate || correctautomapaspect)
+  if (automaprotate || automapsquareaspect)
   {
     start -= m_w / 2;
   }
@@ -1544,7 +1544,7 @@ static void AM_drawGrid(int color)
     start += // (MAPBLOCKUNITS<<FRACBITS)
       - ((start-(bmaporgy>>FRACTOMAPBITS))%gridsize);
   end = m_y + m_h;
-  if (automaprotate || correctautomapaspect)
+  if (automaprotate || automapsquareaspect)
   {
     end += m_w / 2;
   }
@@ -1564,7 +1564,7 @@ static void AM_drawGrid(int color)
       AM_rotatePoint(&ml.a);
       AM_rotatePoint(&ml.b);
     }
-    if (correctautomapaspect)
+    if (automapsquareaspect)
     {
         AM_aspectCorrectPoint(&ml.a);
         AM_aspectCorrectPoint(&ml.b);
@@ -1666,7 +1666,7 @@ static void AM_drawWalls(void)
         AM_rotatePoint(&l.a);
         AM_rotatePoint(&l.b);
     }
-    if (correctautomapaspect)
+    if (automapsquareaspect)
     {
         AM_aspectCorrectPoint(&l.a);
         AM_aspectCorrectPoint(&l.b);
@@ -2029,7 +2029,7 @@ static void AM_drawPlayers(void)
     {
         AM_rotatePoint(&pt);
     }
-    if (correctautomapaspect)
+    if (automapsquareaspect)
     {
         AM_aspectCorrectPoint(&pt);
     }
@@ -2098,7 +2098,7 @@ static void AM_drawPlayers(void)
     {
       smoothangle = LerpAngle(p->mo->oldangle, p->mo->angle);
     }
-    if (correctautomapaspect)
+    if (automapsquareaspect)
     {
         AM_aspectCorrectPoint(&pt);
     }
@@ -2160,7 +2160,7 @@ static void AM_drawThings
       {
         AM_rotatePoint(&pt);
       }
-      if (correctautomapaspect)
+      if (automapsquareaspect)
       {
           AM_aspectCorrectPoint(&pt);
       }
@@ -2271,7 +2271,7 @@ static void AM_drawMarks(void)
 	{
 	  AM_rotatePoint(&pt);
 	}
-	if (correctautomapaspect)
+	if (automapsquareaspect)
 	{
 	  AM_aspectCorrectPoint(&pt);
 	}
@@ -2341,7 +2341,7 @@ void AM_Drawer (void)
   }
 
   // [crispy] required for AM_rotatePoint()
-  if (automaprotate || correctautomapaspect)
+  if (automaprotate || automapsquareaspect)
   {
     mapcenter.x = m_x + m_w / 2;
     mapcenter.y = m_y + m_h / 2;
@@ -2467,8 +2467,8 @@ void AM_BindAutomapVariables(void)
             AM_PRESET_VANILLA, AM_PRESET_ZDOOM, ss_auto, wad_no,
             "Automap color preset (0 = Vanilla Doom; 1 = Crispy Doom; 2 = Boom; 3 = ZDoom)");
 
-  M_BindBool("correctautomapaspect", &correctautomapaspect, NULL, false, ss_auto, wad_no,
-             "Correct Automap Aspect Ratio");
+  M_BindBool("automapsquareaspect", &automapsquareaspect, NULL, false, ss_auto, wad_no,
+             "Use square aspect ratio in automap");
 
 #define BIND_CR(name, v, help) \
   M_BindNum(#name, &name, NULL, (v), 0, 255, ss_none, wad_yes, help)

--- a/src/am_map.c
+++ b/src/am_map.c
@@ -1948,6 +1948,9 @@ static void AM_drawLineCharacter
     if (angle)
       AM_rotate(&l.a.x, &l.a.y, angle);
 
+    if (automapsquareaspect)
+      l.a.y = 5 * l.a.y / 6;
+
     l.a.x += x;
     l.a.y += y;
 
@@ -1962,6 +1965,9 @@ static void AM_drawLineCharacter
 
     if (angle)
       AM_rotate(&l.b.x, &l.b.y, angle);
+
+    if (automapsquareaspect)
+      l.b.y = 5 * l.b.y / 6;
 
     l.b.x += x;
     l.b.y += y;

--- a/src/am_map.c
+++ b/src/am_map.c
@@ -2342,12 +2342,12 @@ void AM_Drawer (void)
   }
 
   // [crispy] required for AM_rotatePoint()
-  if (automaprotate)
+  if (automaprotate || correctautomapaspect)
   {
     mapcenter.x = m_x + m_w / 2;
     mapcenter.y = m_y + m_h / 2;
     // [crispy] keep the map static if not following the player
-    if (followplayer)
+    if (automaprotate && followplayer)
     {
       mapangle = ANG90 - plr->mo->angle;
     }

--- a/src/am_map.c
+++ b/src/am_map.c
@@ -300,7 +300,6 @@ static angle_t mapangle;
 
 // [Woof!] automap aspect ratio correction
 boolean correctautomapaspect = false;
-#define AUTOMAP_ASPECT_CORRECT ((fixed_t) (0x0000D555)) // 5/6
 static void AM_aspectCorrectPoint(mpoint_t *pt);
 
 enum
@@ -1925,8 +1924,8 @@ static void AM_rotatePoint(mpoint_t *pt)
 // [Woof!] Scale y coordinate of point for aspect ratio correction
 static void AM_aspectCorrectPoint(mpoint_t *pt)
 {
-  fixed_t diff = pt->y - mapcenter.y;
-  diff = FixedMul(diff, AUTOMAP_ASPECT_CORRECT);
+  int64_t diff = pt->y - mapcenter.y;
+  diff = 5 * diff / 6;
   pt->y = mapcenter.y + diff;
 }
 

--- a/src/am_map.c
+++ b/src/am_map.c
@@ -292,8 +292,9 @@ static void AM_drawFline_Smooth(fline_t* fl, int color);
 void (*AM_drawFline)(fline_t*, int) = AM_drawFline_Vanilla;
 
 // [crispy/Woof!] automap rotate mode and square aspect ratio need these early on
-boolean automaprotate = false;
-boolean automapsquareaspect = false;
+static boolean automaprotate = false;
+static boolean automapsquareaspect = false;
+#define ADJUST_ASPECT_RATIO (correct_aspect_ratio && automapsquareaspect)
 static void AM_rotate(int64_t *x, int64_t *y, angle_t a);
 static void AM_transformPoint(mpoint_t *pt);
 static mpoint_t mapcenter;
@@ -1512,7 +1513,7 @@ static void AM_drawGrid(int color)
     // [crispy] moved here
     ml.a.y = m_y;
     ml.b.y = m_y+m_h;
-    if (automaprotate || automapsquareaspect)
+    if (automaprotate || ADJUST_ASPECT_RATIO)
     {
       ml.a.y -= m_w / 2;
       ml.b.y += m_w / 2;
@@ -1524,7 +1525,7 @@ static void AM_drawGrid(int color)
 
   // Figure out start of horizontal gridlines
   start = m_y;
-  if (automaprotate || automapsquareaspect)
+  if (automaprotate || ADJUST_ASPECT_RATIO)
   {
     start -= m_w / 2;
   }
@@ -1533,7 +1534,7 @@ static void AM_drawGrid(int color)
     start += // (MAPBLOCKUNITS<<FRACBITS)
       - ((start-(bmaporgy>>FRACTOMAPBITS))%gridsize);
   end = m_y + m_h;
-  if (automaprotate || automapsquareaspect)
+  if (automaprotate || ADJUST_ASPECT_RATIO)
   {
     end += m_w / 2;
   }
@@ -1899,7 +1900,7 @@ static void AM_transformPoint(mpoint_t *pt)
 
     pt->x = tmpx;
   }
-  if (automapsquareaspect)
+  if (ADJUST_ASPECT_RATIO)
   {
     int64_t diff = pt->y - mapcenter.y;
     diff = 5 * diff / 6;
@@ -1948,7 +1949,7 @@ static void AM_drawLineCharacter
     if (angle)
       AM_rotate(&l.a.x, &l.a.y, angle);
 
-    if (automapsquareaspect)
+    if (ADJUST_ASPECT_RATIO)
       l.a.y = 5 * l.a.y / 6;
 
     l.a.x += x;
@@ -1966,7 +1967,7 @@ static void AM_drawLineCharacter
     if (angle)
       AM_rotate(&l.b.x, &l.b.y, angle);
 
-    if (automapsquareaspect)
+    if (ADJUST_ASPECT_RATIO)
       l.b.y = 5 * l.b.y / 6;
 
     l.b.x += x;
@@ -2300,7 +2301,7 @@ void AM_Drawer (void)
   }
 
   // [crispy/Woof!] required for AM_transformPoint()
-  if (automaprotate || automapsquareaspect)
+  if (automaprotate || ADJUST_ASPECT_RATIO)
   {
     mapcenter.x = m_x + m_w / 2;
     mapcenter.y = m_y + m_h / 2;

--- a/src/am_map.c
+++ b/src/am_map.c
@@ -1516,10 +1516,13 @@ static void AM_drawGrid(int color)
     // [crispy] moved here
     ml.a.y = m_y;
     ml.b.y = m_y+m_h;
-    if (automaprotate)
+    if (automaprotate || correctautomapaspect)
     {
       ml.a.y -= m_w / 2;
       ml.b.y += m_w / 2;
+    }
+    if (automaprotate)
+    {
       AM_rotatePoint(&ml.a);
       AM_rotatePoint(&ml.b);
     }
@@ -1533,7 +1536,7 @@ static void AM_drawGrid(int color)
 
   // Figure out start of horizontal gridlines
   start = m_y;
-  if (automaprotate)
+  if (automaprotate || correctautomapaspect)
   {
     start -= m_w / 2;
   }
@@ -1542,7 +1545,7 @@ static void AM_drawGrid(int color)
     start += // (MAPBLOCKUNITS<<FRACBITS)
       - ((start-(bmaporgy>>FRACTOMAPBITS))%gridsize);
   end = m_y + m_h;
-  if (automaprotate)
+  if (automaprotate || correctautomapaspect)
   {
     end += m_w / 2;
   }

--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -242,7 +242,6 @@ typedef enum
 } overlay_t;
 
 extern  overlay_t automapoverlay;
-extern  boolean automaprotate;
 
 #define automap_on (automapactive && !automapoverlay)
 #define automap_off (!automapactive || automapoverlay)

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -2061,6 +2061,8 @@ static setup_menu_t auto_settings1[] = {
     {"Color Keyed Doors", S_CHOICE, H_X, M_SPC, {"map_keyed_door"},
      .strings_id = str_automap_keyed_door},
 
+    {"Aspect Ratio Correction", S_ONOFF, H_X, M_SPC, {"correctautomapaspect"}},
+
     MI_RESET,
 
     MI_END

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -2061,7 +2061,7 @@ static setup_menu_t auto_settings1[] = {
     {"Color Keyed Doors", S_CHOICE, H_X, M_SPC, {"map_keyed_door"},
      .strings_id = str_automap_keyed_door},
 
-    {"Aspect Ratio Correction", S_ONOFF, H_X, M_SPC, {"correctautomapaspect"}},
+    {"Square Aspect Ratio", S_ONOFF, H_X, M_SPC, {"automapsquareaspect"}},
 
     MI_RESET,
 


### PR DESCRIPTION
This PR implements aspect ratio correction for the automap as an optional setting.

Some demos:

https://github.com/user-attachments/assets/d843d9a9-2e4c-45fe-8be8-8001282f097a

The difference is showcased very well with the blockmap grid

https://github.com/user-attachments/assets/e4a2883a-a057-4c48-b934-7c4eed114604

There are some macros/variables for mtof and ftom, and I don't know if they get broken by this, but in game everything seems to work ok. I'm not sure if this is the best way to implement this change, I am happy to get feedback :)

I'm also not sure if the placement in the settings is the best, I just put it as the next option which seemed ok.

Unrelated, but I am thrilled that my blockmap bug fix intended for Crispy Doom some years ago was incorporated into Woof! 😄 Feels nice that the community remembered the patch and revised it.