### PR TITLE
simplify carousel switching duration

### DIFF
--- a/src/st_carousel.c
+++ b/src/st_carousel.c
@@ -129,7 +129,7 @@ void ST_UpdateCarousel(player_t *player)
 {
     if (G_NextWeaponActivate())
     {
-        duration = TICRATE * 2;
+        duration = TICRATE / 2;
     }
 
     if (duration == 0)
@@ -144,7 +144,11 @@ void ST_UpdateCarousel(player_t *player)
         return;
     }
 
-    --duration;
+    if (player->switching == weapswitch_none
+        && player->pendingweapon == wp_nochange)
+    {
+        --duration;
+    }
 
     BuildWeaponIcons(player);
 

--- a/src/st_carousel.c
+++ b/src/st_carousel.c
@@ -129,7 +129,7 @@ void ST_UpdateCarousel(player_t *player)
 {
     if (G_NextWeaponActivate())
     {
-        duration = TICRATE / 2;
+        duration = TICRATE * 2;
     }
 
     if (duration == 0)
@@ -144,10 +144,7 @@ void ST_UpdateCarousel(player_t *player)
         return;
     }
 
-    if (player->switching == weapswitch_none)
-    {
-        --duration;
-    }
+    --duration;
 
     BuildWeaponIcons(player);
 


### PR DESCRIPTION
Fix #2069 

It's worse with fast switching weapon mods, but `player->switching` is not reliable.