### PR TITLE
don't free crosshair patch

### DIFF
--- a/src/hu_crosshair.c
+++ b/src/hu_crosshair.c
@@ -79,11 +79,6 @@ void HU_InitCrosshair(void)
 
 void HU_StartCrosshair(void)
 {
-    if (crosshair.patch)
-    {
-        Z_ChangeTag(crosshair.patch, PU_CACHE);
-    }
-
     if (crosshair_lumps[hud_crosshair])
     {
         crosshair.patch =

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -959,10 +959,6 @@ void R_DrawPlayerSprites(void)
   mfloorclip = screenheightarray;
   mceilingclip = negonearray;
 
-  // display crosshair
-  if (hud_crosshair)
-    HU_DrawCrosshair();
-
   // add all active psprites
   for (i=0, psp=viewplayer->psprites; i<NUMPSPRITES; i++,psp++)
     if (psp->state)

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -959,6 +959,10 @@ void R_DrawPlayerSprites(void)
   mfloorclip = screenheightarray;
   mceilingclip = negonearray;
 
+  // display crosshair
+  if (hud_crosshair)
+    HU_DrawCrosshair();
+
   // add all active psprites
   for (i=0, psp=viewplayer->psprites; i<NUMPSPRITES; i++,psp++)
     if (psp->state)

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -1786,11 +1786,6 @@ void ST_Drawer(void)
     }
 
     DrawStatusBar();
-
-    if (hud_crosshair)
-    {
-        HU_DrawCrosshair();
-    }
 }
 
 void ST_Start(void)


### PR DESCRIPTION
Z_FreeTags in P_SetupLevel can cause "use heap after free" crash.