### PR TITLE
Add NyanDoom widescreen patch support

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -460,7 +460,8 @@ void D_PageTicker(void)
 
 void D_PageDrawer(void)
 {
-  V_DrawPatchFullScreen(V_CachePatchName(M_ApplyWidePatch(pagename), PU_CACHE));
+  V_DrawPatchFullScreen(
+    V_CachePatchName(W_CheckWidescreenPatch(pagename), PU_CACHE));
 }
 
 //

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -460,7 +460,7 @@ void D_PageTicker(void)
 
 void D_PageDrawer(void)
 {
-  V_DrawPatchFullScreen(V_CachePatchName(pagename, PU_CACHE));
+  V_DrawPatchFullScreen(V_CachePatchName(M_ApplyWidePatch(pagename), PU_CACHE));
 }
 
 //

--- a/src/f_finale.c
+++ b/src/f_finale.c
@@ -227,7 +227,8 @@ static boolean MapInfo_Drawer(void)
             else if (gamemapinfo->endpic[0])
             {
                 V_DrawPatchFullScreen(
-                    V_CachePatchName(gamemapinfo->endpic, PU_CACHE));
+                    V_CachePatchName(
+                        M_ApplyWidePatch(gamemapinfo->endpic), PU_CACHE));
             }
             break;
         case FINALE_STAGE_CAST:
@@ -768,7 +769,9 @@ static void F_CastDrawer(void)
   patch_t*            patch;
     
   // erase the entire screen to a background
-  V_DrawPatchFullScreen (V_CachePatchName (bgcastcall, PU_CACHE)); // Ty 03/30/98 bg texture extern
+  // Ty 03/30/98 bg texture extern
+  V_DrawPatchFullScreen(
+    V_CachePatchName(M_ApplyWidePatch(bgcastcall), PU_CACHE));
 
   F_CastPrint (castorder[castnum].name);
     
@@ -797,8 +800,8 @@ static void F_BunnyScroll(void)
   int         stage;
   static int  laststage;
 
-  p1 = V_CachePatchName ("PFUB1", PU_LEVEL);
-  p2 = V_CachePatchName ("PFUB2", PU_LEVEL);
+  p1 = V_CachePatchName(M_ApplyWidePatch("PFUB1"), PU_LEVEL);
+  p2 = V_CachePatchName(M_ApplyWidePatch("PFUB2"), PU_LEVEL);
 
   scrolled = 320 - (finalecount-230)/2;
 
@@ -883,18 +886,22 @@ void F_Drawer (void)
     {
       case 1:
            if ( gamemode == retail || gamemode == commercial )
-             V_DrawPatchFullScreen (V_CachePatchName("CREDIT",PU_CACHE));
+             V_DrawPatchFullScreen(
+            V_CachePatchName(M_ApplyWidePatch("CREDIT"),PU_CACHE));
            else
-             V_DrawPatchFullScreen (V_CachePatchName("HELP2",PU_CACHE));
+             V_DrawPatchFullScreen(
+            V_CachePatchName(M_ApplyWidePatch("HELP2"),PU_CACHE));
            break;
       case 2:
-           V_DrawPatchFullScreen (V_CachePatchName("VICTORY2",PU_CACHE));
+           V_DrawPatchFullScreen(
+            V_CachePatchName(M_ApplyWidePatch("VICTORY2"),PU_CACHE));
            break;
       case 3:
-           F_BunnyScroll ();
+           F_BunnyScroll();
            break;
       case 4:
-           V_DrawPatchFullScreen (V_CachePatchName("ENDPIC",PU_CACHE));
+           V_DrawPatchFullScreen(
+            V_CachePatchName(M_ApplyWidePatch("ENDPIC"),PU_CACHE));
            break;
     }
   }

--- a/src/f_finale.c
+++ b/src/f_finale.c
@@ -228,7 +228,7 @@ static boolean MapInfo_Drawer(void)
             {
                 V_DrawPatchFullScreen(
                     V_CachePatchName(
-                        M_ApplyWidePatch(gamemapinfo->endpic), PU_CACHE));
+                        W_CheckWidescreenPatch(gamemapinfo->endpic), PU_CACHE));
             }
             break;
         case FINALE_STAGE_CAST:
@@ -771,7 +771,7 @@ static void F_CastDrawer(void)
   // erase the entire screen to a background
   // Ty 03/30/98 bg texture extern
   V_DrawPatchFullScreen(
-    V_CachePatchName(M_ApplyWidePatch(bgcastcall), PU_CACHE));
+    V_CachePatchName(W_CheckWidescreenPatch(bgcastcall), PU_CACHE));
 
   F_CastPrint (castorder[castnum].name);
     
@@ -800,8 +800,8 @@ static void F_BunnyScroll(void)
   int         stage;
   static int  laststage;
 
-  p1 = V_CachePatchName(M_ApplyWidePatch("PFUB1"), PU_LEVEL);
-  p2 = V_CachePatchName(M_ApplyWidePatch("PFUB2"), PU_LEVEL);
+  p1 = V_CachePatchName(W_CheckWidescreenPatch("PFUB1"), PU_LEVEL);
+  p2 = V_CachePatchName(W_CheckWidescreenPatch("PFUB2"), PU_LEVEL);
 
   scrolled = 320 - (finalecount-230)/2;
 
@@ -887,21 +887,21 @@ void F_Drawer (void)
       case 1:
            if ( gamemode == retail || gamemode == commercial )
              V_DrawPatchFullScreen(
-            V_CachePatchName(M_ApplyWidePatch("CREDIT"),PU_CACHE));
+              V_CachePatchName(W_CheckWidescreenPatch("CREDIT"), PU_CACHE));
            else
              V_DrawPatchFullScreen(
-            V_CachePatchName(M_ApplyWidePatch("HELP2"),PU_CACHE));
+              V_CachePatchName(W_CheckWidescreenPatch("HELP2"), PU_CACHE));
            break;
       case 2:
            V_DrawPatchFullScreen(
-            V_CachePatchName(M_ApplyWidePatch("VICTORY2"),PU_CACHE));
+            V_CachePatchName(W_CheckWidescreenPatch("VICTORY2"), PU_CACHE));
            break;
       case 3:
            F_BunnyScroll();
            break;
       case 4:
            V_DrawPatchFullScreen(
-            V_CachePatchName(M_ApplyWidePatch("ENDPIC"),PU_CACHE));
+            V_CachePatchName(W_CheckWidescreenPatch("ENDPIC"), PU_CACHE));
            break;
     }
   }

--- a/src/mn_menu.c
+++ b/src/mn_menu.c
@@ -434,7 +434,8 @@ static void M_FinishHelp(int choice) // killough 10/98
 
 static void M_DrawReadThis1(void)
 {
-    V_DrawPatchFullScreen(V_CachePatchName("HELP2", PU_CACHE));
+    V_DrawPatchFullScreen(
+        V_CachePatchName(M_ApplyWidePatch("HELP2"), PU_CACHE));
 }
 
 //
@@ -447,12 +448,14 @@ static void M_DrawReadThis2(void)
     // We only ever draw the second page if this is
     // gameversion == exe_doom_1_9 and gamemode == registered
 
-    V_DrawPatchFullScreen(V_CachePatchName("HELP1", PU_CACHE));
+    V_DrawPatchFullScreen(
+        V_CachePatchName(M_ApplyWidePatch("HELP1"), PU_CACHE));
 }
 
 static void M_DrawReadThisCommercial(void)
 {
-    V_DrawPatchFullScreen(V_CachePatchName("HELP", PU_CACHE));
+    V_DrawPatchFullScreen(
+        V_CachePatchName(M_ApplyWidePatch("HELP"), PU_CACHE));
 }
 
 /////////////////////////////
@@ -1915,11 +1918,11 @@ static void M_DrawHelp(void)
     int helplump;
     if (gamemode == commercial)
     {
-        helplump = W_CheckNumForName("HELP");
+        helplump = W_CheckNumForName(M_ApplyWidePatch("HELP"));
     }
     else
     {
-        helplump = W_CheckNumForName("HELP1");
+        helplump = W_CheckNumForName(M_ApplyWidePatch("HELP1"));
     }
 
     V_DrawPatchFullScreen(V_CachePatchNum(helplump, PU_CACHE));

--- a/src/mn_menu.c
+++ b/src/mn_menu.c
@@ -435,7 +435,7 @@ static void M_FinishHelp(int choice) // killough 10/98
 static void M_DrawReadThis1(void)
 {
     V_DrawPatchFullScreen(
-        V_CachePatchName(M_ApplyWidePatch("HELP2"), PU_CACHE));
+        V_CachePatchName(W_CheckWidescreenPatch("HELP2"), PU_CACHE));
 }
 
 //
@@ -449,13 +449,13 @@ static void M_DrawReadThis2(void)
     // gameversion == exe_doom_1_9 and gamemode == registered
 
     V_DrawPatchFullScreen(
-        V_CachePatchName(M_ApplyWidePatch("HELP1"), PU_CACHE));
+        V_CachePatchName(W_CheckWidescreenPatch("HELP1"), PU_CACHE));
 }
 
 static void M_DrawReadThisCommercial(void)
 {
     V_DrawPatchFullScreen(
-        V_CachePatchName(M_ApplyWidePatch("HELP"), PU_CACHE));
+        V_CachePatchName(W_CheckWidescreenPatch("HELP"), PU_CACHE));
 }
 
 /////////////////////////////
@@ -1918,11 +1918,11 @@ static void M_DrawHelp(void)
     int helplump;
     if (gamemode == commercial)
     {
-        helplump = W_CheckNumForName(M_ApplyWidePatch("HELP"));
+        helplump = W_CheckNumForName(W_CheckWidescreenPatch("HELP"));
     }
     else
     {
-        helplump = W_CheckNumForName(M_ApplyWidePatch("HELP1"));
+        helplump = W_CheckNumForName(W_CheckWidescreenPatch("HELP1"));
     }
 
     V_DrawPatchFullScreen(V_CachePatchNum(helplump, PU_CACHE));

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -1460,7 +1460,7 @@ static void DrawSolidBackground(void)
     // [FG] calculate average color of the 16px left and right of the status bar
     const int vstep[][2] = { {0, 1}, {1, 2}, {2, ST_HEIGHT} };
 
-    patch_t *sbar = V_CachePatchName("STBAR", PU_CACHE);
+    patch_t *sbar = V_CachePatchName(M_ApplyWidePatch("STBAR"), PU_CACHE);
     // [FG] temporarily draw status bar to background buffer
     V_DrawPatch(-video.deltaw, 0, sbar);
 

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -1460,7 +1460,7 @@ static void DrawSolidBackground(void)
     // [FG] calculate average color of the 16px left and right of the status bar
     const int vstep[][2] = { {0, 1}, {1, 2}, {2, ST_HEIGHT} };
 
-    patch_t *sbar = V_CachePatchName(M_ApplyWidePatch("STBAR"), PU_CACHE);
+    patch_t *sbar = V_CachePatchName(W_CheckWidescreenPatch("STBAR"), PU_CACHE);
     // [FG] temporarily draw status bar to background buffer
     V_DrawPatch(-video.deltaw, 0, sbar);
 

--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -385,6 +385,39 @@ int W_GetNumForName (const char* name)     // killough -- const added
   return i;
 }
 
+// [Nyan] Widescreen patches
+const char *M_ApplyWidePatch(const char *lump_main)
+{
+  char *buffer;
+  char lump_short[7];
+  size_t main_size, prefix_size;
+
+  memcpy(lump_short, lump_main, strnlen(lump_main,7));
+
+  if (strlen(lump_main) > 6)
+  {
+    lump_short[6] = 0;
+  }
+  else
+  {
+    lump_short[strlen(lump_main)] = 0;
+  }
+
+  main_size = strlen(lump_short);
+  prefix_size = strlen("W_");
+
+  buffer = Z_Malloc(prefix_size + main_size + 1, PU_STATIC, NULL);
+  memcpy(buffer, "W_", prefix_size);
+  memcpy(buffer + prefix_size, lump_short, main_size + 1);
+
+  if (W_CheckNumForName(buffer) >= 0)
+  {
+    return buffer;
+  }
+
+  return lump_main;
+}
+
 //
 // W_InitMultipleFiles
 // Pass a null terminated list of files to use.

--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -388,7 +388,7 @@ int W_GetNumForName (const char* name)     // killough -- const added
 // [Nyan] Widescreen patches
 const char *M_ApplyWidePatch(const char *lump_main)
 {
-  char lump_wide[9] = "W_";
+  static char lump_wide[9] = "W_";
   char lump_short[7];
 
   memcpy(lump_short, lump_main, strnlen(lump_main, 7));
@@ -408,7 +408,7 @@ const char *M_ApplyWidePatch(const char *lump_main)
 
   if (W_CheckNumForName(lump_wide) >= 0)
   {
-    return M_StringDuplicate(lump_wide);
+    return lump_wide;
   }
 
   return lump_main;

--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -388,11 +388,10 @@ int W_GetNumForName (const char* name)     // killough -- const added
 // [Nyan] Widescreen patches
 const char *M_ApplyWidePatch(const char *lump_main)
 {
-  char *buffer;
+  char lump_wide[9] = "W_";
   char lump_short[7];
-  size_t main_size, prefix_size;
 
-  memcpy(lump_short, lump_main, strnlen(lump_main,7));
+  memcpy(lump_short, lump_main, strnlen(lump_main, 7));
 
   if (strlen(lump_main) > 6)
   {
@@ -403,16 +402,13 @@ const char *M_ApplyWidePatch(const char *lump_main)
     lump_short[strlen(lump_main)] = 0;
   }
 
-  main_size = strlen(lump_short);
-  prefix_size = strlen("W_");
+  size_t short_size = strlen(lump_short);
 
-  buffer = Z_Malloc(prefix_size + main_size + 1, PU_STATIC, NULL);
-  memcpy(buffer, "W_", prefix_size);
-  memcpy(buffer + prefix_size, lump_short, main_size + 1);
+  memcpy(&lump_wide[2], lump_short, short_size + 1);
 
-  if (W_CheckNumForName(buffer) >= 0)
+  if (W_CheckNumForName(lump_wide) >= 0)
   {
-    return buffer;
+    return M_StringDuplicate(lump_wide);
   }
 
   return lump_main;

--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -386,31 +386,15 @@ int W_GetNumForName (const char* name)     // killough -- const added
 }
 
 // [Nyan] Widescreen patches
-const char *M_ApplyWidePatch(const char *lump_main)
+const char *W_CheckWidescreenPatch(const char *lump_main)
 {
   static char lump_wide[9] = "W_";
-  char lump_short[7];
-
-  memcpy(lump_short, lump_main, strnlen(lump_main, 7));
-
-  if (strlen(lump_main) > 6)
-  {
-    lump_short[6] = 0;
-  }
-  else
-  {
-    lump_short[strlen(lump_main)] = 0;
-  }
-
-  size_t short_size = strlen(lump_short);
-
-  memcpy(&lump_wide[2], lump_short, short_size + 1);
+  strncpy(&lump_wide[2], lump_main, 6);
 
   if (W_CheckNumForName(lump_wide) >= 0)
   {
     return lump_wide;
   }
-
   return lump_main;
 }
 

--- a/src/w_wad.h
+++ b/src/w_wad.h
@@ -141,6 +141,8 @@ void    *W_CacheLumpNum(int lump, pu_tag tag);
 
 #define W_CacheLumpName(name,tag) W_CacheLumpNum (W_GetNumForName(name),(tag))
 
+const char *M_ApplyWidePatch(const char *lump);
+
 void W_ExtractFileBase(const char *, char *);       // killough
 unsigned W_LumpNameHash(const char *s);           // killough 1/31/98
 

--- a/src/w_wad.h
+++ b/src/w_wad.h
@@ -141,7 +141,7 @@ void    *W_CacheLumpNum(int lump, pu_tag tag);
 
 #define W_CacheLumpName(name,tag) W_CacheLumpNum (W_GetNumForName(name),(tag))
 
-const char *M_ApplyWidePatch(const char *lump);
+const char *W_CheckWidescreenPatch(const char *lump);
 
 void W_ExtractFileBase(const char *, char *);       // killough
 unsigned W_LumpNameHash(const char *s);           // killough 1/31/98

--- a/src/wi_stuff.c
+++ b/src/wi_stuff.c
@@ -719,7 +719,8 @@ void WI_slamBackground(void)
         name = lump;
     }
 
-    V_DrawPatchFullScreen(V_CachePatchName(M_ApplyWidePatch(name), PU_CACHE));
+    V_DrawPatchFullScreen(
+      V_CachePatchName(W_CheckWidescreenPatch(name), PU_CACHE));
 }
 
 // ====================================================================

--- a/src/wi_stuff.c
+++ b/src/wi_stuff.c
@@ -719,7 +719,7 @@ void WI_slamBackground(void)
         name = lump;
     }
 
-    V_DrawPatchFullScreen(V_CachePatchName(name, PU_CACHE));
+    V_DrawPatchFullScreen(V_CachePatchName(M_ApplyWidePatch(name), PU_CACHE));
 }
 
 // ====================================================================


### PR DESCRIPTION
Committing necromancy on Status: /issues/1919. As I've learned only today that [Nyan changed it's system to be dynamic](https://github.com/andrikpowell/nyan-doom/blob/master/docs/ws.md), following a consistent `W_*` naming scheme, truncating long lump names to 6 characters, e.g. `TITLEPIC` becomes `W_TITLEP`.

Tested with this [Freedoom](https://github.com/user-attachments/files/18726138/freedoom2.zip) build from freedoom/freedoom/pull/1474
