### PR TITLE
Free/destroy SDL video resources on shutdown

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1624,6 +1624,12 @@ typedef enum {
 static exit_sequence_t exit_sequence;
 static boolean endoom_pwad_only;
 
+boolean D_EndDoomEnabled(void)
+{
+  return (exit_sequence == EXIT_SEQUENCE_FULL
+          || exit_sequence == EXIT_SEQUENCE_ENDOOM_ONLY);
+}
+
 boolean D_QuitSoundEnabled(void)
 {
   return (exit_sequence == EXIT_SEQUENCE_FULL
@@ -1642,9 +1648,7 @@ boolean fast_exit = false;
 
 boolean D_AllowEndDoom(void)
 {
-  return (!fast_exit
-          && (exit_sequence == EXIT_SEQUENCE_FULL
-          || exit_sequence == EXIT_SEQUENCE_ENDOOM_ONLY));
+  return (!fast_exit && D_EndDoomEnabled());
 }
 
 static void D_EndDoom(void)

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1624,7 +1624,7 @@ typedef enum {
 static exit_sequence_t exit_sequence;
 static boolean endoom_pwad_only;
 
-boolean D_AllowQuitSound(void)
+boolean D_QuitSoundEnabled(void)
 {
   return (exit_sequence == EXIT_SEQUENCE_FULL
           || exit_sequence == EXIT_SEQUENCE_SOUND_ONLY);

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1648,27 +1648,30 @@ boolean fast_exit = false;
 
 boolean D_AllowEndDoom(void)
 {
-  return (!fast_exit && D_EndDoomEnabled());
+  if (fast_exit)
+  {
+    return false; // Alt-F4 or pressed the close button.
+  }
+
+  if (!D_EndDoomEnabled())
+  {
+    return false; // Exit sequence is set to "Off" or "Sound Only".
+  }
+
+  if (W_IsIWADLump(W_CheckNumForName("ENDOOM")) && endoom_pwad_only)
+  {
+    return false; // User prefers PWAD ENDOOM only.
+  }
+
+  return true;
 }
 
 static void D_EndDoom(void)
 {
-  // Do we even want to show an ENDOOM?
-  if (!D_AllowEndDoom())
+  if (D_AllowEndDoom())
   {
-    return;
+    D_ShowEndDoom();
   }
-
-  // If so, is it from the IWAD?
-  boolean iwad_endoom = W_IsIWADLump(W_CheckNumForName("ENDOOM"));
-
-  // Does the user want to see it, in that case?
-  if (iwad_endoom && endoom_pwad_only)
-  {
-    return;
-  }
-
-  D_ShowEndDoom();
 }
 
 // [FG] fast-forward demo to the desired map

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1638,11 +1638,11 @@ static void D_ShowEndDoom(void)
   I_Endoom(endoom);
 }
 
-boolean disable_endoom = false;
+boolean fast_exit = false;
 
 boolean D_AllowEndDoom(void)
 {
-  return (!disable_endoom
+  return (!fast_exit
           && (exit_sequence == EXIT_SEQUENCE_FULL
           || exit_sequence == EXIT_SEQUENCE_ENDOOM_ONLY));
 }

--- a/src/d_main.h
+++ b/src/d_main.h
@@ -44,7 +44,7 @@ void D_SetMaxHealth(void);
 void D_SetBloodColor(void);
 
 extern boolean fast_exit;
-boolean D_AllowQuitSound(void);
+boolean D_QuitSoundEnabled(void);
 boolean D_AllowEndDoom(void);
 
 // Called by IO functions when input is detected.

--- a/src/d_main.h
+++ b/src/d_main.h
@@ -43,7 +43,7 @@ extern boolean clfastparm; // checkparm of -fast
 void D_SetMaxHealth(void);
 void D_SetBloodColor(void);
 
-extern boolean disable_endoom;
+extern boolean fast_exit;
 boolean D_AllowQuitSound(void);
 boolean D_AllowEndDoom(void);
 

--- a/src/d_main.h
+++ b/src/d_main.h
@@ -44,6 +44,7 @@ void D_SetMaxHealth(void);
 void D_SetBloodColor(void);
 
 extern boolean fast_exit;
+boolean D_EndDoomEnabled(void);
 boolean D_QuitSoundEnabled(void);
 boolean D_AllowEndDoom(void);
 

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -511,7 +511,7 @@ static void ProcessEvent(SDL_Event *ev)
             break;
 
         case SDL_QUIT:
-            disable_endoom = true;
+            fast_exit = true;
             I_SafeExit(0);
             break;
 

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1889,6 +1889,47 @@ void I_ShutdownGraphics(void)
     }
 
     UpdateGrab();
+
+    if (texture_upscaled)
+    {
+        SDL_DestroyTexture(texture_upscaled);
+        texture_upscaled = NULL;
+    }
+
+    if (texture)
+    {
+        SDL_DestroyTexture(texture);
+        texture = NULL;
+    }
+
+    if (argbbuffer)
+    {
+        SDL_FreeSurface(argbbuffer);
+        argbbuffer = NULL;
+    }
+
+    if (screenbuffer)
+    {
+        SDL_FreeSurface(screenbuffer);
+        screenbuffer = NULL;
+    }
+
+    if (!D_AllowEndDoom())
+    {
+        // ENDOOM will be skipped, so destroy the renderer and window now.
+
+        if (renderer)
+        {
+            SDL_DestroyRenderer(renderer);
+            renderer = NULL;
+        }
+
+        if (screen)
+        {
+            SDL_DestroyWindow(screen);
+            screen = NULL;
+        }
+    }
 }
 
 void I_InitGraphics(void)

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1890,45 +1890,16 @@ void I_ShutdownGraphics(void)
 
     UpdateGrab();
 
-    if (texture_upscaled)
-    {
-        SDL_DestroyTexture(texture_upscaled);
-        texture_upscaled = NULL;
-    }
-
-    if (texture)
-    {
-        SDL_DestroyTexture(texture);
-        texture = NULL;
-    }
-
-    if (argbbuffer)
-    {
-        SDL_FreeSurface(argbbuffer);
-        argbbuffer = NULL;
-    }
-
-    if (screenbuffer)
-    {
-        SDL_FreeSurface(screenbuffer);
-        screenbuffer = NULL;
-    }
+    SDL_FreeSurface(argbbuffer);
+    SDL_FreeSurface(screenbuffer);
+    SDL_DestroyTexture(texture_upscaled);
+    SDL_DestroyTexture(texture);
 
     if (!D_AllowEndDoom())
     {
         // ENDOOM will be skipped, so destroy the renderer and window now.
-
-        if (renderer)
-        {
-            SDL_DestroyRenderer(renderer);
-            renderer = NULL;
-        }
-
-        if (screen)
-        {
-            SDL_DestroyWindow(screen);
-            screen = NULL;
-        }
+        SDL_DestroyRenderer(renderer);
+        SDL_DestroyWindow(screen);
     }
 }
 

--- a/src/mn_menu.c
+++ b/src/mn_menu.c
@@ -1489,7 +1489,7 @@ static void M_QuitResponse(int ch)
     {
         return;
     }
-    if (D_AllowQuitSound() &&
+    if (D_QuitSoundEnabled() &&
         (!netgame || demoplayback) && // killough 12/98
         !nosfxparm)                   // avoid delay if no sound card
     {

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -3356,7 +3356,7 @@ static setup_menu_t *gen_settings[] = {
 
 static void UpdatePwadEndoomItem(void)
 {
-    DisableItem(!D_AllowEndDoom(), gen_settings6, "endoom_pwad_only");
+    DisableItem(!D_EndDoomEnabled(), gen_settings6, "endoom_pwad_only");
 }
 
 void MN_UpdateDynamicResolutionItem(void)

--- a/textscreen/txt_sdl.c
+++ b/textscreen/txt_sdl.c
@@ -217,8 +217,31 @@ void TXT_Shutdown(void)
 {
     free(screendata);
     screendata = NULL;
-    SDL_FreeSurface(screenbuffer);
-    screenbuffer = NULL;
+
+    if (texture_upscaled)
+    {
+        SDL_DestroyTexture(texture_upscaled);
+        texture_upscaled = NULL;
+    }
+
+    if (screenbuffer)
+    {
+        SDL_FreeSurface(screenbuffer);
+        screenbuffer = NULL;
+    }
+
+    if (renderer)
+    {
+        SDL_DestroyRenderer(renderer);
+        renderer = NULL;
+    }
+
+    if (TXT_SDLWindow)
+    {
+        SDL_DestroyWindow(TXT_SDLWindow);
+        TXT_SDLWindow = NULL;
+    }
+
     SDL_QuitSubSystem(SDL_INIT_VIDEO);
 }
 

--- a/textscreen/txt_sdl.c
+++ b/textscreen/txt_sdl.c
@@ -217,31 +217,11 @@ void TXT_Shutdown(void)
 {
     free(screendata);
     screendata = NULL;
-
-    if (texture_upscaled)
-    {
-        SDL_DestroyTexture(texture_upscaled);
-        texture_upscaled = NULL;
-    }
-
-    if (screenbuffer)
-    {
-        SDL_FreeSurface(screenbuffer);
-        screenbuffer = NULL;
-    }
-
-    if (renderer)
-    {
-        SDL_DestroyRenderer(renderer);
-        renderer = NULL;
-    }
-
-    if (TXT_SDLWindow)
-    {
-        SDL_DestroyWindow(TXT_SDLWindow);
-        TXT_SDLWindow = NULL;
-    }
-
+    SDL_FreeSurface(screenbuffer);
+    screenbuffer = NULL;
+    SDL_DestroyTexture(texture_upscaled);
+    SDL_DestroyRenderer(renderer);
+    SDL_DestroyWindow(TXT_SDLWindow);
     SDL_QuitSubSystem(SDL_INIT_VIDEO);
 }
 


### PR DESCRIPTION
Fixes https://github.com/fabiangreffrath/woof/issues/2257

The ENDOOM checks had to be cleaned up in order to determine when to destroy the game's renderer and window (at game exit or at ENDOOM exit). This is because the ENDOOM code will reuse the game's renderer/window if available (see `TXT_PreInit()`) and we want to preserve the current fullscreen or windowed presentation.