### PR TITLE
Improved weapon interpolation

### DIFF
--- a/src/am_map.c
+++ b/src/am_map.c
@@ -2312,10 +2312,7 @@ void AM_Drawer (void)
   }
 
   if (automapoverlay == AM_OVERLAY_OFF)
-  {
     AM_clearFB(mapcolor_back);       //jff 1/5/98 background default color
-    pspr_interp = false;
-  }
   // [Alaux] Dark automap overlay
   else if (automapoverlay == AM_OVERLAY_DARK && !MN_MenuIsShaded())
     V_ShadeScreen();

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -1127,8 +1127,6 @@ void P_SpawnPlayer (mapthing_t* mthing)
 
   p->momx = p->momy = 0;   // killough 10/98: initialize bobbing to 0.
 
-  pspr_interp = false;
-
   // setup gun psprite
 
   P_SetupPsprites (p);

--- a/src/p_pspr.c
+++ b/src/p_pspr.c
@@ -1118,6 +1118,9 @@ void P_MovePsprites(player_t *player)
   const int center_weapon_strict = STRICTMODE(center_weapon);
   int i;
 
+  psp[ps_weapon].oldsx2 = psp[ps_weapon].sx2;
+  psp[ps_weapon].oldsy2 = psp[ps_weapon].sy2;
+
   // a null state means not active
   // drop tic count and possibly change state
   // a -1 tic count never changes
@@ -1176,6 +1179,8 @@ void P_MovePsprites(player_t *player)
 
   player->psprites[ps_flash].sx2 = player->psprites[ps_weapon].sx2;
   player->psprites[ps_flash].sy2 = player->psprites[ps_weapon].sy2;
+  player->psprites[ps_flash].oldsx2 = player->psprites[ps_weapon].oldsx2;
+  player->psprites[ps_flash].oldsy2 = player->psprites[ps_weapon].oldsy2;
 }
 
 //

--- a/src/p_pspr.c
+++ b/src/p_pspr.c
@@ -167,9 +167,12 @@ static void P_BringUpWeapon(player_t *player)
 
   player->pendingweapon = wp_nochange;
 
+  pspdef_t *psp = &player->psprites[ps_weapon];
+
   // killough 12/98: prevent pistol from starting visibly at bottom of screen:
-  player->psprites[ps_weapon].sy = demo_version >= DV_MBF ? 
-    WEAPONBOTTOM+FRACUNIT*2 : WEAPONBOTTOM;
+  psp->sy = demo_version >= DV_MBF ? WEAPONBOTTOM + FRACUNIT * 2 : WEAPONBOTTOM;
+
+  psp->sy2 = psp->oldsy2 = psp->sy;
 
   P_SetPsprite(player, ps_weapon, newstate);
 }

--- a/src/p_pspr.h
+++ b/src/p_pspr.h
@@ -60,6 +60,8 @@ typedef struct pspdef_s
   // [FG] centered weapon sprite
   fixed_t sx2;
   fixed_t sy2;
+  fixed_t oldsx2;
+  fixed_t oldsy2;
 } pspdef_t;
 
 extern int weapon_preferences[2][NUMWEAPONS+1];      // killough 5/2/98

--- a/src/p_saveg.c
+++ b/src/p_saveg.c
@@ -761,16 +761,19 @@ static void saveg_read_pspdef_t(pspdef_t *str)
     if (saveg_compat > saveg_mbf)
     {
         // [Woof!]: fixed_t sx2;
-        str->sx2 = str->oldsx2 = saveg_read32();
+        str->sx2 = saveg_read32();
 
         // [Woof!]: fixed_t sy2;
-        str->sy2 = str->oldsy2 = saveg_read32();
+        str->sy2 = saveg_read32();
     }
     else
     {
         str->sx2 = str->sx;
         str->sy2 = str->sy;
     }
+
+    str->oldsx2 = str->sx2;
+    str->oldsy2 = str->sy2;
 }
 
 static void saveg_write_pspdef_t(pspdef_t *str)

--- a/src/p_saveg.c
+++ b/src/p_saveg.c
@@ -761,10 +761,10 @@ static void saveg_read_pspdef_t(pspdef_t *str)
     if (saveg_compat > saveg_mbf)
     {
         // [Woof!]: fixed_t sx2;
-        str->sx2 = saveg_read32();
+        str->sx2 = str->oldsx2 = saveg_read32();
 
         // [Woof!]: fixed_t sy2;
-        str->sy2 = saveg_read32();
+        str->sy2 = str->oldsy2 = saveg_read32();
     }
     else
     {

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -674,8 +674,6 @@ void R_ExecuteSetViewSize (void)
     }
 
   st_refresh_background = true;
-
-  pspr_interp = false;
 }
 
 //

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -787,8 +787,6 @@ void R_NearbySprites (void)
 // R_DrawPSprite
 //
 
-boolean pspr_interp = true; // weapon bobbing interpolation
-
 void R_DrawPSprite (pspdef_t *psp)
 {
   fixed_t       tx;
@@ -823,15 +821,13 @@ void R_DrawPSprite (pspdef_t *psp)
 
   fixed_t sx2, sy2;
 
-  if (uncapped && oldleveltime < leveltime && pspr_interp)
+  if (uncapped && oldleveltime < leveltime)
   {
     sx2 = LerpFixed(psp->oldsx2, psp->sx2);
     sy2 = LerpFixed(psp->oldsy2, psp->sy2);
   }
   else
   {
-    pspr_interp = true;
-
     sx2 = psp->sx2;
     sy2 = psp->sy2;
   }

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -821,8 +821,23 @@ void R_DrawPSprite (pspdef_t *psp)
   lump = sprframe->lump[0];
   flip = (boolean) sprframe->flip[0];
 
+  fixed_t sx2, sy2;
+
+  if (uncapped && oldleveltime < leveltime && pspr_interp)
+  {
+    sx2 = LerpFixed(psp->oldsx2, psp->sx2);
+    sy2 = LerpFixed(psp->oldsy2, psp->sy2);
+  }
+  else
+  {
+    pspr_interp = true;
+
+    sx2 = psp->sx2;
+    sy2 = psp->sy2;
+  }
+
   // calculate edges of the shape
-  tx = psp->sx2-160*FRACUNIT; // [FG] centered weapon sprite
+  tx = sx2 - 160*FRACUNIT; // [FG] centered weapon sprite
 
   tx -= spriteoffset[lump];
   x1 = (centerxfrac + FixedMul (tx,pspritescale))>>FRACBITS;
@@ -845,7 +860,7 @@ void R_DrawPSprite (pspdef_t *psp)
 
   // killough 12/98: fix psprite positioning problem
   vis->texturemid = (BASEYCENTER<<FRACBITS) /* + FRACUNIT/2 */ -
-                    (psp->sy2-spritetopoffset[lump]); // [FG] centered weapon sprite
+                    (sy2 - spritetopoffset[lump]); // [FG] centered weapon sprite
 
   vis->x1 = x1 < 0 ? 0 : x1;
   vis->x2 = x2 >= viewwidth ? viewwidth-1 : x2;
@@ -882,42 +897,6 @@ void R_DrawPSprite (pspdef_t *psp)
     vis->colormap[1] = fullcolormap;
   }
   vis->brightmap = R_BrightmapForState(psp->state - states);
-
-  // interpolation for weapon bobbing
-  if (uncapped)
-  {
-    static int     oldx1, x1_saved;
-    static fixed_t oldtexturemid, texturemid_saved;
-    static int     oldlump = -1;
-    static int     oldgametic = -1;
-
-    if (oldgametic < gametic)
-    {
-      oldx1 = x1_saved;
-      oldtexturemid = texturemid_saved;
-      oldgametic = gametic;
-    }
-
-    x1_saved = vis->x1;
-    texturemid_saved = vis->texturemid;
-
-    if (lump == oldlump && pspr_interp)
-    {
-      int deltax = x2 - vis->x1;
-      vis->x1 = LerpFixed(oldx1, vis->x1);
-      vis->x2 = vis->x1 + deltax;
-      if (vis->x2 >= viewwidth)
-        vis->x2 = viewwidth - 1;
-      vis->texturemid = LerpFixed(oldtexturemid, vis->texturemid);
-    }
-    else
-    {
-      oldx1 = vis->x1;
-      oldtexturemid = vis->texturemid;
-      oldlump = lump;
-      pspr_interp = true;
-    }
-  }
 
   // [crispy] free look
   vis->texturemid += (centery - viewheight/2) * pspriteiscale;

--- a/src/r_things.h
+++ b/src/r_things.h
@@ -39,7 +39,6 @@ extern int64_t sprtopscreen; // [FG] 64-bit integer math
 extern fixed_t pspritescale;
 extern fixed_t pspriteiscale;
 
-extern boolean pspr_interp; // weapon bobbing interpolation
 extern boolean flipcorpses;
 
 extern lighttable_t **spritelights;


### PR DESCRIPTION
This approach, similar to that of mobj interpolation, eliminates some issues from the old approach, namely interpolation having to be reset upon sprite changes and view-size changes; we now interpolate `sx2` and `sy2`, which are independent of resolution and sprite size, instead of the vissprite itself, which _is_ dependent on those factors.

I think it's not necessary to save/load `oldsx2, oldsy2` in/from savegames.

While we're on this, what's the purpose of `pspr_interp = false` in the following `AM_Drawer()` code?

https://github.com/fabiangreffrath/woof/blob/dcf934132db5eb2fff2d1506a1fd7dd7aed09f70/src/am_map.c#L2314-L2318

I think we can remove it.