### PR TITLE
ignore excessive number of openings

### DIFF
--- a/src/r_plane.c
+++ b/src/r_plane.c
@@ -71,8 +71,8 @@ visplane_t *floorplane, *ceilingplane;
 
 // killough 8/1/98: set static number of openings to be large enough
 // (a static limit is okay in this case and avoids difficulties in r_segs.c)
-static int *openings = NULL;
-int *lastopening; // [FG] 32-bit integer math
+int maxopenings;
+int *openings, *lastopening; // [FG] 32-bit integer math
 
 // Clip values are the solid pixel bounding the range.
 //  floorclip starts out SCREENHEIGHT
@@ -128,7 +128,8 @@ void R_InitPlanesRes(void)
   yslope = Z_Calloc(1, video.height * sizeof(*yslope), PU_RENDERER, NULL);
   distscale = Z_Calloc(1, video.width * sizeof(*distscale), PU_RENDERER, NULL);
 
-  openings = Z_Calloc(1, video.width * video.height * sizeof(*openings), PU_RENDERER, NULL);
+  maxopenings = video.width * video.height;
+  openings = Z_Calloc(1, maxopenings * sizeof(*openings), PU_RENDERER, NULL);
 
   xtoskyangle = linearsky ? linearskyangle : xtoviewangle;
 }

--- a/src/r_plane.c
+++ b/src/r_plane.c
@@ -71,8 +71,7 @@ visplane_t *floorplane, *ceilingplane;
 
 // killough 8/1/98: set static number of openings to be large enough
 // (a static limit is okay in this case and avoids difficulties in r_segs.c)
-int *openings;
-int *lastopening; // [FG] 32-bit integer math
+int *openings, *lastopening; // [FG] 32-bit integer math
 
 // Clip values are the solid pixel bounding the range.
 //  floorclip starts out SCREENHEIGHT

--- a/src/r_plane.c
+++ b/src/r_plane.c
@@ -71,7 +71,7 @@ visplane_t *floorplane, *ceilingplane;
 
 // killough 8/1/98: set static number of openings to be large enough
 // (a static limit is okay in this case and avoids difficulties in r_segs.c)
-static int *openings = NULL;
+int *openings;
 int *lastopening; // [FG] 32-bit integer math
 
 // Clip values are the solid pixel bounding the range.
@@ -127,8 +127,6 @@ void R_InitPlanesRes(void)
 
   yslope = Z_Calloc(1, video.height * sizeof(*yslope), PU_RENDERER, NULL);
   distscale = Z_Calloc(1, video.width * sizeof(*distscale), PU_RENDERER, NULL);
-
-  openings = Z_Calloc(1, video.width * video.height * sizeof(*openings), PU_RENDERER, NULL);
 
   xtoskyangle = linearsky ? linearskyangle : xtoviewangle;
 }

--- a/src/r_plane.c
+++ b/src/r_plane.c
@@ -71,7 +71,8 @@ visplane_t *floorplane, *ceilingplane;
 
 // killough 8/1/98: set static number of openings to be large enough
 // (a static limit is okay in this case and avoids difficulties in r_segs.c)
-int *openings, *lastopening; // [FG] 32-bit integer math
+static int *openings = NULL;
+int *lastopening; // [FG] 32-bit integer math
 
 // Clip values are the solid pixel bounding the range.
 //  floorclip starts out SCREENHEIGHT
@@ -126,6 +127,8 @@ void R_InitPlanesRes(void)
 
   yslope = Z_Calloc(1, video.height * sizeof(*yslope), PU_RENDERER, NULL);
   distscale = Z_Calloc(1, video.width * sizeof(*distscale), PU_RENDERER, NULL);
+
+  openings = Z_Calloc(1, video.width * video.height * sizeof(*openings), PU_RENDERER, NULL);
 
   xtoskyangle = linearsky ? linearskyangle : xtoviewangle;
 }

--- a/src/r_plane.h
+++ b/src/r_plane.h
@@ -28,7 +28,7 @@ struct visplane_s;
 #define PL_SKYFLAT (0x80000000)
 
 // Visplane related.
-extern  int *lastopening; // [FG] 32-bit integer math
+extern int *openings, *lastopening; // [FG] 32-bit integer math
 
 extern int *floorclip, *ceilingclip; // [FG] 32-bit integer math
 extern fixed_t *yslope, *distscale;

--- a/src/r_plane.h
+++ b/src/r_plane.h
@@ -28,7 +28,7 @@ struct visplane_s;
 #define PL_SKYFLAT (0x80000000)
 
 // Visplane related.
-extern int *openings, *lastopening; // [FG] 32-bit integer math
+extern  int *lastopening; // [FG] 32-bit integer math
 
 extern int *floorclip, *ceilingclip; // [FG] 32-bit integer math
 extern fixed_t *yslope, *distscale;

--- a/src/r_plane.h
+++ b/src/r_plane.h
@@ -28,7 +28,8 @@ struct visplane_s;
 #define PL_SKYFLAT (0x80000000)
 
 // Visplane related.
-extern  int *lastopening; // [FG] 32-bit integer math
+extern int maxopenings;
+extern int *openings, *lastopening; // [FG] 32-bit integer math
 
 extern int *floorclip, *ceilingclip; // [FG] 32-bit integer math
 extern fixed_t *yslope, *distscale;

--- a/src/r_segs.c
+++ b/src/r_segs.c
@@ -566,6 +566,13 @@ void R_StoreWallRange(const int start, const int stop)
   ds_p->curline = curline;
   rw_stopx = stop+1;
 
+  ptrdiff_t pos = lastopening - openings;
+  size_t need = (rw_stopx - start) * sizeof(*lastopening) + pos;
+  if (need > maxopenings)
+  {
+      return;
+  }
+
   // WiggleFix: add this line, in r_segs.c:R_StoreWallRange,
   // right before calls to R_ScaleFromGlobalAngle
   R_FixWiggle(frontsector);

--- a/src/r_segs.c
+++ b/src/r_segs.c
@@ -568,7 +568,6 @@ void R_StoreWallRange(const int start, const int stop)
   rw_stopx = stop+1;
 
   { // killough 1/6/98, 2/1/98: remove limit on openings
-    extern int *openings; // [FG] 32-bit integer math
     static ptrdiff_t maxopenings;
 
     ptrdiff_t pos = lastopening - openings;

--- a/src/r_segs.c
+++ b/src/r_segs.c
@@ -567,10 +567,10 @@ void R_StoreWallRange(const int start, const int stop)
   rw_stopx = stop+1;
 
   { // killough 1/6/98, 2/1/98: remove limit on openings
-    static ptrdiff_t maxopenings;
+    static size_t maxopenings;
 
     ptrdiff_t pos = lastopening - openings;
-    ptrdiff_t need = (rw_stopx - start) * sizeof(*lastopening) + pos;
+    size_t need = (rw_stopx - start) * sizeof(*lastopening) + pos;
 
     if (need > maxopenings)
       {

--- a/src/r_segs.c
+++ b/src/r_segs.c
@@ -525,10 +525,9 @@ void R_StoreWallRange(const int start, const int stop)
 
   if (ds_p == drawsegs+maxdrawsegs)   // killough 1/98 -- fix 2s line HOM
     {
-      ptrdiff_t pos = ds_p - drawsegs; // jff 8/9/98 fix from ZDOOM1.14a
       unsigned newmax = maxdrawsegs ? maxdrawsegs*2 : 128; // killough
       drawsegs = Z_Realloc(drawsegs,newmax*sizeof(*drawsegs),PU_STATIC,0);
-      ds_p = drawsegs + pos;          // jff 8/9/98 fix from ZDOOM1.14a
+      ds_p = drawsegs+maxdrawsegs;
       maxdrawsegs = newmax;
     }
 

--- a/src/r_segs.c
+++ b/src/r_segs.c
@@ -566,42 +566,6 @@ void R_StoreWallRange(const int start, const int stop)
   ds_p->curline = curline;
   rw_stopx = stop+1;
 
-  { // killough 1/6/98, 2/1/98: remove limit on openings
-    static size_t maxopenings;
-
-    ptrdiff_t pos = lastopening - openings;
-    size_t need = (rw_stopx - start) * sizeof(*lastopening) + pos;
-
-    if (need > maxopenings)
-      {
-        drawseg_t *ds;               // jff 8/9/98 needed for fix from ZDoom
-        int *oldopenings = openings; // [FG] 32-bit integer math
-        int *oldlast = lastopening;  // [FG] 32-bit integer math
-
-        do
-          maxopenings = maxopenings ? maxopenings * 2 : 16384;
-        while (need > maxopenings);
-        openings = Z_Realloc(openings, maxopenings * sizeof(*openings),
-                           PU_STATIC, 0);
-        lastopening = openings + pos;
-
-        // jff 8/9/98 borrowed fix for openings from ZDOOM1.14
-        // [RH] We also need to adjust the openings pointers that
-        //    were already stored in drawsegs.
-        for (ds = drawsegs; ds < ds_p; ds++)
-          {
-#define ADJUST(p)                                                   \
-    if (ds->p + ds->x1 >= oldopenings && ds->p + ds->x1 <= oldlast) \
-        ds->p = ds->p - oldopenings + openings;
-
-              ADJUST(maskedtexturecol);
-              ADJUST(sprtopclip);
-              ADJUST(sprbottomclip);
-          }
-#undef ADJUST
-      }
-  } // killough: end of code to remove limits on openings
-
   // WiggleFix: add this line, in r_segs.c:R_StoreWallRange,
   // right before calls to R_ScaleFromGlobalAngle
   R_FixWiggle(frontsector);


### PR DESCRIPTION
Fix crash in Hardfest 2 MAP01. This room has a lot of openinigs:

![woof0000](https://github.com/user-attachments/assets/a3dc844b-a40e-42d6-822b-fdcc6dc6c66f)
