### PR TITLE
fix switching weapons while zooming automap

### DIFF
--- a/src/am_map.c
+++ b/src/am_map.c
@@ -959,10 +959,12 @@ boolean AM_Responder
     else if (M_InputDeactivated(input_map_zoomout))
     {
       buttons_state[ZOOM_OUT] = 0;
+      rc = true;
     }
     else if (M_InputDeactivated(input_map_zoomin))
     {
       buttons_state[ZOOM_IN] = 0;
+      rc = true;
     }
   }
 


### PR DESCRIPTION
Mouse wheel events were not swallowed by AM_Responder and because of that WS_Responder was called each time mouse wheel was scrolled in automap mode. This made the player switch between berserk/chainsaw and shotgun/ssg on `-complevel vanilla` while zooming the map at the same time.