### PR TITLE
Keep next/prev weapon state synchronized with manual weapon switch

### DIFF
--- a/src/p_user.c
+++ b/src/p_user.c
@@ -500,7 +500,7 @@ void P_PlayerThink (player_t* player)
 
 	if ((newweapon != wp_plasma && newweapon != wp_bfg)
 	    || (gamemode != shareware) )
-	  player->pendingweapon = newweapon;
+	  player->nextweapon = player->pendingweapon = newweapon;
     }
 
   // check for use


### PR DESCRIPTION
Using a number key to manually change weapon didn't seem to update the "weapon cursor" in the switch carousel, which could cause some very confusing results when you use the next/prev weapon binds after doing so. This appears to fix the issue, but it's possible I missed some other spots.