### PR TITLE
always append the absolute IWAD path to iwad_dirs[]

### DIFF
--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -565,6 +565,8 @@ static void AddSteamDirs(void)
 // Build a list of IWAD files
 //
 
+static char **iwad_dirs_append;
+
 void BuildIWADDirList(void)
 {
     char *env;
@@ -616,6 +618,12 @@ void BuildIWADDirList(void)
     AddSteamDirs();
 #  endif
 #endif
+
+    char **dir;
+    array_foreach(dir, iwad_dirs_append)
+    {
+        array_push(iwad_dirs, *dir);
+    }
 }
 
 //
@@ -768,6 +776,11 @@ char *D_FindIWADFile(void)
         if (result == NULL)
         {
             I_Error("IWAD file '%s' not found!", file);
+        }
+        else
+        {
+            char *iwad_dir = M_DirName(result);
+            array_push(iwad_dirs_append, iwad_dir);
         }
 
         free(file);


### PR DESCRIPTION
I have access to my KEX installation under `/media/fabian/Windows-SSD/Program Files (x86)/GOG Galaxy/Games/DOOM + DOOM II`.

So, if I run the engine with `woof -iwad "/media/fabian/Windows-SSD/Program Files (x86)/GOG Galaxy/Games/DOOM + DOOM II/doom2.wad"`, it would be nice if it (1) could automatically find and load the `extras.wad` file from the same directory and (2) if running the engine with e.g. the `-file id1.wad` parameter in addition would find and load that file from the same directory.

This patch achieves that goal by appending the IWAD path to the `iwad_dirs[]` array, while keeping its original order intact.

This only makes sense if the IWAD is explicitly loaded with the `-iwad` parameter. If it is found automatically, then its path is necessarily already an element in the `iwad_dirs[]` array.
