### PR TITLE
Use improved FluidSynth reverb/chorus defaults, add config settings

### DIFF
--- a/src/i_flmusic.c
+++ b/src/i_flmusic.c
@@ -47,8 +47,8 @@ typedef fluid_long_long_t fluid_int_t;
 #include "z_zone.h"
 
 static const char *soundfont_dir = "";
-static boolean mus_chorus;
-static boolean mus_reverb;
+static boolean fl_reverb;
+static boolean fl_chorus;
 
 static fluid_synth_t *synth = NULL;
 static fluid_settings_t *settings = NULL;
@@ -245,10 +245,10 @@ static boolean I_FL_InitStream(int device)
 
     fluid_settings_setnum(settings, "synth.sample-rate", SND_SAMPLERATE);
 
-    fluid_settings_setint(settings, "synth.chorus.active", mus_chorus);
-    fluid_settings_setint(settings, "synth.reverb.active", mus_reverb);
+    fluid_settings_setint(settings, "synth.reverb.active", fl_reverb);
+    fluid_settings_setint(settings, "synth.chorus.active", fl_chorus);
 
-    if (mus_reverb)
+    if (fl_reverb)
     {
         fluid_settings_setnum(settings, "synth.reverb.room-size", 0.6);
         fluid_settings_setnum(settings, "synth.reverb.damp", 0.4);
@@ -256,7 +256,7 @@ static boolean I_FL_InitStream(int device)
         fluid_settings_setnum(settings, "synth.reverb.level", 0.15);
     }
 
-    if (mus_chorus)
+    if (fl_chorus)
     {
         fluid_settings_setnum(settings, "synth.chorus.level", 0.35);
         fluid_settings_setnum(settings, "synth.chorus.depth", 5);
@@ -480,9 +480,11 @@ static void I_FL_BindVariables(void)
     // AppImage
     "../share/" PROJECT_SHORTNAME "/soundfonts",
 #endif
-    wad_no, "FluidSynth soundfont directories");
-    BIND_BOOL_MIDI(mus_chorus, false, "FluidSynth chorus");
-    BIND_BOOL_MIDI(mus_reverb, false, "FluidSynth reverb");
+    wad_no, "[FluidSynth] Soundfont directories");
+    BIND_BOOL_MIDI(fl_reverb, false,
+        "[FluidSynth] Enable reverb effects");
+    BIND_BOOL_MIDI(fl_chorus, false,
+        "[FluidSynth] Enable chorus effects");
 }
 
 static const char *I_FL_MusicFormat(void)

--- a/src/i_flmusic.c
+++ b/src/i_flmusic.c
@@ -48,6 +48,7 @@ typedef fluid_long_long_t fluid_int_t;
 
 static const char *soundfont_dir = "";
 static int fl_polyphony;
+static boolean fl_interpolation;
 static boolean fl_reverb;
 static boolean fl_chorus;
 static int fl_reverb_damp;
@@ -64,6 +65,7 @@ static fluid_settings_t *settings = NULL;
 static fluid_player_t *player = NULL;
 
 static const char **soundfonts = NULL;
+static int interp_method;
 
 // Load SNDFONT lump
 
@@ -252,6 +254,9 @@ static boolean I_FL_InitStream(int device)
 
     settings = new_fluid_settings();
 
+    interp_method =
+        fl_interpolation ? FLUID_INTERP_HIGHEST : FLUID_INTERP_DEFAULT;
+
     fluid_settings_setint(settings, "synth.polyphony", fl_polyphony);
     fluid_settings_setnum(settings, "synth.gain", 0.2);
     fluid_settings_setnum(settings, "synth.sample-rate", SND_SAMPLERATE);
@@ -428,6 +433,7 @@ static void I_FL_PlayStream(boolean looping)
         return;
     }
 
+    fluid_synth_set_interp_method(synth, -1, interp_method);
     fluid_player_set_loop(player, looping ? -1 : 1);
     fluid_player_play(player);
 }
@@ -504,6 +510,8 @@ static void I_FL_BindVariables(void)
     wad_no, "[FluidSynth] Soundfont directories");
     BIND_NUM(fl_polyphony, 256, 1, 65535,
         "[FluidSynth] Number of voices that can be played in parallel");
+    BIND_BOOL(fl_interpolation, false,
+        "[FluidSynth] Interpolation method (0 = Default; 1 = Highest Quality)");
     BIND_BOOL_MIDI(fl_reverb, false,
         "[FluidSynth] Enable reverb effects");
     BIND_BOOL_MIDI(fl_chorus, false,

--- a/src/i_flmusic.c
+++ b/src/i_flmusic.c
@@ -47,8 +47,17 @@ typedef fluid_long_long_t fluid_int_t;
 #include "z_zone.h"
 
 static const char *soundfont_dir = "";
+static int fl_polyphony;
 static boolean fl_reverb;
 static boolean fl_chorus;
+static int fl_reverb_damp;
+static int fl_reverb_level;
+static int fl_reverb_roomsize;
+static int fl_reverb_width;
+static int fl_chorus_depth;
+static int fl_chorus_level;
+static int fl_chorus_nr;
+static int fl_chorus_speed;
 
 static fluid_synth_t *synth = NULL;
 static fluid_settings_t *settings = NULL;
@@ -243,23 +252,35 @@ static boolean I_FL_InitStream(int device)
 
     settings = new_fluid_settings();
 
+    fluid_settings_setint(settings, "synth.polyphony", fl_polyphony);
+    fluid_settings_setnum(settings, "synth.gain", 0.2);
     fluid_settings_setnum(settings, "synth.sample-rate", SND_SAMPLERATE);
-
+    fluid_settings_setint(settings, "synth.device-id", 16);
+    fluid_settings_setstr(settings, "synth.midi-bank-select", "gs");
     fluid_settings_setint(settings, "synth.reverb.active", fl_reverb);
     fluid_settings_setint(settings, "synth.chorus.active", fl_chorus);
 
     if (fl_reverb)
     {
-        fluid_settings_setnum(settings, "synth.reverb.room-size", 0.6);
-        fluid_settings_setnum(settings, "synth.reverb.damp", 0.4);
-        fluid_settings_setnum(settings, "synth.reverb.width", 4);
-        fluid_settings_setnum(settings, "synth.reverb.level", 0.15);
+        fluid_settings_setnum(settings, "synth.reverb.damp",
+                              fl_reverb_damp / 100.0);
+        fluid_settings_setnum(settings, "synth.reverb.level",
+                              fl_reverb_level / 100.0);
+        fluid_settings_setnum(settings, "synth.reverb.room-size",
+                              fl_reverb_roomsize / 100.0);
+        fluid_settings_setnum(settings, "synth.reverb.width",
+                              fl_reverb_width / 100.0);
     }
 
     if (fl_chorus)
     {
-        fluid_settings_setnum(settings, "synth.chorus.level", 0.35);
-        fluid_settings_setnum(settings, "synth.chorus.depth", 5);
+        fluid_settings_setnum(settings, "synth.chorus.depth",
+                              fl_chorus_depth / 100.0);
+        fluid_settings_setnum(settings, "synth.chorus.level",
+                              fl_chorus_level / 100.0);
+        fluid_settings_setint(settings, "synth.chorus.nr", fl_chorus_nr);
+        fluid_settings_setnum(settings, "synth.chorus.speed",
+                              fl_chorus_speed / 100.0);
     }
 
     synth = new_fluid_synth(settings);
@@ -481,10 +502,28 @@ static void I_FL_BindVariables(void)
     "../share/" PROJECT_SHORTNAME "/soundfonts",
 #endif
     wad_no, "[FluidSynth] Soundfont directories");
+    BIND_NUM(fl_polyphony, 256, 1, 65535,
+        "[FluidSynth] Number of voices that can be played in parallel");
     BIND_BOOL_MIDI(fl_reverb, false,
         "[FluidSynth] Enable reverb effects");
     BIND_BOOL_MIDI(fl_chorus, false,
         "[FluidSynth] Enable chorus effects");
+    BIND_NUM(fl_reverb_damp, 30, 0, 100,
+        "[FluidSynth] Reverb damping");
+    BIND_NUM(fl_reverb_level, 70, 0, 100,
+        "[FluidSynth] Reverb output level");
+    BIND_NUM(fl_reverb_roomsize, 50, 0, 100,
+        "[FluidSynth] Reverb room size");
+    BIND_NUM(fl_reverb_width, 80, 0, 10000,
+        "[FluidSynth] Reverb width (stereo spread)");
+    BIND_NUM(fl_chorus_depth, 360, 0, 25600,
+        "[FluidSynth] Chorus modulation depth");
+    BIND_NUM(fl_chorus_level, 55, 0, 1000,
+        "[FluidSynth] Chorus output level");
+    BIND_NUM(fl_chorus_nr, 4, 0, 99,
+        "[FluidSynth] Chorus voice count");
+    BIND_NUM(fl_chorus_speed, 36, 10, 500,
+        "[FluidSynth] Chorus modulation speed");
 }
 
 static const char *I_FL_MusicFormat(void)

--- a/src/i_midimusic.c
+++ b/src/i_midimusic.c
@@ -1501,14 +1501,14 @@ static const char *I_MID_MusicFormat(void)
 static void I_MID_BindVariables(void)
 {
     BIND_NUM_MIDI(midi_complevel, COMP_STANDARD, 0, COMP_NUM - 1,
-        "Native MIDI compatibility level (0 = Vanilla; 1 = Standard; 2 = Full)");
+        "[Native MIDI] Compatibility level (0 = Vanilla; 1 = Standard; 2 = Full)");
     BIND_NUM_MIDI(midi_reset_type, RESET_TYPE_GM, 0, RESET_NUM - 1,
-        "Reset type for native MIDI (0 = No SysEx; 1 = GM; 2 = GS; 3 = XG)");
+        "[Native MIDI] Reset type (0 = No SysEx; 1 = GM; 2 = GS; 3 = XG)");
     BIND_NUM(midi_reset_delay, -1, -1, 2000,
-        "Delay after reset for native MIDI (-1 = Auto; 0 = None; 1-2000 = Milliseconds)");
+        "[Native MIDI] Delay after reset (-1 = Auto; 0 = None; 1-2000 = Milliseconds)");
     BIND_BOOL_MIDI(midi_ctf, true,
-        "Fix invalid instruments by emulating SC-55 capital tone fallback");
-    BIND_NUM_MIDI(midi_gain, 0, -20, 0, "Native MIDI gain [dB]");
+        "[Native MIDI] Fix invalid instruments by emulating SC-55 capital tone fallback");
+    BIND_NUM_MIDI(midi_gain, 0, -20, 0, "[Native MIDI] Gain [dB]");
 }
 
 music_module_t music_mid_module =

--- a/src/i_oalmusic.c
+++ b/src/i_oalmusic.c
@@ -295,8 +295,7 @@ static boolean I_OAL_InitMusic(int device)
     return false;
 }
 
-static int mus_gain = 100;
-static int opl_gain = 200;
+static int fl_gain, opl_gain;
 
 static void I_OAL_SetMusicVolume(int volume)
 {
@@ -314,7 +313,7 @@ static void I_OAL_SetMusicVolume(int volume)
 #if defined(HAVE_FLUIDSYNTH)
     else if (active_module == &stream_fl_module)
     {
-        gain *= (ALfloat)DB_TO_GAIN(mus_gain);
+        gain *= (ALfloat)DB_TO_GAIN(fl_gain);
     }
 #endif
 
@@ -476,10 +475,10 @@ static midiplayertype_t I_OAL_MidiPlayerType(void)
 
 static void I_OAL_BindVariables(void)
 {
-    BIND_NUM_MIDI(opl_gain, 0, -20, 20, "OPL emulation gain [dB]");
 #if defined (HAVE_FLUIDSYNTH)
-    BIND_NUM_MIDI(mus_gain, 0, -20, 20, "FluidSynth gain [dB]");
+    BIND_NUM_MIDI(fl_gain, 0, -20, 20, "[FluidSynth] Gain [dB]");
 #endif
+    BIND_NUM_MIDI(opl_gain, 0, -20, 20, "[OPL3 Emulation] Gain [dB]");
     for (int i = 0; i < arrlen(midi_modules); ++i)
     {
         midi_modules[i]->BindVariables();

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -2590,7 +2590,7 @@ static setup_menu_t midi_settings1[] = {
     MI_GAP,
 
 #if defined (HAVE_FLUIDSYNTH)
-    {"FluidSynth Gain", S_THERMO, CNTR_X, M_THRM_SPC, {"mus_gain"},
+    {"FluidSynth Gain", S_THERMO, CNTR_X, M_THRM_SPC, {"fl_gain"},
      .action = UpdateMusicVolume, .append = "dB"},
 
     {"FluidSynth Reverb", S_ONOFF, CNTR_X, M_SPC, {"fl_reverb"},

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -2593,10 +2593,10 @@ static setup_menu_t midi_settings1[] = {
     {"FluidSynth Gain", S_THERMO, CNTR_X, M_THRM_SPC, {"mus_gain"},
      .action = UpdateMusicVolume, .append = "dB"},
 
-    {"FluidSynth Reverb", S_ONOFF, CNTR_X, M_SPC, {"mus_reverb"},
+    {"FluidSynth Reverb", S_ONOFF, CNTR_X, M_SPC, {"fl_reverb"},
      .action = SetMidiPlayerFluidSynth},
 
-    {"FluidSynth Chorus", S_ONOFF, CNTR_X, M_SPC, {"mus_chorus"},
+    {"FluidSynth Chorus", S_ONOFF, CNTR_X, M_SPC, {"fl_chorus"},
      .action = SetMidiPlayerFluidSynth},
 
     MI_GAP,


### PR DESCRIPTION
The settings are based on [these recommendations](https://github.com/mrbumpy409/GeneralUser-GS/tree/main/documentation#302-fluidsynth) which are very similar to the improved defaults that were introduced with the recent release of [FluidSynth 2.4.0](https://github.com/FluidSynth/fluidsynth/releases). The author of the GeneralUser GS soundfont has provided excellent FluidSynth tweaks in the past and these are the latest (many of the adjusted settings used by various projects actually originate from his suggestions). 

As an aside, there was a big update to the [GeneralUser GS soundfont](https://schristiancollins.com/generaluser.php) and it sounds quite good.

This PR will conflict with https://github.com/fabiangreffrath/woof/pull/1982 but it should be simple to resolve.