### PR TITLE
Changing mouselook angle for "Direct vertical aiming" to GZDoom sw renderer/Odamex like 56.25 degrees.

### DIFF
--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -54,7 +54,7 @@ void P_UpdateDirectVerticalAiming(void)
 {
   direct_vertical_aiming = (CRITICAL(default_direct_vertical_aiming) &&
                             (mouselook || padlook));
-  max_pitch_angle = direct_vertical_aiming ? ANG45 : 32 * ANG1;
+  max_pitch_angle = direct_vertical_aiming ? 5 * ANG11 : 32 * ANG1;
 }
 
 //

--- a/src/tables.h
+++ b/src/tables.h
@@ -52,6 +52,7 @@ extern const fixed_t *const finecosine;
 extern const fixed_t finetangent[FINEANGLES/2];
 
 // Binary Angle Measument, BAM.
+#define ANG11   0x08000000 // 11.25 degrees exactly.
 #define ANG45   0x20000000
 #define ANG75   0x35555555
 #define ANG90   0x40000000


### PR DESCRIPTION
Hello.

This is my first code change and Woof PR. Have mercy, i hope everything is correct :)

These two changes add a new angle definition to tables.h and a new mouselook angle for "Direct vertical aiming" in p_mobj.c.

The 56.25 degrees angle is very similar to that of GZDoom software renderer or the look-down-angle of Odamex. These both have 56 degrees.

Have compared the angles between Woof and GZDoom sw renderer with my sky aligning texture and could confirm that it fits. Woof does 680 pixels, GZDoom 676 pixels.

As this higher angle is coupled with "Direct vertical aiming", it does not change the gameplay for those persons who want to play in a more faithful way.