### PR TITLE
Level-stats format settings

### DIFF
--- a/src/hu_stuff.c
+++ b/src/hu_stuff.c
@@ -523,6 +523,100 @@ static void HU_widget_build_speed(void);
 
 static hu_multiline_t *w_stats;
 
+typedef enum {
+  STATSFORMAT_RATIO,
+  STATSFORMAT_BOOLEAN,
+  STATSFORMAT_PERCENTAGE,
+  STATSFORMAT_REMAINING,
+  STATSFORMAT_COUNT,
+
+  NUM_STATSFORMATS
+} statsformat_t;
+
+static statsformat_t hud_stats_format;
+
+static int StatsFormatFunc_Ratio(
+  char *const str, const size_t str_size,
+  const char prefix_color, const char *const prefix,
+  const char color, const int count, const int total,
+  const boolean space
+)
+{
+  return M_snprintf(str, str_size, "\x1b%c%s\x1b%c%d/%d%s",
+                    prefix_color, prefix, color,
+                    count, total,
+                    space ? " " : "");
+}
+
+static int StatsFormatFunc_Boolean(
+  char *const str, const size_t str_size,
+  const char prefix_color, const char *const prefix,
+  const char color, const int count, const int total,
+  const boolean space
+)
+{
+  return M_snprintf(str, str_size, "\x1b%c%s\x1b%c%s%s",
+                    prefix_color, prefix, color,
+                    (count >= total) ? "YES" : "NO",
+                    space ? " " : "");
+}
+
+static int StatsFormatFunc_Percentage(
+  char *const str, const size_t str_size,
+  const char prefix_color, const char *const prefix,
+  const char color, const int count, const int total,
+  const boolean space
+)
+{
+  return M_snprintf(str, str_size, "\x1b%c%s\x1b%c%d%%%s",
+                    prefix_color, prefix, color,
+                    !total ? 100 : count * 100 / total,
+                    space ? " " : "");
+}
+
+static int StatsFormatFunc_Remaining(
+  char *const str, const size_t str_size,
+  const char prefix_color, const char *const prefix,
+  const char color, const int count, const int total,
+  const boolean space
+)
+{
+  return M_snprintf(str, str_size, "\x1b%c%s\x1b%c%d%s",
+                    prefix_color, prefix, color,
+                    total - count,
+                    space ? " " : "");
+}
+
+static int StatsFormatFunc_Count(
+  char *const str, const size_t str_size,
+  const char prefix_color, const char *const prefix,
+  const char color, const int count, const int total,
+  const boolean space
+)
+{
+  return M_snprintf(str, str_size, "\x1b%c%s\x1b%c%d%s",
+                    prefix_color, prefix, color,
+                    count,
+                    space ? " " : "");
+}
+
+typedef int (*StatsFormatFunc_t)(
+  char *const str, const size_t str_size,
+  const char prefix_color, const char *const prefix,
+  const char color, const int count, const int total,
+  const boolean space
+);
+
+static const StatsFormatFunc_t StatsFormatFuncs[NUM_STATSFORMATS] = {
+  StatsFormatFunc_Ratio,
+  StatsFormatFunc_Boolean,
+  StatsFormatFunc_Percentage,
+  StatsFormatFunc_Remaining,
+  StatsFormatFunc_Count,
+};
+
+static StatsFormatFunc_t StatsFormatFunc;
+
 void HU_Start(void)
 {
   int i;
@@ -608,6 +702,8 @@ void HU_Start(void)
                        NULL, HU_widget_build_monsec);
   // [FG] in deathmatch: w_keys.builder = HU_widget_build_frag()
   w_stats = deathmatch ? &w_keys : &w_monsec;
+
+  StatsFormatFunc = StatsFormatFuncs[hud_stats_format];
 
   HUlib_init_multiline(&w_sttime, 1,
                        &boom_font, colrngs[CR_GRAY],
@@ -1200,20 +1296,6 @@ static void HU_widget_build_frag (void)
   HUlib_add_string_to_cur_line(&w_keys, hud_stringbuffer);
 }
 
-typedef enum {
-  STATSFORMAT_MATCHHUD,
-  STATSFORMAT_RATIO,
-  STATSFORMAT_BOOLEAN,
-  STATSFORMAT_PERCENTAGE,
-  STATSFORMAT_REMAINING,
-  STATSFORMAT_COUNT,
-
-  NUMSTATSFORMATS
-} statsformat_t;
-
-static statsformat_t hud_stats_format;
-static statsformat_t hud_stats_format_map;
-
 static void HU_widget_build_monsec(void)
 {
   int i;
@@ -1247,65 +1329,50 @@ static void HU_widget_build_monsec(void)
   secretcolor = (fullsecretcount >= totalsecret) ? '0'+CR_BLUE : '0'+CR_GRAY;
   itemcolor = (fullitemcount >= totalitems) ? '0'+CR_BLUE : '0'+CR_GRAY;
 
-  char kill_str[32], item_str[32], secret_str[32];
-
-  switch ((automapactive && hud_stats_format_map) ? hud_stats_format_map : hud_stats_format)
-  {
-    case STATSFORMAT_RATIO:
-      M_snprintf(kill_str,   sizeof(kill_str),   "%d/%d", fullkillcount,   max_kill_requirement);
-      M_snprintf(item_str,   sizeof(item_str),   "%d/%d", fullitemcount,   totalitems);
-      M_snprintf(secret_str, sizeof(secret_str), "%d/%d", fullsecretcount, totalsecret);
-      break;
-
-    case STATSFORMAT_BOOLEAN:
-      M_snprintf(kill_str,   sizeof(kill_str),   "%s", (fullkillcount   >= max_kill_requirement) ? "YES" : "NO");
-      M_snprintf(item_str,   sizeof(item_str),   "%s", (fullitemcount   >= totalitems)           ? "YES" : "NO");
-      M_snprintf(secret_str, sizeof(secret_str), "%s", (fullsecretcount >= totalsecret)          ? "YES" : "NO");
-      break;
-
-    case STATSFORMAT_PERCENTAGE:
-      M_snprintf(kill_str,   sizeof(kill_str),   "%d%%", (!max_kill_requirement) ? 100 : fullkillcount   * 100 / max_kill_requirement);
-      M_snprintf(item_str,   sizeof(item_str),   "%d%%", (!totalitems)           ? 100 : fullitemcount   * 100 / totalitems);
-      M_snprintf(secret_str, sizeof(secret_str), "%d%%", (!totalsecret)          ? 100 : fullsecretcount * 100 / totalsecret);
-      break;
-
-    case STATSFORMAT_REMAINING:
-      M_snprintf(kill_str,   sizeof(kill_str),   "%d", max_kill_requirement - fullkillcount);
-      M_snprintf(item_str,   sizeof(item_str),   "%d", totalitems           - fullitemcount);
-      M_snprintf(secret_str, sizeof(secret_str), "%d", totalsecret          - fullsecretcount);
-      break;
-
-    case STATSFORMAT_COUNT:
-      M_snprintf(kill_str,   sizeof(kill_str),   "%d", fullkillcount);
-      M_snprintf(item_str,   sizeof(item_str),   "%d", fullitemcount);
-      M_snprintf(secret_str, sizeof(secret_str), "%d", fullsecretcount);
-      break;
-
-    default:
-      break;
-  }
-
   if (hud_widget_layout)
   {
-    M_snprintf(hud_stringbuffer, sizeof(hud_stringbuffer),
-      "\x1b%cK\t\x1b%c%s", ('0'+CR_RED), killcolor, kill_str);
+    StatsFormatFunc(hud_stringbuffer, sizeof(hud_stringbuffer),
+                    '0'+CR_RED, "K\t",
+                    killcolor, fullkillcount, max_kill_requirement,
+                    false);
     HUlib_add_string_to_cur_line(&w_monsec, hud_stringbuffer);
 
-    M_snprintf(hud_stringbuffer, sizeof(hud_stringbuffer),
-      "\x1b%cI\t\x1b%c%s", ('0'+CR_RED), itemcolor, item_str);
+    StatsFormatFunc(hud_stringbuffer, sizeof(hud_stringbuffer),
+                    '0'+CR_RED, "I\t",
+                    itemcolor, fullitemcount, totalitems,
+                    false);
     HUlib_add_string_to_cur_line(&w_monsec, hud_stringbuffer);
 
-    M_snprintf(hud_stringbuffer, sizeof(hud_stringbuffer),
-      "\x1b%cS\t\x1b%c%s", ('0'+CR_RED), secretcolor, secret_str);
+    StatsFormatFunc(hud_stringbuffer, sizeof(hud_stringbuffer),
+                    '0'+CR_RED, "S\t",
+                    secretcolor, fullsecretcount, totalsecret,
+                    false);
     HUlib_add_string_to_cur_line(&w_monsec, hud_stringbuffer);
   }
   else
   {
-    M_snprintf(hud_stringbuffer, sizeof(hud_stringbuffer),
-      "\x1b%cK \x1b%c%s \x1b%cI \x1b%c%s \x1b%cS \x1b%c%s",
-      '0'+CR_RED, killcolor, kill_str,
-      '0'+CR_RED, itemcolor, item_str,
-      '0'+CR_RED, secretcolor, secret_str);
+    int offset = 0;
+
+    offset += StatsFormatFunc(
+      hud_stringbuffer + offset, sizeof(hud_stringbuffer) - offset,
+      '0'+CR_RED, "K ",
+      killcolor, fullkillcount, max_kill_requirement,
+      true
+    );
+
+    offset += StatsFormatFunc(
+      hud_stringbuffer + offset, sizeof(hud_stringbuffer) - offset,
+      '0'+CR_RED, "I ",
+      itemcolor, fullitemcount, totalitems,
+      true
+    );
+
+    offset += StatsFormatFunc(
+      hud_stringbuffer + offset, sizeof(hud_stringbuffer) - offset,
+      '0'+CR_RED, "S ",
+      secretcolor, fullsecretcount, totalsecret,
+      false
+    );
 
     HUlib_add_string_to_cur_line(&w_monsec, hud_stringbuffer);
   }
@@ -2238,21 +2305,15 @@ void HU_BindHUDVariables(void)
              "Display HUD");
   M_BindNum("hud_active", &hud_active, NULL, 2, 0, 2, ss_stat, wad_yes,
             "HUD layout (by default: 0 = Minimal; 1 = Compact; 2 = Distributed)");
-
   M_BindNum("hud_level_stats", &hud_level_stats, NULL,
             HUD_WIDGET_OFF, HUD_WIDGET_OFF, HUD_WIDGET_ALWAYS,
             ss_stat, wad_no,
             "Show level stats (kills, items, and secrets) widget (1 = On automap; "
             "2 = On HUD; 3 = Always)");
   M_BindNum("hud_stats_format", &hud_stats_format, NULL,
-            STATSFORMAT_RATIO, STATSFORMAT_RATIO, NUMSTATSFORMATS-1,
+            STATSFORMAT_RATIO, STATSFORMAT_RATIO, NUM_STATSFORMATS-1,
             ss_stat, wad_no,
-            "Format of level stats (1 = Ratio; 2 = Boolean; 3 = Percentage; 4 = Remaining; 5 = Count)");
-  M_BindNum("hud_stats_format_map", &hud_stats_format_map, NULL,
-            STATSFORMAT_MATCHHUD, STATSFORMAT_MATCHHUD, NUMSTATSFORMATS-1,
-            ss_stat, wad_no,
-            "Format of level stats in automap (0 = Match HUD)");
-
+            "Format of level stats (0 = Ratio; 1 = Boolean; 2 = Percentage; 3 = Remaining; 4 = Count)");
   M_BindNum("hud_level_time", &hud_level_time, NULL,
             HUD_WIDGET_OFF, HUD_WIDGET_OFF, HUD_WIDGET_ALWAYS,
             ss_stat, wad_no,

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -1889,7 +1889,7 @@ static const char *show_adv_widgets_strings[] = {"Off", "Automap", "HUD",
                                                  "Always", "Advanced"};
 
 static const char *stats_format_strings[] = {
-  "Ratio", "Boolean", "Percentage", "Remaining", "Count"
+  "Ratio", "Boolean", "Percent", "Remaining", "Count"
 };
 
 static setup_menu_t stat_settings2[] = {
@@ -1915,8 +1915,8 @@ static setup_menu_t stat_settings2[] = {
 
     {"Widget Appearance", S_SKIP | S_TITLE, H_X, M_SPC},
 
-    {"Level Stats Format", S_CHOICE, H_X, M_SPC,
-     {"hud_stats_format"}, .strings_id = str_stats_format},
+    {"Level Stats Format", S_CHOICE, H_X, M_SPC, {"hud_stats_format"},
+    .strings_id = str_stats_format, .action = HU_Start},
 
     {"Use Doom Font", S_CHOICE, H_X, M_SPC, {"hud_widget_font"},
      .strings_id = str_show_widgets},

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -1882,12 +1882,14 @@ static setup_menu_t stat_settings1[] = {
     MI_END
 };
 
+static void UpdateStatsFormatItem(void);
+
 static const char *show_widgets_strings[] = {"Off", "Automap", "HUD", "Always"};
 static const char *show_adv_widgets_strings[] = {"Off", "Automap", "HUD",
                                                  "Always", "Advanced"};
 
 static const char *stats_format_strings[] = {
-  "Match HUD", "Ratio", "Boolean", "Percentage", "Remaining", "Count"
+  "Ratio", "Boolean", "Percentage", "Remaining", "Count"
 };
 
 static setup_menu_t stat_settings2[] = {
@@ -1895,7 +1897,7 @@ static setup_menu_t stat_settings2[] = {
     {"Widget Types", S_SKIP | S_TITLE, H_X, M_SPC},
 
     {"Show Level Stats", S_CHOICE, H_X, M_SPC, {"hud_level_stats"},
-     .strings_id = str_show_widgets},
+     .strings_id = str_show_widgets, .action = UpdateStatsFormatItem},
 
     {"Show Level Time", S_CHOICE, H_X, M_SPC, {"hud_level_time"},
      .strings_id = str_show_widgets},
@@ -1913,6 +1915,9 @@ static setup_menu_t stat_settings2[] = {
 
     {"Widget Appearance", S_SKIP | S_TITLE, H_X, M_SPC},
 
+    {"Level Stats Format", S_CHOICE, H_X, M_SPC,
+     {"hud_stats_format"}, .strings_id = str_stats_format},
+
     {"Use Doom Font", S_CHOICE, H_X, M_SPC, {"hud_widget_font"},
      .strings_id = str_show_widgets},
 
@@ -1921,12 +1926,6 @@ static setup_menu_t stat_settings2[] = {
 
     {"Vertical Layout", S_ONOFF, H_X, M_SPC, {"hud_widget_layout"},
      .action = HU_Start},
-
-    {"HUD Level-Stats Format", S_CHOICE, H_X, M_SPC,
-     {"hud_stats_format"}, .strings_id = str_stats_format},
-
-    {"Automap Level-Stats Format", S_CHOICE, H_X, M_SPC,
-     {"hud_stats_format_map"}, .strings_id = str_stats_format},
 
     MI_END
 };
@@ -1977,6 +1976,11 @@ static setup_menu_t stat_settings4[] = {
 
 static setup_menu_t *stat_settings[] = {stat_settings1, stat_settings2,
                                         stat_settings3, stat_settings4, NULL};
+
+static void UpdateStatsFormatItem(void)
+{
+  DisableItem(!hud_level_stats, stat_settings2, "hud_stats_format");
+}
 
 static void UpdateCrosshairItems(void)
 {
@@ -4915,6 +4919,7 @@ void MN_SetupResetMenu(void)
     DisableItem(!brightmaps_found || force_brightmaps, gen_settings5,
                 "brightmaps");
     UpdateInterceptsEmuItem();
+    UpdateStatsFormatItem();
     UpdateCrosshairItems();
     UpdateCenteredWeaponItem();
     UpdateGamepadItems();

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -321,6 +321,7 @@ enum
     str_hudmode,
     str_show_widgets,
     str_show_adv_widgets,
+    str_stats_format,
     str_crosshair,
     str_crosshair_target,
     str_hudcolor,
@@ -1885,6 +1886,10 @@ static const char *show_widgets_strings[] = {"Off", "Automap", "HUD", "Always"};
 static const char *show_adv_widgets_strings[] = {"Off", "Automap", "HUD",
                                                  "Always", "Advanced"};
 
+static const char *stats_format_strings[] = {
+  "Match HUD", "Ratio", "Boolean", "Percentage", "Remaining", "Count"
+};
+
 static setup_menu_t stat_settings2[] = {
 
     {"Widget Types", S_SKIP | S_TITLE, H_X, M_SPC},
@@ -1916,6 +1921,12 @@ static setup_menu_t stat_settings2[] = {
 
     {"Vertical Layout", S_ONOFF, H_X, M_SPC, {"hud_widget_layout"},
      .action = HU_Start},
+
+    {"HUD Level-Stats Format", S_CHOICE, H_X, M_SPC,
+     {"hud_stats_format"}, .strings_id = str_stats_format},
+
+    {"Automap Level-Stats Format", S_CHOICE, H_X, M_SPC,
+     {"hud_stats_format_map"}, .strings_id = str_stats_format},
 
     MI_END
 };
@@ -4820,6 +4831,7 @@ static const char **selectstrings[] = {
     NULL, // str_hudmode
     show_widgets_strings,
     show_adv_widgets_strings,
+    stats_format_strings,
     crosshair_strings,
     crosshair_target_strings,
     hudcolor_strings,


### PR DESCRIPTION
Mostly based on Crispy, though I made some additions:

- A _Count_ format: same as _Ratio_ but without the totals.
- A separate setting for the automap: you could use e.g. the more-concise _Remaining_ in the normal HUD and the more-detailed _Ratio_ in the automap; the default setting makes the automap match the normal HUD.