### PR TITLE
restore Doom font option

### DIFF
--- a/src/m_json.c
+++ b/src/m_json.c
@@ -174,22 +174,12 @@ const char *JS_GetString(json_t *json)
     return json->valuestring;
 }
 
-const char *JS_GetStringRef(json_t *json, const char *string)
+const char *JS_GetStringValue(json_t *json, const char *string)
 {
     json_t *obj = JS_GetObject(json, string);
     if (JS_IsString(obj))
     {
         return obj->valuestring;
-    }
-    return NULL;
-}
-
-const char *JS_GetStringCopy(json_t *json, const char *string)
-{
-    json_t *obj = JS_GetObject(json, string);
-    if (JS_IsString(obj))
-    {
-        return M_StringDuplicate(obj->valuestring);
     }
     return NULL;
 }

--- a/src/m_json.h
+++ b/src/m_json.h
@@ -44,8 +44,7 @@ double JS_GetNumber(json_t *json);
 double JS_GetNumberValue(json_t *json, const char *string);
 int JS_GetInteger(json_t *json);
 const char *JS_GetString(json_t *json);
-const char *JS_GetStringRef(json_t *json, const char *string);
-const char *JS_GetStringCopy(json_t *json, const char *string);
+const char *JS_GetStringValue(json_t *json, const char *string);
 
 int JS_GetArraySize(json_t *json);
 json_t *JS_GetArrayItem(json_t *json, int index);

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -1881,6 +1881,13 @@ static setup_menu_t stat_settings2[] = {
     {"Level Stats Format", S_CHOICE, H_X, M_SPC, {"hud_stats_format"},
      .strings_id = str_stats_format},
 
+    MI_GAP,
+
+    {"Widget Appearance", S_SKIP | S_TITLE, H_X, M_SPC},
+
+    {"Use Doom Font", S_CHOICE, H_X, M_SPC, {"hud_widget_font"},
+     .strings_id = str_show_widgets},
+
     MI_END
 };
 

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -1878,15 +1878,15 @@ static setup_menu_t stat_settings2[] = {
 
     {"Use-Button Timer", S_ONOFF, H_X, M_SPC, {"hud_time_use"}},
 
-    {"Level Stats Format", S_CHOICE, H_X, M_SPC, {"hud_stats_format"},
-     .strings_id = str_stats_format},
-
     MI_GAP,
 
     {"Widget Appearance", S_SKIP | S_TITLE, H_X, M_SPC},
 
     {"Use Doom Font", S_CHOICE, H_X, M_SPC, {"hud_widget_font"},
      .strings_id = str_show_widgets},
+
+    {"Level Stats Format", S_CHOICE, H_X, M_SPC, {"hud_stats_format"},
+     .strings_id = str_stats_format},
 
     MI_END
 };

--- a/src/st_sbardef.h
+++ b/src/st_sbardef.h
@@ -164,7 +164,6 @@ typedef struct
 
 typedef struct
 {
-    const char *font_name;
     numberfont_t *font;
     sbarnumbertype_t type;
     int param;
@@ -192,7 +191,7 @@ typedef struct
 typedef struct sbe_widget_s
 {
     sbarwidgettype_t type;
-    const char *font_name;
+    hudfont_t *default_font;
     hudfont_t *font;
     widgetline_t *lines;
 

--- a/src/st_sbardef.h
+++ b/src/st_sbardef.h
@@ -253,6 +253,7 @@ struct numberfont_s
 struct hudfont_s
 {
     const char *name;
+    const char *stem;
     fonttype_t type;
     int monowidth;
     int maxheight;
@@ -261,11 +262,11 @@ struct hudfont_s
 
 typedef struct
 {
-    numberfont_t *numberfonts;
-    hudfont_t *hudfonts;
     statusbar_t *statusbars;
 } sbardef_t;
 
 sbardef_t *ST_ParseSbarDef(void);
+
+hudfont_t *LoadSTCFN(void);
 
 #endif

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -714,24 +714,13 @@ static void UpdateFace(sbe_face_t *face, player_t *player)
 static void UpdateNumber(sbarelem_t *elem, player_t *player)
 {
     sbe_number_t *number = elem->subtype.number;
+    numberfont_t *font = number->font;
 
     int value = ResolveNumber(number, player);
     int power = (value < 0 ? number->maxlength - 1 : number->maxlength);
     int max = (int)pow(10.0, power) - 1;
     int valglyphs = 0;
     int numvalues = 0;
-
-    numberfont_t *font = number->font;
-    if (font == NULL)
-    {
-        array_foreach(font, sbardef->numberfonts)
-        {
-            if (!strcmp(font->name, number->font_name))
-            {
-                break;
-            }
-        }
-    }
 
     if (value < 0 && font->minus != NULL)
     {
@@ -789,18 +778,7 @@ static void UpdateNumber(sbarelem_t *elem, player_t *player)
 static void UpdateLines(sbarelem_t *elem)
 {
     sbe_widget_t *widget = elem->subtype.widget;
-
     hudfont_t *font = widget->font;
-    if (font == NULL)
-    {
-        array_foreach(font, sbardef->hudfonts)
-        {
-            if (!strcmp(font->name, widget->font_name))
-            {
-                break;
-            }
-        }
-    }
 
     widgetline_t *line;
     array_foreach(line, widget->lines)

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -1707,7 +1707,7 @@ void ST_Start(void)
     HU_StartCrosshair();
 }
 
-hudfont_t *hudfont;
+hudfont_t *stcfnt;
 patch_t **hu_font = NULL;
 
 void ST_Init(void)
@@ -1721,18 +1721,12 @@ void ST_Init(void)
 
     LoadFacePatches();
 
-    array_foreach(hudfont, sbardef->hudfonts)
-    {
-        if (!strcmp(hudfont->name, "Console"))
-        {
-            hu_font = hudfont->characters;
-            break;
-        }
-    }
+    stcfnt = LoadSTCFN();
+    hu_font = stcfnt->characters;
 
     if (!hu_font)
     {
-        I_Error("ST_Init: \"Console\" font not found");
+        I_Error("ST_Init: \"STCFN\" font not found");
     }
 
     HU_InitCrosshair();

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -1729,6 +1729,7 @@ void ST_Start(void)
     HU_StartCrosshair();
 }
 
+hudfont_t *hudfont;
 patch_t **hu_font = NULL;
 
 void ST_Init(void)
@@ -1742,7 +1743,6 @@ void ST_Init(void)
 
     LoadFacePatches();
 
-    hudfont_t *hudfont;
     array_foreach(hudfont, sbardef->hudfonts)
     {
         if (!strcmp(hudfont->name, "Console"))

--- a/src/st_stuff.h
+++ b/src/st_stuff.h
@@ -69,6 +69,7 @@ extern int health_green;  // health amount above is blue, below is green
 
 extern boolean palette_changes;
 
+extern struct hudfont_s *hudfont;
 extern struct patch_s **hu_font;
 
 void WI_DrawWidgets(void);

--- a/src/st_stuff.h
+++ b/src/st_stuff.h
@@ -69,7 +69,7 @@ extern int health_green;  // health amount above is blue, below is green
 
 extern boolean palette_changes;
 
-extern struct hudfont_s *hudfont;
+extern struct hudfont_s *stcfnt;
 extern struct patch_s **hu_font;
 
 void WI_DrawWidgets(void);

--- a/src/st_widgets.c
+++ b/src/st_widgets.c
@@ -38,6 +38,7 @@
 #include "s_sound.h"
 #include "sounds.h"
 #include "st_sbardef.h"
+#include "st_stuff.h"
 #include "i_timer.h"
 #include "v_video.h"
 #include "u_mapinfo.h"
@@ -51,6 +52,7 @@ widgetstate_t hud_level_stats;
 widgetstate_t hud_level_time;
 boolean       hud_time_use;
 widgetstate_t hud_player_coords;
+widgetstate_t hud_widget_font;
 
 static boolean hud_map_announce;
 static boolean message_colorized;
@@ -645,6 +647,25 @@ static boolean WidgetEnabled(widgetstate_t state)
     return true;
 }
 
+static void ForceDoomFont(sbe_widget_t *widget)
+{
+    if (WidgetEnabled(hud_widget_font))
+    {
+        if (widget->font != hudfont)
+        {
+            widget->font = hudfont;
+        }
+    }
+    else
+    {
+        if (widget->font == hudfont && strcmp(widget->font_name, "Console"))
+        {
+            // reset to default
+            widget->font = NULL;
+        }
+    }
+}
+
 static void UpdateCoord(sbe_widget_t *widget, player_t *player)
 {
     if (hud_player_coords == HUD_WIDGET_ADVANCED)
@@ -659,6 +680,8 @@ static void UpdateCoord(sbe_widget_t *widget, player_t *player)
     {
         return;
     }
+
+    ForceDoomFont(widget);
 
     fixed_t x, y, z; // killough 10/98:
     void AM_Coordinates(const mobj_t *, fixed_t *, fixed_t *, fixed_t *);
@@ -735,6 +758,8 @@ static void UpdateMonSec(sbe_widget_t *widget)
         return;
     }
 
+    ForceDoomFont(widget);
+
     static char string[120];
 
     int fullkillcount = 0;
@@ -792,6 +817,8 @@ static void UpdateStTime(sbe_widget_t *widget, player_t *player)
         return;
     }
 
+    ForceDoomFont(widget);
+
     static char string[80];
 
     int offset = 0;
@@ -835,6 +862,8 @@ static void UpdateFPS(sbe_widget_t *widget, player_t *player)
         return;
     }
 
+    ForceDoomFont(widget);
+
     static char string[20];
     M_snprintf(string, sizeof(string), GRAY_S "%d " GREEN_S "FPS", fps);
     ST_AddLine(widget, string);
@@ -875,6 +904,8 @@ static void UpdateSpeed(sbe_widget_t *widget, player_t *player)
         SetLine(widget, "");
         return;
     }
+
+    ForceDoomFont(widget);
 
     static const double factor[] = {TICRATE, 2.4003, 525.0 / 352.0};
     static const char *units[] = {"ups", "km/h", "mph"};
@@ -1078,6 +1109,11 @@ void ST_BindHUDVariables(void)
             "Hide empty commands from command history widget");
   M_BindBool("hud_time_use", &hud_time_use, NULL, false, ss_stat, wad_no,
              "Show split time when pressing the use-button");
+  M_BindNum("hud_widget_font", &hud_widget_font, NULL,
+            HUD_WIDGET_OFF, HUD_WIDGET_OFF, HUD_WIDGET_ALWAYS,
+            ss_stat, wad_no,
+            "Use standard Doom font for widgets (1 = On automap; 2 = On HUD; 3 "
+            "= Always)");
 
   M_BindNum("hudcolor_titl", &hudcolor_titl, NULL,
             CR_GOLD, CR_BRICK, CR_NONE, ss_none, wad_yes,

--- a/src/st_widgets.c
+++ b/src/st_widgets.c
@@ -651,10 +651,7 @@ static void ForceDoomFont(sbe_widget_t *widget)
 {
     if (WidgetEnabled(hud_widget_font))
     {
-        if (widget->font != hudfont)
-        {
-            widget->font = hudfont;
-        }
+        widget->font = stcfnt;
     }
     else
     {

--- a/src/st_widgets.c
+++ b/src/st_widgets.c
@@ -658,11 +658,7 @@ static void ForceDoomFont(sbe_widget_t *widget)
     }
     else
     {
-        if (widget->font == hudfont && strcmp(widget->font_name, "Console"))
-        {
-            // reset to default
-            widget->font = NULL;
-        }
+        widget->font = widget->default_font;
     }
 }
 


### PR DESCRIPTION
Fix #1984 

I don't force the Doom font for the `rate` and `cmd` widgets, I think they look bad with it.