### PR TITLE
add lump priority to determinate load order

### DIFF
--- a/src/mn_internal.h
+++ b/src/mn_internal.h
@@ -45,6 +45,8 @@ typedef enum
     key_mode
 } menu_input_mode_t;
 
+extern int bigfont_priority;
+
 extern menu_input_mode_t help_input, old_help_input; // pad_mode or key_mode.
 extern menu_input_mode_t menu_input, old_menu_input;
 void MN_ResetMouseCursor(void);

--- a/src/mn_menu.c
+++ b/src/mn_menu.c
@@ -3485,6 +3485,7 @@ void M_Drawer(void)
     // [FG] check current menu for missing menu graphics lumps - only once
     if (currentMenu->lumps_missing == 0)
     {
+        int max_priority = -1;
         for (int i = 0; i < max; i++)
         {
             const char *name = currentMenu->menuitems[i].name;
@@ -3497,10 +3498,13 @@ void M_Drawer(void)
                 if (patch_lump >= 0)
                 {
                     patch_priority = lumpinfo[patch_lump].handle.priority;
+                    max_priority = MAX(max_priority, patch_priority);
                 }
             }
 
-            if ((patch_lump < 0 || patch_priority < bigfont_priority)
+            if ((patch_lump < 0
+                 || patch_priority < bigfont_priority
+                 || patch_priority < max_priority)
                 && currentMenu->menuitems[i].alttext)
             {
                 currentMenu->lumps_missing++;

--- a/src/mn_menu.c
+++ b/src/mn_menu.c
@@ -110,6 +110,8 @@ static boolean options_active;
 
 backdrop_t menu_backdrop;
 
+int bigfont_priority = -1;
+
 #define SKULLXOFF        -32
 #define LINEHEIGHT       16
 
@@ -2277,8 +2279,9 @@ void M_Init(void)
     M_ResetAutoSave();
 
     int lumpnum = W_CheckNumForName("DBIGFONT");
-    if (lumpnum > 0)
+    if (lumpnum >= 0)
     {
+        bigfont_priority = lumpinfo[lumpnum].handle.priority;
         MN_LoadFon2(W_CacheLumpNum(lumpnum, PU_CACHE), W_LumpLength(lumpnum));
     }
 
@@ -3486,13 +3489,19 @@ void M_Drawer(void)
         {
             const char *name = currentMenu->menuitems[i].name;
             int patch_lump = -1;
+            int patch_priority = -1;
 
             if (name[0])
             {
                 patch_lump = W_CheckNumForName(name);
+                if (patch_lump >= 0)
+                {
+                    patch_priority = lumpinfo[patch_lump].handle.priority;
+                }
             }
 
-            if (patch_lump < 0 && currentMenu->menuitems[i].alttext)
+            if ((patch_lump < 0 || patch_priority < bigfont_priority)
+                && currentMenu->menuitems[i].alttext)
             {
                 currentMenu->lumps_missing++;
                 break;

--- a/src/mn_menu.c
+++ b/src/mn_menu.c
@@ -3485,7 +3485,6 @@ void M_Drawer(void)
     // [FG] check current menu for missing menu graphics lumps - only once
     if (currentMenu->lumps_missing == 0)
     {
-        int max_priority = -1;
         for (int i = 0; i < max; i++)
         {
             const char *name = currentMenu->menuitems[i].name;
@@ -3498,13 +3497,10 @@ void M_Drawer(void)
                 if (patch_lump >= 0)
                 {
                     patch_priority = lumpinfo[patch_lump].handle.priority;
-                    max_priority = MAX(max_priority, patch_priority);
                 }
             }
 
-            if ((patch_lump < 0
-                 || patch_priority < bigfont_priority
-                 || patch_priority < max_priority)
+            if ((patch_lump < 0 || patch_priority < bigfont_priority)
                 && currentMenu->menuitems[i].alttext)
             {
                 currentMenu->lumps_missing++;

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -4775,8 +4775,14 @@ int MN_StringHeight(const char *string)
 void MN_DrawTitle(int x, int y, const char *patch, const char *alttext)
 {
     int patch_lump = W_CheckNumForName(patch);
+    int patch_priority = -1;
 
     if (patch_lump >= 0)
+    {
+        patch_priority = lumpinfo[patch_lump].handle.priority;
+    }
+
+    if (patch_lump >= 0 && patch_priority >= bigfont_priority)
     {
         patch_t *patch = V_CachePatchNum(patch_lump, PU_CACHE);
         V_DrawPatch(x == M_X_CENTER ? SCREENWIDTH / 2 - patch->width / 2 : x,

--- a/src/w_file.c
+++ b/src/w_file.c
@@ -92,7 +92,8 @@ static boolean W_FILE_AddDir(w_handle_t handle, const char *path,
         item.size = FileLength(descriptor);
 
         item.module = &w_file_module;
-        w_handle_t local_handle = {.p1.descriptor = descriptor};
+        w_handle_t local_handle = {.p1.descriptor = descriptor,
+                                   .priority = handle.priority};
         item.handle = local_handle;
 
         array_push(lumpinfo, item);
@@ -125,7 +126,8 @@ static w_type_t W_FILE_Open(const char *path, w_handle_t *handle)
 
     I_Printf(VB_INFO, " adding %s", path); // killough 8/8/98
 
-    w_handle_t local_handle = {.p1.descriptor = descriptor};
+    w_handle_t local_handle = {.p1.descriptor = descriptor,
+                               .priority = handle->priority};
 
     // open the file and add to directory
 

--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -152,7 +152,11 @@ static void AddDirs(w_module_t *module, w_handle_t handle, const char *base)
 
 boolean W_AddPath(const char *path)
 {
+    static int priority;
+
     w_handle_t handle = {0};
+    handle.priority = priority++;
+
     w_module_t *active_module = NULL;
 
     for (int i = 0; i < arrlen(modules); ++i)

--- a/src/w_wad.h
+++ b/src/w_wad.h
@@ -79,6 +79,8 @@ typedef struct
         int position;
         int index;
     } p2;
+
+    int priority;
 } w_handle_t;
 
 typedef struct

--- a/src/w_zip.c
+++ b/src/w_zip.c
@@ -32,10 +32,12 @@ static void ConvertSlashes(char *path)
     }
 }
 
-static void AddWadInMem(w_handle_t handle, mz_zip_archive *zip,
-                        const char *name, int index, size_t data_size)
+static void AddWadInMem(w_handle_t handle, const char *name, int index,
+                        size_t data_size)
 {
     I_Printf(VB_INFO, " - adding %s", name);
+
+    mz_zip_archive *zip = handle.p1.zip;
 
     byte *data = malloc(data_size);
 
@@ -127,7 +129,7 @@ static boolean W_ZIP_AddDir(w_handle_t handle, const char *path,
 
         if (is_root && M_StringCaseEndsWith(stat.m_filename, ".wad"))
         {
-            AddWadInMem(handle, zip, M_BaseName(stat.m_filename), index,
+            AddWadInMem(handle, M_BaseName(stat.m_filename), index,
                         stat.m_uncomp_size);
             continue;
         }

--- a/src/w_zip.c
+++ b/src/w_zip.c
@@ -32,8 +32,8 @@ static void ConvertSlashes(char *path)
     }
 }
 
-static void AddWadInMem(mz_zip_archive *zip, const char *name, int index,
-                        size_t data_size)
+static void AddWadInMem(w_handle_t handle, mz_zip_archive *zip,
+                        const char *name, int index, size_t data_size)
 {
     I_Printf(VB_INFO, " - adding %s", name);
 
@@ -94,6 +94,8 @@ static void AddWadInMem(mz_zip_archive *zip, const char *name, int index,
         }
         item.size = size;
         item.data = data + position;
+
+        item.handle = handle;
  
         // [FG] WAD file that contains the lump
         item.wad_file = wadname;
@@ -125,7 +127,7 @@ static boolean W_ZIP_AddDir(w_handle_t handle, const char *path,
 
         if (is_root && M_StringCaseEndsWith(stat.m_filename, ".wad"))
         {
-            AddWadInMem(zip, M_BaseName(stat.m_filename), index,
+            AddWadInMem(handle, zip, M_BaseName(stat.m_filename), index,
                         stat.m_uncomp_size);
             continue;
         }
@@ -154,7 +156,8 @@ static boolean W_ZIP_AddDir(w_handle_t handle, const char *path,
         item.size = stat.m_uncomp_size;
 
         item.module = &w_zip_module;
-        w_handle_t local_handle = {.p1.zip = zip, .p2.index = index};
+        w_handle_t local_handle = {.p1.zip = zip, .p2.index = index,
+                                   .priority = handle.priority};
         item.handle = local_handle;
 
         array_push(lumpinfo, item);


### PR DESCRIPTION
Consider this scenario:
1. User has WAD in autoload with menu lumps from original MBF: [mbf.zip](https://github.com/user-attachments/files/17326762/mbf.zip)
2. User loads [Atmospheric Extinction](https://www.doomworld.com/idgames/levels/doom2/Ports/v-z/vel_aex) (which has `DBIGFONT`, but no options menu lumps replacement) then user will have mismach of fonts in options:

![woof0000](https://github.com/user-attachments/assets/07e6adff-2542-4500-8748-ed42fb21d761)

This PR fixes it.

Fix #1912