### PR TITLE
clear active thermo when prematurely exiting out of the menu

### DIFF
--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -4212,6 +4212,8 @@ static boolean NextPage(int inc)
     return true;
 }
 
+static setup_menu_t *active_thermo = NULL;
+
 boolean MN_SetupResponder(menu_action_t action, int ch)
 {
     // phares 3/26/98 - 4/11/98:
@@ -4460,6 +4462,7 @@ boolean MN_SetupResponder(menu_action_t action, int ch)
         set_weapon_active = false;
         default_verify = false;              // phares 4/19/98
         print_warning_about_changes = false; // [FG] reset
+        active_thermo = NULL;
         M_StartSound(sfx_swtchx);
         return true;
     }
@@ -4525,8 +4528,6 @@ boolean MN_SetupMouseResponder(int x, int y)
     {
         return true;
     }
-
-    static setup_menu_t *active_thermo = NULL;
 
     if (M_InputDeactivated(input_menu_enter) && active_thermo)
     {


### PR DESCRIPTION
Fixes #2100

At least this fixes the last thermo still being in an active state when exiting the menu while the mouse button is pressed but not yet released. It does not fix the thermo value != actual value issue, though.

I think we would have to call ` active_thermo->action()` for this, but I don't dare. 