### PR TITLE
move savegame buffer size check to saveg_write* functions

### DIFF
--- a/src/p_saveg.c
+++ b/src/p_saveg.c
@@ -69,6 +69,7 @@ inline static void saveg_write_pad(void)
 
     padding = (4 - ((intptr_t)save_p & 3)) & 3;
 
+    saveg_buffer_size(padding);
     for (i=0; i<padding; ++i)
     {
         savep_putbyte(0);

--- a/src/p_saveg.c
+++ b/src/p_saveg.c
@@ -47,85 +47,9 @@ byte *save_p;
 
 saveg_compat_t saveg_compat = saveg_woof510;
 
-// Endian-safe integer read/write functions
-
-byte saveg_read8(void)
-{
-    return *save_p++;
-}
-
-void saveg_write8(byte value)
-{
-    *save_p++ = value;
-}
-
-static short saveg_read16(void)
-{
-    int result;
-
-    result = saveg_read8();
-    result |= saveg_read8() << 8;
-
-    return result;
-}
-
-static void saveg_write16(short value)
-{
-    saveg_write8(value & 0xff);
-    saveg_write8((value >> 8) & 0xff);
-}
-
-int saveg_read32(void)
-{
-    int result;
-
-    result = saveg_read8();
-    result |= saveg_read8() << 8;
-    result |= saveg_read8() << 16;
-    result |= saveg_read8() << 24;
-
-    return result;
-}
-
-void saveg_write32(int value)
-{
-    saveg_write8(value & 0xff);
-    saveg_write8((value >> 8) & 0xff);
-    saveg_write8((value >> 16) & 0xff);
-    saveg_write8((value >> 24) & 0xff);
-}
-
-int64_t saveg_read64(void)
-{
-    int64_t result;
-
-    result =  (int64_t)(saveg_read8());
-    result |= (int64_t)(saveg_read8()) << 8;
-    result |= (int64_t)(saveg_read8()) << 16;
-    result |= (int64_t)(saveg_read8()) << 24;
-    result |= (int64_t)(saveg_read8()) << 32;
-    result |= (int64_t)(saveg_read8()) << 40;
-    result |= (int64_t)(saveg_read8()) << 48;
-    result |= (int64_t)(saveg_read8()) << 56;
-
-    return result;
-}
-
-void saveg_write64(int64_t value)
-{
-    saveg_write8(value & 0xff);
-    saveg_write8((value >> 8) & 0xff);
-    saveg_write8((value >> 16) & 0xff);
-    saveg_write8((value >> 24) & 0xff);
-    saveg_write8((value >> 32) & 0xff);
-    saveg_write8((value >> 40) & 0xff);
-    saveg_write8((value >> 48) & 0xff);
-    saveg_write8((value >> 56) & 0xff);
-}
-
 // Pad to 4-byte boundaries
 
-static void saveg_read_pad(void)
+inline static void saveg_read_pad(void)
 {
     int padding;
     int i;
@@ -138,7 +62,7 @@ static void saveg_read_pad(void)
     }
 }
 
-static void saveg_write_pad(void)
+inline static void saveg_write_pad(void)
 {
     int padding;
     int i;
@@ -147,19 +71,19 @@ static void saveg_write_pad(void)
 
     for (i=0; i<padding; ++i)
     {
-        saveg_write8(0);
+        savep_putbyte(0);
     }
 }
 
 
 // Pointers
 
-static void *saveg_readp(void)
+inline static void *saveg_readp(void)
 {
     return (void *) (intptr_t) saveg_read32();
 }
 
-static void saveg_writep(const void *p)
+inline static void saveg_writep(const void *p)
 {
     saveg_write32((intptr_t) p);
 }
@@ -2047,7 +1971,6 @@ void P_ArchivePlayers (void)
 {
   int i;
 
-  CheckSaveGame(sizeof(player_t) * MAXPLAYERS); // killough
   for (i=0 ; i<MAXPLAYERS ; i++)
     if (playeringame[i])
       {
@@ -2087,28 +2010,6 @@ void P_ArchiveWorld (void)
   const sector_t *sec;
   const line_t   *li;
   const side_t   *si;
-
-  // killough 3/22/98: fix bug caused by hoisting save_p too early
-  // killough 10/98: adjust size for changes below
-  size_t size = 
-    (sizeof(short)*5 + sizeof sec->floorheight + sizeof sec->ceilingheight
-     + sizeof(sec->floor_xoffs) + sizeof(sec->floor_yoffs)
-     + sizeof(sec->ceiling_xoffs) + sizeof(sec->ceiling_yoffs)
-     + sizeof(sec->ceiling_rotation) + sizeof(sec->floor_rotation)) * numsectors
-    + (sizeof(short) * 3 + sizeof(li->angle) + sizeof(li->frontmusic)
-       + sizeof(li->backmusic) + sizeof(short)) * numlines + 4;
-
-  for (i=0; i<numlines; i++)
-    {
-      if (lines[i].sidenum[0] != NO_INDEX)
-        size +=
-	  sizeof(short)*3 + sizeof si->textureoffset + sizeof si->rowoffset;
-      if (lines[i].sidenum[1] != NO_INDEX)
-	size +=
-	  sizeof(short)*3 + sizeof si->textureoffset + sizeof si->rowoffset;
-    }
-
-  CheckSaveGame(size); // killough
 
   saveg_write_pad();                // killough 3/22/98
 
@@ -2282,7 +2183,7 @@ void P_ArchiveThinkers (void)
   size_t    size = 0;
   mobj_t    tmp;
 
-  CheckSaveGame(sizeof brain);      // killough 3/26/98: Save boss brain state
+  // killough 3/26/98: Save boss brain state
   saveg_write32(brain.easy);
   saveg_write32(brain.targeton);
 
@@ -2293,9 +2194,6 @@ void P_ArchiveThinkers (void)
   for (th = thinkercap.next ; th != &thinkercap ; th=th->next)
     if (th->function.p1 == (actionf_p1)P_MobjThinker)
       th->prev = (thinker_t *) ++size;
-
-  // check that enough room is available in savegame buffer
-  CheckSaveGame(size*(sizeof(mobj_t)+4));       // killough 2/14/98
 
   // save off the current thinkers
 
@@ -2357,7 +2255,6 @@ void P_ArchiveThinkers (void)
   // killough 9/14/98: save soundtargets
   {
      int i;
-     CheckSaveGame(numsectors * sizeof(mobj_t *));       // killough 9/14/98
      for (i = 0; i < numsectors; i++)
      {
         mobj_t *target = sectors[i].soundtarget;
@@ -2560,46 +2457,6 @@ enum {
 void P_ArchiveSpecials (void)
 {
   thinker_t *th;
-  size_t    size = 0;          // killough
-
-  // save off the current thinkers (memory size calculation -- killough)
-
-  for (th = thinkercap.next ; th != &thinkercap ; th=th->next)
-    if (!th->function.v)
-      {
-        platlist_t *pl;
-        ceilinglist_t *cl;     //jff 2/22/98 need this for ceilings too now
-        for (pl=activeplats; pl; pl=pl->next)
-          if (pl->plat == (plat_t *) th)   // killough 2/14/98
-            {
-              size += 4+sizeof(plat_t);
-              goto end;
-            }
-        for (cl=activeceilings; cl; cl=cl->next) // search for activeceiling
-          if (cl->ceiling == (ceiling_t *) th)   //jff 2/22/98
-            {
-              size += 4+sizeof(ceiling_t);
-              goto end;
-            }
-      end:;
-      }
-    else
-      size +=
-        th->function.p1==(actionf_p1)T_MoveCeiling  ? 4+sizeof(ceiling_t) :
-        th->function.p1==(actionf_p1)T_VerticalDoor ? 4+sizeof(vldoor_t)  :
-        th->function.p1==(actionf_p1)T_MoveFloor    ? 4+sizeof(floormove_t):
-        th->function.p1==(actionf_p1)T_PlatRaise    ? 4+sizeof(plat_t)    :
-        th->function.p1==(actionf_p1)T_LightFlash   ? 4+sizeof(lightflash_t):
-        th->function.p1==(actionf_p1)T_StrobeFlash  ? 4+sizeof(strobe_t)  :
-        th->function.p1==(actionf_p1)T_Glow         ? 4+sizeof(glow_t)    :
-        th->function.p1==(actionf_p1)T_MoveElevator ? 4+sizeof(elevator_t):
-        th->function.p1==(actionf_p1)T_Scroll       ? 4+sizeof(scroll_t)  :
-        th->function.p1==(actionf_p1)T_Pusher       ? 4+sizeof(pusher_t)  :
-        th->function.p1==(actionf_p1)T_FireFlicker  ? 4+sizeof(fireflicker_t) :
-        th->function.p1==(actionf_p1)T_Friction     ? 4+sizeof(friction_t) :
-      0;
-
-  CheckSaveGame(size);          // killough
 
   // save off the current thinkers
   for (th=thinkercap.next; th!=&thinkercap; th=th->next)
@@ -2727,8 +2584,6 @@ void P_ArchiveSpecials (void)
           continue;
         }
     }
-
-  CheckSaveGame(MAXBUTTONS * sizeof(button_t));
 
   for (int i = 0; i < MAXBUTTONS; i++)
   {
@@ -2915,7 +2770,6 @@ void P_UnArchiveSpecials (void)
 
 void P_ArchiveRNG(void)
 {
-  CheckSaveGame(sizeof rng);
   saveg_write_rng_t(&rng);
 }
 
@@ -2927,10 +2781,6 @@ void P_UnArchiveRNG(void)
 // killough 2/22/98: Save/restore automap state
 void P_ArchiveMap(void)
 {
-  CheckSaveGame(sizeof followplayer + sizeof markpointnum +
-                markpointnum * sizeof *markpoints +
-                sizeof automapactive + sizeof viewactive);
-
   saveg_write32(automapactive);
   saveg_write32(viewactive);
   saveg_write32(followplayer);

--- a/src/p_saveg.h
+++ b/src/p_saveg.h
@@ -21,6 +21,7 @@
 #define __P_SAVEG__
 
 #include "doomtype.h"
+#include "z_zone.h"
 
 // Persistent storage/archiving.
 // These are the load / save game routines.
@@ -41,15 +42,112 @@ void P_UnArchiveRNG(void);
 void P_ArchiveMap(void);
 void P_UnArchiveMap(void);
 
-extern byte *save_p;
-void CheckSaveGame(size_t);              // killough
+extern byte *save_p, *savebuffer;
+extern size_t savegamesize;
 
-byte saveg_read8(void);
-void saveg_write8(byte value);
-int saveg_read32(void);
-void saveg_write32(int value);
-int64_t saveg_read64(void);
-void saveg_write64(int64_t value);
+// Check for overrun and realloc if necessary -- Lee Killough 1/22/98
+inline static void saveg_buffer_size(size_t size)
+{
+    size_t offset = save_p - savebuffer;
+
+    if (offset + size <= savegamesize)
+    {
+        return;
+    }
+
+    while (offset + size > savegamesize)
+    {
+        savegamesize *= 2;
+    }
+
+    savebuffer = Z_Realloc(savebuffer, savegamesize, PU_STATIC, NULL);
+    save_p = savebuffer + offset;
+}
+
+// Endian-safe integer read/write functions
+
+inline static void savep_putbyte(byte value)
+{
+    *save_p++ = value;
+}
+
+inline static void saveg_write8(byte value)
+{
+    saveg_buffer_size(sizeof(byte));
+    savep_putbyte(value);
+}
+
+inline static void saveg_write16(short value)
+{
+    saveg_buffer_size(sizeof(int16_t));
+    savep_putbyte(value & 0xff);
+    savep_putbyte((value >> 8) & 0xff);
+}
+
+inline static void saveg_write32(int value)
+{
+    saveg_buffer_size(sizeof(int32_t));
+    savep_putbyte(value & 0xff);
+    savep_putbyte((value >> 8) & 0xff);
+    savep_putbyte((value >> 16) & 0xff);
+    savep_putbyte((value >> 24) & 0xff);
+}
+
+inline static void saveg_write64(int64_t value)
+{
+    saveg_buffer_size(sizeof(int64_t));
+    savep_putbyte(value & 0xff);
+    savep_putbyte((value >> 8) & 0xff);
+    savep_putbyte((value >> 16) & 0xff);
+    savep_putbyte((value >> 24) & 0xff);
+    savep_putbyte((value >> 32) & 0xff);
+    savep_putbyte((value >> 40) & 0xff);
+    savep_putbyte((value >> 48) & 0xff);
+    savep_putbyte((value >> 56) & 0xff);
+}
+
+inline static byte saveg_read8(void)
+{
+    return *save_p++;
+}
+
+inline static short saveg_read16(void)
+{
+    int result;
+
+    result = saveg_read8();
+    result |= saveg_read8() << 8;
+
+    return result;
+}
+
+inline static int saveg_read32(void)
+{
+    int result;
+
+    result = saveg_read8();
+    result |= saveg_read8() << 8;
+    result |= saveg_read8() << 16;
+    result |= saveg_read8() << 24;
+
+    return result;
+}
+
+inline static int64_t saveg_read64(void)
+{
+    int64_t result;
+
+    result =  (int64_t)(saveg_read8());
+    result |= (int64_t)(saveg_read8()) << 8;
+    result |= (int64_t)(saveg_read8()) << 16;
+    result |= (int64_t)(saveg_read8()) << 24;
+    result |= (int64_t)(saveg_read8()) << 32;
+    result |= (int64_t)(saveg_read8()) << 40;
+    result |= (int64_t)(saveg_read8()) << 48;
+    result |= (int64_t)(saveg_read8()) << 56;
+
+    return result;
+}
 
 typedef enum
 {


### PR DESCRIPTION
* Inline `saveg_write*` and `saveg_read*` functions for minor speedup.

* Simplify save buffer size checks.