### PR TITLE
move player pain sound to the `sg_oof` sound group

### DIFF
--- a/src/sounds.c
+++ b/src/sounds.c
@@ -155,7 +155,7 @@ sfxinfo_t original_S_sfx[NUMSFX] = {
   SOUND("stnmov", sg_none,  119),
   SOUND("swtchn", sg_none,   78),
   SOUND("swtchx", sg_none,   78),
-  SOUND("plpain", sg_none,   96),
+  SOUND("plpain", sg_oof,    96),
   SOUND("dmpain", sg_none,   96),
   SOUND("popain", sg_none,   96),
   SOUND("vipain", sg_none,   96),


### PR DESCRIPTION
Prevents the chainsaw idle sound and the player pain sound from interruting each other.

https://www.doomworld.com/forum/topic/112333-this-is-woof-1501-dec-06-2024/?page=103&tab=comments#comment-2877815

This fix seems plausible since both "Oof!" and "Ouch!" are voiceful expressions. ;)