### PR TITLE
Implement ID24 DemoLoop specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ Copyright:
  © 2022-2024 Alaux;  
  © 2022-2024 ceski;  
  © 2023 Andrew Apted;  
- © 2023 liPillON.  
+ © 2023 liPillON;  
+ © 2025 Guilherme Miranda.  
 License: [GPL-2.0+](https://www.gnu.org/licenses/old-licenses/gpl-2.0.html)
 
 Files: `src/i_flickstick.*, src/i_gyro.*`  

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ include(WoofSettings)
 set(WOOF_SOURCES
     am_map.c               am_map.h
     d_deh.c                d_deh.h
+    d_demoloop.c           d_demoloop.h
                            d_englsh.h
                            d_event.h
                            d_french.h

--- a/src/d_demoloop.c
+++ b/src/d_demoloop.c
@@ -1,0 +1,306 @@
+//
+//  Copyright (C) 2025 Guilherme Miranda
+//
+//  This program is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU General Public License
+//  as published by the Free Software Foundation; either version 2
+//  of the License, or (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  DESCRIPTION:
+//    ID24 DemoLoop
+
+#include "doomdef.h"
+#include "doomstat.h"
+
+#include "i_printf.h"
+#include "m_array.h"
+#include "m_json.h"
+#include "w_wad.h"
+
+#include "d_demoloop.h"
+
+// DEMO1 lump playback.
+static const demoloop_entry_t dl_demo1 = {
+    "DEMO1",
+    "",
+    0,
+    TYPE_DEMO_LUMP,
+    OUTRO_WIPE_SCREEM_MELT,
+};
+
+// DEMO2 lump playback.
+static const demoloop_entry_t dl_demo2 = {
+    "DEMO2",
+    "",
+    0,
+    TYPE_DEMO_LUMP,
+    OUTRO_WIPE_SCREEM_MELT,
+};
+
+// DEMO3 lump playback.
+static const demoloop_entry_t dl_demo3 = {
+    "DEMO3",
+    "",
+    0,
+    TYPE_DEMO_LUMP,
+    OUTRO_WIPE_SCREEM_MELT,
+};
+
+// DEMO4 lump, only present in Ultimate Doom.
+// The DEMO4 entry crashed in the original Final Doom EXE's loop.
+static const demoloop_entry_t dl_demo4 = {
+    "DEMO4",
+    "",
+    0,
+    TYPE_DEMO_LUMP,
+    OUTRO_WIPE_SCREEM_MELT,
+};
+
+// Oddly, Doom's TITLEPIC lasts for a brifer period than Doom II.
+// About ~4.857 seconds, as opposed to Doom II's exact 11 seconds.
+static const demoloop_entry_t dl_doom1_titlepic = {
+    "TITLEPIC",
+    "D_INTRO",
+    170,
+    TYPE_ART_SCREEN,
+    OUTRO_WIPE_SCREEM_MELT,
+};
+
+// HELP2 titlescreen lasts for about ~5.714 seconds.
+// Used only in Registered mode.
+static const demoloop_entry_t dl_help2 = {
+    "HELP2",
+    "",
+    200,
+    TYPE_ART_SCREEN,
+    OUTRO_WIPE_SCREEM_MELT,
+};
+
+// Plain Doom II, Commercial mode, TITLEPIC lasts for exactly 11.0 seconds.
+static const demoloop_entry_t dl_doom2_titlepic = {
+    "TITLEPIC",
+    "D_DM2TTL",
+    385,
+    TYPE_ART_SCREEN,
+    OUTRO_WIPE_SCREEM_MELT,
+};
+
+// CREDIT titlescreen lasts for about ~5.714 seconds.
+// Used in Retail and Commercial mode.
+static const demoloop_entry_t dl_credit = {
+    "CREDIT",
+    "",
+    200,
+    TYPE_ART_SCREEN,
+    OUTRO_WIPE_SCREEM_MELT,
+};
+
+// Used to check for fault tolerance
+static const demoloop_entry_t dl_none = {
+    "",
+    "",
+    0,
+    TYPE_NONE,
+    OUTRO_WIPE_NONE,
+};
+
+// Doom
+demoloop_entry_t demoloop_registered[6] = {
+    dl_doom1_titlepic,
+    dl_demo1,
+    dl_credit,
+    dl_demo2,
+    dl_help2,
+    dl_demo3,
+};
+
+// Ultiamte Doom
+demoloop_entry_t demoloop_retail[7] = {
+    dl_doom1_titlepic,
+    dl_demo1,
+    dl_credit,
+    dl_demo2,
+    dl_credit,
+    dl_demo3,
+    dl_demo4,
+};
+
+// Doom II & fixed Final Doom
+demoloop_entry_t demoloop_commercial[6] = {
+    dl_doom2_titlepic,
+    dl_demo1,
+    dl_credit,
+    dl_demo2,
+    dl_doom2_titlepic,
+    dl_demo3,
+};
+
+// TNT: Evilution & The Plutonia Experiement
+demoloop_entry_t demoloop_final[7] = {
+    dl_doom2_titlepic,
+    dl_demo1,
+    dl_credit,
+    dl_demo2,
+    dl_doom2_titlepic,
+    dl_demo3,
+    dl_demo4,
+};
+
+// For local parsing purposes only.
+static demoloop_entry_t current_entry;
+
+demoloop_t demoloop;
+int        demoloop_count = 0;
+int        demoloop_current = -1;
+
+
+// TODO: actually finish this and make it work
+demoloop_entry_t D_ParseDemoLoopEntry(json_t *entry)
+{
+    const char* primary_lump   = JS_GetStringValue(entry, "primarylump");
+    const char* secondary_lump = JS_GetStringValue(entry, "secondarylump");
+    double      seconds        = JS_GetNumberValue(entry, "duration");
+    int         type           = JS_GetIntegerValue(entry, "type");
+    int         outro_wipe     = JS_GetIntegerValue(entry, "outro_wipe");
+
+    // We don't want a malformed entry to creep in, and break the titlescreen.
+    // If one such entry does exist, skip it.
+    // TODO: modify later to check locally for lump type.
+    if (type <= TYPE_NONE || type > TYPE_DEMO_LUMP)
+    {
+        return dl_none;
+    }
+
+    // Similarly, but this time it isn't game-breaking.
+    // Let it gracefully default to "closest vanilla behavior".
+    if (outro_wipe <= OUTRO_WIPE_NONE || outro_wipe > OUTRO_WIPE_SCREEM_MELT)
+    {
+        outro_wipe = OUTRO_WIPE_SCREEM_MELT;
+    }
+
+    // Providing the time in seconds is much more intuitive for the end users.
+    int duration = seconds * TICRATE;
+
+    demoloop_entry_t demoloop_entry = {
+        primary_lump,
+        secondary_lump,
+        duration,
+        type,
+        outro_wipe,
+    };
+
+    return demoloop_entry;
+}
+
+void D_ParseDemoLoop(void)
+{
+    // Does the JSON lump even exist?
+    json_t *json = JS_Open("DEMOLOOP", "demoloop", (version_t){1, 0, 0});
+    if (json == NULL)
+    {
+        return;
+    }
+
+    // Does lump actually have any data?
+    json_t *data = JS_GetObject(json, "data");
+    if (JS_IsNull(data) || !JS_IsObject(data))
+    {
+        I_Printf(VB_WARNING, "DEMOLOOP: data object not defined");
+        JS_Close("DEMOLOOP");
+        return;
+    }
+
+    // Does is it even have the definitions we are looking for?
+    json_t *entry_list = JS_GetObject(data, "entries");
+    if (JS_IsNull(entry_list) || !JS_IsArray(entry_list))
+    {
+        I_Printf(VB_WARNING, "DEMOLOOP: no entries defined");
+        JS_Close("DEMOLOOP");
+        return;
+    }
+
+    // If so, now parse them.
+    json_t *entry;
+
+    JS_ArrayForEach(entry, entry_list)
+    {
+        current_entry = D_ParseDemoLoopEntry(entry);
+
+        // Should there be a malformed entry, discard it.
+        if (current_entry.type == TYPE_NONE)
+        {
+            continue;
+        }
+
+        array_push(demoloop, current_entry);
+        demoloop_count++;
+    }
+
+    return;
+}
+
+void D_GetDefaultDemoLoop(GameMission_t mission, GameMode_t mode)
+{
+    switch(mission) {
+        case doom:
+            // The versions of Doom that have HELP2, instead.
+            if (mode == registered || mode == shareware) {
+                demoloop = demoloop_registered;
+                demoloop_count = 6;
+                break;
+            }
+        case pack_chex3v:
+            // Check for chex3d2.wad, "Chex Quest 3: Modding Edition".
+            if (mode == commercial) {
+                demoloop = demoloop_commercial;
+                demoloop_count = 6;
+                break;
+            }
+        case pack_rekkr:
+        case pack_chex:
+            // Plain Ultimate Doom
+            demoloop = demoloop_retail;
+            demoloop_count = 7;
+            break;
+
+        case doom2:
+        case pack_hacx:
+            // Plain Doom II
+            demoloop = demoloop_commercial;
+            demoloop_count = 6;
+            break;
+
+        case pack_tnt:
+        case pack_plut:
+            // Plain Final Doom
+            demoloop = demoloop_final;
+            demoloop_count = 7;
+            break;
+
+        case none:
+        default:
+            // How did we get here?
+            demoloop = NULL;
+            demoloop_count = 0;
+            break;
+    }
+
+    return;
+}
+
+void D_SetupDemoLoop(void) {
+    if (W_CheckNumForName("DEMOLOOP") >= 0)
+    {
+        D_ParseDemoLoop();
+    }
+
+    if (demoloop == NULL)
+    {
+        D_GetDefaultDemoLoop(gamemission, gamemode);
+    }
+}

--- a/src/d_demoloop.h
+++ b/src/d_demoloop.h
@@ -42,11 +42,11 @@ typedef enum
 // Individual demoloop units.
 typedef struct
 {
-    const char *primary_lump;   // Screen graphic or DEMO lump.
-    const char *secondary_lump; // Music lump for screen graphic.
-    int         duration;       // Game tics.
-    dl_type_t   type;
-    dl_wipe_t   outro_wipe;
+    char      primary_lump[9];   // Screen graphic or DEMO lump.
+    char      secondary_lump[9]; // Music lump for screen graphic.
+    int       duration;          // Game tics.
+    dl_type_t type;
+    dl_wipe_t outro_wipe;
 } demoloop_entry_t;
 
 typedef demoloop_entry_t* demoloop_t;
@@ -55,8 +55,6 @@ typedef demoloop_entry_t* demoloop_t;
 extern demoloop_t demoloop;
 // Formerly 7 for Ultimate Doom & Final Doom, 6 otherwise.
 extern int        demoloop_count;
-// Formerly "demosequence".
-extern int        demoloop_current;
 
 // Parse the DEMOLOOP, returning NULL to "demoloop" should any errors occur.
 void D_ParseDemoLoop(void);

--- a/src/d_demoloop.h
+++ b/src/d_demoloop.h
@@ -18,8 +18,6 @@
 //    graphic, music or DEMO lump.
 //
 
-#include "doomdef.h"
-
 #ifndef _D_DEMOLOOP_
 #define _D_DEMOLOOP_
 
@@ -56,10 +54,6 @@ extern demoloop_t demoloop;
 // Formerly 7 for Ultimate Doom & Final Doom, 6 otherwise.
 extern int        demoloop_count;
 
-// Parse the DEMOLOOP, returning NULL to "demoloop" should any errors occur.
-void D_ParseDemoLoop(void);
-// If "demoloop" is NULL, check for defaults using mission and mode.
-void D_GetDefaultDemoLoop(GameMission_t mission, GameMode_t mode);
 // Perform both "D_ParseDemoLoop" and "D_GetDefaultDemoLoop".
 void D_SetupDemoLoop(void);
 

--- a/src/d_demoloop.h
+++ b/src/d_demoloop.h
@@ -30,6 +30,7 @@ typedef enum
 } dl_type_t;
 
 // Immediate switch or screen melt, NONE is used for fault tolerance.
+// TODO: reimplement more cleanly at a later, more relevant moment
 typedef enum
 {
     WIPE_NONE = -1,

--- a/src/d_demoloop.h
+++ b/src/d_demoloop.h
@@ -1,0 +1,59 @@
+//
+//  Copyright (C) 2025 Guilherme Miranda
+//
+//  This program is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU General Public License
+//  as published by the Free Software Foundation; either version 2
+//  of the License, or (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  DESCRIPTION:
+//    ID24 DemoLoop
+
+#include "doomdef.h"
+
+// Screen graphic or DEMO lump, NONE is used for fault tolerance.
+typedef enum
+{
+    TYPE_NONE = -1,
+    TYPE_ART_SCREEN,
+    TYPE_DEMO_LUMP,
+} dl_type_t;
+
+// Immediate switch or screen melt, NONE is used for fault tolerance.
+typedef enum
+{
+    OUTRO_WIPE_NONE = -1,
+    OUTRO_WIPE_IMMEDIATE,
+    OUTRO_WIPE_SCREEM_MELT,
+} dl_outro_wipe_t;
+
+// Individual demoloop units.
+typedef struct
+{
+    const char*     primary_lump;   // Screen graphic or DEMO lump.
+    const char*     secondary_lump; // Music lump for screen graphic.
+    int             duration;       // Game tics.
+    dl_type_t       type;
+    dl_outro_wipe_t outro_wipe;
+} demoloop_entry_t;
+
+typedef demoloop_entry_t* demoloop_t;
+
+// Actual DemoLoop data structure.
+extern demoloop_t demoloop;
+// Formerly 7 for Ultimate Doom & Final Doom, 6 otherwise.
+extern int        demoloop_count;
+// Formerly "demosequence".
+extern int        demoloop_current;
+
+// Parse the DEMOLOOP, returning NULL to "demoloop" should any errors occur.
+void D_ParseDemoLoop(void);
+// If "demoloop" is NULL, check for defaults using mission and mode.
+void D_GetDefaultDemoLoop(GameMission_t mission, GameMode_t mode);
+// Perform both "D_ParseDemoLoop" and "D_GetDefaultDemoLoop".
+void D_SetupDemoLoop(void);

--- a/src/d_demoloop.h
+++ b/src/d_demoloop.h
@@ -12,34 +12,41 @@
 //  GNU General Public License for more details.
 //
 //  DESCRIPTION:
-//    ID24 DemoLoop
+//    ID24 DemoLoop Specification - User customizable title screen sequence.
+//    Though originally hardcoded on the original Doom engine this allows
+//    for Doom modders to define custom sequences, using any provided custom
+//    graphic, music or DEMO lump.
+//
 
 #include "doomdef.h"
+
+#ifndef _D_DEMOLOOP_
+#define _D_DEMOLOOP_
 
 // Screen graphic or DEMO lump, NONE is used for fault tolerance.
 typedef enum
 {
     TYPE_NONE = -1,
-    TYPE_ART_SCREEN,
-    TYPE_DEMO_LUMP,
+    TYPE_ART,
+    TYPE_DEMO,
 } dl_type_t;
 
 // Immediate switch or screen melt, NONE is used for fault tolerance.
 typedef enum
 {
-    OUTRO_WIPE_NONE = -1,
-    OUTRO_WIPE_IMMEDIATE,
-    OUTRO_WIPE_SCREEM_MELT,
-} dl_outro_wipe_t;
+    WIPE_NONE = -1,
+    WIPE_IMMEDIATE,
+    WIPE_MELT,
+} dl_wipe_t;
 
 // Individual demoloop units.
 typedef struct
 {
-    const char*     primary_lump;   // Screen graphic or DEMO lump.
-    const char*     secondary_lump; // Music lump for screen graphic.
-    int             duration;       // Game tics.
-    dl_type_t       type;
-    dl_outro_wipe_t outro_wipe;
+    const char *primary_lump;   // Screen graphic or DEMO lump.
+    const char *secondary_lump; // Music lump for screen graphic.
+    int         duration;       // Game tics.
+    dl_type_t   type;
+    dl_wipe_t   outro_wipe;
 } demoloop_entry_t;
 
 typedef demoloop_entry_t* demoloop_t;
@@ -57,3 +64,5 @@ void D_ParseDemoLoop(void);
 void D_GetDefaultDemoLoop(GameMission_t mission, GameMode_t mode);
 // Perform both "D_ParseDemoLoop" and "D_GetDefaultDemoLoop".
 void D_SetupDemoLoop(void);
+
+#endif // _D_DEMOLOOP_

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -251,16 +251,7 @@ void D_ProcessEvents (void)
 
 // wipegamestate can be set to -1 to force a wipe on the next draw
 gamestate_t    wipegamestate = GS_DEMOSCREEN;
-static int     screen_melt = wipe_Melt, old_screen_melt = -1;
-
-void D_RestoreScreenMelt()
-{
-    if (old_screen_melt >= 0)
-    {
-      screen_melt = old_screen_melt;
-      old_screen_melt = -1;
-    }
-}
+static int     screen_melt = wipe_Melt;
 
 void D_Display (void)
 {
@@ -539,20 +530,6 @@ void D_DoAdvanceDemo(void)
                      "D_DoAdvanceDemo: Invalid demoloop[%d] entry, skipping",
                      demosequence);
             break;
-    }
-
-    if (old_screen_melt < 0)
-    {
-      old_screen_melt = screen_melt;
-    }
-
-    if (demoloop_point->outro_wipe == WIPE_IMMEDIATE)
-    {
-        screen_melt = wipe_None;
-    }
-    else if (demoloop_point->outro_wipe == WIPE_MELT)
-    {
-        screen_melt = wipe_Melt;
     }
 }
 

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -251,7 +251,16 @@ void D_ProcessEvents (void)
 
 // wipegamestate can be set to -1 to force a wipe on the next draw
 gamestate_t    wipegamestate = GS_DEMOSCREEN;
-static int     screen_melt = wipe_Melt;
+static int     screen_melt = wipe_Melt, old_screen_melt = -1;
+
+void D_RestoreScreenMelt()
+{
+    if (old_screen_melt >= 0)
+    {
+      screen_melt = old_screen_melt;
+      old_screen_melt = -1;
+    }
+}
 
 void D_Display (void)
 {
@@ -530,6 +539,20 @@ void D_DoAdvanceDemo(void)
                      "D_DoAdvanceDemo: Invalid demoloop[%d] entry, skipping",
                      demosequence);
             break;
+    }
+
+    if (old_screen_melt < 0)
+    {
+      old_screen_melt = screen_melt;
+    }
+
+    if (demoloop_point->outro_wipe == WIPE_IMMEDIATE)
+    {
+        screen_melt = wipe_None;
+    }
+    else if (demoloop_point->outro_wipe == WIPE_MELT)
+    {
+        screen_melt = wipe_Melt;
     }
 }
 

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -436,7 +436,7 @@ void D_Display (void)
 static int demosequence;         // killough 5/2/98: made static
 static int pagetic;
 static const char *pagename;
-static demoloop_entry_t demoloop_point;
+static demoloop_t demoloop_point;
 
 //
 // D_PageTicker
@@ -477,7 +477,7 @@ void D_AdvanceDemo(void)
 void D_AdvanceDemoLoop(void)
 {
   demosequence = (demosequence + 1) % demoloop_count;
-  demoloop_point = demoloop[demosequence];
+  demoloop_point = &demoloop[demosequence];
 }
 
 void D_DoAdvanceDemo(void)
@@ -489,23 +489,23 @@ void D_DoAdvanceDemo(void)
     gameaction = ga_nothing;
 
     D_AdvanceDemoLoop();
-    switch (demoloop_point.type)
+    switch (demoloop_point->type)
     {
         case TYPE_ART:
             gamestate = GS_DEMOSCREEN;
 
             // Needed to support the Doom 3: BFG Edition variant
-            if (W_CheckNumForName(demoloop_point.primary_lump) < 0
-                && !strcasecmp(demoloop_point.primary_lump, "TITLEPIC"))
+            if (W_CheckNumForName(demoloop_point->primary_lump) < 0
+                && !strcasecmp(demoloop_point->primary_lump, "TITLEPIC"))
             {
-                M_CopyLumpName(demoloop_point.primary_lump, "DMENUPIC");
+                M_CopyLumpName(demoloop_point->primary_lump, "DMENUPIC");
             }
 
-            if (W_CheckNumForName(demoloop_point.primary_lump) >= 0)
+            if (W_CheckNumForName(demoloop_point->primary_lump) >= 0)
             {
-                pagename = demoloop_point.primary_lump;
-                pagetic = demoloop_point.duration;
-                int music = W_CheckNumForName(demoloop_point.secondary_lump);
+                pagename = demoloop_point->primary_lump;
+                pagetic = demoloop_point->duration;
+                int music = W_CheckNumForName(demoloop_point->secondary_lump);
                 if (music >= 0)
                 {
                     S_ChangeMusInfoMusic(music, false);
@@ -517,10 +517,10 @@ void D_DoAdvanceDemo(void)
         case TYPE_DEMO:
             gamestate = GS_DEMOSCREEN;
 
-            if (W_CheckNumForName(demoloop_point.primary_lump) >= 0)
+            if (W_CheckNumForName(demoloop_point->primary_lump) >= 0)
             {
-              G_DeferedPlayDemo(demoloop_point.primary_lump);
-              break;
+                G_DeferedPlayDemo(demoloop_point->primary_lump);
+                break;
             }
             // fallthrough
 

--- a/src/d_main.h
+++ b/src/d_main.h
@@ -62,6 +62,8 @@ void D_StartTitle(void);
 
 extern boolean advancedemo;
 
+void D_RestoreScreenMelt(void);
+
 #endif
 
 //----------------------------------------------------------------------------

--- a/src/d_main.h
+++ b/src/d_main.h
@@ -62,8 +62,6 @@ void D_StartTitle(void);
 
 extern boolean advancedemo;
 
-void D_RestoreScreenMelt(void);
-
 #endif
 
 //----------------------------------------------------------------------------

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -2835,6 +2835,9 @@ void G_Ticker(void)
       G_DoReborn (i);
   P_MapEnd();
 
+  if (gameaction != ga_nothing && gameaction != ga_playdemo)
+    D_RestoreScreenMelt();
+
   // do things to change the game state
   while (gameaction != ga_nothing)
     switch (gameaction)

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -102,7 +102,7 @@
 static size_t   savegamesize = SAVEGAMESIZE; // killough
 static char     *demoname = NULL;
 // [crispy] the name originally chosen for the demo, i.e. without "-00000"
-static char     *orig_demoname = NULL;
+static const char *orig_demoname = NULL;
 static boolean  netdemo;
 static byte     *demobuffer;   // made some static -- killough
 static size_t   maxdemosize;
@@ -1432,7 +1432,7 @@ static void CheckPlayersInNetGame(void)
 
 int playback_tic = 0, playback_totaltics = 0;
 
-static char *defdemoname;
+static const char *defdemoname;
 
 #define DEMOMARKER    0x80
 
@@ -3965,7 +3965,7 @@ void G_InitNew(skill_t skill, int episode, int map)
 // G_RecordDemo
 //
 
-void G_RecordDemo(char *name)
+void G_RecordDemo(const char *name)
 {
   int i;
   size_t demoname_size;
@@ -4417,7 +4417,7 @@ void G_BeginRecording(void)
 
 void D_CheckNetPlaybackSkip(void);
 
-void G_DeferedPlayDemo(char* name)
+void G_DeferedPlayDemo(const char* name)
 {
   defdemoname = name;
   gameaction = ga_playdemo;

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -2835,9 +2835,6 @@ void G_Ticker(void)
       G_DoReborn (i);
   P_MapEnd();
 
-  if (gameaction != ga_nothing && gameaction != ga_playdemo)
-    D_RestoreScreenMelt();
-
   // do things to change the game state
   while (gameaction != ga_nothing)
     switch (gameaction)

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -45,7 +45,7 @@ boolean G_CheckDemoStatus(void);
 void G_DeathMatchSpawnPlayer(int playernum);
 void G_InitNew(skill_t skill, int episode, int map);
 void G_DeferedInitNew(skill_t skill, int episode, int map);
-void G_DeferedPlayDemo(char *demo);
+void G_DeferedPlayDemo(const char *demo);
 void G_LoadAutoSave(char *name, boolean is_command);
 void G_LoadGame(char *name, int slot, boolean is_command); // killough 5/15/98
 void G_ForcedLoadAutoSave(void);
@@ -54,7 +54,7 @@ void G_SaveAutoSave(char *description);
 void G_SaveGame(int slot, char *description); // Called by M_Responder.
 boolean G_AutoSaveEnabled(void);
 boolean G_LoadAutoSaveDeathUse(void);
-void G_RecordDemo(char *name);              // Only called by startup code.
+void G_RecordDemo(const char *name);              // Only called by startup code.
 void G_BeginRecording(void);
 void G_PlayDemo(char *name);
 void G_ExitLevel(void);


### PR DESCRIPTION
Use and customize the `DEMOLOOP` lump in the following WAD file for local testing: [test.zip](https://github.com/user-attachments/files/18409736/test.zip)

I may have been a bit overzealous with the comment-based documentation, in the anticipation someone may fork these cahnges for their own port.

This entire thing was done by reading the ID24 spec itself, and studying the reference implementation in [RnR Doom](https://github.com/GooberMan/rum-and-raisin-doom/blob/master/src/d_demoloop.cpp).

Some older `char *` types had to be changed to `const char *` due to the JSON parsing code only returning in `const`.

Putting this up for general code review and nitpicking but currently it is only missing:
* Slightly better fault tolerance for incorrectly defined `type`, triggering a reading of the `primarylump` field to [determine if it is a DEMO or a graphic lump](https://github.com/elf-alchemist/woof/blob/id24_demoloop/src/d_demoloop.c#L171-L177).
* Figuring out the `outrowipe` behavior, I haven't quite yet understood how to do it, or rather where to put it up to trigger such a immediate switch or a screen melt.

![image](https://github.com/user-attachments/assets/c990e3ea-b3b2-49f0-9b0d-b5f43b77e9a9)
