### PR TITLE
Midi volume fixes

### DIFF
--- a/src/i_midimusic.c
+++ b/src/i_midimusic.c
@@ -1332,17 +1332,6 @@ static void UpdateVolumeFactor(int volume)
 
 static void I_MID_SetMusicVolume(int volume)
 {
-    static int last_volume = -1;
-    static int last_midi_gain = -1;
-
-    if (last_volume == volume && midi_gain == last_midi_gain)
-    {
-        // Ignore holding key down in volume menu.
-        return;
-    }
-    last_volume = volume;
-    last_midi_gain = midi_gain;
-
     if (!SDL_AtomicGet(&player_thread_running))
     {
         UpdateVolumeFactor(volume);

--- a/src/i_midimusic.c
+++ b/src/i_midimusic.c
@@ -1021,6 +1021,7 @@ static midi_state_t NextEvent(midi_position_t *position)
             else if (song.looping)
             {
                 ResetControllers();
+                ResetVolume();
                 RestartTracks();
                 return STATE_PLAYING;
             }


### PR DESCRIPTION
1. For the first commit, see https://github.com/kraflab/dsda-doom/pull/527.
2. The second commit fixes native midi volume getting reset to full volume when setting "native midi reset" to "no sysex" in the menu.