### PR TITLE
rename "FPS Limit" to "Target FPS"

### DIFF
--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -2419,7 +2419,7 @@ static setup_menu_t gen_settings1[] = {
     {"Uncapped FPS", S_ONOFF, CNTR_X, M_SPC, {"uncapped"},
      .action = UpdateFPSLimit},
 
-    {"FPS Limit", S_NUM, CNTR_X, M_SPC, {"fpslimit"},
+    {"Target FPS", S_NUM, CNTR_X, M_SPC, {"fpslimit"},
      .action = UpdateFPSLimit},
 
     {"VSync", S_ONOFF, CNTR_X, M_SPC, {"use_vsync"},


### PR DESCRIPTION
The term "limit" sounds like an upper bound only. However, this value is also used by DRS to decide to decrease screen resolution if it cannot be kept. Thus, I find "target" to fit better.