### PR TITLE
Fix rendering of voxels on top/bottom of screen

### DIFF
--- a/src/r_voxel.c
+++ b/src/r_voxel.c
@@ -871,13 +871,14 @@ static void VX_DrawColumn (vissprite_t * spr, int x, int y)
 			fixed_t uy0 = uy1;
 
 			// clip the slab vertically
-			if (uy1 >= clip_y2) break;
-			if (uy2 <= clip_y1) continue;
+			if (uy1 >= clip_y2) uy1 = clip_y2;
+			if (uy2 <= clip_y1) uy2 = clip_y1;
 
 			if (uy1 < clip_y1) uy1 = clip_y1;
 			if (uy2 > clip_y2) uy2 = clip_y2;
 
-			boolean has_side = ((face & (ux > Bx ? B_face : A_face)) != 0);
+			boolean has_side = ((face & (ux > Bx ? B_face : A_face)) != 0
+                          && uy1 < clip_y2 && uy2 > clip_y1);
 
 			// handle the fuzz effect for Spectres
 			if (shadow)


### PR DESCRIPTION
Rendering is really not my field and I hardly know any math, so I may be understanding this very wrongly, but I've spent hours looking at the voxel code trying to figure out what causes #1277 and I think I got it.

When we enter the slab loop in `VX_DrawColumn()` (a "slab" is apparently a cube in a column of the voxel model, to put it simply), we calculate `uy1` and `uy2`, which seem to be the vertical coordinates between which the current pixel column of the side of the slab should be drawn (i.e. we draw a column of pixels from `uy1` down to `uy2)`. The top of the slab is drawn from slightly above `uy1` down to `uy1` itself, whereas the bottom of the slab is drawn from slightly below `uy2` up to `uy2` itself.

The problem lies in the fact that when either `uy1` goes below the bottom edge of the screen, or `uy2` goes above the top edge, the whole slab is omitted. This makes sense for the sides of the slab, but not for its top or bottom, which as I said slightly exceed `uy1` and `uy2`.

The little change I've made in this PR makes the loop still omit drawing of sides in that case, but it keeps going to see if the top or bottom should be drawn; it fixes #1277.

@andwj thoughts?