### PR TITLE
make menu entry for "palette_changes" less ambigious

### DIFF
--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -3316,7 +3316,7 @@ static setup_menu_t gen_settings6[] = {
     {"Screen wipe effect", S_CHOICE | S_STRICT, OFF_CNTR_X, M_SPC,
      {"screen_melt"}, .strings_id = str_screen_melt},
 
-    {"Screen flashes", S_ONOFF | S_STRICT, OFF_CNTR_X, M_SPC,
+    {"Pain/Pickup/Powerup flashes", S_ONOFF | S_STRICT, OFF_CNTR_X, M_SPC,
      {"palette_changes"}},
 
     {"Invulnerability effect", S_CHOICE | S_STRICT, OFF_CNTR_X, M_SPC,


### PR DESCRIPTION
PrBoom+/DSDA-Doom has this split into three switches:
* Change Palette On Pain
* Change Palette On Bonus
* Change Palette On Powers

Crispy Doom (Setup) has a single switch for this called "Palette Changes" but this merely reveals an implementation detail and is just as ambigious as "Screen flashes" otherwise.

I think our our old menu switch is still the best description.