### PR TITLE
fix linearsky calculation for large sky texture width

### DIFF
--- a/src/r_main.c
+++ b/src/r_main.c
@@ -367,7 +367,7 @@ static void R_InitTextureMapping(void)
       xtoviewangle[x] = (i<<ANGLETOFINESHIFT)-ANG90;
       // [FG] linear horizontal sky scrolling
       int angle = (0.5 - x / (double)viewwidth) * linearskyfactor;
-      linearskyangle[x] = angle >= 0 ? angle : ANGLE_MAX + angle;
+      linearskyangle[x] = (angle >= 0) ? angle : ANGLE_MAX + angle;
     }
     
   // Take out the fencepost cases from viewangletox.

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -367,10 +367,7 @@ static void R_InitTextureMapping(void)
       xtoviewangle[x] = (i<<ANGLETOFINESHIFT)-ANG90;
       // [FG] linear horizontal sky scrolling
       int angle = (0.5 - x / (double)viewwidth) * linearskyfactor;
-      if (angle >= 0)
-        linearskyangle[x] = angle;
-      else
-        linearskyangle[x] = ANG90 + angle;
+      linearskyangle[x] = angle >= 0 ? angle : ANGLE_MAX + angle;
     }
     
   // Take out the fencepost cases from viewangletox.


### PR DESCRIPTION
Bug report: [[doomworld]](https://www.doomworld.com/forum/topic/112333-this-is-woof-1510-jan-17-2025/?do=findComment&comment=2892557)