### PR TITLE
do not mistake WAD-named directories for actual WAD files

### DIFF
--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -624,13 +624,12 @@ void BuildIWADDirList(void)
 
 char *D_FindWADByName(const char *name)
 {
-    char *path;
     char *probe;
 
     // Absolute path?
 
     probe = M_FileCaseExists(name);
-    if (probe != NULL)
+    if (probe != NULL && !M_DirExists(probe))
     {
         return probe;
     }
@@ -655,10 +654,10 @@ char *D_FindWADByName(const char *name)
 
         // Construct a string for the full path
 
-        path = M_StringJoin(*dir, DIR_SEPARATOR_S, name);
+        char *path = M_StringJoin(*dir, DIR_SEPARATOR_S, name);
 
         probe = M_FileCaseExists(path);
-        if (probe != NULL)
+        if (probe != NULL && !M_DirExists(probe))
         {
             return probe;
         }

--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -453,15 +453,6 @@ static void CheckDOSDefaults(void)
 
 #endif
 
-// Returns true if the specified path is a path to a file
-// of the specified name.
-
-static boolean DirIsFile(const char *path, const char *filename)
-{
-    return strchr(path, DIR_SEPARATOR) != NULL
-           && !strcasecmp(M_BaseName(path), filename);
-}
-
 // Add IWAD directories parsed from splitting a path string containing
 // paths separated by PATH_SEPARATOR. 'suffix' is a string to concatenate
 // to the end of the paths before adding them.
@@ -629,7 +620,7 @@ char *D_FindWADByName(const char *name)
     // Absolute path?
 
     probe = M_FileCaseExists(name);
-    if (probe != NULL && !M_DirExists(probe))
+    if (probe != NULL)
     {
         return probe;
     }
@@ -646,7 +637,7 @@ char *D_FindWADByName(const char *name)
         // file.
 
         probe = M_FileCaseExists(*dir);
-        if (DirIsFile(*dir, name) && probe != NULL)
+        if (probe != NULL)
         {
             return probe;
         }
@@ -657,7 +648,7 @@ char *D_FindWADByName(const char *name)
         char *path = M_StringJoin(*dir, DIR_SEPARATOR_S, name);
 
         probe = M_FileCaseExists(path);
-        if (probe != NULL && !M_DirExists(probe))
+        if (probe != NULL)
         {
             return probe;
         }

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -36,7 +36,7 @@
 
 // Check if a file exists
 
-boolean M_FileExists(const char *filename)
+static boolean M_FileExistsNotDir(const char *filename)
 {
     FILE *fstream;
 
@@ -45,14 +45,11 @@ boolean M_FileExists(const char *filename)
     if (fstream != NULL)
     {
         fclose(fstream);
-        return true;
+        return M_DirExists(filename) == false;
     }
     else
     {
-        // If we can't open because the file is a directory, the
-        // "file" exists at least!
-
-        return errno == EISDIR;
+        return false;
     }
 }
 
@@ -118,7 +115,7 @@ char *M_FileCaseExists(const char *path)
     path_dup = M_StringDuplicate(path);
 
     // 0: actual path
-    if (M_FileExists(path_dup))
+    if (M_FileExistsNotDir(path_dup))
     {
         return path_dup;
     }
@@ -130,7 +127,7 @@ char *M_FileCaseExists(const char *path)
     // 1: lowercase filename, e.g. doom2.wad
     M_StringToLower(filename);
 
-    if (M_FileExists(path_dup))
+    if (M_FileExistsNotDir(path_dup))
     {
         return path_dup;
     }
@@ -138,7 +135,7 @@ char *M_FileCaseExists(const char *path)
     // 2: uppercase filename, e.g. DOOM2.WAD
     M_StringToUpper(filename);
 
-    if (M_FileExists(path_dup))
+    if (M_FileExistsNotDir(path_dup))
     {
         return path_dup;
     }
@@ -149,7 +146,7 @@ char *M_FileCaseExists(const char *path)
     {
         M_StringToLower(ext + 1);
 
-        if (M_FileExists(path_dup))
+        if (M_FileExistsNotDir(path_dup))
         {
             return path_dup;
         }
@@ -160,7 +157,7 @@ char *M_FileCaseExists(const char *path)
     {
         M_StringToLower(filename + 1);
 
-        if (M_FileExists(path_dup))
+        if (M_FileExistsNotDir(path_dup))
         {
             return path_dup;
         }

--- a/src/m_misc.h
+++ b/src/m_misc.h
@@ -23,7 +23,6 @@
 
 #include "doomtype.h"
 
-boolean M_FileExists(const char *file);
 boolean M_DirExists(const char *path);
 int M_FileLength(const char *path);
 char *M_TempFile(const char *s);


### PR DESCRIPTION
Fixes a segfault when running the engine e.g. from the `savegames` directory.

Does anyone know the reason why we do not simply `return false` here?

https://github.com/fabiangreffrath/woof/blob/ec7344f041261cd5942c6cbf64b25aa1f2e4f3c6/src/m_misc.c#L50-L56
