### PR TITLE
Add auto save support to `-loadgame`

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -2395,10 +2395,10 @@ void D_DoomMain(void)
 
   //!
   // @category game
-  // @arg <s>
+  // @arg <ps>
   // @vanilla
   //
-  // Load the game in slot s.
+  // Load the game on page p (0-7) in slot s (0-7). Use 255 to load an auto save.
   //
 
   p = M_CheckParmWithArgs("-loadgame", 1);
@@ -2637,7 +2637,15 @@ void D_DoomMain(void)
 
   MN_InitMenuStrings();
 
-  if (startloadgame >= 0)
+  // Auto save slot is 255 for -loadgame command.
+  if (startloadgame == 255 && !demorecording && gameaction != ga_playdemo
+      && !netgame)
+  {
+    char *file = G_AutoSaveName();
+    G_LoadAutoSave(file, true);
+    free(file);
+  }
+  else if (startloadgame >= 0 && startloadgame <= 77) // Page 0-7, slot 0-7.
   {
     char *file;
     file = G_SaveGameName(startloadgame);

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -2210,13 +2210,13 @@ void G_ForcedLoadGame(void)
 // killough 3/16/98: add slot info
 // killough 5/15/98: add command-line
 
-void G_LoadAutoSave(char *name)
+void G_LoadAutoSave(char *name, boolean command)
 {
   free(savename);
   savename = M_StringDuplicate(name);
   gameaction = ga_loadautosave;
   forced_loadgame = false;
-  command_loadgame = false;
+  command_loadgame = command;
 }
 
 void G_LoadGame(char *name, int slot, boolean command)
@@ -2236,6 +2236,13 @@ static void G_LoadAutoSaveErr(const char *msg)
 {
   Z_Free(savebuffer);
   MN_ForcedLoadAutoSave(msg);
+
+  if (command_loadgame)
+  {
+    G_CheckDemoStatus();
+    D_StartTitle();
+    gamestate = GS_DEMOSCREEN;
+  }
 }
 
 static void G_LoadGameErr(const char *msg)
@@ -2761,7 +2768,7 @@ boolean G_LoadAutoSaveDeathUse(void)
 
     if (result)
     {
-      G_LoadAutoSave(auto_path);
+      G_LoadAutoSave(auto_path, false);
     }
   }
 

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -46,7 +46,7 @@ void G_DeathMatchSpawnPlayer(int playernum);
 void G_InitNew(skill_t skill, int episode, int map);
 void G_DeferedInitNew(skill_t skill, int episode, int map);
 void G_DeferedPlayDemo(char *demo);
-void G_LoadAutoSave(char *name);
+void G_LoadAutoSave(char *name, boolean is_command);
 void G_LoadGame(char *name, int slot, boolean is_command); // killough 5/15/98
 void G_ForcedLoadAutoSave(void);
 void G_ForcedLoadGame(void);           // killough 5/15/98: forced loadgames

--- a/src/mn_menu.c
+++ b/src/mn_menu.c
@@ -999,7 +999,7 @@ static void M_LoadAutoSaveSelect(int choice)
 {
     saveg_compat = saveg_woof510;
     char *name = G_AutoSaveName();
-    G_LoadAutoSave(name);
+    G_LoadAutoSave(name, false);
     free(name);
     MN_ClearMenus();
     // Auto save slot doesn't exist for save menu, so don't change lastOn.


### PR DESCRIPTION
Auto saves can be loaded from the command line with `-loadgame 255`. Disabled for demos and multiplayer.

Fixes https://github.com/fabiangreffrath/woof/issues/2028