### PR TITLE
Use Final Doom EXE only for TNT and Plutonia.

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -957,7 +957,7 @@ static void InitGameVersion(void)
         // Determine automatically
 
         if (gamemode == shareware || gamemode == registered ||
-            (gamemode == commercial && (gamemission == doom2 || gamemission == pack_chex3v)))
+            (gamemode == commercial && gamemission != pack_tnt && gamemission != pack_plut))
         {
             // original
             gameversion = exe_doom_1_9;


### PR DESCRIPTION
So, I checked things and Hacx is actually supposed to use the Doom 1.9 behavior, not the Final Doom behavior as it currently assumes. This means that out of the IWADs Woof has explicit support for, three use the Doom 1.9 behavior (doom2.wad, hacx.wad and chex3d2.wad) and two use the Final Doom behavior (tnt.wad and plutonia.wad). Since the supported IWADs that should use 1.9 behavior now outnumber the ones that use Final Doom behavior, combined with the fact that future Doom 2 style IWADs that Woof may add explicit support for are likely to expect Doom 1.9 behavior as well, it makes more sense at this rate to just have Doom 1.9 be the default assumption and Final Doom the special exception instead.