### PR TITLE
add D_DoomPrefDir() instead of D_DoomExeDir() to iwad_dirs

### DIFF
--- a/src/d_iwad.h
+++ b/src/d_iwad.h
@@ -30,6 +30,7 @@ typedef struct
 } iwad_t;
 
 char *D_DoomExeDir(void); // killough 2/16/98: path to executable's dir
+char *D_DoomPrefDir(void); // [FG] default configuration dir
 char *D_FindWADByName(const char *filename);
 char *D_TryFindWADByName(const char *filename);
 char *D_FindLMPByName(const char *filename);

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -622,38 +622,6 @@ char *D_DoomExeName(void)
   return name;
 }
 
-// [FG] get the path to the default configuration dir to use
-
-char *D_DoomPrefDir(void)
-{
-    static char *dir;
-
-    if (dir == NULL)
-    {
-#if !defined(_WIN32) || defined(_WIN32_WCE)
-        // Configuration settings are stored in an OS-appropriate path
-        // determined by SDL.  On typical Unix systems, this might be
-        // ~/.local/share/chocolate-doom.  On Windows, we behave like
-        // Vanilla Doom and save in the current directory.
-
-        char *result = SDL_GetPrefPath("", PROJECT_SHORTNAME);
-        if (result != NULL)
-        {
-            dir = M_DirName(result);
-            SDL_free(result);
-        }
-        else
-#endif /* #ifndef _WIN32 */
-        {
-            dir = D_DoomExeDir();
-        }
-
-        M_MakeDirectory(dir);
-    }
-
-    return dir;
-}
-
 // Calculate the path to the directory for autoloaded WADs/DEHs.
 // Creates the directory as necessary.
 

--- a/src/d_main.h
+++ b/src/d_main.h
@@ -30,7 +30,6 @@ void D_AddFile(const char *file);
 char *D_DoomExeName(void);      // killough 10/98: executable's name
 extern char *basesavegame;     // killough 2/16/98: savegame path
 extern char *screenshotdir; // [FG] screenshot path
-char *D_DoomPrefDir(void); // [FG] default configuration dir
 void D_SetSavegameDirectory(void);
 
 extern const char *gamedescription;

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -30,6 +30,7 @@
 #include "am_map.h"
 #include "config.h"
 #include "d_main.h"
+#include "d_iwad.h"
 #include "doomdef.h"
 #include "doomstat.h"
 #include "doomtype.h"

--- a/src/r_data.c
+++ b/src/r_data.c
@@ -25,7 +25,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "d_main.h"
+#include "d_iwad.h"
 #include "d_think.h"
 #include "doomdef.h"
 #include "doomstat.h"


### PR DESCRIPTION
D_DoomPrefDir() returns the executable directory on Windows, and a user-writable config directory everywhere else.