### PR TITLE
fix garbage column in bunny scroll

### DIFF
--- a/src/doomtype.h
+++ b/src/doomtype.h
@@ -79,10 +79,12 @@ typedef byte lighttable_t;
 
 #define BETWEEN(l, u, x) ((l) > (x) ? (l) : (x) > (u) ? (u) : (x))
 
-inline static int DivRoundClosest(const int n, const int d)
-{
-    return ((n < 0) == (d < 0)) ? ((n + d / 2) / d) : ((n - d / 2) / d);
-}
+#define DIV_ROUND_FLOOR(n, d) (((n) - (d) / 2) / (d))
+
+#define DIV_ROUND_CEIL(n, d) (((n) + (d) / 2) / (d))
+
+#define DIV_ROUND_CLOSEST(n, d) \
+    (((n) < 0) == ((d) < 0)) ? DIV_ROUND_CEIL(n, d) : DIV_ROUND_FLOOR(n, d)
 
 #if defined(_MSC_VER) && !defined(__cplusplus)
 #define inline __inline

--- a/src/f_finale.c
+++ b/src/f_finale.c
@@ -696,13 +696,13 @@ void F_BunnyScroll (void)
 
   scrolled = 320 - (finalecount-230)/2;
 
-  int p1offset = DivRoundClosest(video.unscaledw - SHORT(p1->width), 2);
+  int p1offset = DIV_ROUND_CEIL(video.unscaledw - SHORT(p1->width), 2);
   if (SHORT(p1->width) == 320)
   {
       p1offset += (SHORT(p2->width) - 320) / 2;
   }
 
-  int p2offset = DivRoundClosest(video.unscaledw - SHORT(p2->width), 2);
+  int p2offset = DIV_ROUND_CEIL(video.unscaledw - SHORT(p2->width), 2);
 
   if (scrolled <= 0)
   {

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -514,7 +514,7 @@ void V_DrawPatchTRTR(int x, int y, patch_t *patch, byte *outr1, byte *outr2)
 
 void V_DrawPatchFullScreen(patch_t *patch)
 {
-    const int x = DivRoundClosest(video.unscaledw - SHORT(patch->width), 2);
+    const int x = DIV_ROUND_CLOSEST(video.unscaledw - SHORT(patch->width), 2);
 
     patch->leftoffset = 0;
     patch->topoffset = 0;


### PR DESCRIPTION
Convert `DivRoundClosest` to a macro (we can use it for `int64_t`, for example), add `DIV_ROUND_CEIL` and `DIV_ROUND_FLOOR`.

Fix #1949 