### PR TITLE
Improve sound limiter

### DIFF
--- a/src/i_3dsound.c
+++ b/src/i_3dsound.c
@@ -337,6 +337,7 @@ const sound_module_t sound_3d_module =
     I_3D_AdjustSoundParams,
     I_3D_UpdateSoundParams,
     I_3D_UpdateListenerParams,
+    I_OAL_SetGain,
     I_3D_StartSound,
     I_OAL_StopSound,
     I_OAL_PauseSound,

--- a/src/i_mbfsound.c
+++ b/src/i_mbfsound.c
@@ -175,6 +175,7 @@ const sound_module_t sound_mbf_module =
     I_MBF_AdjustSoundParams,
     I_MBF_UpdateSoundParams,
     NULL,
+    I_OAL_SetGain,
     I_OAL_StartSound,
     I_OAL_StopSound,
     I_OAL_PauseSound,

--- a/src/i_oalsound.c
+++ b/src/i_oalsound.c
@@ -52,7 +52,6 @@
 #define VOL_TO_GAIN(x)          ((ALfloat)(x) / 127)
 
 static int snd_resampler;
-static boolean snd_limiter;
 static boolean snd_hrtf;
 static int snd_absorption;
 static int snd_doppler;
@@ -445,7 +444,6 @@ void I_OAL_BindSoundVariables(void)
         "[OpenAL 3D] Air absorption effect (0 = Off; 10 = Max)");
     BIND_NUM_SFX(snd_doppler, 0, 0, 10,
         "[OpenAL 3D] Doppler effect (0 = Off; 10 = Max)");
-    BIND_BOOL_SFX(snd_limiter, false, "Use sound output limiter");
 }
 
 boolean I_OAL_InitSound(int snd_module)

--- a/src/i_oalsound.c
+++ b/src/i_oalsound.c
@@ -788,6 +788,16 @@ boolean I_OAL_SoundIsPaused(int channel)
     return (state == AL_PAUSED);
 }
 
+void I_OAL_SetGain(int channel, float gain)
+{
+    if (!oal)
+    {
+        return;
+    }
+
+    alSourcef(oal->sources[channel], AL_GAIN, (ALfloat)gain);
+}
+
 void I_OAL_SetVolume(int channel, int volume)
 {
     if (!oal)

--- a/src/i_oalsound.h
+++ b/src/i_oalsound.h
@@ -70,6 +70,8 @@ boolean I_OAL_SoundIsPlaying(int channel);
 
 boolean I_OAL_SoundIsPaused(int channel);
 
+void I_OAL_SetGain(int channel, float gain);
+
 void I_OAL_SetVolume(int channel, int volume);
 
 void I_OAL_SetPan(int channel, int separation);

--- a/src/i_pcsound.c
+++ b/src/i_pcsound.c
@@ -501,6 +501,7 @@ const sound_module_t sound_pcs_module =
     I_PCS_AdjustSoundParams,
     I_PCS_UpdateSoundParams,
     NULL,
+    NULL,
     I_PCS_StartSound,
     I_PCS_StopSound,
     NULL,

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -90,6 +90,7 @@ static float steptable[256];
 
 boolean snd_limiter;
 int snd_channels_per_sfx;
+int snd_volume_per_sfx;
 
 //
 // StopChannel
@@ -792,6 +793,8 @@ void I_BindSoundVariables(void)
     BIND_BOOL_SFX(snd_limiter, false, "Use sound output limiter");
     BIND_NUM(snd_channels_per_sfx, 5, 1, MAX_CHANNELS,
         "[Limiter] Number of channels allowed when simultaneously playing a sound");
+    BIND_NUM(snd_volume_per_sfx, 200, 100, 300,
+        "[Limiter] Peak volume allowed when simultaneously playing a sound [percent]");
     BIND_NUM_GENERAL(snd_module, SND_MODULE_MBF, 0, NUM_SND_MODULES - 1,
         "Sound module (0 = Standard; 1 = OpenAL 3D; 2 = PC Speaker Sound)");
     for (int i = 0; i < arrlen(sound_modules); ++i)

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -89,6 +89,7 @@ static int pitch_bend_range;
 static float steptable[256];
 
 boolean snd_limiter;
+int snd_channels_per_sfx;
 
 //
 // StopChannel
@@ -789,6 +790,8 @@ void I_BindSoundVariables(void)
     BIND_NUM_SFX(snd_channels, MAX_CHANNELS, 1, MAX_CHANNELS,
         "Number of sound channels");
     BIND_BOOL_SFX(snd_limiter, false, "Use sound output limiter");
+    BIND_NUM(snd_channels_per_sfx, 5, 1, MAX_CHANNELS,
+        "[Limiter] Number of channels allowed when simultaneously playing a sound");
     BIND_NUM_GENERAL(snd_module, SND_MODULE_MBF, 0, NUM_SND_MODULES - 1,
         "Sound module (0 = Standard; 1 = OpenAL 3D; 2 = PC Speaker Sound)");
     for (int i = 0; i < arrlen(sound_modules); ++i)

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -520,8 +520,6 @@ boolean I_AllowReinitSound(void)
 
 void I_SetSoundModule(void)
 {
-    int i;
-
     if (!snd_init)
     {
         I_Printf(VB_WARNING, "I_SetSoundModule: Sound was never initialized.");
@@ -532,11 +530,6 @@ void I_SetSoundModule(void)
     {
         I_Printf(VB_WARNING, "I_SetSoundModule: Invalid choice.");
         return;
-    }
-
-    for (i = 0; i < MAX_CHANNELS; i++)
-    {
-        StopChannel(i);
     }
 
     sound_module->ShutdownModule();

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -88,6 +88,8 @@ static int pitch_bend_range;
 // Pitch to stepping lookup.
 static float steptable[256];
 
+boolean snd_limiter;
+
 //
 // StopChannel
 //
@@ -785,7 +787,8 @@ void I_BindSoundVariables(void)
         "Variable pitch bend range (100 = None)");
     BIND_BOOL_SFX(full_sounds, false, "Play sounds in full length (prevents cutoffs)");
     BIND_NUM_SFX(snd_channels, MAX_CHANNELS, 1, MAX_CHANNELS,
-        "Maximum number of simultaneous sound effects");
+        "Number of sound channels");
+    BIND_BOOL_SFX(snd_limiter, false, "Use sound output limiter");
     BIND_NUM_GENERAL(snd_module, SND_MODULE_MBF, 0, NUM_SND_MODULES - 1,
         "Sound module (0 = Standard; 1 = OpenAL 3D; 2 = PC Speaker Sound)");
     for (int i = 0; i < arrlen(sound_modules); ++i)

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -184,6 +184,23 @@ void I_ProcessSoundUpdates(void)
     sound_module->ProcessUpdates();
 }
 
+void I_SetGain(int channel, float gain)
+{
+    if (!snd_init || !sound_module->SetGain)
+    {
+        return;
+    }
+
+#ifdef RANGECHECK
+    if (channel < 0 || channel >= MAX_CHANNELS)
+    {
+        I_Error("I_SetGain: channel out of range");
+    }
+#endif
+
+    sound_module->SetGain(channel, gain);
+}
+
 //
 // I_SetChannels
 //

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -791,11 +791,14 @@ void I_BindSoundVariables(void)
     BIND_NUM_SFX(snd_channels, MAX_CHANNELS, 1, MAX_CHANNELS,
         "Number of sound channels");
     BIND_BOOL_SFX(snd_limiter, false, "Use sound output limiter");
-    BIND_NUM(snd_channels_per_sfx, 5, 1, MAX_CHANNELS,
-        "[Limiter] Number of channels allowed when simultaneously playing a sound");
-    BIND_NUM(snd_volume_per_sfx, 200, 100, 300,
-        "[Limiter] Peak volume allowed when simultaneously playing a sound [percent]");
-    BIND_NUM_GENERAL(snd_module, SND_MODULE_MBF, 0, NUM_SND_MODULES - 1,
+    BIND_NUM(snd_channels_per_sfx, 5, 0, MAX_CHANNELS,
+        "[Limiter] Max number of channels allowed to simultaneously play the "
+        "same sound (0 = Off)");
+    BIND_NUM(snd_volume_per_sfx, 5 * 100, 0, MAX_CHANNELS * 100,
+        "[Limiter] Max volume allowed for a sound that is played "
+        "simultaneously by multiple channels [percent] (0 = Off)");
+    BIND_NUM_GENERAL(
+        snd_module, SND_MODULE_MBF, 0, NUM_SND_MODULES - 1,
         "Sound module (0 = Standard; 1 = OpenAL 3D; 2 = PC Speaker Sound)");
     for (int i = 0; i < arrlen(sound_modules); ++i)
     {

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -797,8 +797,7 @@ void I_BindSoundVariables(void)
     BIND_NUM(snd_volume_per_sfx, 5 * 100, 0, MAX_CHANNELS * 100,
         "[Limiter] Max volume allowed for a sound that is played "
         "simultaneously by multiple channels [percent] (0 = Off)");
-    BIND_NUM_GENERAL(
-        snd_module, SND_MODULE_MBF, 0, NUM_SND_MODULES - 1,
+    BIND_NUM_GENERAL(snd_module, SND_MODULE_MBF, 0, NUM_SND_MODULES - 1,
         "Sound module (0 = Standard; 1 = OpenAL 3D; 2 = PC Speaker Sound)");
     for (int i = 0; i < arrlen(sound_modules); ++i)
     {

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -69,6 +69,7 @@ struct sfxinfo_s;
 struct sfxparams_s;
 
 extern boolean snd_limiter;
+extern int snd_channels_per_sfx;
 
 typedef struct sound_module_s
 {

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -70,6 +70,7 @@ struct sfxparams_s;
 
 extern boolean snd_limiter;
 extern int snd_channels_per_sfx;
+extern int snd_volume_per_sfx;
 
 typedef struct sound_module_s
 {

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -68,6 +68,8 @@ struct mobj_s;
 struct sfxinfo_s;
 struct sfxparams_s;
 
+extern boolean snd_limiter;
+
 typedef struct sound_module_s
 {
     boolean (*InitSound)(void);

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -79,6 +79,7 @@ typedef struct sound_module_s
                                  struct sfxparams_s *params);
     void (*UpdateSoundParams)(int channel, const struct sfxparams_s *params);
     void (*UpdateListenerParams)(const struct mobj_s *listener);
+    void (*SetGain)(int channel, float gain);
     boolean (*StartSound)(int channel, struct sfxinfo_s *sfx, float pitch);
     void (*StopSound)(int channel);
     void (*PauseSound)(int channel);
@@ -143,6 +144,7 @@ void I_UpdateSoundParams(int handle, const struct sfxparams_s *params);
 void I_UpdateListenerParams(const struct mobj_s *listener);
 void I_DeferSoundUpdates(void);
 void I_ProcessSoundUpdates(void);
+void I_SetGain(int handle, float gain);
 
 //
 //  MUSIC I/O

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -2485,6 +2485,7 @@ static void SetSoundModule(void)
         return;
     }
 
+    S_StopChannels();
     I_SetSoundModule();
 }
 

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -103,7 +103,8 @@ static void ResetActive(void)
         max_channels_per_sfx = MIN(snd_channels_per_sfx, snd_channels);
 
         // Limit volume per sfx only when it makes sense to do so.
-        if (snd_volume_per_sfx < max_channels_per_sfx * 100)
+        if (max_channels_per_sfx < 1
+            || snd_volume_per_sfx < max_channels_per_sfx * 100)
         {
             // Convert percent to Doom's volume scale.
             max_volume_per_sfx = 127 * snd_volume_per_sfx / 100;

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -51,6 +51,7 @@ typedef struct channel_s
     int o_priority;       // haleyjd 09/27/06: stored priority value
     int priority;         // current priority value
     int singularity;      // haleyjd 09/27/06: stored singularity value
+    int volume;
 } channel_t;
 
 // the set of channels available
@@ -311,6 +312,7 @@ static void StartSound(const mobj_t *origin, int sfx_id,
         channels[cnum].o_priority = o_priority;    // original priority
         channels[cnum].priority = params.priority; // scaled priority
         channels[cnum].singularity = singularity;
+        channels[cnum].volume = params.volume;
 
         if (rumble_type != RUMBLE_NONE)
         {
@@ -614,6 +616,7 @@ void S_UpdateSounds(const mobj_t *listener)
                     {
                         I_UpdateSoundParams(c->handle, &params);
                         c->priority = params.priority; // haleyjd
+                        c->volume = params.volume;
                     }
                     else
                     {

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -81,6 +81,18 @@ int snd_channels;
 // jff 3/17/98 to keep track of last IDMUS specified music num
 int idmusnum;
 
+static void ResetActive(void)
+{
+    for (int cnum = 0; cnum < MAX_CHANNELS; cnum++)
+    {
+        if (channels[cnum].sfxinfo)
+        {
+            channels[cnum].sfxinfo->active.count = 0;
+            channels[cnum].sfxinfo->active.volume = 0;
+        }
+    }
+}
+
 //
 // Internals.
 //
@@ -102,6 +114,7 @@ static void S_StopChannel(int cnum)
     if (channels[cnum].sfxinfo)
     {
         I_StopSound(channels[cnum].handle); // stop the sound playing
+        channels[cnum].sfxinfo->active.count--;
 
         // haleyjd 09/27/06: clear the entire channel
         memset(&channels[cnum], 0, sizeof(channel_t));
@@ -115,6 +128,7 @@ void S_StopChannels(void)
         I_StopSound(channels[i].handle);
     }
 
+    ResetActive();
     memset(channels, 0, sizeof(channels));
     memset(sobjs, 0, sizeof(sobjs));
 }
@@ -313,6 +327,7 @@ static void StartSound(const mobj_t *origin, int sfx_id,
         channels[cnum].priority = params.priority; // scaled priority
         channels[cnum].singularity = singularity;
         channels[cnum].volume = params.volume;
+        channels[cnum].sfxinfo->active.count++;
 
         if (rumble_type != RUMBLE_NONE)
         {
@@ -1086,6 +1101,8 @@ static void InitFinalDoomMusic()
 
 void S_Init(int sfxVolume, int musicVolume)
 {
+    ResetActive();
+
     // jff 1/22/98 skip sound init if sound not enabled
     if (!nosfxparm)
     {

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -95,8 +95,20 @@ static void ResetActive(void)
         }
     }
 
-    max_channels_per_sfx = MIN(snd_channels_per_sfx, snd_channels);
-    max_volume_per_sfx = 127 * snd_volume_per_sfx / 100;
+    max_channels_per_sfx = 0;
+    max_volume_per_sfx = 0;
+
+    if (snd_limiter)
+    {
+        max_channels_per_sfx = MIN(snd_channels_per_sfx, snd_channels);
+
+        // Limit volume per sfx only when it makes sense to do so.
+        if (snd_volume_per_sfx < max_channels_per_sfx * 100)
+        {
+            // Convert percent to Doom's volume scale.
+            max_volume_per_sfx = 127 * snd_volume_per_sfx / 100;
+        }
+    }
 }
 
 //
@@ -157,7 +169,7 @@ static int S_AdjustSoundParams(const mobj_t *listener, const mobj_t *source,
 static void LimitChannelsPerSfx(const mobj_t *origin, const sfxinfo_t *sfxinfo,
                                 int priority, int *cnum)
 {
-    if (*cnum != snd_channels || !snd_limiter || !origin)
+    if (max_channels_per_sfx < 1 || *cnum != snd_channels || !origin)
     {
         return;
     }
@@ -281,7 +293,7 @@ static int S_getChannel(const mobj_t *origin, const sfxinfo_t *sfxinfo,
 
 static void LimitVolumePerSfx(void)
 {
-    if (!snd_limiter)
+    if (max_volume_per_sfx < 1)
     {
         return;
     }

--- a/src/sounds.h
+++ b/src/sounds.h
@@ -42,6 +42,12 @@ typedef struct sfxrumble_s
   int ticlength;  // Array size equal to sound duration in tics.
 } sfxrumble_t;
 
+typedef struct sfxactive_s
+{
+  int count;      // Number of active channels using this sound.
+  int volume;     // Volume of active channels using this sound.
+} sfxactive_t;
+
 typedef struct sfxinfo_s
 {
   // up to 6-character name
@@ -74,6 +80,8 @@ typedef struct sfxinfo_s
   boolean cached;
 
   sfxrumble_t rumble;
+
+  sfxactive_t active;
 
 } sfxinfo_t;
 


### PR DESCRIPTION
Fixes https://github.com/fabiangreffrath/woof/issues/2105

This limits the volume when a large number of channels are playing the same sound. For simplicity, this feature is toggled using the existing "Output Limiter" menu option (which also toggles OpenAL Soft's built-in limiter). There are two new config-only settings: `snd_channels_per_sfx` and `snd_volume_per_sfx`. The defaults seem balanced to me.

How it works:
1. A new sound is about to start.
2. If there are too many channels playing the sound, then stop the lowest priority channel. If none are lower, don't start the new sound.
3. If the total volume of all channels playing the sound is too loud, then reduce the volume of each of those channels.

Testing:
1. Set "Sound Volume" to 1 for easier comparisons
2. Toggle "Output Limiter" on or off
3. Test wads:
    a. [dsda_parallellimit.zip](https://github.com/user-attachments/files/20050755/dsda_parallellimit.zip)
    b. [lifts_and_stairs.zip](https://github.com/user-attachments/files/20050758/lifts_and_stairs.zip)
    c. [scythe](https://www.doomworld.com/idgames/levels/doom2/megawads/scythe) (map26)
    d. Default plasma and [nice_plasma.zip](https://github.com/user-attachments/files/20050760/nice_plasma.zip)
    e. The above plus [bunch_of_spiders.zip](https://github.com/user-attachments/files/20051056/bunch_of_spiders.zip)

Sounds okay to me, but I recommend some testing and feedback from users.