### PR TITLE
Disable SysEx for FluidSynth

### DIFF
--- a/src/i_flmusic.c
+++ b/src/i_flmusic.c
@@ -249,7 +249,7 @@ static boolean I_FL_InitStream(int device)
     fluid_settings_setint(settings, "synth.polyphony", fl_polyphony);
     fluid_settings_setnum(settings, "synth.gain", 0.2);
     fluid_settings_setnum(settings, "synth.sample-rate", SND_SAMPLERATE);
-    fluid_settings_setint(settings, "synth.device-id", 16);
+    fluid_settings_setint(settings, "synth.device-id", 0); // Disable SysEx.
     fluid_settings_setstr(settings, "synth.midi-bank-select", "gs");
     fluid_settings_setint(settings, "synth.reverb.active", fl_reverb);
     fluid_settings_setint(settings, "synth.chorus.active", fl_chorus);


### PR DESCRIPTION
There are broken songs like DBP37_AUGZEN.wad MAP22 that don't work correctly when SysEx is enabled. 

This commit may be the reason some other apps are having issues too (e.g. Slade):
https://github.com/FluidSynth/fluidsynth/commit/e27738b377b6b83d932779a32c16019d9ccfb6d2