### PR TITLE
enable ANIMATE feature for default sky and SKYDEFS

### DIFF
--- a/src/r_plane.c
+++ b/src/r_plane.c
@@ -416,9 +416,9 @@ static void DrawSkyFire(visplane_t *pl, fire_t *fire)
 
 static void DrawSkyTex(visplane_t *pl, skytex_t *skytex)
 {
-    int texture = R_TextureNumForName(skytex->name);
+    int texture = texturetranslation[skytex->texture];
 
-    dc_texturemid = skytex->mid * FRACUNIT;
+    dc_texturemid = skytex->mid;
     dc_texheight = textureheight[texture] >> FRACBITS;
     dc_iscale = FixedMul(skyiscale, skytex->scaley);
 
@@ -551,7 +551,7 @@ static void do_draw_mbf_sky(visplane_t *pl)
     else // Normal Doom sky, only one allowed per level
     {
         dc_texturemid = skytexturemid; // Default y-offset
-        texture = skytexture;          // Default texture
+        texture = texturetranslation[skytexture]; // Default texture
         flip = 0;                      // Doom flips it
     }
 

--- a/src/r_sky.c
+++ b/src/r_sky.c
@@ -162,7 +162,7 @@ static void InitSky(void)
 
     array_foreach(sky, skydefs->skies)
     {
-        if (skytexture == R_CheckTextureNumForName(sky->skytex.name))
+        if (skytexture == sky->skytex.texture)
         {
             if (sky->type == SkyType_Fire)
             {

--- a/src/r_skydefs.c
+++ b/src/r_skydefs.c
@@ -20,6 +20,7 @@
 #include "m_fixed.h"
 #include "m_json.h"
 #include "m_misc.h"
+#include "r_data.h"
 
 static boolean ParseFire(json_t *json, fire_t *out)
 {
@@ -47,13 +48,12 @@ static boolean ParseFire(json_t *json, fire_t *out)
 
 static boolean ParseSkyTex(json_t *json, skytex_t *out)
 {
-    json_t *name = JS_GetObject(json, "name");
-    if (!JS_IsString(name))
+    const char *name = JS_GetStringValue(json, "name");
+    if (!name)
     {
-        out->name = "-"; // no texture
         return false;
     }
-    out->name = M_StringDuplicate(JS_GetString(name));
+    out->texture = R_TextureNumForName(name);
 
     json_t *mid = JS_GetObject(json, "mid");
     json_t *scrollx = JS_GetObject(json, "scrollx");
@@ -66,7 +66,7 @@ static boolean ParseSkyTex(json_t *json, skytex_t *out)
     {
         return false;
     }
-    out->mid = JS_GetNumber(mid);
+    out->mid = JS_GetNumber(mid) * FRACUNIT;
     const double ticratescale = 1.0 / TICRATE;
     out->scrollx = (JS_GetNumber(scrollx) * ticratescale) * FRACUNIT;
     out->scrolly = (JS_GetNumber(scrolly) * ticratescale) * FRACUNIT;

--- a/src/r_skydefs.h
+++ b/src/r_skydefs.h
@@ -33,8 +33,8 @@ typedef struct fire_s
 
 typedef struct
 {
-    const char *name;
-    double mid;
+    int texture;
+    fixed_t mid;
     fixed_t scrollx;
     fixed_t currx;
     fixed_t prevx;


### PR DESCRIPTION
Fix from DSDA-Doom: https://github.com/kraflab/dsda-doom/commit/445470201525a3c079574618dcabf7f2414ec2dd