### PR TITLE
Simplify IWAD list building, add more search locations

### DIFF
--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -211,7 +211,7 @@ static registry_value_t uninstall_values[] =
 
 // Values installed by the GOG.com and Collector's Edition versions
 
-static root_path_t gog_ce_paths[] =
+static const root_path_t gog_ce_paths[] =
 {
     // Doom Collector's Edition
     {
@@ -251,7 +251,7 @@ static root_path_t gog_ce_paths[] =
 
 // Values installed by the Steam versions
 
-static root_path_t steam_paths[] =
+static const root_path_t steam_paths[] =
 {
     // Ultimate Doom, Doom I Enhanced, DOOM + DOOM II
     {STEAM_REG(2280), SUB_DIRS("base",
@@ -364,7 +364,7 @@ static void CheckUninstallStrings(void)
 
 // Check for GOG.com, Steam, and Doom: Collector's Edition
 
-static void CheckInstallRootPaths(root_path_t *root_paths, int length)
+static void CheckInstallRootPaths(const root_path_t *root_paths, int length)
 {
     unsigned int i;
 
@@ -374,7 +374,8 @@ static void CheckInstallRootPaths(root_path_t *root_paths, int length)
         char *subpath;
         unsigned int j;
 
-        install_path = GetRegistryString(&root_paths[i].key);
+        registry_value_t key = root_paths[i].key;
+        install_path = GetRegistryString(&key);
 
         if (install_path == NULL || *install_path == '\0')
         {

--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -393,7 +393,7 @@ static void CheckInstallRootPaths(void)
 
         install_path = GetRegistryString(&root_path_keys[i]);
 
-        if (install_path == NULL)
+        if (install_path == NULL || *install_path == '\0')
         {
             continue;
         }
@@ -483,7 +483,10 @@ static void AddIWADPath(const char *path, const char *suffix)
         }
     }
 
-    array_push(iwad_dirs, M_StringJoin(left, suffix));
+    if (*left != '\0')
+    {
+        array_push(iwad_dirs, M_StringJoin(left, suffix));
+    }
 
     free(dup_path);
 }

--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -549,9 +549,8 @@ static void AddSteamDirs(void)
     {
         for (int j = 0; steam_paths[i].subdirs[j] != NULL; j++)
         {
-            subpath = M_StringJoin(steampath, DIR_SEPARATOR_S,
-                                   steam_paths[i].basedir, DIR_SEPARATOR_S,
-                                   steam_paths[i].subdirs[j]);
+            subpath = M_StringJoin(DIR_SEPARATOR_S, steam_paths[i].basedir,
+                                   DIR_SEPARATOR_S, steam_paths[i].subdirs[j]);
             AddIWADPath(steampath, subpath);
         }
     }

--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -209,20 +209,10 @@ static registry_value_t uninstall_values[] =
     },
 };
 
-// Values installed by the GOG.com and Collector's Edition versions
+// Values installed by the GOG.com versions
 
-static const root_path_t gog_ce_paths[] =
+static const root_path_t gog_paths[] =
 {
-    // Doom Collector's Edition
-    {
-        {
-            HKEY_LOCAL_MACHINE,
-            SOFTWARE_KEY "\\Activision\\DOOM Collector's Edition\\v1.0",
-            "INSTALLPATH"
-        },
-        SUB_DIRS("Ultimate Doom", "Doom2", "Final Doom")
-    },
-
     // Doom II
     {GOG_REG(1435848814), SUB_DIRS("doom2")},
 
@@ -278,6 +268,21 @@ static const root_path_t steam_paths[] =
 
     // Doom Eternal
     {STEAM_REG(782330), SUB_DIRS("base\\classicwads")},
+};
+
+// Values installed by other versions (non-GOG.com, non-Steam)
+
+static const root_path_t misc_paths[] = 
+{
+    // Doom Collector's Edition
+    {
+        {
+            HKEY_LOCAL_MACHINE,
+            SOFTWARE_KEY "\\Activision\\DOOM Collector's Edition\\v1.0",
+            "INSTALLPATH"
+        },
+        SUB_DIRS("Ultimate Doom", "Doom2", "Final Doom")
+    },
 };
 
 static char *GetRegistryString(registry_value_t *reg_val)
@@ -556,8 +561,9 @@ void BuildIWADDirList(void)
     // Search the registry and find where IWADs have been installed.
 
     CheckUninstallStrings();
-    CheckInstallRootPaths(gog_ce_paths, arrlen(gog_ce_paths));
+    CheckInstallRootPaths(gog_paths, arrlen(gog_paths));
     CheckInstallRootPaths(steam_paths, arrlen(steam_paths));
+    CheckInstallRootPaths(misc_paths, arrlen(misc_paths));
     CheckDOSDefaults();
 
 #else


### PR DESCRIPTION
- DOOM + DOOM II added the original IWADs in a recent update, so those are checked now
- Steam games are now added based on the presence of install entries in the registry, just like GOG games were previously
- The generated wad list is much shorter now because it contains only valid paths (except for a few legacy paths which are left in place)