### PR TITLE
Add overlooked W_CheckWidescreenPatch calls

### DIFF
--- a/src/f_finale.c
+++ b/src/f_finale.c
@@ -463,7 +463,8 @@ static void F_TextWrite(void)
   if (gamemapinfo && W_CheckNumForName(finaleflat) != -1 &&
       (W_CheckNumForName)(finaleflat, ns_flats) == -1)
   {
-    V_DrawPatchFullScreen(V_CachePatchName(finaleflat, PU_LEVEL));
+    V_DrawPatchFullScreen(
+      V_CachePatchName(W_CheckWidescreenPatch(finaleflat), PU_LEVEL));
   }
   else if ((W_CheckNumForName)(finaleflat, ns_flats) != -1)
   {

--- a/src/wi_stuff.c
+++ b/src/wi_stuff.c
@@ -559,7 +559,8 @@ static boolean DrawAnimation(void)
     if (animation->background_lump)
     {
         V_DrawPatchFullScreen(
-            V_CachePatchName(animation->background_lump, PU_CACHE));
+            V_CachePatchName(
+              W_CheckWidescreenPatch(animation->background_lump), PU_CACHE));
     }
 
     wi_animationstate_t *state;


### PR DESCRIPTION
Now works with `interlevel`'s `backgroundimage` and `UMAPINFO`'s `interbackdrop`.

`interlevel` before:
![woof0004](https://github.com/user-attachments/assets/e38c6051-28ee-400c-a72c-88c1f415cbb6)

`UMAPINFO` before:
![woof0005](https://github.com/user-attachments/assets/3713a331-09f6-48b3-bf42-14fd0968730c)

`interlevel` after:
![woof0006](https://github.com/user-attachments/assets/bfbb7229-666a-41b3-a13b-1a461f59d686)

`UMAPINFO` after:
![woof0008](https://github.com/user-attachments/assets/3a5dbd93-283e-41c5-9c44-c7cbcfdc8d66)
