### PR TITLE
fix ESC key during chat input

### DIFF
--- a/src/mn_menu.c
+++ b/src/mn_menu.c
@@ -3107,8 +3107,10 @@ boolean M_Responder(event_t *ev)
 
     if (!menuactive)
     {
-        if ((demoplayback && (action == MENU_ENTER || action == MENU_BACKSPACE))
-            || action == MENU_ESCAPE) // phares
+        if (!chat_on
+            && ((demoplayback
+                 && (action == MENU_ENTER || action == MENU_BACKSPACE))
+                || action == MENU_ESCAPE)) // phares
         {
             I_ShowMouseCursor(menu_input != pad_mode);
             MN_StartControlPanel();


### PR DESCRIPTION
Although starting the main menu by pressing ESC during chat input is vanilla behavior, there was an attempt to fix it in Boom, see: https://github.com/fabiangreffrath/woof/blob/0c2cf54f5451c385de5e7239e11452544d0e86a2/src/st_widgets.c#L455