### PR TITLE
Fix resurrected pools of gore being blood-colored

### DIFF
--- a/src/p_enemy.c
+++ b/src/p_enemy.c
@@ -1766,7 +1766,10 @@ static boolean P_HealCorpse(mobj_t* actor, int radius, statenum_t healstate, sfx
 		      I_Printf(VB_WARNING, "A_VileChase: Resurrected ghost monster (%d) at (%d/%d)!",
 		              corpsehit->type, corpsehit->x>>FRACBITS, corpsehit->y>>FRACBITS);
 		  }
-		  
+
+		  corpsehit->flags2 &= ~MF2_COLOREDBLOOD;
+		  corpsehit->bloodcolor = 0;
+
                   corpsehit->health = info->spawnhealth;
 		  P_SetTarget(&corpsehit->target, NULL);  // killough 11/98
 


### PR DESCRIPTION
When a thing is crushed, it becomes a pool of gore, which is colored accordingly if the thing has a blood color set. Said coloring wasn't cleared upon revival, leading to this bug:
![imagen](https://github.com/user-attachments/assets/2bcaf062-cc81-450e-b10e-69101c6a1598)

This PR fixes that.