### PR TITLE
Add in-game custom HRTF selection

### DIFF
--- a/src/i_oalcommon.h
+++ b/src/i_oalcommon.h
@@ -37,6 +37,7 @@
 #endif
 
 #define ALFUNC(T, ptr) (ptr = FUNCTION_CAST(T, alGetProcAddress(#ptr)))
+#define ALCFUNC(d, T, ptr) (ptr = FUNCTION_CAST(T, alcGetProcAddress(d, #ptr)))
 
 #define DB_TO_GAIN(db) powf(10.0f, (db) / 20.0f)
 

--- a/src/i_oalsound.h
+++ b/src/i_oalsound.h
@@ -50,6 +50,10 @@ void I_OAL_UpdateListenerParams(const ALfloat *position,
 
 const char **I_OAL_GetResamplerStrings(void);
 
+const char **I_OAL_GetHrtfStrings(void);
+
+boolean I_OAL_3dSound(void);
+
 boolean I_OAL_InitSound(int snd_module);
 
 boolean I_OAL_ReinitSound(int snd_module);

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -442,7 +442,7 @@ void I_InitSound(void)
 
     I_AtExit(I_ShutdownSound, true);
 
-    MN_UpdateAdvancedSoundItems(snd_module != SND_MODULE_3D);
+    MN_UpdateAdvancedSoundItems();
 
     snd_init = true;
 
@@ -520,7 +520,7 @@ void I_SetSoundModule(void)
         I_Printf(VB_WARNING, "I_SetSoundModule: Failed to reinitialize sound.");
     }
 
-    MN_UpdateAdvancedSoundItems(snd_module != SND_MODULE_3D);
+    MN_UpdateAdvancedSoundItems();
 }
 
 midiplayertype_t I_MidiPlayerType(void)

--- a/src/m_io.c
+++ b/src/m_io.c
@@ -383,3 +383,29 @@ char *M_getenv(const char *name)
     return getenv(name);
 #endif
 }
+
+// Doesn't overwrite an existing environment variable. See env_vars.
+int M_setenv(const char *name, const char *value)
+{
+#ifdef _WIN32
+    if (!name || !value || M_getenv(name) != NULL)
+    {
+        return -1;
+    }
+
+    char *pair = M_StringJoin(name, "=", value);
+    wchar_t *wpair = ConvertUtf8ToWide(pair);
+    free(pair);
+
+    if (!wpair)
+    {
+        return -1;
+    }
+
+    const int ret = _wputenv(wpair);
+    free(wpair);
+    return ret;
+#else
+    return setenv(name, value, 0);
+#endif
+}

--- a/src/m_io.h
+++ b/src/m_io.h
@@ -46,6 +46,7 @@ int M_open(const char *filename, int oflag);
 int M_access(const char *path, int mode);
 void M_MakeDirectory(const char *dir);
 char *M_getenv(const char *name);
+int M_setenv(const char *name, const char *value);
 
 #ifdef _WIN32
 char *M_ConvertWideToUtf8(const wchar_t *wstr);

--- a/src/mn_menu.h
+++ b/src/mn_menu.h
@@ -66,7 +66,7 @@ void MN_UpdateMouseLook(void);
 void MN_UpdatePadLook(void);
 void MN_UpdateAllGamepadItems(void);
 void MN_UpdateEqualizerItems(void);
-void MN_UpdateAdvancedSoundItems(boolean toggle);
+void MN_UpdateAdvancedSoundItems(void);
 void MN_ResetTimeScale(void);
 void MN_SetHUFontKerning(void);
 void MN_DisableVoxelsRenderingItem(void);

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -337,6 +337,7 @@ enum
     str_gamma,
     str_sound_module,
     str_resampler,
+    str_hrtf,
     str_equalizer_preset,
     str_midi_complevel,
     str_midi_reset_type,
@@ -2562,8 +2563,8 @@ static setup_menu_t gen_settings2[] = {
     {"Sound Module", S_CHOICE, CNTR_X, M_SPC, {"snd_module"},
      .strings_id = str_sound_module, .action = SetSoundModule},
 
-    {"Headphones Mode", S_ONOFF, CNTR_X, M_SPC, {"snd_hrtf"}, 
-     .action = SetSoundModule},
+    {"Headphones Mode", S_CHOICE | S_ACTION, CNTR_X, M_SPC, {"snd_hrtf"},
+     .strings_id = str_hrtf, .action = SetSoundModule},
 
     {"Pitch-Shifting", S_ONOFF, CNTR_X, M_SPC, {"pitched_sounds"}},
 
@@ -2594,6 +2595,12 @@ static const char **GetResamplerStrings(void)
     const char **strings = I_OAL_GetResamplerStrings();
     DisableItem(!strings, gen_settings2, "snd_resampler");
     return strings;
+}
+
+static const char **GetHrtfStrings(void)
+{
+    MN_UpdateAdvancedSoundItems();
+    return I_OAL_GetHrtfStrings();
 }
 
 static const char *midi_complevel_strings[] = {
@@ -3369,9 +3376,10 @@ void MN_UpdateDynamicResolutionItem(void)
                 "dynamic_resolution");
 }
 
-void MN_UpdateAdvancedSoundItems(boolean toggle)
+void MN_UpdateAdvancedSoundItems(void)
 {
-    DisableItem(toggle, gen_settings2, "snd_hrtf");
+    const boolean condition = (!I_OAL_3dSound() || !I_OAL_GetHrtfStrings());
+    DisableItem(condition, gen_settings2, "snd_hrtf");
 }
 
 void MN_UpdateFpsLimitItem(void)
@@ -4833,6 +4841,7 @@ static const char **selectstrings[] = {
     gamma_strings,
     sound_module_strings,
     NULL, // str_resampler
+    NULL, // str_hrtf
     equalizer_preset_strings,
     midi_complevel_strings,
     midi_reset_type_strings,
@@ -4889,6 +4898,7 @@ void MN_InitMenuStrings(void)
     selectstrings[str_gyro_sens] = GetGyroSensitivityStrings();
     selectstrings[str_gyro_accel] = GetGyroAccelStrings();
     selectstrings[str_resampler] = GetResamplerStrings();
+    selectstrings[str_hrtf] = GetHrtfStrings();
 }
 
 void MN_SetupResetMenu(void)


### PR DESCRIPTION
Draft for now because I want to test Linux and macOS some more. I'm also wondering if this is worth pursuing or if it's too abstract and niche.

![woof0008](https://github.com/user-attachments/assets/bbedc77f-8a13-4e9e-b99b-7f127f27d599)

This works like soundfonts:
- Copy `.sf2/.sf3` into `soundfonts` --> Copy `.mhr` into `hrtf`.
- `TimGM6mb.sf2` is default soundfont --> `Default HRTF.mhr` embedded in OpenAL32.dll ("Built-in HRTF").
- `RLNDGM.SF2` is decent and balanced --> "dummy head" HRTFs are decent approximations of an average human.

To make this as easy as possible for users, I tracked down the original sources for the most popular HRTF data sets and converted them to OpenAL Soft .mhr format myself. I placed these files in a [separate repo](https://github.com/ceski-1/openal-soft-hrtf).

I plan on writing a 3D audio article on the Woof wiki that will explain how to use this feature, along with some example videos/sounds, and a link to the above repo. [Here's a small excerpt](https://gist.github.com/ceski-1/eda6e6961759d7a54f4d72258543a356).

This is just the "dummy head" HRTFs for quick testing: [sample_hrtfs.zip](https://github.com/user-attachments/files/17348881/sample_hrtfs.zip)

This is the old test wad I showed before (platforms moving around the player): [hrtftest.zip](https://github.com/user-attachments/files/17348882/hrtftest.zip)