### PR TITLE
fix background erase for carousel and and various widgets

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -317,18 +317,12 @@ void D_Display (void)
   switch (gamestate)                // do buffered drawing
     {
     case GS_LEVEL:
-      if (!gametic)
-        break;
-      if (automapactive)
-      {
-        if (!automapoverlay)
+      if (automapactive && !automapoverlay && gametic)
         {
           // [FG] update automap while playing
           R_RenderPlayerView(&players[displayplayer]);
           AM_Drawer();
         }
-        ST_Drawer();
-      }
       break;
     case GS_INTERMISSION:
       WI_Drawer();
@@ -345,10 +339,7 @@ void D_Display (void)
 
   // draw the view directly
   if (gamestate == GS_LEVEL && automap_off && gametic)
-    {
-      R_RenderPlayerView(&players[displayplayer]);
-      ST_Drawer();
-    }
+    R_RenderPlayerView(&players[displayplayer]);
 
   // clean up border stuff
   if (gamestate != oldgamestate && gamestate != GS_LEVEL)
@@ -369,7 +360,6 @@ void D_Display (void)
       if (borderdrawcount)
         {
           R_DrawViewBorder();    // erase old menu stuff
-          ST_Drawer();
           borderdrawcount--;
         }
     }
@@ -381,11 +371,12 @@ void D_Display (void)
   if (gamestate == GS_LEVEL && automapactive && automapoverlay)
     {
       AM_Drawer();
-      ST_Drawer();
-
       // [crispy] force redraw of border
       viewactivestate = false;
     }
+
+  if (gamestate == GS_LEVEL && gametic)
+    ST_Drawer();
 
   // draw pause pic
   if (paused)

--- a/src/st_carousel.c
+++ b/src/st_carousel.c
@@ -22,6 +22,7 @@
 #include "m_array.h"
 #include "m_misc.h"
 #include "r_defs.h"
+#include "r_draw.h"
 #include "st_sbardef.h"
 #include "v_fmt.h"
 #include "v_video.h"
@@ -199,6 +200,22 @@ static int CalcOffset(void)
     }
 
     return 0;
+}
+
+void ST_EraseCarousel(int y)
+{
+    static boolean erase;
+
+    if (duration > 0)
+    {
+        R_VideoErase(0, y - 16, video.unscaledw, 32);
+        erase = true;
+    }
+    else if (erase)
+    {
+        R_VideoErase(0, y - 16, video.unscaledw, 32);
+        erase = false;
+    }
 }
 
 void ST_DrawCarousel(int x, int y, sbarelem_t *elem)

--- a/src/st_carousel.h
+++ b/src/st_carousel.h
@@ -21,6 +21,8 @@ void ST_ResetCarousel(void);
 
 void ST_UpdateCarousel(struct player_s *player);
 
+void ST_EraseCarousel(int y);
+
 void ST_DrawCarousel(int x, int y, struct sbarelem_s *elem);
 
 #endif

--- a/src/st_sbardef.h
+++ b/src/st_sbardef.h
@@ -196,6 +196,8 @@ typedef struct sbe_widget_s
     hudfont_t *font;
     widgetline_t *lines;
 
+    int height;
+
     // message
     int duration;
 } sbe_widget_t;

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -1552,6 +1552,19 @@ static void DrawStatusBar(void)
     DrawCenteredMessage();
 }
 
+static void EraseBackground(int y, int height)
+{
+    if (y > scaledviewy && y < scaledviewy + scaledviewheight - height)
+    {
+        R_VideoErase(0, y, scaledviewx, height);
+        R_VideoErase(scaledviewx + scaledviewwidth, y, scaledviewx, height);
+    }
+    else
+    {
+        R_VideoErase(0, y, video.unscaledw, height);
+    }
+}
+
 static void EraseElem(int x, int y, sbarelem_t *elem, player_t *player)
 {
     if (!CheckConditions(elem->conditions, player))
@@ -1578,15 +1591,20 @@ static void EraseElem(int x, int y, sbarelem_t *elem, player_t *player)
             height += font->maxheight;
         }
 
-        if (y > scaledviewy && y < scaledviewy + scaledviewheight - height)
+        if (height > 0)
         {
-            R_VideoErase(0, y, scaledviewx, height);
-            R_VideoErase(scaledviewx + scaledviewwidth, y, scaledviewx, height);
+            EraseBackground(y, height);
+            widget->height = height;
         }
-        else
+        else if (widget->height)
         {
-            R_VideoErase(0, y, video.unscaledw, height);
+            EraseBackground(y, widget->height);
+            widget->height = 0;
         }
+    }
+    else if (elem->type == sbe_carousel)
+    {
+        ST_EraseCarousel(y);
     }
 
     sbarelem_t *child;
@@ -1598,7 +1616,7 @@ static void EraseElem(int x, int y, sbarelem_t *elem, player_t *player)
 
 void ST_Erase(void)
 {
-    if (!sbardef)
+    if (!sbardef || screenblocks >= 10)
     {
         return;
     }

--- a/src/st_widgets.c
+++ b/src/st_widgets.c
@@ -89,9 +89,10 @@ static boolean message_review;
 
 static void UpdateMessage(sbe_widget_t *widget, player_t *player)
 {
+    ST_ClearLines(widget);
+
     if (!player->message)
     {
-        ST_ClearLines(widget);
         return;
     }
 
@@ -129,12 +130,11 @@ static void UpdateMessage(sbe_widget_t *widget, player_t *player)
 
     if (duration_left == 0)
     {
-        ST_ClearLines(widget);
         overwrite = true;
     }
     else
     {
-        SetLine(widget, string);
+        ST_AddLine(widget, string);
         --duration_left;
     }
 }
@@ -464,6 +464,8 @@ boolean ST_MessagesResponder(event_t *ev)
 
 static void UpdateChat(sbe_widget_t *widget)
 {
+    ST_ClearLines(widget);
+
     static char string[HU_MAXLINELENGTH + 1];
 
     string[0] = '\0';
@@ -476,9 +478,8 @@ static void UpdateChat(sbe_widget_t *widget)
         {
             M_StringConcat(string, "_", sizeof(string));
         }
+        ST_AddLine(widget, string);
     }
-
-    SetLine(widget, string);
 }
 
 static boolean IsVanillaMap(int e, int m)
@@ -909,7 +910,7 @@ static void UpdateSpeed(sbe_widget_t *widget, player_t *player)
 {
     if (speedometer <= 0)
     {
-        SetLine(widget, "");
+        ST_ClearLines(widget);
         return;
     }
 
@@ -927,7 +928,7 @@ static void UpdateSpeed(sbe_widget_t *widget, player_t *player)
     static char string[60];
     M_snprintf(string, sizeof(string), GRAY_S "%.*f " GREEN_S "%s",
                type && speed ? 1 : 0, speed, units[type]);
-    SetLine(widget, string);
+    ST_AddLine(widget, string);
 }
 
 static void UpdateCmd(sbe_widget_t *widget)


### PR DESCRIPTION
At this point we should probably just redraw the entire background for simplicity. There will be no difference in performance.

Fix this issue: [[discord]](https://discord.com/channels/218106532406099969/1205400822687473705/1310268992253853816)