### PR TITLE
fix 'pwad endoom only' logic

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1633,16 +1633,21 @@ static boolean AllowEndDoom(void)
           || exit_sequence == EXIT_SEQUENCE_ENDOOM_ONLY));
 }
 
-static boolean AllowEndDoomPWADOnly() {
-  return (!W_IsIWADLump(W_CheckNumForName("ENDOOM")) && endoom_pwad_only);
-}
+
 
 static void D_EndDoom(void)
 {
-  if (AllowEndDoom() && AllowEndDoomPWADOnly())
-  {
-    D_ShowEndDoom();
-  }
+  // Do we even want to show an ENDOOM?
+  if (!AllowEndDoom()) return;
+
+  // If so, is it from the IWAD?
+  bool iwad_endoom = W_IsIWADLump(W_CheckNumForName("ENDOOM"));
+
+  // Does the user want to see it, in that case?
+  if (iwad_endoom && endoom_pwad_only) return;
+
+  D_ShowEndDoom();
+
 }
 
 // [FG] fast-forward demo to the desired map

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1633,21 +1633,24 @@ static boolean AllowEndDoom(void)
           || exit_sequence == EXIT_SEQUENCE_ENDOOM_ONLY));
 }
 
-
-
 static void D_EndDoom(void)
 {
   // Do we even want to show an ENDOOM?
-  if (!AllowEndDoom()) return;
+  if (!AllowEndDoom())
+  {
+    return;
+  }
 
   // If so, is it from the IWAD?
   bool iwad_endoom = W_IsIWADLump(W_CheckNumForName("ENDOOM"));
 
   // Does the user want to see it, in that case?
-  if (iwad_endoom && endoom_pwad_only) return;
+  if (iwad_endoom && endoom_pwad_only)
+  {
+    return;
+  }
 
   D_ShowEndDoom();
-
 }
 
 // [FG] fast-forward demo to the desired map


### PR DESCRIPTION
I noticed after the fact, there was an error in my original logic implementation that caused it to only show the PWAD ENDOOM, if the setting itself was turned on, and never showed the IWAD ENDOOM.

This time, this was properly, thoroughly tested with all use case combinations, on both Doom II and Eviternity:
* Show any ENDOOM + play sound
* Show any ENDOOM
* Show PWAD ENDOOM + play sound 
* Show PWAD ENDOOM
* Play sound
* None