### PR TITLE
[refactor] clearner, more maintainable complevel checks

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1572,7 +1572,7 @@ static void D_InitTables(void)
 
 void D_SetMaxHealth(void)
 {
-  if (demo_compatibility)
+  if (prior_boom)
   {
     maxhealth = 100;
     maxhealthbonus = deh_set_maxhealth ? deh_maxhealth : 200;

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1572,7 +1572,7 @@ static void D_InitTables(void)
 
 void D_SetMaxHealth(void)
 {
-  if (prior_boom)
+  if (at_most_vanilla)
   {
     maxhealth = 100;
     maxhealthbonus = deh_set_maxhealth ? deh_maxhealth : 200;

--- a/src/d_net.c
+++ b/src/d_net.c
@@ -121,7 +121,7 @@ static void LoadGameSettings(net_gamesettings_t *settings)
         compatibility = true;
     }
 
-    if (min_mbf21)
+    if (at_least_mbf21)
     {
         G_ReadOptionsMBF21(settings->options);
     }
@@ -168,7 +168,7 @@ static void SaveGameSettings(net_gamesettings_t *settings)
     // Record a high resolution "Doom 1.91" demo.
     //
 
-    longtics = (prior_boom && M_ParmExists("-longtics")) || min_mbf21;
+    longtics = (at_most_vanilla && M_ParmExists("-longtics")) || at_least_mbf21;
 
     settings->lowres_turn = ((M_ParmExists("-record") && !longtics) ||
 
@@ -223,7 +223,7 @@ static void InitConnectData(net_connect_data_t *connect_data)
     connect_data->gamemode = gamemode;
     connect_data->gamemission = gamemission;
 
-    longtics = (prior_boom && M_ParmExists("-longtics")) || min_mbf21;
+    longtics = (at_most_vanilla && M_ParmExists("-longtics")) || at_least_mbf21;
 
     // Are we recording a demo? Possibly set lowres turn mode
 

--- a/src/d_net.c
+++ b/src/d_net.c
@@ -121,7 +121,7 @@ static void LoadGameSettings(net_gamesettings_t *settings)
         compatibility = true;
     }
 
-    if (mbf21)
+    if (min_mbf21)
     {
         G_ReadOptionsMBF21(settings->options);
     }
@@ -168,7 +168,7 @@ static void SaveGameSettings(net_gamesettings_t *settings)
     // Record a high resolution "Doom 1.91" demo.
     //
 
-    longtics = (demo_compatibility && M_ParmExists("-longtics")) || mbf21;
+    longtics = (prior_boom && M_ParmExists("-longtics")) || min_mbf21;
 
     settings->lowres_turn = ((M_ParmExists("-record") && !longtics) ||
 
@@ -223,7 +223,7 @@ static void InitConnectData(net_connect_data_t *connect_data)
     connect_data->gamemode = gamemode;
     connect_data->gamemission = gamemission;
 
-    longtics = (demo_compatibility && M_ParmExists("-longtics")) || mbf21;
+    longtics = (prior_boom && M_ParmExists("-longtics")) || min_mbf21;
 
     // Are we recording a demo? Possibly set lowres turn mode
 

--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -102,6 +102,7 @@ typedef enum {
   DV_BOOM    = 202,
   DV_MBF     = 203,
   DV_MBF21   = 221,
+  DV_ID24    = 224, // [EA] (2025-03-20) COMPATIBILITY NOT YET STABLE
   DV_UM      = 255,
 } demo_version_t;
 
@@ -110,9 +111,19 @@ extern demo_version_t demo_version;           // killough 7/19/98: Version of de
 // Only true when playing back an old demo -- used only in "corner cases"
 // which break playback but are otherwise unnoticable or are just desirable:
 
-#define demo_compatibility (demo_version < DV_BOOM200) /* killough 11/98: macroized */
+// #define demo_compatibility (demo_version < DV_BOOM200) /* killough 11/98: macroized */
+// #define mbf21 (demo_version == DV_MBF21)
 
-#define mbf21 (demo_version == DV_MBF21)
+// [EA] Common complevel checks made more generic
+#define prior_boom  (demo_version < DV_BOOM200)
+#define prior_mbf   (demo_version < DV_MBF)
+#define prior_mbf21 (demo_version < DV_MBF21)
+#define prior_id24  (demo_version < DV_ID24)
+
+#define min_boom  (demo_version >= DV_BOOM200)
+#define min_mbf   (demo_version >= DV_MBF)
+#define min_mbf21 (demo_version >= DV_MBF21)
+#define min_id24  (demo_version >= DV_ID24)
 
 // killough 7/19/98: whether monsters should fight against each other
 extern boolean monster_infighting, default_monster_infighting;

--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -115,15 +115,15 @@ extern demo_version_t demo_version;           // killough 7/19/98: Version of de
 // #define mbf21 (demo_version == DV_MBF21)
 
 // [EA] Common complevel checks made more generic
-#define prior_boom  (demo_version < DV_BOOM200)
-#define prior_mbf   (demo_version < DV_MBF)
-#define prior_mbf21 (demo_version < DV_MBF21)
-#define prior_id24  (demo_version < DV_ID24)
+#define at_most_vanilla (demo_version < DV_BOOM200)
+#define at_most_boom    (demo_version < DV_MBF)
+#define at_most_mbf     (demo_version < DV_MBF21)
+#define at_most_mbf21   (demo_version < DV_ID24)
 
-#define min_boom  (demo_version >= DV_BOOM200)
-#define min_mbf   (demo_version >= DV_MBF)
-#define min_mbf21 (demo_version >= DV_MBF21)
-#define min_id24  (demo_version >= DV_ID24)
+#define at_least_boom  (demo_version >= DV_BOOM200)
+#define at_least_mbf   (demo_version >= DV_MBF)
+#define at_least_mbf21 (demo_version >= DV_MBF21)
+#define at_least_id24  (demo_version >= DV_ID24)
 
 // killough 7/19/98: whether monsters should fight against each other
 extern boolean monster_infighting, default_monster_infighting;

--- a/src/f_finale.c
+++ b/src/f_finale.c
@@ -159,7 +159,7 @@ static boolean MapInfo_Ticker()
             int textcount = 0;
             if (finaletext)
             {
-                float speed = demo_compatibility ? TEXTSPEED : Get_TextSpeed();
+                float speed = prior_boom ? TEXTSPEED : Get_TextSpeed();
                 textcount = strlen(finaletext) * speed
                             + (midstage ? NEWTEXTWAIT : TEXTWAIT);
             }
@@ -397,7 +397,7 @@ void F_Ticker(void)
   }
 
   int i;
-  if (!demo_compatibility)
+  if (min_boom)
     WI_checkForAccelerate();  // killough 3/28/98: check for acceleration
   else
     if (gamemode == commercial && finalecount > 50) // check for skipping
@@ -413,7 +413,7 @@ void F_Ticker(void)
 
   if (finalestage == FINALE_STAGE_TEXT)
     {
-      float speed = demo_compatibility ? TEXTSPEED : Get_TextSpeed();
+      float speed = prior_boom ? TEXTSPEED : Get_TextSpeed();
       if (finalecount > strlen(finaletext)*speed +  // phares
           (midstage ? NEWTEXTWAIT : TEXTWAIT) ||  // killough 2/28/98:
           (midstage && acceleratestage))       // changed to allow acceleration
@@ -427,7 +427,7 @@ void F_Ticker(void)
               S_StartMusic(mus_bunny);
           }
         else   // you must press a button to continue in Doom 2
-          if (!demo_compatibility && midstage)
+          if (min_boom && midstage)
             {
             next_level:
               if (gamemap == 30)

--- a/src/f_finale.c
+++ b/src/f_finale.c
@@ -159,7 +159,7 @@ static boolean MapInfo_Ticker()
             int textcount = 0;
             if (finaletext)
             {
-                float speed = prior_boom ? TEXTSPEED : Get_TextSpeed();
+                float speed = at_most_vanilla ? TEXTSPEED : Get_TextSpeed();
                 textcount = strlen(finaletext) * speed
                             + (midstage ? NEWTEXTWAIT : TEXTWAIT);
             }
@@ -397,7 +397,7 @@ void F_Ticker(void)
   }
 
   int i;
-  if (min_boom)
+  if (at_least_boom)
     WI_checkForAccelerate();  // killough 3/28/98: check for acceleration
   else
     if (gamemode == commercial && finalecount > 50) // check for skipping
@@ -413,7 +413,7 @@ void F_Ticker(void)
 
   if (finalestage == FINALE_STAGE_TEXT)
     {
-      float speed = prior_boom ? TEXTSPEED : Get_TextSpeed();
+      float speed = at_most_vanilla ? TEXTSPEED : Get_TextSpeed();
       if (finalecount > strlen(finaletext)*speed +  // phares
           (midstage ? NEWTEXTWAIT : TEXTWAIT) ||  // killough 2/28/98:
           (midstage && acceleratestage))       // changed to allow acceleration
@@ -427,7 +427,7 @@ void F_Ticker(void)
               S_StartMusic(mus_bunny);
           }
         else   // you must press a button to continue in Doom 2
-          if (min_boom && midstage)
+          if (at_least_boom && midstage)
             {
             next_level:
               if (gamemap == 30)

--- a/src/g_compatibility.c
+++ b/src/g_compatibility.c
@@ -199,7 +199,7 @@ void G_ApplyLevelCompatibility(int lump)
 
     if (restore_comp)
     {
-        if (prior_mbf21)
+        if (at_most_mbf)
         {
             demo_version = DV_MBF21;
             G_ReloadDefaults(true);
@@ -207,7 +207,7 @@ void G_ApplyLevelCompatibility(int lump)
         memcpy(comp, old_comp, sizeof(*comp));
         restore_comp = false;
     }
-    else if (demorecording || demoplayback || netgame || prior_mbf21)
+    else if (demorecording || demoplayback || netgame || at_most_mbf)
     {
         return;
     }
@@ -235,7 +235,7 @@ void G_ApplyLevelCompatibility(int lump)
                          G_GetCurrentComplevelName());
             }
 
-            if (prior_mbf21)
+            if (at_most_mbf)
             {
                 return;
             }

--- a/src/g_compatibility.c
+++ b/src/g_compatibility.c
@@ -199,7 +199,7 @@ void G_ApplyLevelCompatibility(int lump)
 
     if (restore_comp)
     {
-        if (demo_version != DV_MBF21)
+        if (prior_mbf21)
         {
             demo_version = DV_MBF21;
             G_ReloadDefaults(true);
@@ -207,7 +207,7 @@ void G_ApplyLevelCompatibility(int lump)
         memcpy(comp, old_comp, sizeof(*comp));
         restore_comp = false;
     }
-    else if (demorecording || demoplayback || netgame || !mbf21)
+    else if (demorecording || demoplayback || netgame || prior_mbf21)
     {
         return;
     }
@@ -235,7 +235,7 @@ void G_ApplyLevelCompatibility(int lump)
                          G_GetCurrentComplevelName());
             }
 
-            if (!mbf21)
+            if (prior_mbf21)
             {
                 return;
             }

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -233,7 +233,7 @@ static weapontype_t LastWeapon(void)
         return wp_nochange;
     }
 
-    if (prior_boom && weapon == wp_supershotgun)
+    if (at_most_vanilla && weapon == wp_supershotgun)
     {
         return wp_shotgun;
     }
@@ -250,7 +250,7 @@ static weapontype_t WeaponSSG(void)
         return wp_nochange;
     }
 
-    if (min_boom)
+    if (at_least_boom)
     {
         return wp_supershotgun;
     }
@@ -793,7 +793,7 @@ void G_BuildTiccmd(ticcmd_t* cmd)
   G_NextWeaponResendCmd();
   boolean nextweapon_cmd = false;
 
-  if ((min_boom && players[consoleplayer].attackdown &&
+  if ((at_least_boom && players[consoleplayer].attackdown &&
        !P_CheckAmmo(&players[consoleplayer]) &&
        ((boom_weapon_state_injection && !done_autoswitch) ||
        (cmd->buttons & BT_ATTACK && players[consoleplayer].pendingweapon == wp_nochange))) ||
@@ -813,7 +813,7 @@ void G_BuildTiccmd(ticcmd_t* cmd)
   }
   else if (G_NextWeaponDeactivate())
   {
-    newweapon = prior_boom
+    newweapon = at_most_vanilla
                     ? nextweapon_translate[players[consoleplayer].nextweapon]
                     : players[consoleplayer].nextweapon;
     nextweapon_cmd = true;
@@ -832,7 +832,7 @@ void G_BuildTiccmd(ticcmd_t* cmd)
         M_InputGameActive(input_weapon9) ? WeaponSSG() :
         wp_nochange;
 
-      if (min_boom && doom_weapon_toggles)
+      if (at_least_boom && doom_weapon_toggles)
         {
           AdjustWeaponSelection(&newweapon);
         }
@@ -954,7 +954,7 @@ static void G_DoLoadLevel(void)
 
   playback_levelstarttic = playback_tic;
 
-  if (min_boom && prior_mbf)   // killough 9/29/98
+  if (at_least_boom && at_most_boom)   // killough 9/29/98
     basetic = gametic;
 
   if (wipegamestate == GS_LEVEL)
@@ -1815,7 +1815,7 @@ static void G_DoCompleted(void)
   if (gamemode == commercial)
   {
     // MAP33 reads its par time from beyond the cpars[] array.
-    if (prior_boom && gamemap == 33)
+    if (at_most_vanilla && gamemap == 33)
     {
       int cpars32;
 
@@ -1830,7 +1830,7 @@ static void G_DoCompleted(void)
   else
   {
     // Doom Episode 4 doesn't have a par time, so this overflows into the cpars[] array.
-    if (prior_boom && gameepisode == 4 && gamemap >= 1 && gamemap <= 9)
+    if (at_most_vanilla && gameepisode == 4 && gamemap >= 1 && gamemap <= 9)
     {
       wminfo.partime = TICRATE*cpars[gamemap];
     }
@@ -2023,7 +2023,7 @@ static void G_DoPlayDemo(void)
   demo_version = demover;     // killough 7/19/98: use the version id stored in demo
 
   // [FG] PrBoom's own demo format starts with demo version 210
-  if (demover >= 210 && prior_mbf21)
+  if (demover >= 210 && at_most_mbf)
   {
     I_Printf(VB_WARNING, "Unknown demo format %d.", demover);
     InvalidDemo();
@@ -2092,7 +2092,7 @@ static void G_DoPlayDemo(void)
     {
       demo_p += 6;               // skip signature;
 
-      if (min_mbf21)
+      if (at_least_mbf21)
       {
         longtics = true;
         compatibility = 0;
@@ -2112,7 +2112,7 @@ static void G_DoPlayDemo(void)
 	option_p = demo_p;
 
       // killough 3/1/98: Read game options
-      if (min_mbf21)
+      if (at_least_mbf21)
         demo_p = G_ReadOptionsMBF21(demo_p);
       else
         demo_p = G_ReadOptions(demo_p);
@@ -2121,7 +2121,7 @@ static void G_DoPlayDemo(void)
         demo_p += 256-G_GameOptionSize();
     }
 
-  if (prior_boom)  // only 4 players can exist in old demos
+  if (at_most_vanilla)  // only 4 players can exist in old demos
     {
       for (i=0; i<4; i++)  // intentionally hard-coded 4 -- killough
         playeringame[i] = *demo_p++;
@@ -2154,7 +2154,7 @@ static void G_DoPlayDemo(void)
       
       if (option_p)
       {
-        if (min_mbf21)
+        if (at_least_mbf21)
           G_ReadOptionsMBF21(option_p);
         else
           G_ReadOptions(option_p);
@@ -2621,7 +2621,7 @@ static boolean DoLoadGame(boolean do_load_autosave)
   idmusnum = *(signed char *) save_p++;
 
   /* cph 2001/05/23 - Must read options before we set up the level */
-  if (min_mbf21)
+  if (at_least_mbf21)
     G_ReadOptionsMBF21(save_p);
   else
     G_ReadOptions(save_p);
@@ -2633,7 +2633,7 @@ static boolean DoLoadGame(boolean do_load_autosave)
   // killough 11/98: move down to here
   /* cph - MBF needs to reread the savegame options because G_InitNew
    * rereads the WAD options. The demo playback code does this too. */
-  if (min_mbf21)
+  if (at_least_mbf21)
     save_p = G_ReadOptionsMBF21(save_p);
   else
     save_p = G_ReadOptions(save_p);
@@ -3181,7 +3181,7 @@ static boolean G_CheckSpot(int playernum, mapthing_t *mthing)
     // 'an' will always be positive.
     an = (ANG45 >> ANGLETOFINESHIFT) * ((signed int) mthing->angle / 45);
 
-    if (prior_boom)
+    if (at_most_vanilla)
       switch (an)
       {
         case 4096:  // -4096:
@@ -3787,7 +3787,7 @@ void G_ReloadDefaults(boolean keep_demover)
   {
     if (demo_version == DV_MBF)
       G_MBFDefaults();
-    else if (min_mbf21)
+    else if (at_least_mbf21)
       G_MBF21Defaults();
   }
 
@@ -3797,7 +3797,7 @@ void G_ReloadDefaults(boolean keep_demover)
 
   R_InvulMode();
 
-  if (prior_mbf21)
+  if (at_most_mbf)
   {
     // Set new compatibility options
     G_MBFComp();
@@ -3812,13 +3812,13 @@ void G_ReloadDefaults(boolean keep_demover)
   if (beta_emulation && demo_version != DV_MBF)
     I_Error("G_ReloadDefaults: Beta emulation requires complevel MBF.");
 
-  if ((M_CheckParm("-dog") || M_CheckParm("-dogs")) && prior_mbf)
+  if ((M_CheckParm("-dog") || M_CheckParm("-dogs")) && at_most_boom)
     I_Error("G_ReloadDefaults: Helper dogs require complevel MBF or MBF21.");
 
-  if (M_CheckParm("-skill") && startskill == sk_none && min_boom)
+  if (M_CheckParm("-skill") && startskill == sk_none && at_least_boom)
     I_Error("G_ReloadDefaults: '-skill 0' requires complevel Vanilla.");
 
-  if (prior_mbf)
+  if (at_most_boom)
   {
     monster_infighting = 1;
     monster_backing = 0;
@@ -3842,7 +3842,7 @@ void G_ReloadDefaults(boolean keep_demover)
       G_BoomComp();
     }
   }
-  else if (min_mbf21)
+  else if (at_least_mbf21)
   {
     // These are not configurable
     variable_friction = 1;
@@ -3888,7 +3888,7 @@ void G_SetFastParms(int fast_pending)
     if ((fast = fast_pending))
     {
       for (i = 0; i < num_states; i++)
-        if (states[i].flags & STATEF_SKILL5FAST && (states[i].tics != 1 || prior_boom))
+        if (states[i].flags & STATEF_SKILL5FAST && (states[i].tics != 1 || at_most_vanilla))
           states[i].tics >>= 1;  // don't change 1->0 since it causes cycles
     }
     else
@@ -4043,7 +4043,7 @@ void G_RecordDemo(const char *name)
 // Lee Killough 3/1/98
 
 static int G_GameOptionSize(void) {
-  return min_mbf21 ? MBF21_GAME_OPTION_SIZE : GAME_OPTION_SIZE;
+  return at_least_mbf21 ? MBF21_GAME_OPTION_SIZE : GAME_OPTION_SIZE;
 }
 
 static byte* G_WriteOptionsMBF21(byte* demo_p)
@@ -4092,7 +4092,7 @@ byte *G_WriteOptions(byte *demo_p)
 {
   byte *target = demo_p + GAME_OPTION_SIZE;
 
-  if (min_mbf21)
+  if (at_least_mbf21)
   {
     return G_WriteOptionsMBF21(demo_p);
   }
@@ -4263,7 +4263,7 @@ byte *G_ReadOptions(byte *demo_p)
   rngseed += *demo_p++ & 0xff;
 
   // Options new to v2.03
-  if (min_mbf)
+  if (at_least_mbf)
     {
       monster_infighting = *demo_p++;   // killough 7/19/98
 
@@ -4335,7 +4335,7 @@ void G_BeginRecording(void)
 
   demo_p = demobuffer;
 
-  if (min_mbf)
+  if (at_least_mbf)
   {
   *demo_p++ = demo_version;
 
@@ -4347,7 +4347,7 @@ void G_BeginRecording(void)
   *demo_p++ = 0xe6;
   *demo_p++ = '\0';
 
-  if (prior_mbf21)
+  if (at_most_mbf)
   {
   // killough 2/22/98: save compatibility flag in new demos
   *demo_p++ = compatibility;       // killough 2/22/98
@@ -4496,7 +4496,7 @@ static size_t WriteCmdLineLump(MEMFILE *stream)
     }
   }
 
-  if (prior_boom)
+  if (at_most_vanilla)
   {
     if (gameversion == exe_doom_1_9)
       mem_fputs(" -complevel 2", stream);

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -96,6 +96,7 @@ typedef enum
   CL_BOOM,
   CL_MBF,
   CL_MBF21,
+  CL_ID24,
 } complevel_t;
 
 extern complevel_t force_complevel, default_complevel;

--- a/src/g_nextweapon.c
+++ b/src/g_nextweapon.c
@@ -75,7 +75,7 @@ boolean G_WeaponSelectable(weapontype_t weapon)
     // Can't select the fist if we have the chainsaw, unless
     // we also have the berserk pack.
 
-    if ((prior_boom || (min_boom && doom_weapon_cycle))
+    if ((at_most_vanilla || (at_least_boom && doom_weapon_cycle))
         && weapon == wp_fist
         && players[consoleplayer].weaponowned[wp_chainsaw]
         && !players[consoleplayer].powers[pw_strength])
@@ -88,7 +88,7 @@ boolean G_WeaponSelectable(weapontype_t weapon)
 
 weapontype_t G_AdjustSelection(weapontype_t weapon)
 {
-    if (min_boom && !doom_weapon_cycle)
+    if (at_least_boom && !doom_weapon_cycle)
     {
         return weapon;
     }

--- a/src/g_nextweapon.c
+++ b/src/g_nextweapon.c
@@ -75,7 +75,7 @@ boolean G_WeaponSelectable(weapontype_t weapon)
     // Can't select the fist if we have the chainsaw, unless
     // we also have the berserk pack.
 
-    if ((demo_compatibility || (!demo_compatibility && doom_weapon_cycle))
+    if ((prior_boom || (min_boom && doom_weapon_cycle))
         && weapon == wp_fist
         && players[consoleplayer].weaponowned[wp_chainsaw]
         && !players[consoleplayer].powers[pw_strength])
@@ -88,7 +88,7 @@ boolean G_WeaponSelectable(weapontype_t weapon)
 
 weapontype_t G_AdjustSelection(weapontype_t weapon)
 {
-    if (!demo_compatibility && !doom_weapon_cycle)
+    if (min_boom && !doom_weapon_cycle)
     {
         return weapon;
     }

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -466,7 +466,7 @@ boolean M_ParseOption(const char *p, boolean wad)
         dp->setup_menu = dp_preset->setup_menu;
     }
 
-    if (demo_version < DV_MBF && dp->setup_menu
+    if (prior_mbf && dp->setup_menu
         && !(dp->setup_menu->m_flags & S_COSMETIC))
     {
         return 1;

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -466,7 +466,7 @@ boolean M_ParseOption(const char *p, boolean wad)
         dp->setup_menu = dp_preset->setup_menu;
     }
 
-    if (prior_mbf && dp->setup_menu
+    if (at_most_boom && dp->setup_menu
         && !(dp->setup_menu->m_flags & S_COSMETIC))
     {
         return 1;

--- a/src/m_random.c
+++ b/src/m_random.c
@@ -94,7 +94,7 @@ int P_Random(pr_class_t pr_class)
 
   rng.seed[pr_class] = boom * 1664525ul + 221297ul + pr_class*2;
 
-  if (prior_boom)
+  if (at_most_vanilla)
     return rndtable[compat];
 
   boom >>= 20;

--- a/src/m_random.c
+++ b/src/m_random.c
@@ -94,7 +94,7 @@ int P_Random(pr_class_t pr_class)
 
   rng.seed[pr_class] = boom * 1664525ul + 221297ul + pr_class*2;
 
-  if (demo_compatibility)
+  if (prior_boom)
     return rndtable[compat];
 
   boom >>= 20;

--- a/src/p_doors.c
+++ b/src/p_doors.c
@@ -463,7 +463,7 @@ int EV_VerticalDoor(line_t *line, mobj_t *thing)
 
   // [FG] DR doors corrupt other actions
   // http://prboom.sourceforge.net/mbf-bugs.html
-  if (prior_boom)
+  if (at_most_vanilla)
   {
     if (!door) door = sec->floordata;
     if (!door) door = sec->lightingdata;
@@ -487,7 +487,7 @@ int EV_VerticalDoor(line_t *line, mobj_t *thing)
 
               // [FG] DR doors corrupt other actions
               // http://prboom.sourceforge.net/mbf-bugs.html
-              if (door->thinker.function.p1 == (actionf_p1)T_VerticalDoor || min_boom)
+              if (door->thinker.function.p1 == (actionf_p1)T_VerticalDoor || at_least_boom)
               {
               door->direction = -1; // start going down immediately
               }

--- a/src/p_doors.c
+++ b/src/p_doors.c
@@ -463,7 +463,7 @@ int EV_VerticalDoor(line_t *line, mobj_t *thing)
 
   // [FG] DR doors corrupt other actions
   // http://prboom.sourceforge.net/mbf-bugs.html
-  if (demo_compatibility)
+  if (prior_boom)
   {
     if (!door) door = sec->floordata;
     if (!door) door = sec->lightingdata;
@@ -487,7 +487,7 @@ int EV_VerticalDoor(line_t *line, mobj_t *thing)
 
               // [FG] DR doors corrupt other actions
               // http://prboom.sourceforge.net/mbf-bugs.html
-              if (door->thinker.function.p1 == (actionf_p1)T_VerticalDoor || !demo_compatibility)
+              if (door->thinker.function.p1 == (actionf_p1)T_VerticalDoor || min_boom)
               {
               door->direction = -1; // start going down immediately
               }

--- a/src/p_enemy.c
+++ b/src/p_enemy.c
@@ -455,14 +455,14 @@ static boolean P_Move(mobj_t *actor, int dropoff) // killough 9/12/98
       if (demo_version == DV_BOOM)
         return good && (compatibility || (P_Random(pr_trywalk)&3)); //jff 8/13/98
       else
-      return good && (prior_mbf || comp[comp_doorstuck] ||
+      return good && (at_most_boom || comp[comp_doorstuck] ||
 		      (P_Random(pr_opendoor) >= 230) ^ (good & 1));
     }
   else
     actor->flags &= ~MF_INFLOAT;
 
   // killough 11/98: fall more slowly, under gravity, if felldown==true
-  if (!(actor->flags & MF_FLOAT) && (!felldown || prior_mbf))
+  if (!(actor->flags & MF_FLOAT) && (!felldown || at_most_boom))
     actor->z = actor->floorz;
 
   return true;
@@ -688,7 +688,7 @@ static void P_NewChaseDir(mobj_t *actor)
 
   actor->strafecount = 0;
 
-  if (min_mbf)
+  if (at_least_mbf)
   {
     if (actor->floorz - actor->dropoffz > FRACUNIT*24 &&
 	actor->z <= actor->floorz && !(actor->flags & (MF_DROPOFF|MF_FLOAT)) &&
@@ -854,7 +854,7 @@ static boolean P_LookForPlayers(mobj_t *actor, boolean allaround)
 
   c = 0;
 
-  stopc = min_boom && prior_mbf && monsters_remember ?
+  stopc = at_least_boom && at_most_boom && monsters_remember ?
     MAXPLAYERS : 2;       // killough 9/9/98
 
   for (;; actor->lastlook = (actor->lastlook+1)&(MAXPLAYERS-1))
@@ -870,7 +870,7 @@ static boolean P_LookForPlayers(mobj_t *actor, boolean allaround)
         // There are no more desyncs on Donce's demos on horror.wad
 
         // Use last known enemy if no players sighted -- killough 2/15/98:
-        if (min_boom && prior_mbf && monsters_remember)
+        if (at_least_boom && at_most_boom && monsters_remember)
         {
           if (actor->lastenemy && actor->lastenemy->health > 0)
           {
@@ -898,7 +898,7 @@ static boolean P_LookForPlayers(mobj_t *actor, boolean allaround)
 
       // killough 9/9/98: give monsters a threshold towards getting players
       // (we don't want it to be too easy for a player with dogs :)
-      if (min_mbf && !comp[comp_pursuit])
+      if (at_least_mbf && !comp[comp_pursuit])
 	actor->threshold = 60;
 
       return true;
@@ -917,7 +917,7 @@ static boolean P_LookForMonsters(mobj_t *actor, boolean allaround)
 {
   thinker_t *cap, *th;
 
-  if (prior_boom)
+  if (at_most_vanilla)
     return false;
 
   if (actor->lastenemy && actor->lastenemy->health > 0 && monsters_remember &&
@@ -928,7 +928,7 @@ static boolean P_LookForMonsters(mobj_t *actor, boolean allaround)
       return true;
     }
 
-  if (prior_mbf)  // Old demos do not support monster-seeking bots
+  if (at_most_boom)  // Old demos do not support monster-seeking bots
     return false;
 
   // Search the threaded list corresponding to this object's potential targets
@@ -1214,7 +1214,7 @@ void A_Chase(mobj_t *actor)
 
   if (!actor->threshold)
   {
-    if (prior_mbf)
+    if (at_most_boom)
       {   // killough 9/9/98: for backward demo compatibility
 	if (netgame && !P_CheckSight(actor, actor->target) &&
 	    P_LookForPlayers(actor, true))
@@ -1773,7 +1773,7 @@ static boolean P_HealCorpse(mobj_t* actor, int radius, statenum_t healstate, sfx
                   corpsehit->health = info->spawnhealth;
 		  P_SetTarget(&corpsehit->target, NULL);  // killough 11/98
 
-		  if (min_mbf)
+		  if (at_least_mbf)
 		    {         // kilough 9/9/98
 		      P_SetTarget(&corpsehit->lastenemy, NULL);
 		      corpsehit->flags &= ~MF_JUSTHIT;
@@ -1867,7 +1867,7 @@ void A_VileTarget(mobj_t *actor)
 
   // killough 12/98: fix Vile fog coordinates
   fog = P_SpawnMobj(actor->target->x,
-                    prior_mbf ? actor->target->x : actor->target->y,
+                    at_most_boom ? actor->target->x : actor->target->y,
                     actor->target->z,MT_FIRE);
 
   P_SetTarget(&actor->tracer, fog);   // killough 11/98
@@ -2036,7 +2036,7 @@ void A_BetaSkullAttack(mobj_t *actor)
 {
   int damage;
 
-  if (prior_mbf)
+  if (at_most_boom)
     return;
 
   if (!actor->target || actor->target->type == MT_SKULL)
@@ -2053,7 +2053,7 @@ void A_BetaSkullAttack(mobj_t *actor)
 
 void A_Stop(mobj_t *actor)
 {
-  if (prior_mbf)
+  if (at_most_boom)
     return;
   actor->momx = actor->momy = actor->momz = 0;
 }
@@ -2219,7 +2219,7 @@ void A_Fall(mobj_t *actor)
 // killough 11/98: kill an object
 void A_Die(mobj_t *actor)
 {
-  if (prior_mbf)
+  if (at_most_boom)
     return;
   P_DamageMobj(actor, NULL, NULL, actor->health);
 }
@@ -2239,7 +2239,7 @@ void A_Explode(mobj_t *thingy)
 
 void A_Detonate(mobj_t *mo)
 {
-  if (prior_mbf)
+  if (at_most_boom)
     return;
   P_RadiusAttack(mo, mo->target, mo->info->damage, mo->info->damage);
 }
@@ -2257,7 +2257,7 @@ void A_Mushroom(mobj_t *actor)
   fixed_t misc1 = actor->state->misc1 ? actor->state->misc1 : FRACUNIT*4;
   fixed_t misc2 = actor->state->misc2 ? actor->state->misc2 : FRACUNIT/2;
 
-  if (prior_mbf)
+  if (at_most_boom)
     return;
   A_Explode(actor);               // make normal explosion
 
@@ -2365,7 +2365,7 @@ void A_BossDeath(mobj_t *mo)
   else
     {
       // [FG] game version specific differences
-      if (prior_boom && gameversion < exe_ultimate)
+      if (at_most_vanilla && gameversion < exe_ultimate)
       {
         if (gamemap != 8)
           return;
@@ -2770,7 +2770,7 @@ void A_KeenDie(mobj_t* mo)
 
 void A_Spawn(mobj_t *mo)
 {
-  if (prior_mbf)
+  if (at_most_boom)
     return;
   if (mo->state->misc1)
     {
@@ -2787,21 +2787,21 @@ void A_Spawn(mobj_t *mo)
 
 void A_Turn(mobj_t *mo)
 {
-  if (prior_mbf)
+  if (at_most_boom)
     return;
   mo->angle += (angle_t)(((uint64_t) mo->state->misc1 << 32) / 360);
 }
 
 void A_Face(mobj_t *mo)
 {
-  if (prior_mbf)
+  if (at_most_boom)
     return;
   mo->angle = (angle_t)(((uint64_t) mo->state->misc1 << 32) / 360);
 }
 
 void A_Scratch(mobj_t *mo)
 {
-  if (prior_mbf)
+  if (at_most_boom)
     return;
   mo->target && (A_FaceTarget(mo), P_CheckMeleeRange(mo)) ?
     mo->state->misc2 ? S_StartSound(mo, mo->state->misc2) : (void) 0,
@@ -2810,14 +2810,14 @@ void A_Scratch(mobj_t *mo)
 
 void A_PlaySound(mobj_t *mo)
 {
-  if (prior_mbf)
+  if (at_most_boom)
     return;
   S_StartSoundOrigin(mo, mo->state->misc2 ? NULL : mo, mo->state->misc1);
 }
 
 void A_RandomJump(mobj_t *mo)
 {
-  if (prior_mbf)
+  if (at_most_boom)
     return;
   if (P_Random(pr_randomjump) < mo->state->misc2)
     P_SetMobjState(mo, mo->state->misc1);
@@ -2829,7 +2829,7 @@ void A_RandomJump(mobj_t *mo)
 
 void A_LineEffect(mobj_t *mo)
 {
-  if (prior_mbf)
+  if (at_most_boom)
     return;
   if (!(mo->intflags & MIF_LINEDONE))                // Unless already used up
     {
@@ -2874,7 +2874,7 @@ void A_SpawnObject(mobj_t *actor)
   int fan, dx, dy;
   mobj_t *mo;
 
-  if (prior_mbf21 || !actor->state->args[0])
+  if (at_most_mbf || !actor->state->args[0])
     return;
 
   type  = actor->state->args[0] - 1;
@@ -2941,7 +2941,7 @@ void A_MonsterProjectile(mobj_t *actor)
   mobj_t *mo;
   int an;
 
-  if (prior_mbf21 || !actor->target || !actor->state->args[0])
+  if (at_most_mbf || !actor->target || !actor->state->args[0])
     return;
 
   type        = actor->state->args[0] - 1;
@@ -2990,7 +2990,7 @@ void A_MonsterBulletAttack(mobj_t *actor)
   int hspread, vspread, numbullets, damagebase, damagemod;
   int aimslope, i, damage, angle, slope;
 
-  if (prior_mbf21 || !actor->target)
+  if (at_most_mbf || !actor->target)
     return;
 
   hspread    = actor->state->args[0];
@@ -3027,7 +3027,7 @@ void A_MonsterMeleeAttack(mobj_t *actor)
   int damagebase, damagemod, hitsound, range;
   int damage;
 
-  if (prior_mbf21 || !actor->target)
+  if (at_most_mbf || !actor->target)
     return;
 
   damagebase = actor->state->args[0];
@@ -3058,7 +3058,7 @@ void A_MonsterMeleeAttack(mobj_t *actor)
 //
 void A_RadiusDamage(mobj_t *actor)
 {
-  if (prior_mbf21 || !actor->state)
+  if (at_most_mbf || !actor->state)
     return;
 
   P_RadiusAttack(actor, actor->target, actor->state->args[0], actor->state->args[1]);
@@ -3070,7 +3070,7 @@ void A_RadiusDamage(mobj_t *actor)
 //
 void A_NoiseAlert(mobj_t *actor)
 {
-  if (prior_mbf21 || !actor->target)
+  if (at_most_mbf || !actor->target)
     return;
 
   P_NoiseAlert(actor->target, actor);
@@ -3086,7 +3086,7 @@ void A_HealChase(mobj_t* actor)
 {
   int state, sound;
 
-  if (prior_mbf21 || !actor)
+  if (at_most_mbf || !actor)
     return;
 
   state = actor->state->args[0];
@@ -3106,7 +3106,7 @@ void A_SeekTracer(mobj_t *actor)
 {
   angle_t threshold, maxturnangle;
 
-  if (prior_mbf21 || !actor)
+  if (at_most_mbf || !actor)
     return;
 
   threshold    = FixedToAngle(actor->state->args[0]);
@@ -3126,7 +3126,7 @@ void A_FindTracer(mobj_t *actor)
   angle_t fov;
   int dist;
 
-  if (prior_mbf21 || !actor || actor->tracer)
+  if (at_most_mbf || !actor || actor->tracer)
     return;
 
   fov  = FixedToAngle(actor->state->args[0]);
@@ -3141,7 +3141,7 @@ void A_FindTracer(mobj_t *actor)
 //
 void A_ClearTracer(mobj_t *actor)
 {
-  if (prior_mbf21 || !actor)
+  if (at_most_mbf || !actor)
     return;
 
   P_SetTarget(&actor->tracer, NULL);
@@ -3157,7 +3157,7 @@ void A_JumpIfHealthBelow(mobj_t* actor)
 {
   int state, health;
 
-  if (prior_mbf21 || !actor)
+  if (at_most_mbf || !actor)
     return;
 
   state  = actor->state->args[0];
@@ -3178,7 +3178,7 @@ void A_JumpIfTargetInSight(mobj_t* actor)
   int state;
   angle_t fov;
 
-  if (prior_mbf21 || !actor || !actor->target)
+  if (at_most_mbf || !actor || !actor->target)
     return;
 
   state =             (actor->state->args[0]);
@@ -3202,7 +3202,7 @@ void A_JumpIfTargetCloser(mobj_t* actor)
 {
   int state, distance;
 
-  if (prior_mbf21 || !actor || !actor->target)
+  if (at_most_mbf || !actor || !actor->target)
     return;
 
   state    = actor->state->args[0];
@@ -3224,7 +3224,7 @@ void A_JumpIfTracerInSight(mobj_t* actor)
   angle_t fov;
   int state;
 
-  if (prior_mbf21 || !actor || !actor->tracer)
+  if (at_most_mbf || !actor || !actor->tracer)
     return;
 
   state =             (actor->state->args[0]);
@@ -3248,7 +3248,7 @@ void A_JumpIfTracerCloser(mobj_t* actor)
 {
   int state, distance;
 
-  if (prior_mbf21 || !actor || !actor->tracer)
+  if (at_most_mbf || !actor || !actor->tracer)
     return;
 
   state    = actor->state->args[0];
@@ -3271,7 +3271,7 @@ void A_JumpIfFlagsSet(mobj_t* actor)
   int state;
   unsigned int flags, flags2;
 
-  if (prior_mbf21 || !actor)
+  if (at_most_mbf || !actor)
     return;
 
   state  = actor->state->args[0];
@@ -3294,7 +3294,7 @@ void A_AddFlags(mobj_t* actor)
   unsigned int flags, flags2;
   boolean update_blockmap;
 
-  if (prior_mbf21 || !actor)
+  if (at_most_mbf || !actor)
     return;
 
   flags  = actor->state->args[0];
@@ -3326,7 +3326,7 @@ void A_RemoveFlags(mobj_t* actor)
   unsigned int flags, flags2;
   boolean update_blockmap;
 
-  if (prior_mbf21 || !actor)
+  if (at_most_mbf || !actor)
     return;
 
   flags  = actor->state->args[0];

--- a/src/p_enemy.c
+++ b/src/p_enemy.c
@@ -450,19 +450,19 @@ static boolean P_Move(mobj_t *actor, int dropoff) // killough 9/12/98
       // Boom v2.02 and LxDoom return good && (P_Random(pr_trywalk)&3)
       // MBF plays even more games
 
-      if (demo_version < DV_BOOM)
+      if (prior_boom)
         return good;
-      if (demo_version < DV_MBF)
+      if (prior_mbf)
         return good && (compatibility || (P_Random(pr_trywalk)&3)); //jff 8/13/98
       else
-      return good && (demo_version < DV_MBF || comp[comp_doorstuck] ||
+      return good && (prior_mbf || comp[comp_doorstuck] ||
 		      (P_Random(pr_opendoor) >= 230) ^ (good & 1));
     }
   else
     actor->flags &= ~MF_INFLOAT;
 
   // killough 11/98: fall more slowly, under gravity, if felldown==true
-  if (!(actor->flags & MF_FLOAT) && (!felldown || demo_version < DV_MBF))
+  if (!(actor->flags & MF_FLOAT) && (!felldown || prior_mbf))
     actor->z = actor->floorz;
 
   return true;
@@ -688,7 +688,7 @@ static void P_NewChaseDir(mobj_t *actor)
 
   actor->strafecount = 0;
 
-  if (demo_version >= DV_MBF)
+  if (min_mbf)
   {
     if (actor->floorz - actor->dropoffz > FRACUNIT*24 &&
 	actor->z <= actor->floorz && !(actor->flags & (MF_DROPOFF|MF_FLOAT)) &&
@@ -854,7 +854,7 @@ static boolean P_LookForPlayers(mobj_t *actor, boolean allaround)
 
   c = 0;
 
-  stopc = demo_version < DV_MBF && !demo_compatibility && monsters_remember ?
+  stopc = min_boom && prior_mbf && monsters_remember ?
     MAXPLAYERS : 2;       // killough 9/9/98
 
   for (;; actor->lastlook = (actor->lastlook+1)&(MAXPLAYERS-1))
@@ -870,7 +870,7 @@ static boolean P_LookForPlayers(mobj_t *actor, boolean allaround)
         // There are no more desyncs on Donce's demos on horror.wad
 
         // Use last known enemy if no players sighted -- killough 2/15/98:
-        if (demo_version < DV_MBF && !demo_compatibility && monsters_remember)
+        if (min_boom && prior_mbf && monsters_remember)
         {
           if (actor->lastenemy && actor->lastenemy->health > 0)
           {
@@ -898,7 +898,7 @@ static boolean P_LookForPlayers(mobj_t *actor, boolean allaround)
 
       // killough 9/9/98: give monsters a threshold towards getting players
       // (we don't want it to be too easy for a player with dogs :)
-      if (demo_version >= DV_MBF && !comp[comp_pursuit])
+      if (min_mbf && !comp[comp_pursuit])
 	actor->threshold = 60;
 
       return true;
@@ -917,7 +917,7 @@ static boolean P_LookForMonsters(mobj_t *actor, boolean allaround)
 {
   thinker_t *cap, *th;
 
-  if (demo_compatibility)
+  if (prior_boom)
     return false;
 
   if (actor->lastenemy && actor->lastenemy->health > 0 && monsters_remember &&
@@ -928,7 +928,7 @@ static boolean P_LookForMonsters(mobj_t *actor, boolean allaround)
       return true;
     }
 
-  if (demo_version < DV_MBF)  // Old demos do not support monster-seeking bots
+  if (prior_mbf)  // Old demos do not support monster-seeking bots
     return false;
 
   // Search the threaded list corresponding to this object's potential targets
@@ -1214,7 +1214,7 @@ void A_Chase(mobj_t *actor)
 
   if (!actor->threshold)
   {
-    if (demo_version < DV_MBF)
+    if (prior_mbf)
       {   // killough 9/9/98: for backward demo compatibility
 	if (netgame && !P_CheckSight(actor, actor->target) &&
 	    P_LookForPlayers(actor, true))
@@ -1773,7 +1773,7 @@ static boolean P_HealCorpse(mobj_t* actor, int radius, statenum_t healstate, sfx
                   corpsehit->health = info->spawnhealth;
 		  P_SetTarget(&corpsehit->target, NULL);  // killough 11/98
 
-		  if (demo_version >= DV_MBF)
+		  if (min_mbf)
 		    {         // kilough 9/9/98
 		      P_SetTarget(&corpsehit->lastenemy, NULL);
 		      corpsehit->flags &= ~MF_JUSTHIT;
@@ -1867,7 +1867,7 @@ void A_VileTarget(mobj_t *actor)
 
   // killough 12/98: fix Vile fog coordinates
   fog = P_SpawnMobj(actor->target->x,
-                    demo_version < DV_MBF ? actor->target->x : actor->target->y,
+                    prior_mbf ? actor->target->x : actor->target->y,
                     actor->target->z,MT_FIRE);
 
   P_SetTarget(&actor->tracer, fog);   // killough 11/98
@@ -2036,7 +2036,7 @@ void A_BetaSkullAttack(mobj_t *actor)
 {
   int damage;
 
-  if (demo_version < DV_MBF)
+  if (prior_mbf)
     return;
 
   if (!actor->target || actor->target->type == MT_SKULL)
@@ -2053,7 +2053,7 @@ void A_BetaSkullAttack(mobj_t *actor)
 
 void A_Stop(mobj_t *actor)
 {
-  if (demo_version < DV_MBF)
+  if (prior_mbf)
     return;
   actor->momx = actor->momy = actor->momz = 0;
 }
@@ -2219,7 +2219,7 @@ void A_Fall(mobj_t *actor)
 // killough 11/98: kill an object
 void A_Die(mobj_t *actor)
 {
-  if (demo_version < DV_MBF)
+  if (prior_mbf)
     return;
   P_DamageMobj(actor, NULL, NULL, actor->health);
 }
@@ -2239,7 +2239,7 @@ void A_Explode(mobj_t *thingy)
 
 void A_Detonate(mobj_t *mo)
 {
-  if (demo_version < DV_MBF)
+  if (prior_mbf)
     return;
   P_RadiusAttack(mo, mo->target, mo->info->damage, mo->info->damage);
 }
@@ -2257,7 +2257,7 @@ void A_Mushroom(mobj_t *actor)
   fixed_t misc1 = actor->state->misc1 ? actor->state->misc1 : FRACUNIT*4;
   fixed_t misc2 = actor->state->misc2 ? actor->state->misc2 : FRACUNIT/2;
 
-  if (demo_version < DV_MBF)
+  if (prior_mbf)
     return;
   A_Explode(actor);               // make normal explosion
 
@@ -2365,7 +2365,7 @@ void A_BossDeath(mobj_t *mo)
   else
     {
       // [FG] game version specific differences
-      if (demo_compatibility && gameversion < exe_ultimate)
+      if (prior_boom && gameversion < exe_ultimate)
       {
         if (gamemap != 8)
           return;
@@ -2770,7 +2770,7 @@ void A_KeenDie(mobj_t* mo)
 
 void A_Spawn(mobj_t *mo)
 {
-  if (demo_version < DV_MBF)
+  if (prior_mbf)
     return;
   if (mo->state->misc1)
     {
@@ -2787,21 +2787,21 @@ void A_Spawn(mobj_t *mo)
 
 void A_Turn(mobj_t *mo)
 {
-  if (demo_version < DV_MBF)
+  if (prior_mbf)
     return;
   mo->angle += (angle_t)(((uint64_t) mo->state->misc1 << 32) / 360);
 }
 
 void A_Face(mobj_t *mo)
 {
-  if (demo_version < DV_MBF)
+  if (prior_mbf)
     return;
   mo->angle = (angle_t)(((uint64_t) mo->state->misc1 << 32) / 360);
 }
 
 void A_Scratch(mobj_t *mo)
 {
-  if (demo_version < DV_MBF)
+  if (prior_mbf)
     return;
   mo->target && (A_FaceTarget(mo), P_CheckMeleeRange(mo)) ?
     mo->state->misc2 ? S_StartSound(mo, mo->state->misc2) : (void) 0,
@@ -2810,14 +2810,14 @@ void A_Scratch(mobj_t *mo)
 
 void A_PlaySound(mobj_t *mo)
 {
-  if (demo_version < DV_MBF)
+  if (prior_mbf)
     return;
   S_StartSoundOrigin(mo, mo->state->misc2 ? NULL : mo, mo->state->misc1);
 }
 
 void A_RandomJump(mobj_t *mo)
 {
-  if (demo_version < DV_MBF)
+  if (prior_mbf)
     return;
   if (P_Random(pr_randomjump) < mo->state->misc2)
     P_SetMobjState(mo, mo->state->misc1);
@@ -2829,7 +2829,7 @@ void A_RandomJump(mobj_t *mo)
 
 void A_LineEffect(mobj_t *mo)
 {
-  if (demo_version < DV_MBF)
+  if (prior_mbf)
     return;
   if (!(mo->intflags & MIF_LINEDONE))                // Unless already used up
     {
@@ -2874,7 +2874,7 @@ void A_SpawnObject(mobj_t *actor)
   int fan, dx, dy;
   mobj_t *mo;
 
-  if (!mbf21 || !actor->state->args[0])
+  if (prior_mbf21 || !actor->state->args[0])
     return;
 
   type  = actor->state->args[0] - 1;
@@ -2941,7 +2941,7 @@ void A_MonsterProjectile(mobj_t *actor)
   mobj_t *mo;
   int an;
 
-  if (!mbf21 || !actor->target || !actor->state->args[0])
+  if (prior_mbf21 || !actor->target || !actor->state->args[0])
     return;
 
   type        = actor->state->args[0] - 1;
@@ -2990,7 +2990,7 @@ void A_MonsterBulletAttack(mobj_t *actor)
   int hspread, vspread, numbullets, damagebase, damagemod;
   int aimslope, i, damage, angle, slope;
 
-  if (!mbf21 || !actor->target)
+  if (prior_mbf21 || !actor->target)
     return;
 
   hspread    = actor->state->args[0];
@@ -3027,7 +3027,7 @@ void A_MonsterMeleeAttack(mobj_t *actor)
   int damagebase, damagemod, hitsound, range;
   int damage;
 
-  if (!mbf21 || !actor->target)
+  if (prior_mbf21 || !actor->target)
     return;
 
   damagebase = actor->state->args[0];
@@ -3058,7 +3058,7 @@ void A_MonsterMeleeAttack(mobj_t *actor)
 //
 void A_RadiusDamage(mobj_t *actor)
 {
-  if (!mbf21 || !actor->state)
+  if (prior_mbf21 || !actor->state)
     return;
 
   P_RadiusAttack(actor, actor->target, actor->state->args[0], actor->state->args[1]);
@@ -3070,7 +3070,7 @@ void A_RadiusDamage(mobj_t *actor)
 //
 void A_NoiseAlert(mobj_t *actor)
 {
-  if (!mbf21 || !actor->target)
+  if (prior_mbf21 || !actor->target)
     return;
 
   P_NoiseAlert(actor->target, actor);
@@ -3086,7 +3086,7 @@ void A_HealChase(mobj_t* actor)
 {
   int state, sound;
 
-  if (!mbf21 || !actor)
+  if (prior_mbf21 || !actor)
     return;
 
   state = actor->state->args[0];
@@ -3106,7 +3106,7 @@ void A_SeekTracer(mobj_t *actor)
 {
   angle_t threshold, maxturnangle;
 
-  if (!mbf21 || !actor)
+  if (prior_mbf21 || !actor)
     return;
 
   threshold    = FixedToAngle(actor->state->args[0]);
@@ -3126,7 +3126,7 @@ void A_FindTracer(mobj_t *actor)
   angle_t fov;
   int dist;
 
-  if (!mbf21 || !actor || actor->tracer)
+  if (prior_mbf21 || !actor || actor->tracer)
     return;
 
   fov  = FixedToAngle(actor->state->args[0]);
@@ -3141,7 +3141,7 @@ void A_FindTracer(mobj_t *actor)
 //
 void A_ClearTracer(mobj_t *actor)
 {
-  if (!mbf21 || !actor)
+  if (prior_mbf21 || !actor)
     return;
 
   P_SetTarget(&actor->tracer, NULL);
@@ -3157,7 +3157,7 @@ void A_JumpIfHealthBelow(mobj_t* actor)
 {
   int state, health;
 
-  if (!mbf21 || !actor)
+  if (prior_mbf21 || !actor)
     return;
 
   state  = actor->state->args[0];
@@ -3178,7 +3178,7 @@ void A_JumpIfTargetInSight(mobj_t* actor)
   int state;
   angle_t fov;
 
-  if (!mbf21 || !actor || !actor->target)
+  if (prior_mbf21 || !actor || !actor->target)
     return;
 
   state =             (actor->state->args[0]);
@@ -3202,7 +3202,7 @@ void A_JumpIfTargetCloser(mobj_t* actor)
 {
   int state, distance;
 
-  if (!mbf21 || !actor || !actor->target)
+  if (prior_mbf21 || !actor || !actor->target)
     return;
 
   state    = actor->state->args[0];
@@ -3224,7 +3224,7 @@ void A_JumpIfTracerInSight(mobj_t* actor)
   angle_t fov;
   int state;
 
-  if (!mbf21 || !actor || !actor->tracer)
+  if (prior_mbf21 || !actor || !actor->tracer)
     return;
 
   state =             (actor->state->args[0]);
@@ -3248,7 +3248,7 @@ void A_JumpIfTracerCloser(mobj_t* actor)
 {
   int state, distance;
 
-  if (!mbf21 || !actor || !actor->tracer)
+  if (prior_mbf21 || !actor || !actor->tracer)
     return;
 
   state    = actor->state->args[0];
@@ -3271,7 +3271,7 @@ void A_JumpIfFlagsSet(mobj_t* actor)
   int state;
   unsigned int flags, flags2;
 
-  if (!mbf21 || !actor)
+  if (prior_mbf21 || !actor)
     return;
 
   state  = actor->state->args[0];
@@ -3294,7 +3294,7 @@ void A_AddFlags(mobj_t* actor)
   unsigned int flags, flags2;
   boolean update_blockmap;
 
-  if (!mbf21 || !actor)
+  if (prior_mbf21 || !actor)
     return;
 
   flags  = actor->state->args[0];
@@ -3326,7 +3326,7 @@ void A_RemoveFlags(mobj_t* actor)
   unsigned int flags, flags2;
   boolean update_blockmap;
 
-  if (!mbf21 || !actor)
+  if (prior_mbf21 || !actor)
     return;
 
   flags  = actor->state->args[0];

--- a/src/p_enemy.c
+++ b/src/p_enemy.c
@@ -450,9 +450,9 @@ static boolean P_Move(mobj_t *actor, int dropoff) // killough 9/12/98
       // Boom v2.02 and LxDoom return good && (P_Random(pr_trywalk)&3)
       // MBF plays even more games
 
-      if (prior_boom)
+      if (demo_version <= DV_BOOM201)
         return good;
-      if (prior_mbf)
+      if (demo_version == DV_BOOM)
         return good && (compatibility || (P_Random(pr_trywalk)&3)); //jff 8/13/98
       else
       return good && (prior_mbf || comp[comp_doorstuck] ||

--- a/src/p_floor.c
+++ b/src/p_floor.c
@@ -109,7 +109,7 @@ result_e T_MovePlane
 
             // [FG] Compatibility bug in T_MovePlane
             // http://prboom.sourceforge.net/mbf-bugs.html
-            if ((flag == true) && demo_compatibility)
+            if ((flag == true) && prior_boom)
             {
               sector->floorheight = lastpos;
               P_ChangeSector(sector,crush);
@@ -122,7 +122,7 @@ result_e T_MovePlane
           // Moving a floor up
           // jff 02/04/98 keep floor from moving thru ceilings
           // jff 2/22/98 weaken check to demo_compatibility
-          destheight = (demo_compatibility || (demo_version >= DV_MBF && comp[comp_floors]) ||
+          destheight = (prior_boom || (min_mbf && comp[comp_floors]) ||
 			dest<sector->ceilingheight)? // killough 10/98
                           dest : sector->ceilingheight;
           if (sector->floorheight + speed > destheight)
@@ -145,7 +145,7 @@ result_e T_MovePlane
             flag = P_CheckSector(sector,crush); //jff 3/19/98 use faster chk
             if (flag == true)
             {
-              if (demo_compatibility || (demo_version >= DV_MBF && comp[comp_floors])) // killough 10/98
+              if (prior_boom || (min_mbf && comp[comp_floors])) // killough 10/98
                 if (crush == true) //jff 1/25/98 fix floor crusher
                   return crushed;
               sector->floorheight = lastpos;
@@ -782,7 +782,7 @@ int EV_BuildStairs
       case build8:
         speed = FLOORSPEED/4;
         stairsize = 8*FRACUNIT;
-        if (!demo_compatibility)
+        if (min_boom)
           floor->crush = false; //jff 2/27/98 fix uninitialized crush field
         // [FG] initialize crush field
         else
@@ -791,7 +791,7 @@ int EV_BuildStairs
       case turbo16:
         speed = FLOORSPEED*4;
         stairsize = 16*FRACUNIT;
-        if (!demo_compatibility)
+        if (min_boom)
           floor->crush = true;  //jff 2/27/98 fix uninitialized crush field
         // [FG] initialize crush field
         else
@@ -860,7 +860,7 @@ int EV_BuildStairs
         floor->floordestheight = height;
         floor->type = buildStair; //jff 3/31/98 do not leave uninited
         //jff 2/27/98 fix uninitialized crush field
-        if (!demo_compatibility)
+        if (min_boom)
           floor->crush = type==build8? false : true;
         // [FG] initialize crush field
         else
@@ -902,7 +902,7 @@ int EV_BuildStairs
 
 static boolean DonutOverrun(fixed_t *pfloorheight, short *pfloorpic)
 {
-  if (demo_compatibility && overflow[emu_donut].enabled)
+  if (prior_boom && overflow[emu_donut].enabled)
   {
     overflow[emu_donut].triggered = true;
 

--- a/src/p_floor.c
+++ b/src/p_floor.c
@@ -109,7 +109,7 @@ result_e T_MovePlane
 
             // [FG] Compatibility bug in T_MovePlane
             // http://prboom.sourceforge.net/mbf-bugs.html
-            if ((flag == true) && prior_boom)
+            if ((flag == true) && at_most_vanilla)
             {
               sector->floorheight = lastpos;
               P_ChangeSector(sector,crush);
@@ -122,7 +122,7 @@ result_e T_MovePlane
           // Moving a floor up
           // jff 02/04/98 keep floor from moving thru ceilings
           // jff 2/22/98 weaken check to demo_compatibility
-          destheight = (prior_boom || (min_mbf && comp[comp_floors]) ||
+          destheight = (at_most_vanilla || (at_least_mbf && comp[comp_floors]) ||
 			dest<sector->ceilingheight)? // killough 10/98
                           dest : sector->ceilingheight;
           if (sector->floorheight + speed > destheight)
@@ -145,7 +145,7 @@ result_e T_MovePlane
             flag = P_CheckSector(sector,crush); //jff 3/19/98 use faster chk
             if (flag == true)
             {
-              if (prior_boom || (min_mbf && comp[comp_floors])) // killough 10/98
+              if (at_most_vanilla || (at_least_mbf && comp[comp_floors])) // killough 10/98
                 if (crush == true) //jff 1/25/98 fix floor crusher
                   return crushed;
               sector->floorheight = lastpos;
@@ -782,7 +782,7 @@ int EV_BuildStairs
       case build8:
         speed = FLOORSPEED/4;
         stairsize = 8*FRACUNIT;
-        if (min_boom)
+        if (at_least_boom)
           floor->crush = false; //jff 2/27/98 fix uninitialized crush field
         // [FG] initialize crush field
         else
@@ -791,7 +791,7 @@ int EV_BuildStairs
       case turbo16:
         speed = FLOORSPEED*4;
         stairsize = 16*FRACUNIT;
-        if (min_boom)
+        if (at_least_boom)
           floor->crush = true;  //jff 2/27/98 fix uninitialized crush field
         // [FG] initialize crush field
         else
@@ -860,7 +860,7 @@ int EV_BuildStairs
         floor->floordestheight = height;
         floor->type = buildStair; //jff 3/31/98 do not leave uninited
         //jff 2/27/98 fix uninitialized crush field
-        if (min_boom)
+        if (at_least_boom)
           floor->crush = type==build8? false : true;
         // [FG] initialize crush field
         else
@@ -902,7 +902,7 @@ int EV_BuildStairs
 
 static boolean DonutOverrun(fixed_t *pfloorheight, short *pfloorpic)
 {
-  if (prior_boom && overflow[emu_donut].enabled)
+  if (at_most_vanilla && overflow[emu_donut].enabled)
   {
     overflow[emu_donut].triggered = true;
 

--- a/src/p_inter.c
+++ b/src/p_inter.c
@@ -140,7 +140,7 @@ boolean P_GiveAmmo(player_t *player, ammotype_t ammo, int num)
   if (player->ammo[ammo] > player->maxammo[ammo])
     player->ammo[ammo] = player->maxammo[ammo];
 
-  if (mbf21)
+  if (min_mbf21)
     return P_GiveAmmoAutoSwitch(player, ammo, oldammo);
 
   // If non zero ammo, don't change up weapons, player was lower on purpose.
@@ -728,7 +728,7 @@ static void P_KillMobj(mobj_t *source, mobj_t *target, method_t mod)
 
             if (playerscount)
             {
-              if (demo_version >= DV_MBF)
+              if (min_mbf)
                 i = P_Random(pr_friends) % playerscount;
               else
                 i = Woof_Random() % playerscount;
@@ -937,7 +937,7 @@ void P_DamageMobjBy(mobj_t *target,mobj_t *inflictor, mobj_t *source, int damage
     }
 
   // killough 9/7/98: keep track of targets so that friends can help friends
-  if (demo_version >= DV_MBF)
+  if (min_mbf)
     {
       // If target is a player, set player's target to source,
       // so that a friend can tell who's hurting a player
@@ -970,7 +970,7 @@ void P_DamageMobjBy(mobj_t *target,mobj_t *inflictor, mobj_t *source, int damage
   if (source && source != target && !(source->flags2 & MF2_DMGIGNORED) &&
       (!target->threshold || target->flags2 & MF2_NOTHRESHOLD) &&
       ((source->flags ^ target->flags) & MF_FRIEND || 
-       monster_infighting || demo_version < DV_MBF) &&
+       monster_infighting || prior_mbf) &&
       !P_InfightingImmune(target, source))
     {
       // if not intent on another player, chase after this one
@@ -980,7 +980,7 @@ void P_DamageMobjBy(mobj_t *target,mobj_t *inflictor, mobj_t *source, int damage
       // killough 9/9/98: cleaned up, made more consistent:
 
       if (!target->lastenemy || target->lastenemy->health <= 0 ||
-	  (demo_version < DV_MBF ? !target->lastenemy->player :
+	  (prior_mbf ? !target->lastenemy->player :
 	   !((target->flags ^ target->lastenemy->flags) & MF_FRIEND) &&
 	   target->target != source)) // remember last enemy - killough
 	P_SetTarget(&target->lastenemy, target->target);

--- a/src/p_inter.c
+++ b/src/p_inter.c
@@ -140,7 +140,7 @@ boolean P_GiveAmmo(player_t *player, ammotype_t ammo, int num)
   if (player->ammo[ammo] > player->maxammo[ammo])
     player->ammo[ammo] = player->maxammo[ammo];
 
-  if (min_mbf21)
+  if (at_least_mbf21)
     return P_GiveAmmoAutoSwitch(player, ammo, oldammo);
 
   // If non zero ammo, don't change up weapons, player was lower on purpose.
@@ -728,7 +728,7 @@ static void P_KillMobj(mobj_t *source, mobj_t *target, method_t mod)
 
             if (playerscount)
             {
-              if (min_mbf)
+              if (at_least_mbf)
                 i = P_Random(pr_friends) % playerscount;
               else
                 i = Woof_Random() % playerscount;
@@ -937,7 +937,7 @@ void P_DamageMobjBy(mobj_t *target,mobj_t *inflictor, mobj_t *source, int damage
     }
 
   // killough 9/7/98: keep track of targets so that friends can help friends
-  if (min_mbf)
+  if (at_least_mbf)
     {
       // If target is a player, set player's target to source,
       // so that a friend can tell who's hurting a player
@@ -970,7 +970,7 @@ void P_DamageMobjBy(mobj_t *target,mobj_t *inflictor, mobj_t *source, int damage
   if (source && source != target && !(source->flags2 & MF2_DMGIGNORED) &&
       (!target->threshold || target->flags2 & MF2_NOTHRESHOLD) &&
       ((source->flags ^ target->flags) & MF_FRIEND || 
-       monster_infighting || prior_mbf) &&
+       monster_infighting || at_most_boom) &&
       !P_InfightingImmune(target, source))
     {
       // if not intent on another player, chase after this one
@@ -980,7 +980,7 @@ void P_DamageMobjBy(mobj_t *target,mobj_t *inflictor, mobj_t *source, int damage
       // killough 9/9/98: cleaned up, made more consistent:
 
       if (!target->lastenemy || target->lastenemy->health <= 0 ||
-	  (prior_mbf ? !target->lastenemy->player :
+	  (at_most_boom ? !target->lastenemy->player :
 	   !((target->flags ^ target->lastenemy->flags) & MF_FRIEND) &&
 	   target->target != source)) // remember last enemy - killough
 	P_SetTarget(&target->lastenemy, target->target);

--- a/src/p_map.c
+++ b/src/p_map.c
@@ -150,7 +150,7 @@ int P_GetFriction(const mobj_t *mo, int *frictionfactor)
   // friction value (muddy has precedence over icy).
 
   if (!(mo->flags & (MF_NOCLIP|MF_NOGRAVITY)) 
-      && (min_mbf || (mo->player && !compatibility)) &&
+      && (at_least_mbf || (mo->player && !compatibility)) &&
       variable_friction)
     for (m = mo->touching_sectorlist; m; m = m->m_tnext)
       if ((sec = m->m_sector)->special & FRICTION_MASK &&
@@ -158,7 +158,7 @@ int P_GetFriction(const mobj_t *mo, int *frictionfactor)
 	  (mo->z <= sec->floorheight ||
 	   (sec->heightsec != -1 &&
 	    mo->z <= sectors[sec->heightsec].floorheight &&
-	    min_mbf)))
+	    at_least_mbf)))
 	friction = sec->friction, movefactor = sec->movefactor;
   
   if (frictionfactor)
@@ -179,7 +179,7 @@ int P_GetMoveFactor(const mobj_t *mo, int *frictionp)
 
   // Restore original Boom friction code for
   // demo compatibility
-  if (prior_mbf)
+  if (at_most_boom)
   {
     int momentum;
 
@@ -257,7 +257,7 @@ boolean P_TeleportMove(mobj_t *thing, fixed_t x, fixed_t y, boolean boss)
 
   // killough 8/9/98: make telefragging more consistent, preserve compatibility
   telefrag = thing->player || 
-    (comp[comp_telefrag] || prior_mbf ? gamemap==30 : boss);
+    (comp[comp_telefrag] || at_most_boom ? gamemap==30 : boss);
 
   // kill anything occupying the position
 
@@ -411,7 +411,7 @@ static boolean PIT_CheckLine(line_t *ld) // killough 3/26/98: make static
     {
       // explicitly blocking everything
       // or blocking player
-      if (ld->flags & ML_BLOCKING || (min_mbf21 && tmthing->player && ld->flags & ML_BLOCKPLAYERS))
+      if (ld->flags & ML_BLOCKING || (at_least_mbf21 && tmthing->player && ld->flags & ML_BLOCKPLAYERS))
 	return tmunstuck && !untouched(ld);  // killough 8/1/98: allow escape
 
       // killough 8/9/98: monster-blockers don't affect friends
@@ -419,7 +419,7 @@ static boolean PIT_CheckLine(line_t *ld) // killough 3/26/98: make static
 	  &&
 	  (
 	    ld->flags & ML_BLOCKMONSTERS ||
-	    (min_mbf21 && ld->flags & ML_BLOCKLANDMONSTERS && !(tmthing->flags & MF_FLOAT))
+	    (at_least_mbf21 && ld->flags & ML_BLOCKLANDMONSTERS && !(tmthing->flags & MF_FLOAT))
 	  )
 	 )
 	return false; // block monsters only
@@ -462,7 +462,7 @@ static boolean PIT_CheckLine(line_t *ld) // killough 3/26/98: make static
       spechit[numspechit++] = ld;
 
       // [FG] SPECHITS overflow emulation from Chocolate Doom / PrBoom+
-      if (numspechit > MAXSPECIALCROSS_ORIGINAL && prior_boom
+      if (numspechit > MAXSPECIALCROSS_ORIGINAL && at_most_vanilla
           && overflow[emu_spechits].enabled)
 	{
 	  if (numspechit == MAXSPECIALCROSS_ORIGINAL + 1)
@@ -678,7 +678,7 @@ static boolean PIT_CheckThing(mobj_t *thing) // killough 3/26/98: make static
   // killough 4/11/98: Treat no-clipping things as not blocking
 
   return !((thing->flags & MF_SOLID && !(thing->flags & MF_NOCLIP))
-           && (tmthing->flags & MF_SOLID || prior_boom));
+           && (tmthing->flags & MF_SOLID || at_most_vanilla));
 
   // return !(thing->flags & MF_SOLID);   // old code -- killough
 }
@@ -781,7 +781,7 @@ boolean P_CheckPosition(mobj_t *thing, fixed_t x, fixed_t y)
   // Whether object can get out of a sticky situation:
   tmunstuck = thing->player &&          // only players
     thing->player->mo == thing &&       // not voodoo dolls
-    min_mbf;                            // not under old demos
+    at_least_mbf;                            // not under old demos
 
   // The base floor / ceiling is from the subsector
   // that contains the point.
@@ -824,7 +824,7 @@ boolean P_CheckPosition(mobj_t *thing, fixed_t x, fixed_t y)
   // ripper projectiles (and possibly other cases) will expose this bug and cause desyncs.
   // I recommend adding an extra validcount increment in P_CheckPosition before running 
   // the P_BlockLinesIterator.
-  if (min_mbf21)
+  if (at_least_mbf21)
   {
     validcount++;
   }
@@ -877,7 +877,7 @@ boolean P_TryMove(mobj_t *thing, fixed_t x, fixed_t y, int dropoff)
       if (!(thing->flags & (MF_DROPOFF|MF_FLOAT)))
       {
         boolean ledgeblock = comp[comp_ledgeblock] &&
-                            !(min_mbf21 && thing->intflags & MIF_SCROLLING);
+                            !(at_least_mbf21 && thing->intflags & MIF_SCROLLING);
 
 	if (comp[comp_dropoff] || ledgeblock)
 	  {
@@ -890,7 +890,7 @@ boolean P_TryMove(mobj_t *thing, fixed_t x, fixed_t y, int dropoff)
 			   (tmfloorz-tmdropoffz > 128*FRACUNIT || 
 			    !thing->target || thing->target->z >tmdropoffz)))
 	    {
-	      if (!monkeys || prior_mbf ?
+	      if (!monkeys || at_most_boom ?
 		  tmfloorz - tmdropoffz > 24*FRACUNIT :
 		  thing->floorz  - tmfloorz > 24*FRACUNIT ||
 		  thing->dropoffz - tmdropoffz > 24*FRACUNIT)
@@ -1157,7 +1157,7 @@ static void P_HitSlideLine(line_t *ld)
 
   // killough 10/98: only bounce if hit hard (prevents wobbling)
 
-  if (min_mbf)
+  if (at_least_mbf)
   {
   icyfloor = 
      P_AproxDistance(tmxmove, tmymove) > 4*FRACUNIT &&
@@ -1214,7 +1214,7 @@ static void P_HitSlideLine(line_t *ld)
   // The moveangle+=10 breaks v1.9 demo compatibility in
   // some demos, so it needs demo_compatibility switch.
 
-  if (min_boom)
+  if (at_least_boom)
     moveangle += 10;
   // ^ prevents sudden path reversal due to rounding error // phares
 
@@ -1586,7 +1586,7 @@ static boolean PTR_ShootTraverse(intercept_t *in)
 	  // it's a sky hack wall
 	  // fix bullet-eaters -- killough:
 	  if  (li->backsector && li->backsector->ceilingpic == skyflatnum)
-	    if (prior_boom || li->backsector->ceilingheight < z)
+	    if (at_most_vanilla || li->backsector->ceilingheight < z)
 	      return false;
 	}
 
@@ -1752,7 +1752,7 @@ static boolean PTR_UseTraverse(intercept_t *in)
     //WAS can't use for than one special line in a row
     //jff 3/21/98 NOW multiple use allowed with enabling line flag
     
-    min_boom && in->d.line->flags & ML_PASSUSE :
+    at_least_boom && in->d.line->flags & ML_PASSUSE :
 
     (P_LineOpening(in->d.line), openrange <= 0) ?
 
@@ -2137,7 +2137,7 @@ boolean P_CheckSector(sector_t *sector,boolean crunch)
   msecnode_t *n;
 
   // killough 10/98: sometimes use Doom's method
-  if (comp[comp_floors] && (prior_boom || min_mbf))
+  if (comp[comp_floors] && (at_most_vanilla || at_least_mbf))
     return P_ChangeSector(sector,crunch);
 
   nofit = false;
@@ -2407,12 +2407,12 @@ void P_CreateSecNodeList(mobj_t *thing,fixed_t x,fixed_t y)
 
   // [FG] Overlapping uses of global variables in p_map.c
   // http://prboom.sourceforge.net/mbf-bugs.html
-   if (prior_boom || min_mbf21)
+   if (at_most_vanilla || at_least_mbf21)
    {
      tmthing = saved_tmthing;
      tmflags = saved_tmflags;
    }
-   if (prior_boom)
+   if (at_most_vanilla)
    {
      tmx = saved_tmx;
      tmy = saved_tmy;

--- a/src/p_map.c
+++ b/src/p_map.c
@@ -150,7 +150,7 @@ int P_GetFriction(const mobj_t *mo, int *frictionfactor)
   // friction value (muddy has precedence over icy).
 
   if (!(mo->flags & (MF_NOCLIP|MF_NOGRAVITY)) 
-      && (demo_version >= DV_MBF || (mo->player && !compatibility)) &&
+      && (min_mbf || (mo->player && !compatibility)) &&
       variable_friction)
     for (m = mo->touching_sectorlist; m; m = m->m_tnext)
       if ((sec = m->m_sector)->special & FRICTION_MASK &&
@@ -158,7 +158,7 @@ int P_GetFriction(const mobj_t *mo, int *frictionfactor)
 	  (mo->z <= sec->floorheight ||
 	   (sec->heightsec != -1 &&
 	    mo->z <= sectors[sec->heightsec].floorheight &&
-	    demo_version >= DV_MBF)))
+	    min_mbf)))
 	friction = sec->friction, movefactor = sec->movefactor;
   
   if (frictionfactor)
@@ -179,7 +179,7 @@ int P_GetMoveFactor(const mobj_t *mo, int *frictionp)
 
   // Restore original Boom friction code for
   // demo compatibility
-  if (demo_version < DV_MBF)
+  if (prior_mbf)
   {
     int momentum;
 
@@ -257,7 +257,7 @@ boolean P_TeleportMove(mobj_t *thing, fixed_t x, fixed_t y, boolean boss)
 
   // killough 8/9/98: make telefragging more consistent, preserve compatibility
   telefrag = thing->player || 
-    (comp[comp_telefrag] || demo_version < DV_MBF ? gamemap==30 : boss);
+    (comp[comp_telefrag] || prior_mbf ? gamemap==30 : boss);
 
   // kill anything occupying the position
 
@@ -411,7 +411,7 @@ static boolean PIT_CheckLine(line_t *ld) // killough 3/26/98: make static
     {
       // explicitly blocking everything
       // or blocking player
-      if (ld->flags & ML_BLOCKING || (mbf21 && tmthing->player && ld->flags & ML_BLOCKPLAYERS))
+      if (ld->flags & ML_BLOCKING || (min_mbf21 && tmthing->player && ld->flags & ML_BLOCKPLAYERS))
 	return tmunstuck && !untouched(ld);  // killough 8/1/98: allow escape
 
       // killough 8/9/98: monster-blockers don't affect friends
@@ -419,7 +419,7 @@ static boolean PIT_CheckLine(line_t *ld) // killough 3/26/98: make static
 	  &&
 	  (
 	    ld->flags & ML_BLOCKMONSTERS ||
-	    (mbf21 && ld->flags & ML_BLOCKLANDMONSTERS && !(tmthing->flags & MF_FLOAT))
+	    (min_mbf21 && ld->flags & ML_BLOCKLANDMONSTERS && !(tmthing->flags & MF_FLOAT))
 	  )
 	 )
 	return false; // block monsters only
@@ -462,7 +462,7 @@ static boolean PIT_CheckLine(line_t *ld) // killough 3/26/98: make static
       spechit[numspechit++] = ld;
 
       // [FG] SPECHITS overflow emulation from Chocolate Doom / PrBoom+
-      if (numspechit > MAXSPECIALCROSS_ORIGINAL && demo_compatibility
+      if (numspechit > MAXSPECIALCROSS_ORIGINAL && prior_boom
           && overflow[emu_spechits].enabled)
 	{
 	  if (numspechit == MAXSPECIALCROSS_ORIGINAL + 1)
@@ -678,7 +678,7 @@ static boolean PIT_CheckThing(mobj_t *thing) // killough 3/26/98: make static
   // killough 4/11/98: Treat no-clipping things as not blocking
 
   return !((thing->flags & MF_SOLID && !(thing->flags & MF_NOCLIP))
-           && (tmthing->flags & MF_SOLID || demo_compatibility));
+           && (tmthing->flags & MF_SOLID || prior_boom));
 
   // return !(thing->flags & MF_SOLID);   // old code -- killough
 }
@@ -781,7 +781,7 @@ boolean P_CheckPosition(mobj_t *thing, fixed_t x, fixed_t y)
   // Whether object can get out of a sticky situation:
   tmunstuck = thing->player &&          // only players
     thing->player->mo == thing &&       // not voodoo dolls
-    demo_version >= DV_MBF;             // not under old demos
+    min_mbf;                            // not under old demos
 
   // The base floor / ceiling is from the subsector
   // that contains the point.
@@ -824,7 +824,7 @@ boolean P_CheckPosition(mobj_t *thing, fixed_t x, fixed_t y)
   // ripper projectiles (and possibly other cases) will expose this bug and cause desyncs.
   // I recommend adding an extra validcount increment in P_CheckPosition before running 
   // the P_BlockLinesIterator.
-  if (mbf21)
+  if (min_mbf21)
   {
     validcount++;
   }
@@ -877,7 +877,7 @@ boolean P_TryMove(mobj_t *thing, fixed_t x, fixed_t y, int dropoff)
       if (!(thing->flags & (MF_DROPOFF|MF_FLOAT)))
       {
         boolean ledgeblock = comp[comp_ledgeblock] &&
-                            !(mbf21 && thing->intflags & MIF_SCROLLING);
+                            !(min_mbf21 && thing->intflags & MIF_SCROLLING);
 
 	if (comp[comp_dropoff] || ledgeblock)
 	  {
@@ -890,7 +890,7 @@ boolean P_TryMove(mobj_t *thing, fixed_t x, fixed_t y, int dropoff)
 			   (tmfloorz-tmdropoffz > 128*FRACUNIT || 
 			    !thing->target || thing->target->z >tmdropoffz)))
 	    {
-	      if (!monkeys || demo_version < DV_MBF ?
+	      if (!monkeys || prior_mbf ?
 		  tmfloorz - tmdropoffz > 24*FRACUNIT :
 		  thing->floorz  - tmfloorz > 24*FRACUNIT ||
 		  thing->dropoffz - tmdropoffz > 24*FRACUNIT)
@@ -1157,7 +1157,7 @@ static void P_HitSlideLine(line_t *ld)
 
   // killough 10/98: only bounce if hit hard (prevents wobbling)
 
-  if (demo_version >= DV_MBF)
+  if (min_mbf)
   {
   icyfloor = 
      P_AproxDistance(tmxmove, tmymove) > 4*FRACUNIT &&
@@ -1214,7 +1214,7 @@ static void P_HitSlideLine(line_t *ld)
   // The moveangle+=10 breaks v1.9 demo compatibility in
   // some demos, so it needs demo_compatibility switch.
 
-  if (!demo_compatibility)
+  if (min_boom)
     moveangle += 10;
   // ^ prevents sudden path reversal due to rounding error // phares
 
@@ -1586,7 +1586,7 @@ static boolean PTR_ShootTraverse(intercept_t *in)
 	  // it's a sky hack wall
 	  // fix bullet-eaters -- killough:
 	  if  (li->backsector && li->backsector->ceilingpic == skyflatnum)
-	    if (demo_compatibility || li->backsector->ceilingheight < z)
+	    if (prior_boom || li->backsector->ceilingheight < z)
 	      return false;
 	}
 
@@ -1752,7 +1752,7 @@ static boolean PTR_UseTraverse(intercept_t *in)
     //WAS can't use for than one special line in a row
     //jff 3/21/98 NOW multiple use allowed with enabling line flag
     
-    !demo_compatibility && in->d.line->flags & ML_PASSUSE :
+    min_boom && in->d.line->flags & ML_PASSUSE :
 
     (P_LineOpening(in->d.line), openrange <= 0) ?
 
@@ -2137,7 +2137,7 @@ boolean P_CheckSector(sector_t *sector,boolean crunch)
   msecnode_t *n;
 
   // killough 10/98: sometimes use Doom's method
-  if (comp[comp_floors] && (demo_version >= DV_MBF || demo_compatibility))
+  if (comp[comp_floors] && (prior_boom || min_mbf))
     return P_ChangeSector(sector,crunch);
 
   nofit = false;
@@ -2407,12 +2407,12 @@ void P_CreateSecNodeList(mobj_t *thing,fixed_t x,fixed_t y)
 
   // [FG] Overlapping uses of global variables in p_map.c
   // http://prboom.sourceforge.net/mbf-bugs.html
-   if (demo_compatibility || mbf21)
+   if (prior_boom || min_mbf21)
    {
      tmthing = saved_tmthing;
      tmflags = saved_tmflags;
    }
-   if (demo_compatibility)
+   if (prior_boom)
    {
      tmx = saved_tmx;
      tmy = saved_tmy;

--- a/src/p_maputl.c
+++ b/src/p_maputl.c
@@ -135,7 +135,7 @@ void P_MakeDivline(line_t *li, divline_t *dl)
 
 fixed_t P_InterceptVector(divline_t *v2, divline_t *v1)
 {
-  if (!mbf21)
+  if (prior_mbf21)
   {
   fixed_t den = FixedMul(v1->dy>>8, v2->dx) - FixedMul(v1->dx>>8, v2->dy);
   return den ? FixedDiv((FixedMul((v1->x-v2->x)>>8, v1->dy) +
@@ -400,7 +400,7 @@ boolean P_BlockLinesIterator(int x, int y, boolean func(line_t*))
 
   // killough 2/22/98: demo_compatibility check
   // mbf21: Fix blockmap issue seen in btsx e2 Map 20
-  if ((!demo_compatibility && !mbf21) || (mbf21 && skipblstart))
+  if ((min_boom && prior_mbf21) || (min_mbf21 && skipblstart))
     list++;     // skip 0 starting delimiter                      // phares
   for ( ; *list != -1 ; list++)                                   // phares
     {
@@ -438,7 +438,7 @@ boolean P_BlockThingsIterator(int x, int y, boolean func(mobj_t*),
   // Add other mobjs from surrounding blocks that overlap this one
   if (CRITICAL(blockmapfix) && do_blockmapfix)
   {
-    if (demo_compatibility && overflow[emu_intercepts].enabled)
+    if (prior_boom && overflow[emu_intercepts].enabled)
       return true;
 
     // Unwrapped for least number of bounding box checks
@@ -795,7 +795,7 @@ static void InterceptsMemoryOverrun(int location, int value)
 
 static void InterceptsOverrun(int num_intercepts, intercept_t *intercept)
 {
-  if (num_intercepts > MAXINTERCEPTS_ORIGINAL && demo_compatibility
+  if (num_intercepts > MAXINTERCEPTS_ORIGINAL && prior_boom
       && overflow[emu_intercepts].enabled)
   {
     int location;

--- a/src/p_maputl.c
+++ b/src/p_maputl.c
@@ -135,7 +135,7 @@ void P_MakeDivline(line_t *li, divline_t *dl)
 
 fixed_t P_InterceptVector(divline_t *v2, divline_t *v1)
 {
-  if (prior_mbf21)
+  if (at_most_mbf)
   {
   fixed_t den = FixedMul(v1->dy>>8, v2->dx) - FixedMul(v1->dx>>8, v2->dy);
   return den ? FixedDiv((FixedMul((v1->x-v2->x)>>8, v1->dy) +
@@ -400,7 +400,7 @@ boolean P_BlockLinesIterator(int x, int y, boolean func(line_t*))
 
   // killough 2/22/98: demo_compatibility check
   // mbf21: Fix blockmap issue seen in btsx e2 Map 20
-  if ((min_boom && prior_mbf21) || (min_mbf21 && skipblstart))
+  if ((at_least_boom && at_most_mbf) || (at_least_mbf21 && skipblstart))
     list++;     // skip 0 starting delimiter                      // phares
   for ( ; *list != -1 ; list++)                                   // phares
     {
@@ -438,7 +438,7 @@ boolean P_BlockThingsIterator(int x, int y, boolean func(mobj_t*),
   // Add other mobjs from surrounding blocks that overlap this one
   if (CRITICAL(blockmapfix) && do_blockmapfix)
   {
-    if (prior_boom && overflow[emu_intercepts].enabled)
+    if (at_most_vanilla && overflow[emu_intercepts].enabled)
       return true;
 
     // Unwrapped for least number of bounding box checks
@@ -795,7 +795,7 @@ static void InterceptsMemoryOverrun(int location, int value)
 
 static void InterceptsOverrun(int num_intercepts, intercept_t *intercept)
 {
-  if (num_intercepts > MAXINTERCEPTS_ORIGINAL && prior_boom
+  if (num_intercepts > MAXINTERCEPTS_ORIGINAL && at_most_vanilla
       && overflow[emu_intercepts].enabled)
   {
     int location;

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -217,7 +217,7 @@ void P_XYMovement (mobj_t* mo)
       // to pass through walls.
 
       if (xmove > MAXMOVE/2 || ymove > MAXMOVE/2 ||  // killough 8/9/98:
-	  ((xmove < -MAXMOVE/2 || ymove < -MAXMOVE/2) && min_mbf))
+	  ((xmove < -MAXMOVE/2 || ymove < -MAXMOVE/2) && at_least_mbf))
 	{
 	  ptryx = mo->x + xmove/2;
 	  ptryy = mo->y + ymove/2;
@@ -241,7 +241,7 @@ void P_XYMovement (mobj_t* mo)
 	  // killough 10/98:
 	  // Add ability for objects other than players to bounce on ice
 	  
-	  if (!(mo->flags & MF_MISSILE) && min_mbf &&
+	  if (!(mo->flags & MF_MISSILE) && at_least_mbf &&
 	      (mo->flags & MF_BOUNCES || 
 	       (!player && blockline &&
 		variable_friction && mo->z <= mo->floorz &&
@@ -284,7 +284,7 @@ void P_XYMovement (mobj_t* mo)
 		  if (ceilingline &&
 		      ceilingline->backsector &&
 		      ceilingline->backsector->ceilingpic == skyflatnum)
-		    if (prior_boom ||  // killough
+		    if (at_most_vanilla ||  // killough
 			mo->z > ceilingline->backsector->ceilingheight)
 		      {
 			// Hack to prevent missiles exploding
@@ -335,7 +335,7 @@ void P_XYMovement (mobj_t* mo)
   if (mo->momx > -STOPSPEED && mo->momx < STOPSPEED &&
       mo->momy > -STOPSPEED && mo->momy < STOPSPEED &&
       (!player || !(player->cmd.forwardmove | player->cmd.sidemove) ||
-       (player->mo != mo && min_mbf &&
+       (player->mo != mo && at_least_mbf &&
         (comp[comp_voodooscroller] || !(mo->intflags & MIF_SCROLLING)))))
     {
       // if in a walking frame, stop moving
@@ -344,7 +344,7 @@ void P_XYMovement (mobj_t* mo)
       // Don't affect main player when voodoo dolls stop, except in old demos:
 
       if (player && (unsigned)(player->mo->state - states - S_PLAY_RUN1) < 4 
-	  && (player->mo == mo || prior_mbf))
+	  && (player->mo == mo || at_most_boom))
 	P_SetMobjState(player->mo, S_PLAY);
 
       mo->momx = mo->momy = 0;
@@ -369,7 +369,7 @@ void P_XYMovement (mobj_t* mo)
       // Reducing player momentum is no longer needed to reduce
       // bobbing, so ice works much better now.
 
-      if (prior_mbf)
+      if (at_most_boom)
       {
         // phares 9/10/98: reduce bobbing/momentum when on ice & up against wall
 
@@ -535,7 +535,7 @@ floater:
       // hit the floor
 
       // [FG] game version specific differences
-      int correct_lost_soul_bounce = min_boom || gameversion >= exe_ultimate;
+      int correct_lost_soul_bounce = at_least_boom || gameversion >= exe_ultimate;
 
       if ((!comp[comp_soul] || correct_lost_soul_bounce) && mo->flags & MF_SKULLFLY)
       {
@@ -779,13 +779,13 @@ void P_MobjThinker (mobj_t* mobj)
 
 	if (mobj->z > mobj->dropoffz &&      // Only objects contacting dropoff
 	    !(mobj->flags & MF_NOGRAVITY) && // Only objects which fall
-	    !comp[comp_falloff] && min_mbf) // Not in old demos
+	    !comp[comp_falloff] && at_least_mbf) // Not in old demos
 	  P_ApplyTorque(mobj);               // Apply torque
 	else
 	  mobj->intflags &= ~MIF_FALLING, mobj->gear = 0;  // Reset torque
       }
 
-  if (min_mbf21)
+  if (at_least_mbf21)
   {
     sector_t* sector = mobj->subsector->sector;
 
@@ -844,7 +844,7 @@ mobj_t *P_SpawnMobj(fixed_t x, fixed_t y, fixed_t z, mobjtype_t type)
   mobj->flags2 = info->flags2;
 
   // killough 8/23/98: no friends, bouncers, or touchy things in old demos
-  if (prior_mbf)
+  if (at_most_boom)
     mobj->flags &= ~(MF_BOUNCES | MF_FRIEND | MF_TOUCHY); 
   else
     if (type == MT_PLAYER)         // Except in old demos, players
@@ -964,7 +964,7 @@ void P_RemoveMobj (mobj_t *mobj)
   // if multiple thinkers reference each other indirectly before the
   // end of the current tic.
 
-  if (min_mbf)
+  if (at_least_mbf)
     {
       P_SetTarget(&mobj->target,    NULL);
       P_SetTarget(&mobj->tracer,    NULL);
@@ -1177,8 +1177,8 @@ void P_SpawnMapThing (mapthing_t* mthing)
   // bits that weren't used in Doom (such as HellMaker wads). So we should
   // then simply ignore all upper bits.
 
-  if (prior_boom || 
-      (min_mbf && mthing->options & MTF_RESERVED))
+  if (at_most_vanilla || 
+      (at_least_mbf && mthing->options & MTF_RESERVED))
     mthing->options &= MTF_EASY|MTF_NORMAL|MTF_HARD|MTF_AMBUSH|MTF_NOTSINGLE;
 
   // count deathmatch start positions
@@ -1190,7 +1190,7 @@ void P_SpawnMapThing (mapthing_t* mthing)
       size_t offset = deathmatch_p - deathmatchstarts;
 
       // doom2.exe has at most 10 deathmatch starts
-      if (prior_boom && offset >= 10)
+      if (at_most_vanilla && offset >= 10)
         return;
 
       if (offset >= num_deathmatchstarts)
@@ -1247,7 +1247,7 @@ void P_SpawnMapThing (mapthing_t* mthing)
     return;
 
   // killough 11/98: simplify
-  if ((gameskill == sk_none && prior_boom) ||
+  if ((gameskill == sk_none && at_most_vanilla) ||
       (gameskill == sk_baby || gameskill == sk_easy ?
       !(mthing->options & MTF_EASY) :
       gameskill == sk_hard || gameskill == sk_nightmare ?
@@ -1305,7 +1305,7 @@ spawnit:
 
   if (!(mobj->flags & MF_FRIEND) &&
       mthing->options & MTF_FRIEND && 
-      min_mbf)
+      at_least_mbf)
     {
       mobj->flags |= MF_FRIEND;            // killough 10/98:
       P_UpdateThinker(&mobj->thinker);     // transfer friendliness flag
@@ -1410,7 +1410,7 @@ boolean P_CheckMissileSpawn (mobj_t* th)
   th->z += th->momz>>1;
 
   // killough 8/12/98: for non-missile objects (e.g. grenades)
-  if (!(th->flags & MF_MISSILE) && min_mbf)
+  if (!(th->flags & MF_MISSILE) && at_least_mbf)
     return true;
 
   // killough 3/15/98: no dropoff (really = don't care for missiles)
@@ -1482,7 +1482,7 @@ mobj_t* P_SpawnPlayerMissile(mobj_t* source,mobjtype_t type)
   if (!beta_emulation || autoaim)
     {
       // killough 8/2/98: prefer autoaiming at enemies
-      int mask = prior_mbf ? 0 : MF_FRIEND;
+      int mask = at_most_boom ? 0 : MF_FRIEND;
       if (direct_vertical_aiming)
       {
         slope = source->player->slope;

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -217,7 +217,7 @@ void P_XYMovement (mobj_t* mo)
       // to pass through walls.
 
       if (xmove > MAXMOVE/2 || ymove > MAXMOVE/2 ||  // killough 8/9/98:
-	  ((xmove < -MAXMOVE/2 || ymove < -MAXMOVE/2) && demo_version >= DV_MBF))
+	  ((xmove < -MAXMOVE/2 || ymove < -MAXMOVE/2) && min_mbf))
 	{
 	  ptryx = mo->x + xmove/2;
 	  ptryy = mo->y + ymove/2;
@@ -241,7 +241,7 @@ void P_XYMovement (mobj_t* mo)
 	  // killough 10/98:
 	  // Add ability for objects other than players to bounce on ice
 	  
-	  if (!(mo->flags & MF_MISSILE) && demo_version >= DV_MBF &&
+	  if (!(mo->flags & MF_MISSILE) && min_mbf &&
 	      (mo->flags & MF_BOUNCES || 
 	       (!player && blockline &&
 		variable_friction && mo->z <= mo->floorz &&
@@ -284,7 +284,7 @@ void P_XYMovement (mobj_t* mo)
 		  if (ceilingline &&
 		      ceilingline->backsector &&
 		      ceilingline->backsector->ceilingpic == skyflatnum)
-		    if (demo_compatibility ||  // killough
+		    if (prior_boom ||  // killough
 			mo->z > ceilingline->backsector->ceilingheight)
 		      {
 			// Hack to prevent missiles exploding
@@ -335,7 +335,7 @@ void P_XYMovement (mobj_t* mo)
   if (mo->momx > -STOPSPEED && mo->momx < STOPSPEED &&
       mo->momy > -STOPSPEED && mo->momy < STOPSPEED &&
       (!player || !(player->cmd.forwardmove | player->cmd.sidemove) ||
-       (player->mo != mo && demo_version >= DV_MBF &&
+       (player->mo != mo && min_mbf &&
         (comp[comp_voodooscroller] || !(mo->intflags & MIF_SCROLLING)))))
     {
       // if in a walking frame, stop moving
@@ -344,7 +344,7 @@ void P_XYMovement (mobj_t* mo)
       // Don't affect main player when voodoo dolls stop, except in old demos:
 
       if (player && (unsigned)(player->mo->state - states - S_PLAY_RUN1) < 4 
-	  && (player->mo == mo || demo_version < DV_MBF))
+	  && (player->mo == mo || prior_mbf))
 	P_SetMobjState(player->mo, S_PLAY);
 
       mo->momx = mo->momy = 0;
@@ -369,7 +369,7 @@ void P_XYMovement (mobj_t* mo)
       // Reducing player momentum is no longer needed to reduce
       // bobbing, so ice works much better now.
 
-      if (demo_version < DV_MBF)
+      if (prior_mbf)
       {
         // phares 9/10/98: reduce bobbing/momentum when on ice & up against wall
 
@@ -535,7 +535,7 @@ floater:
       // hit the floor
 
       // [FG] game version specific differences
-      int correct_lost_soul_bounce = !demo_compatibility || gameversion >= exe_ultimate;
+      int correct_lost_soul_bounce = min_boom || gameversion >= exe_ultimate;
 
       if ((!comp[comp_soul] || correct_lost_soul_bounce) && mo->flags & MF_SKULLFLY)
       {
@@ -779,13 +779,13 @@ void P_MobjThinker (mobj_t* mobj)
 
 	if (mobj->z > mobj->dropoffz &&      // Only objects contacting dropoff
 	    !(mobj->flags & MF_NOGRAVITY) && // Only objects which fall
-	    !comp[comp_falloff] && demo_version >= DV_MBF) // Not in old demos
+	    !comp[comp_falloff] && min_mbf) // Not in old demos
 	  P_ApplyTorque(mobj);               // Apply torque
 	else
 	  mobj->intflags &= ~MIF_FALLING, mobj->gear = 0;  // Reset torque
       }
 
-  if (mbf21)
+  if (min_mbf21)
   {
     sector_t* sector = mobj->subsector->sector;
 
@@ -844,7 +844,7 @@ mobj_t *P_SpawnMobj(fixed_t x, fixed_t y, fixed_t z, mobjtype_t type)
   mobj->flags2 = info->flags2;
 
   // killough 8/23/98: no friends, bouncers, or touchy things in old demos
-  if (demo_version < DV_MBF)
+  if (prior_mbf)
     mobj->flags &= ~(MF_BOUNCES | MF_FRIEND | MF_TOUCHY); 
   else
     if (type == MT_PLAYER)         // Except in old demos, players
@@ -964,7 +964,7 @@ void P_RemoveMobj (mobj_t *mobj)
   // if multiple thinkers reference each other indirectly before the
   // end of the current tic.
 
-  if (demo_version >= DV_MBF)
+  if (min_mbf)
     {
       P_SetTarget(&mobj->target,    NULL);
       P_SetTarget(&mobj->tracer,    NULL);
@@ -1177,8 +1177,8 @@ void P_SpawnMapThing (mapthing_t* mthing)
   // bits that weren't used in Doom (such as HellMaker wads). So we should
   // then simply ignore all upper bits.
 
-  if (demo_compatibility || 
-      (demo_version >= DV_MBF && mthing->options & MTF_RESERVED))
+  if (prior_boom || 
+      (min_mbf && mthing->options & MTF_RESERVED))
     mthing->options &= MTF_EASY|MTF_NORMAL|MTF_HARD|MTF_AMBUSH|MTF_NOTSINGLE;
 
   // count deathmatch start positions
@@ -1190,7 +1190,7 @@ void P_SpawnMapThing (mapthing_t* mthing)
       size_t offset = deathmatch_p - deathmatchstarts;
 
       // doom2.exe has at most 10 deathmatch starts
-      if (demo_compatibility && offset >= 10)
+      if (prior_boom && offset >= 10)
         return;
 
       if (offset >= num_deathmatchstarts)
@@ -1247,7 +1247,7 @@ void P_SpawnMapThing (mapthing_t* mthing)
     return;
 
   // killough 11/98: simplify
-  if ((gameskill == sk_none && demo_compatibility) ||
+  if ((gameskill == sk_none && prior_boom) ||
       (gameskill == sk_baby || gameskill == sk_easy ?
       !(mthing->options & MTF_EASY) :
       gameskill == sk_hard || gameskill == sk_nightmare ?
@@ -1305,7 +1305,7 @@ spawnit:
 
   if (!(mobj->flags & MF_FRIEND) &&
       mthing->options & MTF_FRIEND && 
-      demo_version >= DV_MBF)
+      min_mbf)
     {
       mobj->flags |= MF_FRIEND;            // killough 10/98:
       P_UpdateThinker(&mobj->thinker);     // transfer friendliness flag
@@ -1410,7 +1410,7 @@ boolean P_CheckMissileSpawn (mobj_t* th)
   th->z += th->momz>>1;
 
   // killough 8/12/98: for non-missile objects (e.g. grenades)
-  if (!(th->flags & MF_MISSILE) && demo_version >= DV_MBF)
+  if (!(th->flags & MF_MISSILE) && min_mbf)
     return true;
 
   // killough 3/15/98: no dropoff (really = don't care for missiles)
@@ -1482,7 +1482,7 @@ mobj_t* P_SpawnPlayerMissile(mobj_t* source,mobjtype_t type)
   if (!beta_emulation || autoaim)
     {
       // killough 8/2/98: prefer autoaiming at enemies
-      int mask = demo_version < DV_MBF ? 0 : MF_FRIEND;
+      int mask = prior_mbf ? 0 : MF_FRIEND;
       if (direct_vertical_aiming)
       {
         slope = source->player->slope;

--- a/src/p_plats.c
+++ b/src/p_plats.c
@@ -127,7 +127,7 @@ void T_PlatRaise(plat_t* plat)
         //killough 1/31/98: relax compatibility to demo_compatibility
 
         // remove the plat if its a pure raise type
-        if (demo_version < DV_MBF ? !demo_compatibility : !comp[comp_floors])
+        if (prior_mbf ? min_boom : !comp[comp_floors])
         {
           switch(plat->type)
           {

--- a/src/p_plats.c
+++ b/src/p_plats.c
@@ -127,7 +127,7 @@ void T_PlatRaise(plat_t* plat)
         //killough 1/31/98: relax compatibility to demo_compatibility
 
         // remove the plat if its a pure raise type
-        if (prior_mbf ? min_boom : !comp[comp_floors])
+        if (at_most_boom ? at_least_boom : !comp[comp_floors])
         {
           switch(plat->type)
           {

--- a/src/p_pspr.c
+++ b/src/p_pspr.c
@@ -170,7 +170,7 @@ static void P_BringUpWeapon(player_t *player)
   pspdef_t *psp = &player->psprites[ps_weapon];
 
   // killough 12/98: prevent pistol from starting visibly at bottom of screen:
-  psp->sy = demo_version >= DV_MBF ? WEAPONBOTTOM + FRACUNIT * 2 : WEAPONBOTTOM;
+  psp->sy = min_mbf ? WEAPONBOTTOM + FRACUNIT * 2 : WEAPONBOTTOM;
 
   psp->sy2 = psp->oldsy2 = psp->sy;
 
@@ -265,7 +265,7 @@ static int P_SwitchWeaponMBF21(player_t *player)
 
 int P_SwitchWeapon(player_t *player)
 {
-  int *prefer = weapon_preferences[demo_compatibility!=0]; // killough 3/22/98
+  int *prefer = weapon_preferences[prior_boom!=0]; // killough 3/22/98
   int currentweapon = player->readyweapon;
   int newweapon = currentweapon;
   int i = NUMWEAPONS+1;   // killough 5/2/98
@@ -276,11 +276,11 @@ int P_SwitchWeapon(player_t *player)
   // for a discrete compat option for this, as
   // it doesn't impact demo playback (weapon
   // switches are saved in the demo itself)
-  if (mbf21)
+  if (min_mbf21)
     return P_SwitchWeaponMBF21(player);
 
   // Fix weapon switch logic in vanilla (example: chainsaw with ammo)
-  if (demo_compatibility)
+  if (prior_boom)
     currentweapon = newweapon = wp_nochange;
 
   // killough 2/8/98: follow preferences and fix BFG/SSG bugs
@@ -317,7 +317,7 @@ int P_SwitchWeapon(player_t *player)
         break;
       case 7:
         if (player->weaponowned[wp_bfg] && gamemode != shareware &&
-            player->ammo[am_cell] >= (demo_compatibility ? 41 : 40))
+            player->ammo[am_cell] >= (prior_boom ? 41 : 40))
           newweapon = wp_bfg;
         break;
       case 8:
@@ -326,7 +326,7 @@ int P_SwitchWeapon(player_t *player)
         break;
       case 9:
         if (player->weaponowned[wp_supershotgun] && ALLOW_SSG &&
-            player->ammo[am_shell] >= (demo_compatibility ? 3 : 2))
+            player->ammo[am_shell] >= (prior_boom ? 3 : 2))
           newweapon = wp_supershotgun;
         break;
       }
@@ -361,7 +361,7 @@ boolean P_CheckAmmo(player_t *player)
   ammotype_t ammo = weaponinfo[player->readyweapon].ammo;
   int count = 1;  // Regular
 
-  if (mbf21)
+  if (min_mbf21)
     count = weaponinfo[player->readyweapon].ammopershot;
   else
   if (player->readyweapon == wp_bfg)  // Minimal amount for one shot varies.
@@ -383,7 +383,7 @@ boolean P_CheckAmmo(player_t *player)
   // preferences across demos or networks, so we have to use the
   // G_BuildTiccmd() interface instead of making the switch here.
 
-  if (demo_compatibility)
+  if (prior_boom)
     {
       player->pendingweapon = P_SwitchWeapon(player);      // phares
       // Now set appropriate weapon overlay.
@@ -417,17 +417,17 @@ void P_SubtractAmmo(struct player_s *player, int vanilla_amount)
   int amount;
   ammotype_t ammotype = weaponinfo[player->readyweapon].ammo;
 
-  if (mbf21 && ammotype == am_noammo)
+  if (min_mbf21 && ammotype == am_noammo)
     return; // [XA] hmm... I guess vanilla/boom will go out of bounds then?
 
-  if (mbf21 && (weaponinfo[player->readyweapon].intflags & WIF_ENABLEAPS))
+  if (min_mbf21 && (weaponinfo[player->readyweapon].intflags & WIF_ENABLEAPS))
     amount = weaponinfo[player->readyweapon].ammopershot;
   else
     amount = vanilla_amount;
 
   player->ammo[ammotype] -= amount;
 
-  if (mbf21 && player->ammo[ammotype] < 0)
+  if (min_mbf21 && player->ammo[ammotype] < 0)
     player->ammo[ammotype] = 0;
 }
 
@@ -554,7 +554,7 @@ boolean boom_weapon_state_injection;
 
 void A_CheckReload(player_t *player, pspdef_t *psp)
 {
-  if (!P_CheckAmmo(player) && mbf21)
+  if (!P_CheckAmmo(player) && min_mbf21)
   {
     // cph 2002/08/08 - In old Doom, P_CheckAmmo would start the weapon lowering
     // immediately. This was lost in Boom when the weapon switching logic was
@@ -596,7 +596,7 @@ void A_Lower(player_t *player, pspdef_t *psp)
       return;
     }
 
-  if (player->pendingweapon < NUMWEAPONS || !mbf21)
+  if (player->pendingweapon < NUMWEAPONS || prior_mbf21)
   {
     player->lastweapon = player->readyweapon;
     player->readyweapon = player->pendingweapon;
@@ -642,7 +642,7 @@ static void A_FireSomething(player_t* player,int adder)
 
   // killough 3/27/98: prevent recoil in no-clipping mode
   if (!(player->mo->flags & MF_NOCLIP))
-    if (weapon_recoil && (demo_version >= DV_MBF || !compatibility))
+    if (weapon_recoil && (min_mbf || !compatibility))
       P_Thrust(player, ANG180 + player->mo->angle,
                2048*recoil_values[player->readyweapon].thrust);          // phares
 }
@@ -693,10 +693,10 @@ void A_Punch(player_t *player, pspdef_t *psp)
   t = P_Random(pr_punchangle);
   angle += (t - P_Random(pr_punchangle))<<18;
 
-  range = (mbf21 ? player->mo->info->meleerange : MELEERANGE);
+  range = (min_mbf21 ? player->mo->info->meleerange : MELEERANGE);
 
   // killough 8/2/98: make autoaiming prefer enemies
-  if (demo_version < DV_MBF ||
+  if (prior_mbf ||
       (slope = P_AimLineAttack(player->mo, angle, range, MF_FRIEND),
        !linetarget))
     slope = P_AimLineAttack(player->mo, angle, range, 0);
@@ -732,10 +732,10 @@ void A_Saw(player_t *player, pspdef_t *psp)
   angle += (t - P_Random(pr_saw))<<18;
 
   // Use meleerange + 1 so that the puff doesn't skip the flash
-  range = (mbf21 ? player->mo->info->meleerange : MELEERANGE) + 1;
+  range = (min_mbf21 ? player->mo->info->meleerange : MELEERANGE) + 1;
 
   // killough 8/2/98: make autoaiming prefer enemies
-  if (demo_version < DV_MBF ||
+  if (prior_mbf ||
       (slope = P_AimLineAttack(player->mo, angle, range, MF_FRIEND),
        !linetarget))
     slope = P_AimLineAttack(player->mo, angle, range, 0);
@@ -898,7 +898,7 @@ static void P_BulletSlope(mobj_t *mo)
   angle_t an = mo->angle;    // see which target is to be aimed at
 
   // killough 8/2/98: make autoaiming prefer enemies
-  int mask = demo_version < DV_MBF ? 0 : MF_FRIEND;
+  int mask = prior_mbf ? 0 : MF_FRIEND;
 
   if (direct_vertical_aiming)
   {
@@ -1066,7 +1066,7 @@ void A_BFGSpray(mobj_t *mo)
       // mo->target is the originator (player) of the missile
 
       // killough 8/2/98: make autoaiming prefer enemies
-      if (demo_version < DV_MBF || 
+      if (prior_mbf || 
 	  (P_AimLineAttack(mo->target, an, 16*64*FRACUNIT, MF_FRIEND), 
 	   !linetarget))
 	P_AimLineAttack(mo->target, an, 16*64*FRACUNIT, 0);
@@ -1209,7 +1209,7 @@ void A_WeaponProjectile(player_t *player, pspdef_t *psp)
   mobj_t *mo;
   int an;
 
-  if (!mbf21 || !psp->state || !psp->state->args[0])
+  if (prior_mbf21 || !psp->state || !psp->state->args[0])
     return;
 
   type        = psp->state->args[0] - 1;
@@ -1258,7 +1258,7 @@ void A_WeaponBulletAttack(player_t *player, pspdef_t *psp)
   int hspread, vspread, numbullets, damagebase, damagemod;
   int i, damage, angle, slope;
 
-  if (!mbf21 || !psp->state)
+  if (prior_mbf21 || !psp->state)
     return;
 
   hspread    = psp->state->args[0];
@@ -1296,7 +1296,7 @@ void A_WeaponMeleeAttack(player_t *player, pspdef_t *psp)
   angle_t angle;
   int t, slope, damage;
 
-  if (!mbf21 || !psp->state)
+  if (prior_mbf21 || !psp->state)
     return;
 
   damagebase = psp->state->args[0];
@@ -1349,7 +1349,7 @@ void A_WeaponMeleeAttack(player_t *player, pspdef_t *psp)
 //
 void A_WeaponSound(player_t *player, pspdef_t *psp)
 {
-  if (!mbf21 || !psp->state)
+  if (prior_mbf21 || !psp->state)
     return;
 
   S_StartSoundOrigin(player->mo, (psp->state->args[1] ? NULL : player->mo),
@@ -1362,7 +1362,7 @@ void A_WeaponSound(player_t *player, pspdef_t *psp)
 //
 void A_WeaponAlert(player_t *player, pspdef_t *psp)
 {
-  if (!mbf21)
+  if (prior_mbf21)
     return;
 
   P_NoiseAlert(player->mo, player->mo);
@@ -1377,7 +1377,7 @@ void A_WeaponAlert(player_t *player, pspdef_t *psp)
 //
 void A_WeaponJump(player_t *player, pspdef_t *psp)
 {
-  if (!mbf21 || !psp->state)
+  if (prior_mbf21 || !psp->state)
     return;
 
   if (P_Random(pr_mbf21) < psp->state->args[1])
@@ -1394,7 +1394,7 @@ void A_ConsumeAmmo(player_t *player, pspdef_t *psp)
   int amount;
   ammotype_t type;
 
-  if (!mbf21)
+  if (prior_mbf21)
     return;
 
   // don't do dumb things, kids
@@ -1427,7 +1427,7 @@ void A_CheckAmmo(player_t *player, pspdef_t *psp)
   int amount;
   ammotype_t type;
 
-  if (!mbf21)
+  if (prior_mbf21)
     return;
 
   type = weaponinfo[player->readyweapon].ammo;
@@ -1451,7 +1451,7 @@ void A_CheckAmmo(player_t *player, pspdef_t *psp)
 //
 void A_RefireTo(player_t *player, pspdef_t *psp)
 {
-  if (!mbf21 || !psp->state)
+  if (prior_mbf21 || !psp->state)
     return;
 
   if ((psp->state->args[1] || P_CheckAmmo(player))
@@ -1468,7 +1468,7 @@ void A_RefireTo(player_t *player, pspdef_t *psp)
 //
 void A_GunFlashTo(player_t *player, pspdef_t *psp)
 {
-  if (!mbf21 || !psp->state)
+  if (prior_mbf21 || !psp->state)
     return;
 
   if(!psp->state->args[1])

--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -166,7 +166,7 @@ sector_t* GetSectorAtNullAddress(void)
   static boolean null_sector_is_initialized = false;
   static sector_t null_sector;
 
-  if (prior_boom && overflow[emu_missedbackside].enabled)
+  if (at_most_vanilla && overflow[emu_missedbackside].enabled)
   {
     overflow[emu_missedbackside].triggered = true;
 
@@ -551,7 +551,7 @@ void P_LoadLineDefs2(int lump)
 
       if (ld->sidenum[1] == NO_INDEX)
       {
-	if (min_boom || !overflow[emu_missedbackside].enabled)
+	if (at_least_boom || !overflow[emu_missedbackside].enabled)
 	ld->flags &= ~ML_TWOSIDED;  // Clear 2s flag for missing left side
       }
 
@@ -1400,7 +1400,7 @@ void P_RemoveSlimeTrails(void)                // killough 10/98
 		    v->r_y = (fixed_t)((dy2 * y0 + dx2 * y1 + dxy * (x0 - x1)) / s);
 
 		    // [FG] override actual vertex coordinates except in compatibility mode
-		    if (min_mbf)
+		    if (at_least_mbf)
 		    {
 		      v->x = v->r_x;
 		      v->y = v->r_y;
@@ -1518,7 +1518,7 @@ static boolean P_LoadReject(int lumpnum, int totallines)
 
         memset(rejectmatrix + lumplen, padvalue, minlength - lumplen);
 
-        if (prior_boom && overflow[emu_reject].enabled)
+        if (at_most_vanilla && overflow[emu_reject].enabled)
         {
             unsigned int i;
             unsigned int byte_num;

--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -166,7 +166,7 @@ sector_t* GetSectorAtNullAddress(void)
   static boolean null_sector_is_initialized = false;
   static sector_t null_sector;
 
-  if (demo_compatibility && overflow[emu_missedbackside].enabled)
+  if (prior_boom && overflow[emu_missedbackside].enabled)
   {
     overflow[emu_missedbackside].triggered = true;
 
@@ -551,7 +551,7 @@ void P_LoadLineDefs2(int lump)
 
       if (ld->sidenum[1] == NO_INDEX)
       {
-	if (!demo_compatibility || !overflow[emu_missedbackside].enabled)
+	if (min_boom || !overflow[emu_missedbackside].enabled)
 	ld->flags &= ~ML_TWOSIDED;  // Clear 2s flag for missing left side
       }
 
@@ -1400,7 +1400,7 @@ void P_RemoveSlimeTrails(void)                // killough 10/98
 		    v->r_y = (fixed_t)((dy2 * y0 + dx2 * y1 + dxy * (x0 - x1)) / s);
 
 		    // [FG] override actual vertex coordinates except in compatibility mode
-		    if (demo_version >= DV_MBF)
+		    if (min_mbf)
 		    {
 		      v->x = v->r_x;
 		      v->y = v->r_y;
@@ -1518,7 +1518,7 @@ static boolean P_LoadReject(int lumpnum, int totallines)
 
         memset(rejectmatrix + lumplen, padvalue, minlength - lumplen);
 
-        if (demo_compatibility && overflow[emu_reject].enabled)
+        if (prior_boom && overflow[emu_reject].enabled)
         {
             unsigned int i;
             unsigned int byte_num;

--- a/src/p_sight.c
+++ b/src/p_sight.c
@@ -56,7 +56,7 @@ int P_DivlineSide(fixed_t x, fixed_t y, const divline_t *node)
   fixed_t left = 0, right = 0; // [FG] initialize
   return
     !node->dx ? x == node->x ? 2 : x <= node->x ? node->dy > 0 : node->dy < 0 :
-    !node->dy ? (min_mbf21 ? y : x) == node->y ? 2 : y <= node->y ? node->dx < 0 : node->dx > 0 :
+    !node->dy ? (at_least_mbf21 ? y : x) == node->y ? 2 : y <= node->y ? node->dx < 0 : node->dx > 0 :
     (right = ((y - node->y) >> FRACBITS) * (node->dx >> FRACBITS)) <
     (left  = ((x - node->x) >> FRACBITS) * (node->dy >> FRACBITS)) ? 0 :
     right == left ? 2 : 1;
@@ -116,7 +116,7 @@ static boolean P_CrossSubsector(int num, register los_t *los)
 
       // [FG] Compatibility bug in P_CrossSubsector
       // http://prboom.sourceforge.net/mbf-bugs.html
-      if (min_boom)
+      if (at_least_boom)
       {
       if (line->bbox[BOXLEFT  ] > los->bbox[BOXRIGHT ] ||
           line->bbox[BOXRIGHT ] < los->bbox[BOXLEFT  ] ||
@@ -150,7 +150,7 @@ static boolean P_CrossSubsector(int num, register los_t *los)
       back = seg->backsector;
 
       // missed back side on two-sided lines.
-      if (prior_boom && !back)
+      if (at_most_vanilla && !back)
       {
         back = GetSectorAtNullAddress();
       }
@@ -260,7 +260,7 @@ static boolean P_CheckSight_MBF(mobj_t *t1, mobj_t *t2)
   // killough 11/98: shortcut for melee situations
   // [FG] Compatibility bug in P_CheckSight
   // http://prboom.sourceforge.net/mbf-bugs.html
-  if (t1->subsector == t2->subsector && min_mbf)     // same subsector? obviously visible
+  if (t1->subsector == t2->subsector && at_least_mbf)     // same subsector? obviously visible
     return true;
 
   // An unobstructed LOS is possible.

--- a/src/p_sight.c
+++ b/src/p_sight.c
@@ -56,7 +56,7 @@ int P_DivlineSide(fixed_t x, fixed_t y, const divline_t *node)
   fixed_t left = 0, right = 0; // [FG] initialize
   return
     !node->dx ? x == node->x ? 2 : x <= node->x ? node->dy > 0 : node->dy < 0 :
-    !node->dy ? (mbf21 ? y : x) == node->y ? 2 : y <= node->y ? node->dx < 0 : node->dx > 0 :
+    !node->dy ? (min_mbf21 ? y : x) == node->y ? 2 : y <= node->y ? node->dx < 0 : node->dx > 0 :
     (right = ((y - node->y) >> FRACBITS) * (node->dx >> FRACBITS)) <
     (left  = ((x - node->x) >> FRACBITS) * (node->dy >> FRACBITS)) ? 0 :
     right == left ? 2 : 1;
@@ -116,7 +116,7 @@ static boolean P_CrossSubsector(int num, register los_t *los)
 
       // [FG] Compatibility bug in P_CrossSubsector
       // http://prboom.sourceforge.net/mbf-bugs.html
-      if (!demo_compatibility)
+      if (min_boom)
       {
       if (line->bbox[BOXLEFT  ] > los->bbox[BOXRIGHT ] ||
           line->bbox[BOXRIGHT ] < los->bbox[BOXLEFT  ] ||
@@ -150,7 +150,7 @@ static boolean P_CrossSubsector(int num, register los_t *los)
       back = seg->backsector;
 
       // missed back side on two-sided lines.
-      if (demo_compatibility && !back)
+      if (prior_boom && !back)
       {
         back = GetSectorAtNullAddress();
       }
@@ -260,7 +260,7 @@ static boolean P_CheckSight_MBF(mobj_t *t1, mobj_t *t2)
   // killough 11/98: shortcut for melee situations
   // [FG] Compatibility bug in P_CheckSight
   // http://prboom.sourceforge.net/mbf-bugs.html
-  if (t1->subsector == t2->subsector && demo_version >= DV_MBF)     // same subsector? obviously visible
+  if (t1->subsector == t2->subsector && min_mbf)     // same subsector? obviously visible
     return true;
 
   // An unobstructed LOS is possible.

--- a/src/p_spec.c
+++ b/src/p_spec.c
@@ -661,7 +661,7 @@ sector_t *P_FindModelFloorSector(fixed_t floordestheight, int secnum)
 
   int i, linecount = sec->linecount;
 
-  for (i = 0; i < (prior_boom && sec->linecount < linecount ?
+  for (i = 0; i < (at_most_vanilla && sec->linecount < linecount ?
                    sec->linecount : linecount); i++)
     if (twoSided(secnum, i) &&
         (sec = getSector(secnum, i,
@@ -697,7 +697,7 @@ sector_t *P_FindModelCeilingSector(fixed_t ceildestheight, int secnum)
   // but allow early exit in old demos
   int i, linecount = sec->linecount;
 
-  for (i = 0; i < (prior_boom && sec->linecount<linecount?
+  for (i = 0; i < (at_most_vanilla && sec->linecount<linecount?
                    sec->linecount : linecount); i++)
     if (twoSided(secnum, i) &&
         (sec = getSector(secnum, i,
@@ -918,7 +918,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
 
 int P_SectorActive(special_e t,sector_t *sec)
 {
-  return prior_boom ?  // return whether any thinker is active
+  return at_most_vanilla ?  // return whether any thinker is active
     sec->floordata || sec->ceilingdata || sec->lightingdata :
     t == floor_special ? !!sec->floordata :        // return whether
     t == ceiling_special ? !!sec->ceilingdata :    // thinker of same
@@ -1007,7 +1007,7 @@ boolean P_IsDeathExit(sector_t *sector)
   {
     return (sector->special == 11);
   }
-  else if (min_mbf21 && sector->special & DEATH_MASK)
+  else if (at_least_mbf21 && sector->special & DEATH_MASK)
   {
     const int i = (sector->special & DAMAGE_MASK) >> DAMAGE_SHIFT;
 
@@ -1091,7 +1091,7 @@ void P_CrossSpecialLine(line_t *line, int side, mobj_t *thing, boolean bossactio
       }
 
   //jff 02/04/98 add check here for generalized lindef types
-  if (min_boom) // generalized types not recognized if old demo
+  if (at_least_boom) // generalized types not recognized if old demo
     {
       // pointer to line function is NULL by default, set non-null if
       // line special is walkover generalized linedef type
@@ -1166,7 +1166,7 @@ void P_CrossSpecialLine(line_t *line, int side, mobj_t *thing, boolean bossactio
                     linefunc = EV_DoGenStairs;
                   }
               else
-                if (min_mbf21 && (unsigned)line->special >= GenCrusherBase)
+                if (at_least_mbf21 && (unsigned)line->special >= GenCrusherBase)
                   {
                     // haleyjd 06/09/09: This was completely forgotten in BOOM, disabling
                     // all generalized walk-over crusher types!
@@ -1238,128 +1238,128 @@ void P_CrossSpecialLine(line_t *line, int side, mobj_t *thing, boolean bossactio
 
     case 2:
       // Open Door
-      if (EV_DoDoor(line,doorOpen) || prior_boom)
+      if (EV_DoDoor(line,doorOpen) || at_most_vanilla)
         line->special = 0;
       break;
 
     case 3:
       // Close Door
-      if (EV_DoDoor(line,doorClose) || prior_boom)
+      if (EV_DoDoor(line,doorClose) || at_most_vanilla)
         line->special = 0;
       break;
 
     case 4:
       // Raise Door
-      if (EV_DoDoor(line,doorNormal) || prior_boom)
+      if (EV_DoDoor(line,doorNormal) || at_most_vanilla)
         line->special = 0;
       break;
 
     case 5:
       // Raise Floor
-      if (EV_DoFloor(line,raiseFloor) || prior_boom)
+      if (EV_DoFloor(line,raiseFloor) || at_most_vanilla)
         line->special = 0;
       break;
 
     case 6:
       // Fast Ceiling Crush & Raise
-      if (EV_DoCeiling(line,fastCrushAndRaise) || prior_boom)
+      if (EV_DoCeiling(line,fastCrushAndRaise) || at_most_vanilla)
         line->special = 0;
       break;
 
     case 8:
       // Build Stairs
-      if (EV_BuildStairs(line,build8) || prior_boom)
+      if (EV_BuildStairs(line,build8) || at_most_vanilla)
         line->special = 0;
       break;
 
     case 10:
       // PlatDownWaitUp
-      if (EV_DoPlat(line,downWaitUpStay,0) || prior_boom)
+      if (EV_DoPlat(line,downWaitUpStay,0) || at_most_vanilla)
         line->special = 0;
       break;
 
     case 12:
       // Light Turn On - brightest near
-      if (EV_LightTurnOn(line,0) || prior_boom)
+      if (EV_LightTurnOn(line,0) || at_most_vanilla)
         line->special = 0;
       break;
 
     case 13:
       // Light Turn On 255
-      if (EV_LightTurnOn(line,255) || prior_boom)
+      if (EV_LightTurnOn(line,255) || at_most_vanilla)
         line->special = 0;
       break;
 
     case 16:
       // Close Door 30
-      if (EV_DoDoor(line,close30ThenOpen) || prior_boom)
+      if (EV_DoDoor(line,close30ThenOpen) || at_most_vanilla)
         line->special = 0;
       break;
 
     case 17:
       // Start Light Strobing
-      if (EV_StartLightStrobing(line) || prior_boom)
+      if (EV_StartLightStrobing(line) || at_most_vanilla)
         line->special = 0;
       break;
 
     case 19:
       // Lower Floor
-      if (EV_DoFloor(line,lowerFloor) || prior_boom)
+      if (EV_DoFloor(line,lowerFloor) || at_most_vanilla)
         line->special = 0;
       break;
 
     case 22:
       // Raise floor to nearest height and change texture
-      if (EV_DoPlat(line,raiseToNearestAndChange,0) || prior_boom)
+      if (EV_DoPlat(line,raiseToNearestAndChange,0) || at_most_vanilla)
         line->special = 0;
       break;
 
     case 25:
       // Ceiling Crush and Raise
-      if (EV_DoCeiling(line,crushAndRaise) || prior_boom)
+      if (EV_DoCeiling(line,crushAndRaise) || at_most_vanilla)
         line->special = 0;
       break;
 
     case 30:
       // Raise floor to shortest texture height
       //  on either side of lines.
-      if (EV_DoFloor(line,raiseToTexture) || prior_boom)
+      if (EV_DoFloor(line,raiseToTexture) || at_most_vanilla)
         line->special = 0;
       break;
 
     case 35:
       // Lights Very Dark
-      if (EV_LightTurnOn(line,35) || prior_boom)
+      if (EV_LightTurnOn(line,35) || at_most_vanilla)
         line->special = 0;
       break;
 
     case 36:
       // Lower Floor (TURBO)
-      if (EV_DoFloor(line,turboLower) || prior_boom)
+      if (EV_DoFloor(line,turboLower) || at_most_vanilla)
         line->special = 0;
       break;
 
     case 37:
       // LowerAndChange
-      if (EV_DoFloor(line,lowerAndChange) || prior_boom)
+      if (EV_DoFloor(line,lowerAndChange) || at_most_vanilla)
         line->special = 0;
       break;
 
     case 38:
       // Lower Floor To Lowest
-      if (EV_DoFloor(line, lowerFloorToLowest) || prior_boom)
+      if (EV_DoFloor(line, lowerFloorToLowest) || at_most_vanilla)
         line->special = 0;
       break;
 
     case 39:
       // TELEPORT! //jff 02/09/98 fix using up with wrong side crossing
-      if (EV_Teleport(line, side, thing) || prior_boom)
+      if (EV_Teleport(line, side, thing) || at_most_vanilla)
         line->special = 0;
       break;
 
     case 40:
       // RaiseCeilingLowerFloor
-      if (prior_boom)
+      if (at_most_vanilla)
         {
           EV_DoCeiling( line, raiseToHighest );
           EV_DoFloor( line, lowerFloorToLowest ); //jff 02/12/98 doesn't work
@@ -1372,7 +1372,7 @@ void P_CrossSpecialLine(line_t *line, int side, mobj_t *thing, boolean bossactio
 
     case 44:
       // Ceiling Crush
-      if (EV_DoCeiling(line, lowerAndCrush) || prior_boom)
+      if (EV_DoCeiling(line, lowerAndCrush) || at_most_vanilla)
         line->special = 0;
       break;
 
@@ -1386,79 +1386,79 @@ void P_CrossSpecialLine(line_t *line, int side, mobj_t *thing, boolean bossactio
 
     case 53:
       // Perpetual Platform Raise
-      if (EV_DoPlat(line,perpetualRaise,0) || prior_boom)
+      if (EV_DoPlat(line,perpetualRaise,0) || at_most_vanilla)
         line->special = 0;
       break;
 
     case 54:
       // Platform Stop
-      if (EV_StopPlat(line) || prior_boom)
+      if (EV_StopPlat(line) || at_most_vanilla)
         line->special = 0;
       break;
 
     case 56:
       // Raise Floor Crush
-      if (EV_DoFloor(line,raiseFloorCrush) || prior_boom)
+      if (EV_DoFloor(line,raiseFloorCrush) || at_most_vanilla)
         line->special = 0;
       break;
 
     case 57:
       // Ceiling Crush Stop
-      if (EV_CeilingCrushStop(line) || prior_boom)
+      if (EV_CeilingCrushStop(line) || at_most_vanilla)
         line->special = 0;
       break;
 
     case 58:
       // Raise Floor 24
-      if (EV_DoFloor(line,raiseFloor24) || prior_boom)
+      if (EV_DoFloor(line,raiseFloor24) || at_most_vanilla)
         line->special = 0;
       break;
 
     case 59:
       // Raise Floor 24 And Change
-      if (EV_DoFloor(line,raiseFloor24AndChange) || prior_boom)
+      if (EV_DoFloor(line,raiseFloor24AndChange) || at_most_vanilla)
         line->special = 0;
       break;
 
     case 100:
       // Build Stairs Turbo 16
-      if (EV_BuildStairs(line,turbo16) || prior_boom)
+      if (EV_BuildStairs(line,turbo16) || at_most_vanilla)
         line->special = 0;
       break;
 
     case 104:
       // Turn lights off in sector(tag)
-      if (EV_TurnTagLightsOff(line) || prior_boom)
+      if (EV_TurnTagLightsOff(line) || at_most_vanilla)
         line->special = 0;
       break;
 
     case 108:
       // Blazing Door Raise (faster than TURBO!)
-      if (EV_DoDoor(line,blazeRaise) || prior_boom)
+      if (EV_DoDoor(line,blazeRaise) || at_most_vanilla)
         line->special = 0;
       break;
 
     case 109:
       // Blazing Door Open (faster than TURBO!)
-      if (EV_DoDoor (line,blazeOpen) || prior_boom)
+      if (EV_DoDoor (line,blazeOpen) || at_most_vanilla)
         line->special = 0;
       break;
 
     case 110:
       // Blazing Door Close (faster than TURBO!)
-      if (EV_DoDoor (line,blazeClose) || prior_boom)
+      if (EV_DoDoor (line,blazeClose) || at_most_vanilla)
         line->special = 0;
       break;
 
     case 119:
       // Raise floor to nearest surr. floor
-      if (EV_DoFloor(line,raiseFloorToNearest) || prior_boom)
+      if (EV_DoFloor(line,raiseFloorToNearest) || at_most_vanilla)
         line->special = 0;
       break;
 
     case 121:
       // Blazing PlatDownWaitUpStay
-      if (EV_DoPlat(line,blazeDWUS,0) || prior_boom)
+      if (EV_DoPlat(line,blazeDWUS,0) || at_most_vanilla)
         line->special = 0;
       break;
 
@@ -1473,19 +1473,19 @@ void P_CrossSpecialLine(line_t *line, int side, mobj_t *thing, boolean bossactio
     case 125:
       // TELEPORT MonsterONLY
       if (!thing->player &&
-          (EV_Teleport(line, side, thing) || prior_boom))
+          (EV_Teleport(line, side, thing) || at_most_vanilla))
         line->special = 0;
       break;
 
     case 130:
       // Raise Floor Turbo
-      if (EV_DoFloor(line,raiseFloorTurbo) || prior_boom)
+      if (EV_DoFloor(line,raiseFloorTurbo) || at_most_vanilla)
         line->special = 0;
       break;
 
     case 141:
       // Silent Ceiling Crush & Raise
-      if (EV_DoCeiling(line,silentCrushAndRaise) || prior_boom)
+      if (EV_DoCeiling(line,silentCrushAndRaise) || at_most_vanilla)
         line->special = 0;
       break;
 
@@ -1666,7 +1666,7 @@ void P_CrossSpecialLine(line_t *line, int side, mobj_t *thing, boolean bossactio
       // killough 2/16/98: Fix problems with W1 types being cleared too early
 
     default:
-      if (min_boom)
+      if (at_least_boom)
         switch (line->special)
           {
             // Extended walk once triggers
@@ -1977,7 +1977,7 @@ void P_CrossSpecialLine(line_t *line, int side, mobj_t *thing, boolean bossactio
 void P_ShootSpecialLine(mobj_t *thing, line_t *line)
 {
   //jff 02/04/98 add check here for generalized linedef
-  if (min_boom)
+  if (at_least_boom)
     {
       // pointer to line function is NULL by default, set non-null if
       // line special is gun triggered generalized linedef type
@@ -2102,7 +2102,7 @@ void P_ShootSpecialLine(mobj_t *thing, line_t *line)
     {
     case 24:
       // 24 G1 raise floor to highest adjacent
-      if (EV_DoFloor(line,raiseFloor) || prior_boom)
+      if (EV_DoFloor(line,raiseFloor) || at_most_vanilla)
         P_ChangeSwitchTexture(line,0);
       break;
 
@@ -2114,7 +2114,7 @@ void P_ShootSpecialLine(mobj_t *thing, line_t *line)
 
     case 47:
       // 47 G1 raise floor to nearest and change texture and type
-      if (EV_DoPlat(line,raiseToNearestAndChange,0) || prior_boom)
+      if (EV_DoPlat(line,raiseToNearestAndChange,0) || at_most_vanilla)
         P_ChangeSwitchTexture(line,0);
       break;
 
@@ -2122,7 +2122,7 @@ void P_ShootSpecialLine(mobj_t *thing, line_t *line)
       // killough 1/31/98: added demo_compatibility check, added inner switch
 
     default:
-      if (min_boom)
+      if (at_least_boom)
         switch (line->special)
           {
           case 197:
@@ -2269,7 +2269,7 @@ void P_PlayerInSpecialSector (player_t *player)
     }
   else //jff 3/14/98 handle extended sector types for secrets and damage
     {
-      if (min_mbf21 && sector->special & DEATH_MASK)
+      if (at_least_mbf21 && sector->special & DEATH_MASK)
       {
         int i;
 
@@ -2580,7 +2580,7 @@ void P_SpawnSpecials (void)
 
   P_SpawnScrollers(); // killough 3/7/98: Add generalized scrollers
 
-  if (min_boom)
+  if (at_least_boom)
   {
   P_SpawnFriction();  // phares 3/12/98: New friction model using linedefs
 
@@ -2838,7 +2838,7 @@ static void P_SpawnScrollers(void)
       int control = -1, accel = 0;         // no control sector or acceleration
       int special = l->special;
 
-      if (prior_boom && special != 48)
+      if (at_most_vanilla && special != 48)
         continue;
 
       // killough 3/7/98: Types 245-249 are same as 250-254 except that the
@@ -3083,7 +3083,7 @@ static void P_SpawnFriction(void)
         else
           movefactor = ((friction - 0xDB34)*(0xA))/0x80;
 
-        if (min_mbf)
+        if (at_least_mbf)
           { // killough 8/28/98: prevent odd situations
             if (friction > FRACUNIT)
               friction = FRACUNIT;
@@ -3106,7 +3106,7 @@ static void P_SpawnFriction(void)
             // at level startup, and then uses this friction value.
 
             // Boom's friction code for demo compatibility
-            if (min_boom && prior_mbf)
+            if (at_least_boom && at_most_boom)
               Add_Friction(friction,movefactor,s);
 
             sectors[s].friction = friction;
@@ -3204,7 +3204,7 @@ pusher_t* tmpusher; // pusher structure for blockmap searches
 
 boolean PIT_PushThing(mobj_t* thing)
 {
-  if (prior_mbf  ?     // killough 10/98: made more general
+  if (at_most_boom  ?     // killough 10/98: made more general
       thing->player && !(thing->flags & (MF_NOCLIP | MF_NOGRAVITY)) :
       (sentient(thing) || thing->flags & MF_SHOOTABLE) &&
       !(thing->flags & MF_NOCLIP))
@@ -3226,7 +3226,7 @@ boolean PIT_PushThing(mobj_t* thing)
       // to stay close to source, grow increasingly hard as you
       // get closer, as expected. Still, it doesn't consider z :(
 
-      if (speed > 0 && min_mbf)
+      if (speed > 0 && at_least_mbf)
         {
           int x = (thing->x-sx) >> FRACBITS;
           int y = (thing->y-sy) >> FRACBITS;

--- a/src/p_spec.c
+++ b/src/p_spec.c
@@ -661,7 +661,7 @@ sector_t *P_FindModelFloorSector(fixed_t floordestheight, int secnum)
 
   int i, linecount = sec->linecount;
 
-  for (i = 0; i < (demo_compatibility && sec->linecount < linecount ?
+  for (i = 0; i < (prior_boom && sec->linecount < linecount ?
                    sec->linecount : linecount); i++)
     if (twoSided(secnum, i) &&
         (sec = getSector(secnum, i,
@@ -697,7 +697,7 @@ sector_t *P_FindModelCeilingSector(fixed_t ceildestheight, int secnum)
   // but allow early exit in old demos
   int i, linecount = sec->linecount;
 
-  for (i = 0; i < (demo_compatibility && sec->linecount<linecount?
+  for (i = 0; i < (prior_boom && sec->linecount<linecount?
                    sec->linecount : linecount); i++)
     if (twoSided(secnum, i) &&
         (sec = getSector(secnum, i,
@@ -918,7 +918,7 @@ boolean P_CanUnlockGenDoor(line_t *line, player_t *player)
 
 int P_SectorActive(special_e t,sector_t *sec)
 {
-  return demo_compatibility ?  // return whether any thinker is active
+  return prior_boom ?  // return whether any thinker is active
     sec->floordata || sec->ceilingdata || sec->lightingdata :
     t == floor_special ? !!sec->floordata :        // return whether
     t == ceiling_special ? !!sec->ceilingdata :    // thinker of same
@@ -1007,7 +1007,7 @@ boolean P_IsDeathExit(sector_t *sector)
   {
     return (sector->special == 11);
   }
-  else if (mbf21 && sector->special & DEATH_MASK)
+  else if (min_mbf21 && sector->special & DEATH_MASK)
   {
     const int i = (sector->special & DAMAGE_MASK) >> DAMAGE_SHIFT;
 
@@ -1091,7 +1091,7 @@ void P_CrossSpecialLine(line_t *line, int side, mobj_t *thing, boolean bossactio
       }
 
   //jff 02/04/98 add check here for generalized lindef types
-  if (!demo_compatibility) // generalized types not recognized if old demo
+  if (min_boom) // generalized types not recognized if old demo
     {
       // pointer to line function is NULL by default, set non-null if
       // line special is walkover generalized linedef type
@@ -1166,7 +1166,7 @@ void P_CrossSpecialLine(line_t *line, int side, mobj_t *thing, boolean bossactio
                     linefunc = EV_DoGenStairs;
                   }
               else
-                if (mbf21 && (unsigned)line->special >= GenCrusherBase)
+                if (min_mbf21 && (unsigned)line->special >= GenCrusherBase)
                   {
                     // haleyjd 06/09/09: This was completely forgotten in BOOM, disabling
                     // all generalized walk-over crusher types!
@@ -1238,128 +1238,128 @@ void P_CrossSpecialLine(line_t *line, int side, mobj_t *thing, boolean bossactio
 
     case 2:
       // Open Door
-      if (EV_DoDoor(line,doorOpen) || demo_compatibility)
+      if (EV_DoDoor(line,doorOpen) || prior_boom)
         line->special = 0;
       break;
 
     case 3:
       // Close Door
-      if (EV_DoDoor(line,doorClose) || demo_compatibility)
+      if (EV_DoDoor(line,doorClose) || prior_boom)
         line->special = 0;
       break;
 
     case 4:
       // Raise Door
-      if (EV_DoDoor(line,doorNormal) || demo_compatibility)
+      if (EV_DoDoor(line,doorNormal) || prior_boom)
         line->special = 0;
       break;
 
     case 5:
       // Raise Floor
-      if (EV_DoFloor(line,raiseFloor) || demo_compatibility)
+      if (EV_DoFloor(line,raiseFloor) || prior_boom)
         line->special = 0;
       break;
 
     case 6:
       // Fast Ceiling Crush & Raise
-      if (EV_DoCeiling(line,fastCrushAndRaise) || demo_compatibility)
+      if (EV_DoCeiling(line,fastCrushAndRaise) || prior_boom)
         line->special = 0;
       break;
 
     case 8:
       // Build Stairs
-      if (EV_BuildStairs(line,build8) || demo_compatibility)
+      if (EV_BuildStairs(line,build8) || prior_boom)
         line->special = 0;
       break;
 
     case 10:
       // PlatDownWaitUp
-      if (EV_DoPlat(line,downWaitUpStay,0) || demo_compatibility)
+      if (EV_DoPlat(line,downWaitUpStay,0) || prior_boom)
         line->special = 0;
       break;
 
     case 12:
       // Light Turn On - brightest near
-      if (EV_LightTurnOn(line,0) || demo_compatibility)
+      if (EV_LightTurnOn(line,0) || prior_boom)
         line->special = 0;
       break;
 
     case 13:
       // Light Turn On 255
-      if (EV_LightTurnOn(line,255) || demo_compatibility)
+      if (EV_LightTurnOn(line,255) || prior_boom)
         line->special = 0;
       break;
 
     case 16:
       // Close Door 30
-      if (EV_DoDoor(line,close30ThenOpen) || demo_compatibility)
+      if (EV_DoDoor(line,close30ThenOpen) || prior_boom)
         line->special = 0;
       break;
 
     case 17:
       // Start Light Strobing
-      if (EV_StartLightStrobing(line) || demo_compatibility)
+      if (EV_StartLightStrobing(line) || prior_boom)
         line->special = 0;
       break;
 
     case 19:
       // Lower Floor
-      if (EV_DoFloor(line,lowerFloor) || demo_compatibility)
+      if (EV_DoFloor(line,lowerFloor) || prior_boom)
         line->special = 0;
       break;
 
     case 22:
       // Raise floor to nearest height and change texture
-      if (EV_DoPlat(line,raiseToNearestAndChange,0) || demo_compatibility)
+      if (EV_DoPlat(line,raiseToNearestAndChange,0) || prior_boom)
         line->special = 0;
       break;
 
     case 25:
       // Ceiling Crush and Raise
-      if (EV_DoCeiling(line,crushAndRaise) || demo_compatibility)
+      if (EV_DoCeiling(line,crushAndRaise) || prior_boom)
         line->special = 0;
       break;
 
     case 30:
       // Raise floor to shortest texture height
       //  on either side of lines.
-      if (EV_DoFloor(line,raiseToTexture) || demo_compatibility)
+      if (EV_DoFloor(line,raiseToTexture) || prior_boom)
         line->special = 0;
       break;
 
     case 35:
       // Lights Very Dark
-      if (EV_LightTurnOn(line,35) || demo_compatibility)
+      if (EV_LightTurnOn(line,35) || prior_boom)
         line->special = 0;
       break;
 
     case 36:
       // Lower Floor (TURBO)
-      if (EV_DoFloor(line,turboLower) || demo_compatibility)
+      if (EV_DoFloor(line,turboLower) || prior_boom)
         line->special = 0;
       break;
 
     case 37:
       // LowerAndChange
-      if (EV_DoFloor(line,lowerAndChange) || demo_compatibility)
+      if (EV_DoFloor(line,lowerAndChange) || prior_boom)
         line->special = 0;
       break;
 
     case 38:
       // Lower Floor To Lowest
-      if (EV_DoFloor(line, lowerFloorToLowest) || demo_compatibility)
+      if (EV_DoFloor(line, lowerFloorToLowest) || prior_boom)
         line->special = 0;
       break;
 
     case 39:
       // TELEPORT! //jff 02/09/98 fix using up with wrong side crossing
-      if (EV_Teleport(line, side, thing) || demo_compatibility)
+      if (EV_Teleport(line, side, thing) || prior_boom)
         line->special = 0;
       break;
 
     case 40:
       // RaiseCeilingLowerFloor
-      if (demo_compatibility)
+      if (prior_boom)
         {
           EV_DoCeiling( line, raiseToHighest );
           EV_DoFloor( line, lowerFloorToLowest ); //jff 02/12/98 doesn't work
@@ -1372,7 +1372,7 @@ void P_CrossSpecialLine(line_t *line, int side, mobj_t *thing, boolean bossactio
 
     case 44:
       // Ceiling Crush
-      if (EV_DoCeiling(line, lowerAndCrush) || demo_compatibility)
+      if (EV_DoCeiling(line, lowerAndCrush) || prior_boom)
         line->special = 0;
       break;
 
@@ -1386,79 +1386,79 @@ void P_CrossSpecialLine(line_t *line, int side, mobj_t *thing, boolean bossactio
 
     case 53:
       // Perpetual Platform Raise
-      if (EV_DoPlat(line,perpetualRaise,0) || demo_compatibility)
+      if (EV_DoPlat(line,perpetualRaise,0) || prior_boom)
         line->special = 0;
       break;
 
     case 54:
       // Platform Stop
-      if (EV_StopPlat(line) || demo_compatibility)
+      if (EV_StopPlat(line) || prior_boom)
         line->special = 0;
       break;
 
     case 56:
       // Raise Floor Crush
-      if (EV_DoFloor(line,raiseFloorCrush) || demo_compatibility)
+      if (EV_DoFloor(line,raiseFloorCrush) || prior_boom)
         line->special = 0;
       break;
 
     case 57:
       // Ceiling Crush Stop
-      if (EV_CeilingCrushStop(line) || demo_compatibility)
+      if (EV_CeilingCrushStop(line) || prior_boom)
         line->special = 0;
       break;
 
     case 58:
       // Raise Floor 24
-      if (EV_DoFloor(line,raiseFloor24) || demo_compatibility)
+      if (EV_DoFloor(line,raiseFloor24) || prior_boom)
         line->special = 0;
       break;
 
     case 59:
       // Raise Floor 24 And Change
-      if (EV_DoFloor(line,raiseFloor24AndChange) || demo_compatibility)
+      if (EV_DoFloor(line,raiseFloor24AndChange) || prior_boom)
         line->special = 0;
       break;
 
     case 100:
       // Build Stairs Turbo 16
-      if (EV_BuildStairs(line,turbo16) || demo_compatibility)
+      if (EV_BuildStairs(line,turbo16) || prior_boom)
         line->special = 0;
       break;
 
     case 104:
       // Turn lights off in sector(tag)
-      if (EV_TurnTagLightsOff(line) || demo_compatibility)
+      if (EV_TurnTagLightsOff(line) || prior_boom)
         line->special = 0;
       break;
 
     case 108:
       // Blazing Door Raise (faster than TURBO!)
-      if (EV_DoDoor(line,blazeRaise) || demo_compatibility)
+      if (EV_DoDoor(line,blazeRaise) || prior_boom)
         line->special = 0;
       break;
 
     case 109:
       // Blazing Door Open (faster than TURBO!)
-      if (EV_DoDoor (line,blazeOpen) || demo_compatibility)
+      if (EV_DoDoor (line,blazeOpen) || prior_boom)
         line->special = 0;
       break;
 
     case 110:
       // Blazing Door Close (faster than TURBO!)
-      if (EV_DoDoor (line,blazeClose) || demo_compatibility)
+      if (EV_DoDoor (line,blazeClose) || prior_boom)
         line->special = 0;
       break;
 
     case 119:
       // Raise floor to nearest surr. floor
-      if (EV_DoFloor(line,raiseFloorToNearest) || demo_compatibility)
+      if (EV_DoFloor(line,raiseFloorToNearest) || prior_boom)
         line->special = 0;
       break;
 
     case 121:
       // Blazing PlatDownWaitUpStay
-      if (EV_DoPlat(line,blazeDWUS,0) || demo_compatibility)
+      if (EV_DoPlat(line,blazeDWUS,0) || prior_boom)
         line->special = 0;
       break;
 
@@ -1473,19 +1473,19 @@ void P_CrossSpecialLine(line_t *line, int side, mobj_t *thing, boolean bossactio
     case 125:
       // TELEPORT MonsterONLY
       if (!thing->player &&
-          (EV_Teleport(line, side, thing) || demo_compatibility))
+          (EV_Teleport(line, side, thing) || prior_boom))
         line->special = 0;
       break;
 
     case 130:
       // Raise Floor Turbo
-      if (EV_DoFloor(line,raiseFloorTurbo) || demo_compatibility)
+      if (EV_DoFloor(line,raiseFloorTurbo) || prior_boom)
         line->special = 0;
       break;
 
     case 141:
       // Silent Ceiling Crush & Raise
-      if (EV_DoCeiling(line,silentCrushAndRaise) || demo_compatibility)
+      if (EV_DoCeiling(line,silentCrushAndRaise) || prior_boom)
         line->special = 0;
       break;
 
@@ -1666,7 +1666,7 @@ void P_CrossSpecialLine(line_t *line, int side, mobj_t *thing, boolean bossactio
       // killough 2/16/98: Fix problems with W1 types being cleared too early
 
     default:
-      if (!demo_compatibility)
+      if (min_boom)
         switch (line->special)
           {
             // Extended walk once triggers
@@ -1977,7 +1977,7 @@ void P_CrossSpecialLine(line_t *line, int side, mobj_t *thing, boolean bossactio
 void P_ShootSpecialLine(mobj_t *thing, line_t *line)
 {
   //jff 02/04/98 add check here for generalized linedef
-  if (!demo_compatibility)
+  if (min_boom)
     {
       // pointer to line function is NULL by default, set non-null if
       // line special is gun triggered generalized linedef type
@@ -2102,7 +2102,7 @@ void P_ShootSpecialLine(mobj_t *thing, line_t *line)
     {
     case 24:
       // 24 G1 raise floor to highest adjacent
-      if (EV_DoFloor(line,raiseFloor) || demo_compatibility)
+      if (EV_DoFloor(line,raiseFloor) || prior_boom)
         P_ChangeSwitchTexture(line,0);
       break;
 
@@ -2114,7 +2114,7 @@ void P_ShootSpecialLine(mobj_t *thing, line_t *line)
 
     case 47:
       // 47 G1 raise floor to nearest and change texture and type
-      if (EV_DoPlat(line,raiseToNearestAndChange,0) || demo_compatibility)
+      if (EV_DoPlat(line,raiseToNearestAndChange,0) || prior_boom)
         P_ChangeSwitchTexture(line,0);
       break;
 
@@ -2122,7 +2122,7 @@ void P_ShootSpecialLine(mobj_t *thing, line_t *line)
       // killough 1/31/98: added demo_compatibility check, added inner switch
 
     default:
-      if (!demo_compatibility)
+      if (min_boom)
         switch (line->special)
           {
           case 197:
@@ -2269,7 +2269,7 @@ void P_PlayerInSpecialSector (player_t *player)
     }
   else //jff 3/14/98 handle extended sector types for secrets and damage
     {
-      if (mbf21 && sector->special & DEATH_MASK)
+      if (min_mbf21 && sector->special & DEATH_MASK)
       {
         int i;
 
@@ -2580,7 +2580,7 @@ void P_SpawnSpecials (void)
 
   P_SpawnScrollers(); // killough 3/7/98: Add generalized scrollers
 
-  if (!demo_compatibility)
+  if (min_boom)
   {
   P_SpawnFriction();  // phares 3/12/98: New friction model using linedefs
 
@@ -2838,7 +2838,7 @@ static void P_SpawnScrollers(void)
       int control = -1, accel = 0;         // no control sector or acceleration
       int special = l->special;
 
-      if (demo_compatibility && special != 48)
+      if (prior_boom && special != 48)
         continue;
 
       // killough 3/7/98: Types 245-249 are same as 250-254 except that the
@@ -3083,7 +3083,7 @@ static void P_SpawnFriction(void)
         else
           movefactor = ((friction - 0xDB34)*(0xA))/0x80;
 
-        if (demo_version >= DV_MBF)
+        if (min_mbf)
           { // killough 8/28/98: prevent odd situations
             if (friction > FRACUNIT)
               friction = FRACUNIT;
@@ -3106,7 +3106,7 @@ static void P_SpawnFriction(void)
             // at level startup, and then uses this friction value.
 
             // Boom's friction code for demo compatibility
-            if (!demo_compatibility && demo_version < DV_MBF)
+            if (min_boom && prior_mbf)
               Add_Friction(friction,movefactor,s);
 
             sectors[s].friction = friction;
@@ -3204,7 +3204,7 @@ pusher_t* tmpusher; // pusher structure for blockmap searches
 
 boolean PIT_PushThing(mobj_t* thing)
 {
-  if (demo_version < DV_MBF  ?     // killough 10/98: made more general
+  if (prior_mbf  ?     // killough 10/98: made more general
       thing->player && !(thing->flags & (MF_NOCLIP | MF_NOGRAVITY)) :
       (sentient(thing) || thing->flags & MF_SHOOTABLE) &&
       !(thing->flags & MF_NOCLIP))
@@ -3226,7 +3226,7 @@ boolean PIT_PushThing(mobj_t* thing)
       // to stay close to source, grow increasingly hard as you
       // get closer, as expected. Still, it doesn't consider z :(
 
-      if (speed > 0 && demo_version >= DV_MBF)
+      if (speed > 0 && min_mbf)
         {
           int x = (thing->x-sx) >> FRACBITS;
           int y = (thing->y-sy) >> FRACBITS;

--- a/src/p_switch.c
+++ b/src/p_switch.c
@@ -248,7 +248,7 @@ P_UseSpecialLine
     return false;
 
   //jff 02/04/98 add check here for generalized floor/ceil mover
-  if (min_boom)
+  if (at_least_boom)
   {
     // pointer to line function is NULL by default, set non-null if
     // line special is push or switch generalized linedef type
@@ -614,7 +614,7 @@ P_UseSpecialLine
       // added inner switch, relaxed check to demo_compatibility
 
     default:
-      if (min_boom)
+      if (at_least_boom)
         switch (line->special)
         {
           //jff 1/29/98 added linedef types to fill all functions out so that

--- a/src/p_switch.c
+++ b/src/p_switch.c
@@ -248,7 +248,7 @@ P_UseSpecialLine
     return false;
 
   //jff 02/04/98 add check here for generalized floor/ceil mover
-  if (!demo_compatibility)
+  if (min_boom)
   {
     // pointer to line function is NULL by default, set non-null if
     // line special is push or switch generalized linedef type
@@ -614,7 +614,7 @@ P_UseSpecialLine
       // added inner switch, relaxed check to demo_compatibility
 
     default:
-      if (!demo_compatibility)
+      if (min_boom)
         switch (line->special)
         {
           //jff 1/29/98 added linedef types to fill all functions out so that

--- a/src/p_telept.c
+++ b/src/p_telept.c
@@ -76,7 +76,7 @@ int EV_Teleport(line_t *line, int side, mobj_t *thing)
             return 0;
 
           // [FG] game version specific differences
-          if (min_boom || gameversion != exe_final)
+          if (at_least_boom || gameversion != exe_final)
           {
           thing->z = thing->floorz;
           }

--- a/src/p_telept.c
+++ b/src/p_telept.c
@@ -76,7 +76,7 @@ int EV_Teleport(line_t *line, int side, mobj_t *thing)
             return 0;
 
           // [FG] game version specific differences
-          if (!demo_compatibility || gameversion != exe_final)
+          if (min_boom || gameversion != exe_final)
           {
           thing->z = thing->floorz;
           }

--- a/src/p_user.c
+++ b/src/p_user.c
@@ -85,7 +85,7 @@ void P_Thrust(player_t* player,angle_t angle,fixed_t move)
 
 void P_Bob(player_t *player, angle_t angle, fixed_t move)
 {
-  if (demo_version < DV_MBF)
+  if (prior_mbf)
     return;
 
   player->momx += FixedMul(move,finecosine[angle >>= ANGLETOFINESHIFT]);
@@ -117,10 +117,10 @@ void P_CalcHeight (player_t* player)
 
   // [FG] MBF player bobbing rewrite causes demo sync problems
   // http://prboom.sourceforge.net/mbf-bugs.html
-  player->bob = (demo_version >= DV_MBF && player_bobbing) ?
+  player->bob = (min_mbf && player_bobbing) ?
       (FixedMul(player->momx,player->momx)
       + FixedMul(player->momy,player->momy))>>2 :
-      (demo_compatibility || player_bobbing) ?
+      (prior_boom || player_bobbing) ?
       (FixedMul (player->mo->momx, player->mo->momx)
       + FixedMul (player->mo->momy,player->mo->momy))>>2 : 0;
 
@@ -214,7 +214,7 @@ void P_MovePlayer (player_t* player)
   // ice, because the player still "works just as hard" to move, while the
   // thrust applied to the movement varies with 'movefactor'.
 
-  if ((!demo_compatibility && demo_version < DV_MBF) ||
+  if ((min_boom && prior_mbf) ||
       cmd->forwardmove | cmd->sidemove) // killough 10/98
     {
       if (onground || mo->flags & MF_BOUNCES) // killough 8/9/98
@@ -469,7 +469,7 @@ void P_PlayerThink (player_t* player)
       // and SSG weapons switches here, rather than in G_BuildTiccmd(). For
       // other games which rely on user preferences, we must use the latter.
 
-      if (demo_compatibility)
+      if (prior_boom)
 	{ // compatibility mode -- required for old demos -- killough
 	  newweapon = (cmd->buttons & BT_WEAPONMASK_OLD) >> BT_WEAPONSHIFT;
 	  if (newweapon == wp_fist && player->weaponowned[wp_chainsaw] &&

--- a/src/p_user.c
+++ b/src/p_user.c
@@ -85,7 +85,7 @@ void P_Thrust(player_t* player,angle_t angle,fixed_t move)
 
 void P_Bob(player_t *player, angle_t angle, fixed_t move)
 {
-  if (prior_mbf)
+  if (at_most_boom)
     return;
 
   player->momx += FixedMul(move,finecosine[angle >>= ANGLETOFINESHIFT]);
@@ -117,10 +117,10 @@ void P_CalcHeight (player_t* player)
 
   // [FG] MBF player bobbing rewrite causes demo sync problems
   // http://prboom.sourceforge.net/mbf-bugs.html
-  player->bob = (min_mbf && player_bobbing) ?
+  player->bob = (at_least_mbf && player_bobbing) ?
       (FixedMul(player->momx,player->momx)
       + FixedMul(player->momy,player->momy))>>2 :
-      (prior_boom || player_bobbing) ?
+      (at_most_vanilla || player_bobbing) ?
       (FixedMul (player->mo->momx, player->mo->momx)
       + FixedMul (player->mo->momy,player->mo->momy))>>2 : 0;
 
@@ -214,7 +214,7 @@ void P_MovePlayer (player_t* player)
   // ice, because the player still "works just as hard" to move, while the
   // thrust applied to the movement varies with 'movefactor'.
 
-  if ((min_boom && prior_mbf) ||
+  if ((at_least_boom && at_most_boom) ||
       cmd->forwardmove | cmd->sidemove) // killough 10/98
     {
       if (onground || mo->flags & MF_BOUNCES) // killough 8/9/98
@@ -469,7 +469,7 @@ void P_PlayerThink (player_t* player)
       // and SSG weapons switches here, rather than in G_BuildTiccmd(). For
       // other games which rely on user preferences, we must use the latter.
 
-      if (prior_boom)
+      if (at_most_vanilla)
 	{ // compatibility mode -- required for old demos -- killough
 	  newweapon = (cmd->buttons & BT_WEAPONMASK_OLD) >> BT_WEAPONSHIFT;
 	  if (newweapon == wp_fist && player->weaponowned[wp_chainsaw] &&

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -451,7 +451,7 @@ void R_DrawVisSprite(vissprite_t *vis, int x1, int x2)
           ((vis->mobjflags & MF_TRANSLATION) >> (MF_TRANSSHIFT-8) );
       }
     else
-      if (translucency && !(strictmode && demo_compatibility)
+      if (translucency && !(strictmode && prior_boom)
           && vis->mobjflags & MF_TRANSLUCENT) // phares
         {
           colfunc = R_DrawTLColumn;
@@ -730,7 +730,7 @@ void R_AddSprites(sector_t* sec, int lightlevel)
   // Well, now it will be done.
   sec->validcount = validcount;
 
-  if (demo_version <= DV_BOOM)
+  if (prior_mbf)
     lightlevel = sec->lightlevel;
 
   lightnum = (lightlevel >> LIGHTSEGSHIFT)+extralight;

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -451,7 +451,7 @@ void R_DrawVisSprite(vissprite_t *vis, int x1, int x2)
           ((vis->mobjflags & MF_TRANSLATION) >> (MF_TRANSSHIFT-8) );
       }
     else
-      if (translucency && !(strictmode && prior_boom)
+      if (translucency && !(strictmode && at_most_vanilla)
           && vis->mobjflags & MF_TRANSLUCENT) // phares
         {
           colfunc = R_DrawTLColumn;
@@ -730,7 +730,7 @@ void R_AddSprites(sector_t* sec, int lightlevel)
   // Well, now it will be done.
   sec->validcount = validcount;
 
-  if (prior_mbf)
+  if (at_most_boom)
     lightlevel = sec->lightlevel;
 
   lightnum = (lightlevel >> LIGHTSEGSHIFT)+extralight;

--- a/src/wi_stuff.c
+++ b/src/wi_stuff.c
@@ -1872,7 +1872,7 @@ static void WI_updateNetgameStats(void)
 
               // [FG] Intermission screen secrets desync
               // http://prboom.sourceforge.net/mbf-bugs.html
-              if (cnt_secret[i] >= (wbs->maxsecret ? (plrs[i].ssecret * 100) / wbs->maxsecret : prior_boom ? 0 : 100))
+              if (cnt_secret[i] >= (wbs->maxsecret ? (plrs[i].ssecret * 100) / wbs->maxsecret : at_most_vanilla ? 0 : 100))
                 cnt_secret[i] = wbs->maxsecret ? (plrs[i].ssecret * 100) / wbs->maxsecret : 100;
               else
                 stillticking = true;
@@ -2087,7 +2087,7 @@ static void WI_updateStats(void)
           // killough 2/22/98: Make secrets = 100% if maxsecret = 0:
           // [FG] Intermission screen secrets desync
           // http://prboom.sourceforge.net/mbf-bugs.html
-          if ((!wbs->maxsecret && prior_mbf) ||
+          if ((!wbs->maxsecret && at_most_boom) ||
               cnt_secret[0] >= (wbs->maxsecret ? 
                                 (plrs[me].ssecret * 100) / wbs->maxsecret : 100))
             {
@@ -2121,10 +2121,10 @@ static void WI_updateStats(void)
 
                 // This check affects demo compatibility with PrBoom+
                 if ((cnt_time >= plrs[me].stime / TICRATE) &&
-                    (prior_mbf || cnt_total_time >= wbs->totaltimes / TICRATE)
+                    (at_most_boom || cnt_total_time >= wbs->totaltimes / TICRATE)
                    )
                   {
-                    if (prior_mbf)
+                    if (at_most_boom)
                       cnt_total_time = wbs->totaltimes / TICRATE;
                     S_StartSound(0, sfx_barexp);
                     sp_state++;

--- a/src/wi_stuff.c
+++ b/src/wi_stuff.c
@@ -1872,7 +1872,7 @@ static void WI_updateNetgameStats(void)
 
               // [FG] Intermission screen secrets desync
               // http://prboom.sourceforge.net/mbf-bugs.html
-              if (cnt_secret[i] >= (wbs->maxsecret ? (plrs[i].ssecret * 100) / wbs->maxsecret : demo_compatibility ? 0 : 100))
+              if (cnt_secret[i] >= (wbs->maxsecret ? (plrs[i].ssecret * 100) / wbs->maxsecret : prior_boom ? 0 : 100))
                 cnt_secret[i] = wbs->maxsecret ? (plrs[i].ssecret * 100) / wbs->maxsecret : 100;
               else
                 stillticking = true;
@@ -2087,7 +2087,7 @@ static void WI_updateStats(void)
           // killough 2/22/98: Make secrets = 100% if maxsecret = 0:
           // [FG] Intermission screen secrets desync
           // http://prboom.sourceforge.net/mbf-bugs.html
-          if ((!wbs->maxsecret && demo_version < DV_MBF) ||
+          if ((!wbs->maxsecret && prior_mbf) ||
               cnt_secret[0] >= (wbs->maxsecret ? 
                                 (plrs[me].ssecret * 100) / wbs->maxsecret : 100))
             {
@@ -2121,10 +2121,10 @@ static void WI_updateStats(void)
 
                 // This check affects demo compatibility with PrBoom+
                 if ((cnt_time >= plrs[me].stime / TICRATE) &&
-                    (demo_version < DV_MBF || cnt_total_time >= wbs->totaltimes / TICRATE)
+                    (prior_mbf || cnt_total_time >= wbs->totaltimes / TICRATE)
                    )
                   {
-                    if (demo_version < DV_MBF)
+                    if (prior_mbf)
                       cnt_total_time = wbs->totaltimes / TICRATE;
                     S_StartSound(0, sfx_barexp);
                     sp_state++;

--- a/src/ws_stuff.c
+++ b/src/ws_stuff.c
@@ -725,7 +725,7 @@ weapontype_t WS_SlotWeapon(void)
     const weapontype_t *slot_weapons = state.current_slot->weapons;
     const int num_weapons = state.current_slot->num_weapons;
 
-    if (!demo_compatibility)
+    if (min_boom)
     {
         return SlotWeapon(player, current_weapon, slot_weapons, num_weapons);
     }

--- a/src/ws_stuff.c
+++ b/src/ws_stuff.c
@@ -725,7 +725,7 @@ weapontype_t WS_SlotWeapon(void)
     const weapontype_t *slot_weapons = state.current_slot->weapons;
     const int num_weapons = state.current_slot->num_weapons;
 
-    if (min_boom)
+    if (at_least_boom)
     {
         return SlotWeapon(player, current_weapon, slot_weapons, num_weapons);
     }


### PR DESCRIPTION
Pulled from my work-in-progress branch on the ID24 line actions. The use of the `#define mbf21 (demo_version == DV_MBF21)` macro was problematic, given the expected future additions of ID24 and MBF2y building on top of MBF21. This helps smooth the development going forward by turning the most common checks into more practical macros, which can still be easily built on top of, on later complevels.

The key factor here being the move to the following `#define`s:
```c
#define prior_boom  (demo_version < DV_BOOM200)
#define prior_mbf   (demo_version < DV_MBF)
#define prior_mbf21 (demo_version < DV_MBF21)
#define prior_id24  (demo_version < DV_ID24)

#define min_boom  (demo_version >= DV_BOOM200)
#define min_mbf   (demo_version >= DV_MBF)
#define min_mbf21 (demo_version >= DV_MBF21)
#define min_id24  (demo_version >= DV_ID24)
```