### PR TITLE
Improve looping for older midi hardware devices

### DIFF
--- a/src/i_midimusic.c
+++ b/src/i_midimusic.c
@@ -358,19 +358,6 @@ static void SendNotesSoundOff(void)
     }
 }
 
-// Writes "reset all controllers" message for each channel. Despite the name,
-// this only resets some controllers (see MIDI Recommended Practice RP-015).
-
-static void ResetControllers(void)
-{
-    int i;
-
-    for (i = 0; i < MIDI_CHANNELS_PER_TRACK; i++)
-    {
-        SendControlChange(i, MIDI_CONTROLLER_RESET_ALL_CTRLS, 0);
-    }
-}
-
 // Resets commonly used controllers. This is only for a reset type of "No SysEx"
 // for devices that don't support SysEx resets.
 

--- a/src/i_midimusic.c
+++ b/src/i_midimusic.c
@@ -214,7 +214,6 @@ static void SendControlChange(byte channel, byte number, byte value)
 {
     const byte message[] = {MIDI_EVENT_CONTROLLER | channel, number, value};
     MIDI_SendShortMsg(message, sizeof(message));
-    channel_used[channel] = true;
 }
 
 // Writes a MIDI program change message. If applicable, emulates capital tone
@@ -258,6 +257,7 @@ static void SendBankSelectMSB(byte channel, byte value)
     }
 
     SendControlChange(channel, MIDI_CONTROLLER_BANK_SELECT_MSB, value);
+    channel_used[channel] = true;
 }
 
 static void SendBankSelectLSB(byte channel, byte value)
@@ -281,6 +281,7 @@ static void SendBankSelectLSB(byte channel, byte value)
     }
 
     SendControlChange(channel, MIDI_CONTROLLER_BANK_SELECT_LSB, value);
+    channel_used[channel] = true;
 }
 
 // Writes an RPN message set to NULL (0x7F). Prevents accidental data entry.
@@ -290,6 +291,7 @@ static void SendNullRPN(const midi_event_t *event)
     const byte channel = event->data.channel.channel;
     SendControlChange(channel, MIDI_CONTROLLER_RPN_LSB, MIDI_RPN_NULL);
     SendControlChange(channel, MIDI_CONTROLLER_RPN_MSB, MIDI_RPN_NULL);
+    channel_used[channel] = true;
 }
 
 static void UpdateTempo(const midi_event_t *event)
@@ -317,6 +319,7 @@ static void SendVolumeMsg(const midi_event_t *event)
 {
     SendManualVolumeMsg(event->data.channel.channel,
                         event->data.channel.param2);
+    channel_used[event->data.channel.channel] = true;
 }
 
 // Sets each channel to its saved volume level, scaled by the volume slider.
@@ -514,6 +517,7 @@ static void SendSysExMsg(const midi_event_t *event)
         case MIDI_SYSEX_PART_LEVEL:
             // Replace SysEx part level message with channel volume message.
             SendManualVolumeMsg(event->data.sysex.channel, data[8]);
+            channel_used[event->data.sysex.channel] = true;
             break;
     }
 }


### PR DESCRIPTION
This was reported on the speedrunner Discord. Apparently there's stuttering with vanilla songs (E2M1) when using Nuked SC-55 (I couldn't reproduce it). However, I verified there was stuttering with a real SC-55. Test wad: [shortloop.zip](https://github.com/user-attachments/files/18654844/shortloop.zip)

When a midi song finishes playing, the DMX system in vanilla Doom sends "reset controllers" and "default volume" events, but just for the channels that are used by the current song. Then it loops from the beginning. Woof and DSDA-Doom (and maybe others) send the same events but to every channel. It seems these extra events are enough to overload older midi hardware. It's more noticeable with songs that place too many events together at the very start of a song (E2M1). The fix is to just mimic what vanilla Doom does.