### PR TITLE
Add `MF2_FLIPPABLE` enemy corpses to Legacy of Rust

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -220,6 +220,7 @@ set(BASE_SOURCES
     hacx.wad/brghtmps.lmp
     hacx.wad/dehacked.deh
 
+    id1.wad/dehacked.lmp
     id1.wad/sbardef.lmp
 
     rekkr.wad/dehacked.lmp

--- a/base/id1.wad/dehacked.lmp
+++ b/base/id1.wad/dehacked.lmp
@@ -1,0 +1,26 @@
+
+# [Woof!] Randomly mirrored corpses.
+
+Thing 150
+MBF21 Bits = FLIPPABLE
+
+Thing 151
+MBF21 Bits = FLIPPABLE
+
+Thing 152
+MBF21 Bits = FLIPPABLE
+
+Thing 153
+MBF21 Bits = FLIPPABLE
+
+Thing 154
+MBF21 Bits = FLIPPABLE
+
+Thing 155
+MBF21 Bits = BOSS+FLIPPABLE
+
+Thing 156
+MBF21 Bits = BOSS+FLIPPABLE
+
+Thing 157
+MBF21 Bits = BOSS+FLIPPABLE

--- a/src/d_deh.c
+++ b/src/d_deh.c
@@ -1285,6 +1285,7 @@ static const deh_flag_t deh_mobjflags_mbf21[] = {
     {"E4M8BOSS",       MF2_E4M8BOSS     }, // E4M8 boss
     {"RIP",            MF2_RIP          }, // projectile rips through targets
     {"FULLVOLSOUNDS",  MF2_FULLVOLSOUNDS}, // full volume see / death sound
+    {"FLIPPABLE",      MF2_FLIPPABLE    }, // [crispy] randomly flip corpse, blood and death animation sprites
 };
 
 static const deh_flag_t deh_weaponflags_mbf21[] = {


### PR DESCRIPTION
Ghoul monster closet in E1M2 as example:

![woof0000](https://github.com/user-attachments/assets/894861f3-23da-4112-a7b0-e166c403a7a5)
