### PR TITLE
Add missing FluidSynth checks, consistency tweak

### DIFF
--- a/src/i_oalmusic.c
+++ b/src/i_oalmusic.c
@@ -609,7 +609,7 @@ static const char **I_OAL_DeviceList(void)
 
 static midiplayertype_t I_OAL_MidiPlayerType(void)
 {
-#ifdef HAVE_FLUIDSYNTH
+#if defined (HAVE_FLUIDSYNTH)
     if (active_module == &stream_fl_module)
     {
         return midiplayer_fluidsynth;

--- a/src/i_oalmusic.c
+++ b/src/i_oalmusic.c
@@ -439,7 +439,11 @@ static boolean I_OAL_InitMusic(int device)
     return false;
 }
 
-static int fl_gain, opl_gain;
+#if defined(HAVE_FLUIDSYNTH)
+static int fl_gain;
+#endif
+
+static int opl_gain;
 
 static void I_OAL_SetMusicVolume(int volume)
 {

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -2492,6 +2492,7 @@ static void SetMidiPlayerOpl(void)
     }
 }
 
+#if defined(HAVE_FLUIDSYNTH)
 static void SetMidiPlayerFluidSynth(void)
 {
     if (I_MidiPlayerType() == midiplayer_fluidsynth)
@@ -2499,6 +2500,7 @@ static void SetMidiPlayerFluidSynth(void)
         SetMidiPlayer();
     }
 }
+#endif
 
 static void RestartMusic(void)
 {

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -2653,7 +2653,10 @@ static setup_menu_t music_settings1[] = {
 
 static void UpdateGainItems(void)
 {
+#if defined (HAVE_FLUIDSYNTH)
     DisableItem(auto_gain, music_settings1, "fl_gain");
+#endif
+
     DisableItem(auto_gain, music_settings1, "opl_gain");
 }
 


### PR DESCRIPTION
Should fix [this Doomworld report](<https://www.doomworld.com/forum/post/2883030>).

While we're on this, I noticed that the following check uses `#ifdef` instead of `#if defined`:

https://github.com/fabiangreffrath/woof/blob/164098805c163d6f3e68f5ae50b6a0fe039cde0f/src/i_oalmusic.c#L612-L617

Why? Should we change it or all the others for consistency?