### PR TITLE
Make chex3v.wad its own mission pack, add support for chex3d2.wad.

### DIFF
--- a/setup/multiplayer.c
+++ b/setup/multiplayer.c
@@ -282,6 +282,7 @@ static void UpdateSkillButton(void)
     switch(iwad->mission)
     {
         case pack_chex:
+        case pack_chex3v:
             skillbutton->values = chex_skills;
             break;
         case pack_hacx:

--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -28,25 +28,26 @@
 #include "m_misc.h"
 
 static const iwad_t iwads[] = {
-    {"doom2.wad",     doom2,      commercial,   "DOOM II: Hell on Earth"         },
-    {"plutonia.wad",  pack_plut,  commercial,   "Final DOOM: Plutonia Experiment"},
-    {"tnt.wad",       pack_tnt,   commercial,   "Final DOOM: TNT - Evilution"    },
+    {"doom2.wad",     doom2,       commercial,   "DOOM II: Hell on Earth"         },
+    {"plutonia.wad",  pack_plut,   commercial,   "Final DOOM: Plutonia Experiment"},
+    {"tnt.wad",       pack_tnt,    commercial,   "Final DOOM: TNT - Evilution"    },
     // "doom.wad" may be retail or registered
-    {"doom.wad",      doom,       indetermined, "DOOM"                           },
-    {"doom.wad",      doom,       registered,   "DOOM Registered"                },
-    {"doom.wad",      doom,       retail,       "The Ultimate DOOM"              },
+    {"doom.wad",      doom,        indetermined, "DOOM"                           },
+    {"doom.wad",      doom,        registered,   "DOOM Registered"                },
+    {"doom.wad",      doom,        retail,       "The Ultimate DOOM"              },
     // "doomu.wad" alias to allow retail wad to coexist with registered in the same folder
-    {"doomu.wad",     doom,       retail,       "The Ultimate DOOM"              },
-    {"doom1.wad",     doom,       shareware,    "DOOM Shareware"                 },
-    {"doom2f.wad",    doom2,      commercial,   "DOOM II: L'Enfer sur Terre"     },
-    {"freedoom2.wad", doom2,      commercial,   "Freedoom: Phase 2"              },
-    {"freedoom1.wad", doom,       retail,       "Freedoom: Phase 1"              },
-    {"freedm.wad",    doom2,      commercial,   "FreeDM"                         },
-    {"chex.wad",      pack_chex,  retail,       "Chex Quest"                     },
-    {"chex3v.wad",    pack_chex,  retail,       "Chex Quest 3: Vanilla Edition"  },
-    {"hacx.wad",      pack_hacx,  commercial,   "HACX: Twitch n' Kill"           },
-    {"rekkrsa.wad",   pack_rekkr, retail,       "REKKR"                          },
-    {"rekkrsl.wad",   pack_rekkr, retail,       "REKKR: Sunken Land"             },
+    {"doomu.wad",     doom,        retail,       "The Ultimate DOOM"              },
+    {"doom1.wad",     doom,        shareware,    "DOOM Shareware"                 },
+    {"doom2f.wad",    doom2,       commercial,   "DOOM II: L'Enfer sur Terre"     },
+    {"freedoom2.wad", doom2,       commercial,   "Freedoom: Phase 2"              },
+    {"freedoom1.wad", doom,        retail,       "Freedoom: Phase 1"              },
+    {"freedm.wad",    doom2,       commercial,   "FreeDM"                         },
+    {"chex.wad",      pack_chex,   retail,       "Chex Quest"                     },
+    {"chex3v.wad",    pack_chex3v, retail,       "Chex Quest 3: Vanilla Edition"  },
+    {"chex3d2.wad",   pack_chex3v, commercial,   "Chex Quest 3: Modding Edition"  },
+    {"hacx.wad",      pack_hacx,   commercial,   "HACX: Twitch n' Kill"           },
+    {"rekkrsa.wad",   pack_rekkr,  retail,       "REKKR"                          },
+    {"rekkrsl.wad",   pack_rekkr,  retail,       "REKKR: Sunken Land"             },
 };
 
 static const char *const gamemode_str[] = {

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -957,7 +957,7 @@ static void InitGameVersion(void)
         // Determine automatically
 
         if (gamemode == shareware || gamemode == registered ||
-            (gamemode == commercial && gamemission == doom2))
+            (gamemode == commercial && (gamemission == doom2 || gamemission == pack_chex3v)))
         {
             // original
             gameversion = exe_doom_1_9;

--- a/src/doomdef.h
+++ b/src/doomdef.h
@@ -40,6 +40,7 @@ typedef enum {
   pack_chex,    // Chex Quest
   pack_hacx,    // Hacx
   pack_rekkr,   // Rekkr
+  pack_chex3v,  // Chex Quest 3: Vanilla Edition
   none
 } GameMission_t;
 


### PR DESCRIPTION
As explained by [Plerb over on Doomworld](https://www.doomworld.com/forum/topic/73086-chex-quest-series-demos-complevel-3/?page=4&tab=comments#comment-2877618), Chex 3 Vanilla is essentially a PWAD for the Ultimate Doom that happens to be runnable as a standalone IWAD. Putting it under the "pack_chex" game mission is thus incorrect as Chex 3 Vanilla actually needs to use the Ultimate Doom EXE behavior rather than the Chex Quest one, and Chex 3 Vanilla already uses other means to achieve the same things that the specialized CHEX.EXE did (for example, Chex 3 Vanilla achieves the green damage flash via a modified PLAYPAL rather than any hard-coded changes). While using the "pack_chex" gamemission only has slight cosmetic differences for Chex 3 Vanilla itself as well as a potentially broken cheat code, this could end up causing unexpected behavior for DEHACKED-based PWADS for Chex 3 Vanilla.

And the reason to give it its own mission pack is this: The `gamemission < pack_chex` checks will still work, because here the "Chex 3 Vanilla" gamemission comes after the regular "Chex Quest" game mission.

Additionally, this PR will also add explicit support for the "modding version" of Chex 3 Vanilla (chex3d2.wad), an alternate version of Chex 3 Vanilla that only contains dummy levels but uses the Doom 2 map format, intended solely as a base for PWADs. More information about this can be found on [the official website](https://melodic-spaceship.neocities.org/chex3v/).