### PR TITLE
Added a keepammo parm for keeping ammo after death

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ CMakeSettings.json
 /.cache/
 CMakeFiles/
 src/CMakeFiles/
+
+# Terminal scripts (keepammo branch workflow)
+# inventor200 2025/05/28
+build.sh
+test.sh

--- a/docs/log_inventor200
+++ b/docs/log_inventor200
@@ -1,0 +1,27 @@
+# Log of changes by inventor200
+
+## 2025/05/28 -- keepammo parameter added
+
+I have recently been physically disabled by a chronic injury
+and I'm unable to use my desktop. Instead, I'm only
+physically able to use a mini-computer in the closet, which
+does not have the RAM or processing power to handle most
+OpenGL-based Doom ports. A family member wanted to spend
+time with me, and wanted to learn how to play Doom via coop.
+They tend to die a lot, but the main thing that bothers them
+is the loss of ammo. The losses of armor and weapons feel
+fair to them, but losing ammo makes them feel like the team
+as a whole is being punished for having a new player.
+
+So I decided to adjust the source code to add an option for
+keeping ammo after death, and so they will feel less
+frustrated while keeping me company.
+
+I am very thankful for the existence of the Woof! port.
+
+### Affected files
+
+* params.h
+* doomstat.h
+* g_game.c
+* d_main.c

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -165,6 +165,8 @@ int organize_savefiles;
 
 boolean coop_spawns = false;
 
+boolean keepammo = false;
+
 static boolean demobar;
 
 // [FG] colored blood and gibs
@@ -2489,6 +2491,17 @@ void D_DoomMain(void)
   if (M_ParmExists("-coop_spawns"))
     {
       coop_spawns = true;
+    }
+
+  //!
+  // @category game
+  //
+  // Players keep any collected ammo (and backpacks) after death.
+  //
+
+  if (M_ParmExists("-keepammo"))
+    {
+      keepammo = true;
     }
 
   //!

--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -210,6 +210,13 @@ extern int deathmatch;
 
 extern boolean coop_spawns;
 
+// inventor200 2025/05/28
+// If true, players keep ammo after death.
+// Intended for coop play, but there's no reason
+// to make this option less flexible and deny it
+// for other game modes.
+extern boolean keepammo;
+
 // ------------------------------------------
 // Internal parameters for sound rendering.
 // These have been taken from the DOS version,

--- a/src/params.h
+++ b/src/params.h
@@ -55,6 +55,7 @@ static const char *params[] = {
 "-shorttics",
 "-strict",
 "-nogui",
+"-keepammo",
 };
 
 static const char *params_with_args[] = {


### PR DESCRIPTION
# New cmd parameter: keepammo

## Summary

Added a no-args parameter, `keepammo`, which retains the player's ammo state when they die.

## Purpose

I have recently been physically disabled by a chronic injury and I'm unable to use my desktop. Instead, I'm only physically able to use a mini-computer in the closet, which does not have the RAM or processing power to handle most OpenGL-based Doom ports. A family member wanted to spend time with me, and wanted to learn how to play Doom via coop. They tend to die a lot, but the main thing that bothers them is the loss of ammo. The losses of armor and weapons feel fair to them, but losing ammo makes them feel like the team as a whole is being punished for having a new player.

So I decided to adjust the source code to add an option for keeping ammo after death, and so they will feel less frustrated while keeping me company.

I am very thankful for the existence of the Woof! port.

I hope this pull request meets the quality standards of the project. I am, of course, open to feedback. If this feature does not belong in the project, then that is also understandable.

## Affected files

* params.h
* doomstat.h
* g_game.c
* d_main.c