### PR TITLE
Consistently use `pixel_t` for screen buffer

### DIFF
--- a/src/am_map.c
+++ b/src/am_map.c
@@ -1090,7 +1090,7 @@ void AM_Ticker (void)
 static void AM_clearFB(int color)
 {
   int h = f_h;
-  byte *src = I_VideoBuffer;
+  pixel_t *src = I_VideoBuffer;
   while (h--)
   {
     memset(src, color, f_w);
@@ -1327,7 +1327,7 @@ static void AM_drawFline_Vanilla(fline_t* fl, int color)
 //
 static void AM_putWuDot(int x, int y, int color, int weight)
 {
-   byte *dest = &I_VideoBuffer[y * video.pitch + x];
+   pixel_t *dest = &I_VideoBuffer[y * video.pitch + x];
    unsigned int *fg2rgb = Col2RGB8[weight];
    unsigned int *bg2rgb = Col2RGB8[64 - weight];
    unsigned int fg, bg;

--- a/src/f_wipe.c
+++ b/src/f_wipe.c
@@ -43,9 +43,9 @@ static int wipe_columns;
 // SCREEN WIPE PACKAGE
 //
 
-static byte *wipe_scr_start;
-static byte *wipe_scr_end;
-static byte *wipe_scr;
+static pixel_t *wipe_scr_start;
+static pixel_t *wipe_scr_end;
+static pixel_t *wipe_scr;
 
 // [FG] cross-fading screen wipe implementation
 
@@ -67,9 +67,9 @@ static int wipe_doColorXForm(int width, int height, int ticks)
 
     for (int y = 0; y < height; y++)
     {
-        byte *sta = wipe_scr_start + y * width;
-        byte *end = wipe_scr_end + y * width;
-        byte *dst = wipe_scr + y * video.pitch;
+        pixel_t *sta = wipe_scr_start + y * width;
+        pixel_t *end = wipe_scr_end + y * width;
+        pixel_t *dst = wipe_scr + y * video.pitch;
 
         for (int x = 0; x < width; x++)
         {
@@ -399,8 +399,8 @@ static int wipe_doFizzle(int width, int height, int ticks)
         vrect_t rect = {x, y, 1, 1};
         V_ScaleRect(&rect);
 
-        byte *src = wipe_scr_end + rect.sy * width + rect.sx;
-        byte *dest = wipe_scr + rect.sy * video.pitch + rect.sx;
+        pixel_t *src = wipe_scr_end + rect.sy * width + rect.sx;
+        pixel_t *dest = wipe_scr + rect.sy * video.pitch + rect.sx;
 
         while (rect.sh--)
         {

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -915,7 +915,7 @@ void I_FinishUpdate(void)
 // I_ReadScreen
 //
 
-void I_ReadScreen(byte *dst)
+void I_ReadScreen(pixel_t *dst)
 {
     V_GetBlock(0, 0, video.width, video.height, dst);
 }
@@ -1104,7 +1104,7 @@ boolean I_WritePNGfile(char *filename)
     // [FG] allocate memory for screenshot image
     int pitch = rect.w * 3;
     int size = rect.h * pitch;
-    byte *pixels = malloc(size);
+    pixel_t *pixels = malloc(size);
 
     SDL_RenderReadPixels(renderer, &rect, SDL_PIXELFORMAT_RGB24, pixels, pitch);
 

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -60,7 +60,7 @@ void I_SetPalette(byte *palette);
 
 void I_FinishUpdate(void);
 
-void I_ReadScreen(byte *dst);
+void I_ReadScreen(pixel_t *dst);
 
 void I_ResetScreen(void); // killough 10/98
 void I_ToggleVsync(void); // [JN] Calls native SDL vsync toggle

--- a/src/mn_snapshot.c
+++ b/src/mn_snapshot.c
@@ -31,10 +31,10 @@
 
 static const char snapshot_str[] = "WOOF_SNAPSHOT";
 static const int snapshot_len = arrlen(snapshot_str);
-static const int snapshot_size = SCREENWIDTH * SCREENHEIGHT;
+static const int snapshot_size = (SCREENWIDTH * SCREENHEIGHT) * sizeof(pixel_t);
 
-static byte *snapshots[10];
-static byte *current_snapshot;
+static pixel_t *snapshots[10];
+static pixel_t *current_snapshot;
 static char savegametimes[10][32];
 
 const int MN_SnapshotDataSize(void)
@@ -132,9 +132,9 @@ static void TakeSnapshot(void)
         current_snapshot = malloc(snapshot_size * sizeof(**snapshots));
     }
 
-    byte *p = current_snapshot;
+    pixel_t *p = current_snapshot;
 
-    const byte *s = I_VideoBuffer;
+    const pixel_t *s = I_VideoBuffer;
 
     int x, y;
     for (y = 0; y < SCREENHEIGHT; y++)
@@ -148,7 +148,7 @@ static void TakeSnapshot(void)
     R_SetViewSize(old_screenblocks);
 }
 
-void MN_WriteSnapshot(byte *p)
+void MN_WriteSnapshot(pixel_t *p)
 {
     TakeSnapshot();
 
@@ -181,11 +181,11 @@ boolean MN_DrawSnapshot(int n, int x, int y, int w, int h)
     const fixed_t step_x = (SCREENWIDTH << FRACBITS) / rect.sw;
     const fixed_t step_y = (SCREENHEIGHT << FRACBITS) / rect.sh;
 
-    byte *dest = I_VideoBuffer + rect.sy * video.pitch + rect.sx;
+    pixel_t *dest = I_VideoBuffer + rect.sy * video.pitch + rect.sx;
 
     fixed_t srcx, srcy;
     int destx, desty;
-    byte *destline, *srcline;
+    pixel_t *destline, *srcline;
 
     for (desty = 0, srcy = 0; desty < rect.sh; desty++, srcy += step_y)
     {

--- a/src/r_draw.c
+++ b/src/r_draw.c
@@ -54,7 +54,7 @@ int viewwidth;
 int viewheight;
 int viewwindowx;
 int viewwindowy;
-static byte **ylookup = NULL;
+static pixel_t **ylookup = NULL;
 static int *columnofs = NULL;
 static int linesize; // killough 11/98
 
@@ -112,7 +112,7 @@ byte dc_skycolor;
                     dc_x);                                               \
         }                                                                \
                                                                          \
-        byte *dest = ylookup[dc_yl] + columnofs[dc_x];                   \
+        pixel_t *dest = ylookup[dc_yl] + columnofs[dc_x];                \
                                                                          \
         const fixed_t fracstep = dc_iscale;                              \
         fixed_t frac = dc_texturemid + (dc_yl - centery) * fracstep;     \
@@ -200,7 +200,7 @@ void R_DrawSkyColumn(void)
     }
 #endif
 
-    byte *dest = ylookup[dc_yl] + columnofs[dc_x];
+    pixel_t *dest = ylookup[dc_yl] + columnofs[dc_x];
 
     const fixed_t fracstep = dc_iscale;
     fixed_t frac = dc_texturemid + (dc_yl - centery) * fracstep;
@@ -406,7 +406,7 @@ static void DrawFuzzColumnOriginal(void)
     //  or blocky mode removed.
 
     // Does not work with blocky mode.
-    byte *dest = ylookup[dc_yl] + columnofs[dc_x];
+    pixel_t *dest = ylookup[dc_yl] + columnofs[dc_x];
 
     // Looks like an attempt at dithering,
     // using the colormap #6 (of 0-31, a bit brighter than average).
@@ -484,7 +484,7 @@ static void DrawFuzzColumnBlocky(void)
 
     ++count;
 
-    byte *dest = ylookup[dc_yl] + columnofs[dc_x];
+    pixel_t *dest = ylookup[dc_yl] + columnofs[dc_x];
 
     int lines = fuzzblocksize - (dc_yl % fuzzblocksize);
 
@@ -578,7 +578,7 @@ static void DrawFuzzColumnRefraction(void)
 
     ++count;
 
-    byte *dest = ylookup[dc_yl] + columnofs[dc_x];
+    pixel_t *dest = ylookup[dc_yl] + columnofs[dc_x];
 
     int lines = fuzzblocksize - (dc_yl % fuzzblocksize);
 
@@ -644,7 +644,7 @@ static void DrawFuzzColumnShadow(void)
     }
 #endif
 
-    byte *dest = ylookup[dc_yl] + columnofs[dc_x];
+    pixel_t *dest = ylookup[dc_yl] + columnofs[dc_x];
 
     count++; // killough 1/99: minor tuning
 
@@ -769,66 +769,66 @@ fixed_t ds_ystep;
 // start of a 64*64 tile image
 byte *ds_source;
 
-#define R_DRAW_SPAN(NAME, SRCPIXEL)                    \
-    static void DrawSpan##NAME(void)                   \
-    {                                                  \
-        byte *dest = ylookup[ds_y] + columnofs[ds_x1]; \
-                                                       \
-        unsigned count = ds_x2 - ds_x1 + 1;            \
-                                                       \
-        unsigned xtemp, ytemp, spot;                   \
-                                                       \
-        while (count >= 4)                             \
-        {                                              \
-            byte src;                                  \
-            ytemp = (ds_yfrac >> 10) & 0x0FC0;         \
-            xtemp = (ds_xfrac >> 16) & 0x003F;         \
-            spot = xtemp | ytemp;                      \
-            ds_xfrac += ds_xstep;                      \
-            ds_yfrac += ds_ystep;                      \
-            src = ds_source[spot];                     \
-            dest[0] = SRCPIXEL;                        \
-                                                       \
-            ytemp = (ds_yfrac >> 10) & 0x0FC0;         \
-            xtemp = (ds_xfrac >> 16) & 0x003F;         \
-            spot = xtemp | ytemp;                      \
-            ds_xfrac += ds_xstep;                      \
-            ds_yfrac += ds_ystep;                      \
-            src = ds_source[spot];                     \
-            dest[1] = SRCPIXEL;                        \
-                                                       \
-            ytemp = (ds_yfrac >> 10) & 0x0FC0;         \
-            xtemp = (ds_xfrac >> 16) & 0x003F;         \
-            spot = xtemp | ytemp;                      \
-            ds_xfrac += ds_xstep;                      \
-            ds_yfrac += ds_ystep;                      \
-            src = ds_source[spot];                     \
-            dest[2] = SRCPIXEL;                        \
-                                                       \
-            ytemp = (ds_yfrac >> 10) & 0x0FC0;         \
-            xtemp = (ds_xfrac >> 16) & 0x003F;         \
-            spot = xtemp | ytemp;                      \
-            ds_xfrac += ds_xstep;                      \
-            ds_yfrac += ds_ystep;                      \
-            src = ds_source[spot];                     \
-            dest[3] = SRCPIXEL;                        \
-                                                       \
-            dest += 4;                                 \
-            count -= 4;                                \
-        }                                              \
-                                                       \
-        while (count)                                  \
-        {                                              \
-            byte src;                                  \
-            ytemp = (ds_yfrac >> 10) & 0x0FC0;         \
-            xtemp = (ds_xfrac >> 16) & 0x003F;         \
-            spot = xtemp | ytemp;                      \
-            ds_xfrac += ds_xstep;                      \
-            ds_yfrac += ds_ystep;                      \
-            src = ds_source[spot];                     \
-            *dest++ = SRCPIXEL;                        \
-            count--;                                   \
-        }                                              \
+#define R_DRAW_SPAN(NAME, SRCPIXEL)                       \
+    static void DrawSpan##NAME(void)                      \
+    {                                                     \
+        pixel_t *dest = ylookup[ds_y] + columnofs[ds_x1]; \
+                                                          \
+        unsigned count = ds_x2 - ds_x1 + 1;               \
+                                                          \
+        unsigned xtemp, ytemp, spot;                      \
+                                                          \
+        while (count >= 4)                                \
+        {                                                 \
+            byte src;                                     \
+            ytemp = (ds_yfrac >> 10) & 0x0FC0;            \
+            xtemp = (ds_xfrac >> 16) & 0x003F;            \
+            spot = xtemp | ytemp;                         \
+            ds_xfrac += ds_xstep;                         \
+            ds_yfrac += ds_ystep;                         \
+            src = ds_source[spot];                        \
+            dest[0] = SRCPIXEL;                           \
+                                                          \
+            ytemp = (ds_yfrac >> 10) & 0x0FC0;            \
+            xtemp = (ds_xfrac >> 16) & 0x003F;            \
+            spot = xtemp | ytemp;                         \
+            ds_xfrac += ds_xstep;                         \
+            ds_yfrac += ds_ystep;                         \
+            src = ds_source[spot];                        \
+            dest[1] = SRCPIXEL;                           \
+                                                          \
+            ytemp = (ds_yfrac >> 10) & 0x0FC0;            \
+            xtemp = (ds_xfrac >> 16) & 0x003F;            \
+            spot = xtemp | ytemp;                         \
+            ds_xfrac += ds_xstep;                         \
+            ds_yfrac += ds_ystep;                         \
+            src = ds_source[spot];                        \
+            dest[2] = SRCPIXEL;                           \
+                                                          \
+            ytemp = (ds_yfrac >> 10) & 0x0FC0;            \
+            xtemp = (ds_xfrac >> 16) & 0x003F;            \
+            spot = xtemp | ytemp;                         \
+            ds_xfrac += ds_xstep;                         \
+            ds_yfrac += ds_ystep;                         \
+            src = ds_source[spot];                        \
+            dest[3] = SRCPIXEL;                           \
+                                                          \
+            dest += 4;                                    \
+            count -= 4;                                   \
+        }                                                 \
+                                                          \
+        while (count)                                     \
+        {                                                 \
+            byte src;                                     \
+            ytemp = (ds_yfrac >> 10) & 0x0FC0;            \
+            xtemp = (ds_xfrac >> 16) & 0x003F;            \
+            spot = xtemp | ytemp;                         \
+            ds_xfrac += ds_xstep;                         \
+            ds_yfrac += ds_ystep;                         \
+            src = ds_source[spot];                        \
+            *dest++ = SRCPIXEL;                           \
+            count--;                                      \
+        }                                                 \
     }
 
 R_DRAW_SPAN(, ds_colormap[0][src])

--- a/src/r_voxel.c
+++ b/src/r_voxel.c
@@ -829,7 +829,7 @@ static void VX_DrawColumn (vissprite_t * spr, int x, int y)
 	boolean shadow = ((spr->mobjflags & MF_SHADOW) != 0);
 
 	int linesize = video.pitch;
-	byte * dest = I_VideoBuffer + viewwindowy * linesize + viewwindowx;
+	pixel_t * dest = I_VideoBuffer + viewwindowy * linesize + viewwindowx;
 
 	// iterate over screen columns
 	fixed_t ux = ((Ax - 1) | FRACMASK) + 1;

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -1435,7 +1435,7 @@ static void DrawSolidBackground(void)
         {
             for (x = 0; x < depth; x++)
             {
-                byte *c = st_backing_screen + V_ScaleY(y) * video.pitch
+                pixel_t *c = st_backing_screen + V_ScaleY(y) * video.pitch
                           + V_ScaleX(x);
                 r += pal[3 * c[0] + 0];
                 g += pal[3 * c[0] + 1];

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -272,7 +272,7 @@ static void (*drawcolfunc)(const patch_column_t *patchcol);
                     patchcol->y2, patchcol->x);                               \
         }                                                                     \
                                                                               \
-        byte *dest = V_ADDRESS(dest_screen, patchcol->x, patchcol->y1);       \
+        pixel_t *dest = V_ADDRESS(dest_screen, patchcol->x, patchcol->y1);    \
                                                                               \
         const fixed_t fracstep = patchcol->step;                              \
         fixed_t frac =                                                        \
@@ -568,13 +568,13 @@ void V_ShadeScreen(void)
 {
     const byte *darkcolormap = &colormaps[0][20 * 256];
 
-    byte *row = dest_screen;
+    pixel_t *row = dest_screen;
     int height = video.height;
 
     while (height--)
     {
         int width = video.width;
-        byte *col = row;
+        pixel_t *col = row;
 
         while (width--)
         {
@@ -656,7 +656,7 @@ void V_FillRect(int x, int y, int width, int height, byte color)
 
     ScaleClippedRect(&dstrect);
 
-    byte *dest = V_ADDRESS(dest_screen, dstrect.sx, dstrect.sy);
+    pixel_t *dest = V_ADDRESS(dest_screen, dstrect.sx, dstrect.sy);
 
     while (dstrect.sh--)
     {
@@ -677,7 +677,7 @@ void V_CopyRect(int srcx, int srcy, pixel_t *source, int width, int height,
                 int destx, int desty)
 {
     vrect_t srcrect, dstrect;
-    byte *src, *dest;
+    pixel_t *src, *dest;
     int usew, useh;
 
 #ifdef RANGECHECK
@@ -745,8 +745,8 @@ void V_CopyRect(int srcx, int srcy, pixel_t *source, int width, int height,
 
 void V_DrawBlock(int x, int y, int width, int height, pixel_t *src)
 {
-    const byte *source;
-    byte *dest;
+    const pixel_t *source;
+    pixel_t *dest;
     vrect_t dstrect;
 
     dstrect.x = x;
@@ -775,7 +775,7 @@ void V_DrawBlock(int x, int y, int width, int height, pixel_t *src)
         int w;
         fixed_t xfrac, yfrac;
         int xtex, ytex;
-        byte *row;
+        pixel_t *row;
 
         yfrac = 0;
 
@@ -801,7 +801,7 @@ void V_DrawBlock(int x, int y, int width, int height, pixel_t *src)
 
 void V_TileBlock64(int line, int width, int height, const byte *src)
 {
-    byte *dest, *row;
+    pixel_t *dest, *row;
     fixed_t xfrac, yfrac;
     int xtex, ytex, h;
     vrect_t dstrect;
@@ -847,9 +847,9 @@ void V_TileBlock64(int line, int width, int height, const byte *src)
 // No return value
 //
 
-void V_GetBlock(int x, int y, int width, int height, byte *dest)
+void V_GetBlock(int x, int y, int width, int height, pixel_t *dest)
 {
-    byte *src;
+    pixel_t *src;
 
 #ifdef RANGECHECK
     if (x < 0 || x + width > video.width || y < 0 || y + height > video.height)
@@ -870,9 +870,9 @@ void V_GetBlock(int x, int y, int width, int height, byte *dest)
 
 // [FG] non hires-scaling variant of V_DrawBlock, used in disk icon drawing
 
-void V_PutBlock(int x, int y, int width, int height, byte *src)
+void V_PutBlock(int x, int y, int width, int height, pixel_t *src)
 {
-    byte *dest;
+    pixel_t *dest;
 
 #ifdef RANGECHECK
     if (x < 0 || x + width > video.width || y < 0 || y + height > video.height)


### PR DESCRIPTION
Just for correctness, and maybe future convenience; shouldn't have any effects right now.

Based on [my rough attempt to implement true color](https://github.com/MrAlaux/Nugget-Doom/pull/132), wherein I turned `pixel_t` into a `uint32_t` and therefore many variables across the source code had to be promoted to accommodate the change.