### PR TITLE
allow saving when recording a joined demo

### DIFF
--- a/src/g_game.c
+++ b/src/g_game.c
@@ -1532,6 +1532,7 @@ static void G_JoinDemo(void)
 
   // [crispy] continue recording
   demoplayback = false;
+  usergame = true;
 
   // clear progress demo bar
   ST_Start();


### PR DESCRIPTION
Saving is allowed when regularly recording a demo anyway