### PR TITLE
Show map number below save game snapshot

### DIFF
--- a/src/g_game.c
+++ b/src/g_game.c
@@ -2591,17 +2591,15 @@ const char *G_GetMapNameFromSaveGame(const char *name)
 
   byte *ptr = tempbuffer + SAVESTRINGSIZE;
 
-  saveg_compat_t saveg_temp = -1;
+  saveg_compat_t saveg_temp = saveg_current;
 
   char vcheck[VERSIONSIZE];
   M_snprintf(vcheck, VERSIONSIZE, VERSIONID, MBFVERSION);
   CheckSaveVersionEx(&saveg_temp, ptr, vcheck, saveg_mbf);
   CheckSaveVersionEx(&saveg_temp, ptr, "Woof 6.0.0", saveg_woof600);
   CheckSaveVersionEx(&saveg_temp, ptr, "Woof 13.0.0", saveg_woof1300);
-  CheckSaveVersionEx(&saveg_temp, ptr, CURRENT_SAVE_VERSION, saveg_current);
 
-  if (saveg_temp == -1
-      || (saveg_temp != saveg_mbf && saveg_temp < saveg_woof600))
+  if (saveg_temp != saveg_mbf && saveg_temp < saveg_woof600)
   {
     Z_Free(tempbuffer);
     return NULL;

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -2569,10 +2569,10 @@ static void G_DoSaveAutoSave(void)
   DoSaveGame(name);
 }
 
-static void CheckSaveVersionEx(saveg_compat_t *out, const char *ptr,
+static void CheckSaveVersionEx(saveg_compat_t *out, byte *ptr,
                                const char *str, saveg_compat_t ver)
 {
-  if (strncmp(ptr, str, strlen(str)) == 0)
+  if (strncmp((const char *)ptr, str, strlen(str)) == 0)
   {
     *out = ver;
   }

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -52,6 +52,7 @@ void G_ForcedLoadAutoSave(void);
 void G_ForcedLoadGame(void);           // killough 5/15/98: forced loadgames
 void G_SaveAutoSave(char *description);
 void G_SaveGame(int slot, char *description); // Called by M_Responder.
+const char *G_GetMapNameFromSaveGame(const char *name);
 boolean G_AutoSaveEnabled(void);
 boolean G_LoadAutoSaveDeathUse(void);
 void G_RecordDemo(char *name);              // Only called by startup code.

--- a/src/mn_menu.c
+++ b/src/mn_menu.c
@@ -843,7 +843,7 @@ static void M_DrawBorderedSnapshot(int slot)
     const int x =
         video.deltaw + currentMenu->x + SKULLXOFF - snapshot_width - 8;
     const int y = (currentMenu->numitems * LINEHEIGHT - snapshot_height) * slot
-                  / currentMenu->numitems;
+                  / currentMenu->numitems * 8 / 10;
 
     const int snapshot_x = MAX(8, x);
     const int snapshot_y = currentMenu->y + MAX(0, y);
@@ -865,10 +865,13 @@ static void M_DrawBorderedSnapshot(int slot)
     }
 
     txt = MN_GetSavegameTime(slot);
-    MN_DrawString(snapshot_x + snapshot_width / 2 - MN_GetPixelWidth(txt) / 2
-                      - video.deltaw,
-                  snapshot_y + snapshot_height + MN_StringHeight(txt), CR_GOLD,
-                  txt);
+    const int txt_x = snapshot_x + snapshot_width / 2 - video.deltaw;
+    const int txt_y = snapshot_y + snapshot_height + MN_StringHeight(txt);
+    MN_DrawString(txt_x - MN_GetPixelWidth(txt) / 2, txt_y, CR_GOLD, txt);
+
+    txt = MN_GetMapName(slot);
+    MN_DrawString(txt_x - MN_GetPixelWidth(txt) / 2,
+                  txt_y + MN_StringHeight(txt) * 3 / 2, CR_GOLD, txt);
 
     // [FG] draw the view border around the snapshot
     R_DrawBorder(snapshot_x, snapshot_y, snapshot_width, snapshot_height);
@@ -1196,6 +1199,7 @@ static void M_ReadSaveString(char *name, int menu_slot, int save_slot,
 {
     FILE *fp = M_fopen(name, "rb");
     MN_ReadSavegameTime(menu_slot, name);
+    MN_ReadMapName(menu_slot, name, fp != NULL);
     free(name);
 
     MN_ResetSnapshot(menu_slot);

--- a/src/mn_snapshot.c
+++ b/src/mn_snapshot.c
@@ -24,8 +24,10 @@
 #include "doomdef.h"
 #include "doomstat.h"
 #include "doomtype.h"
+#include "g_game.h"
 #include "m_fixed.h"
 #include "m_io.h"
+#include "m_misc.h"
 #include "r_main.h"
 #include "v_video.h"
 
@@ -36,6 +38,9 @@ static const int snapshot_size = SCREENWIDTH * SCREENHEIGHT;
 static byte *snapshots[10];
 static byte *current_snapshot;
 static char savegametimes[10][32];
+
+#define MAPNAMESIZE 8
+static char mapnames[10][MAPNAMESIZE];
 
 const int MN_SnapshotDataSize(void)
 {
@@ -113,6 +118,25 @@ void MN_ReadSavegameTime(int i, char *name)
 char *MN_GetSavegameTime(int i)
 {
     return savegametimes[i];
+}
+
+void MN_ReadMapName(int i, const char *name, boolean read_file)
+{
+    const char *buf = (read_file ? G_GetMapNameFromSaveGame(name) : NULL);
+
+    if (buf)
+    {
+        M_StringCopy(mapnames[i], buf, MAPNAMESIZE);
+    }
+    else
+    {
+        mapnames[i][0] = '\0';
+    }
+}
+
+const char *MN_GetMapName(int i)
+{
+    return mapnames[i];
 }
 
 // [FG] take a snapshot in SCREENWIDTH*SCREENHEIGHT resolution, i.e.

--- a/src/mn_snapshot.h
+++ b/src/mn_snapshot.h
@@ -31,4 +31,7 @@ boolean MN_DrawSnapshot(int i, int x, int y, int w, int h);
 void MN_ReadSavegameTime(int i, char *name);
 char *MN_GetSavegameTime(int i);
 
+void MN_ReadMapName(int i, const char *name, boolean read_file);
+const char *MN_GetMapName(int i);
+
 #endif


### PR DESCRIPTION
Fixes https://github.com/fabiangreffrath/woof/issues/1948

Good idea or too much clutter?

![woof0002](https://github.com/user-attachments/assets/941e90b5-079d-4e59-afbb-796293c822c5)

There have always been some edge cases with the auto naming, but I'm not sure if we can do anything about it:

![woof0004](https://github.com/user-attachments/assets/cd18b4c4-b71b-48d8-a307-0df5961129c1)
