### PR TITLE
Implement separate Woof!-exclusive `Thing` flags

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -220,6 +220,7 @@ set(BASE_SOURCES
     hacx.wad/brghtmps.lmp
     hacx.wad/dehacked.deh
 
+    id1.wad/dehacked.lmp
     id1.wad/sbardef.lmp
 
     rekkr.wad/dehacked.lmp

--- a/base/id1.wad/dehacked.lmp
+++ b/base/id1.wad/dehacked.lmp
@@ -1,0 +1,26 @@
+
+# [Woof!] Randomly mirrored corpses.
+
+Thing 150
+MBF21 Bits = FLIPPABLE
+
+Thing 151
+MBF21 Bits = FLIPPABLE
+
+Thing 152
+MBF21 Bits = FLIPPABLE
+
+Thing 153
+MBF21 Bits = FLIPPABLE
+
+Thing 154
+MBF21 Bits = FLIPPABLE
+
+Thing 155
+MBF21 Bits = BOSS+FLIPPABLE
+
+Thing 156
+MBF21 Bits = BOSS+FLIPPABLE
+
+Thing 157
+MBF21 Bits = BOSS+FLIPPABLE

--- a/base/id1.wad/dehacked.lmp
+++ b/base/id1.wad/dehacked.lmp
@@ -2,25 +2,25 @@
 # [Woof!] Randomly mirrored corpses.
 
 Thing 150
-Woof Bits = FLIPPABLE
+Woof Bits = MIRROREDCORPSE
 
 Thing 151
-Woof Bits = FLIPPABLE
+Woof Bits = MIRROREDCORPSE
 
 Thing 152
-Woof Bits = FLIPPABLE
+Woof Bits = MIRROREDCORPSE
 
 Thing 153
-Woof Bits = FLIPPABLE
+Woof Bits = MIRROREDCORPSE
 
 Thing 154
-Woof Bits = FLIPPABLE
+Woof Bits = MIRROREDCORPSE
 
 Thing 155
-Woof Bits = FLIPPABLE
+Woof Bits = MIRROREDCORPSE
 
 Thing 156
-Woof Bits = FLIPPABLE
+Woof Bits = MIRROREDCORPSE
 
 Thing 157
-Woof Bits = FLIPPABLE
+Woof Bits = MIRROREDCORPSE

--- a/base/id1.wad/dehacked.lmp
+++ b/base/id1.wad/dehacked.lmp
@@ -2,25 +2,25 @@
 # [Woof!] Randomly mirrored corpses.
 
 Thing 150
-MBF21 Bits = FLIPPABLE
+Woof Bits = FLIPPABLE
 
 Thing 151
-MBF21 Bits = FLIPPABLE
+Woof Bits = FLIPPABLE
 
 Thing 152
-MBF21 Bits = FLIPPABLE
+Woof Bits = FLIPPABLE
 
 Thing 153
-MBF21 Bits = FLIPPABLE
+Woof Bits = FLIPPABLE
 
 Thing 154
-MBF21 Bits = FLIPPABLE
+Woof Bits = FLIPPABLE
 
 Thing 155
-MBF21 Bits = BOSS+FLIPPABLE
+Woof Bits = FLIPPABLE
 
 Thing 156
-MBF21 Bits = BOSS+FLIPPABLE
+Woof Bits = FLIPPABLE
 
 Thing 157
-MBF21 Bits = BOSS+FLIPPABLE
+Woof Bits = FLIPPABLE

--- a/src/d_deh.c
+++ b/src/d_deh.c
@@ -1285,6 +1285,7 @@ static const deh_flag_t deh_mobjflags_mbf21[] = {
     {"E4M8BOSS",       MF2_E4M8BOSS     }, // E4M8 boss
     {"RIP",            MF2_RIP          }, // projectile rips through targets
     {"FULLVOLSOUNDS",  MF2_FULLVOLSOUNDS}, // full volume see / death sound
+    {"FLIPPABLE",      MF2_FLIPPABLE    }, // [crispy] randomly flip corpse, blood and death animation sprites
 };
 
 static const deh_flag_t deh_weaponflags_mbf21[] = {

--- a/src/d_deh.c
+++ b/src/d_deh.c
@@ -1290,7 +1290,7 @@ static const deh_flag_t deh_mobjflags_mbf21[] = {
 };
 
 static const deh_flag_t deh_mobjflags_extra[] = {
-    {"FLIPPABLE",      MFX_FLIPPABLE    }, // [crispy] randomly flip corpse, blood and death animation sprites
+    {"MIRROREDCORPSE", MFX_MIRROREDCORPSE} // [crispy] randomly flip corpse, blood and death animation sprites
 };
 
 static const deh_flag_t deh_weaponflags_mbf21[] = {

--- a/src/d_deh.c
+++ b/src/d_deh.c
@@ -1159,6 +1159,7 @@ enum
 
     // [Woof!]
     DEH_MOBJINFO_BLOODCOLOR,
+    DEH_MOBJINFO_FLAGS_EXTRA,
 
     // DEHEXTRA
     DEH_MOBJINFO_DROPPEDITEM,
@@ -1202,6 +1203,7 @@ static const char *deh_mobjinfo[] = {
 
     // [Woof!]
     "Blood color", // .bloodcolor
+    "Woof Bits",   // .flags_extra
 
     // DEHEXTRA
     "Dropped item", // .droppeditem
@@ -1285,7 +1287,10 @@ static const deh_flag_t deh_mobjflags_mbf21[] = {
     {"E4M8BOSS",       MF2_E4M8BOSS     }, // E4M8 boss
     {"RIP",            MF2_RIP          }, // projectile rips through targets
     {"FULLVOLSOUNDS",  MF2_FULLVOLSOUNDS}, // full volume see / death sound
-    {"FLIPPABLE",      MF2_FLIPPABLE    }, // [crispy] randomly flip corpse, blood and death animation sprites
+};
+
+static const deh_flag_t deh_mobjflags_extra[] = {
+    {"FLIPPABLE",      MFX_FLIPPABLE    }, // [crispy] randomly flip corpse, blood and death animation sprites
 };
 
 static const deh_flag_t deh_weaponflags_mbf21[] = {
@@ -1906,6 +1911,39 @@ static void deh_procThing(DEHFILE *fpin, char *line)
 
             switch (ix)
             {
+                // Woof!
+                case DEH_MOBJINFO_FLAGS_EXTRA:
+                    if (!value)
+                    {
+                        for (value = 0; (strval = strtok(strval, ",+| \t\f\r"));
+                            strval = NULL)
+                        {
+                            size_t iy;
+
+                            for (iy = 0; iy < arrlen(deh_mobjflags_extra); iy++)
+                            {
+                                if (strcasecmp(strval,
+                                              deh_mobjflags_extra[iy].name))
+                                {
+                                    continue;
+                                }
+
+                                value |= deh_mobjflags_extra[iy].value;
+                                break;
+                            }
+
+                            if (iy >= arrlen(deh_mobjflags_extra))
+                            {
+                                deh_log(
+                                    "Could not find Woof bit mnemonic %s\n",
+                                    strval);
+                            }
+                        }
+                    }
+
+                    mobjinfo[indexnum].flags_extra = value;
+                    break;
+
                 // mbf21: process thing flags
                 case DEH_MOBJINFO_FLAGS2:
                     if (!value)

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1563,16 +1563,16 @@ static void D_InitTables(void)
       case MT_CYBORG:
         continue;
     }
-    mobjinfo[i].flags2 |= MF2_FLIPPABLE;
+    mobjinfo[i].flags_extra |= MFX_FLIPPABLE;
   }
 
-  mobjinfo[MT_PUFF].flags2 |= MF2_FLIPPABLE;
-  mobjinfo[MT_BLOOD].flags2 |= MF2_FLIPPABLE;
+  mobjinfo[MT_PUFF].flags_extra |= MFX_FLIPPABLE;
+  mobjinfo[MT_BLOOD].flags_extra |= MFX_FLIPPABLE;
 
   for (i = MT_MISC61; i <= MT_MISC69; ++i)
-     mobjinfo[i].flags2 |= MF2_FLIPPABLE;
+     mobjinfo[i].flags_extra |= MFX_FLIPPABLE;
 
-  mobjinfo[MT_DOGS].flags2 |= MF2_FLIPPABLE;
+  mobjinfo[MT_DOGS].flags_extra |= MFX_FLIPPABLE;
 
   for (i = S_SARG_RUN1; i <= S_SARG_PAIN2; ++i)
     states[i].flags |= STATEF_SKILL5FAST;

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1563,16 +1563,16 @@ static void D_InitTables(void)
       case MT_CYBORG:
         continue;
     }
-    mobjinfo[i].flags_extra |= MFX_FLIPPABLE;
+    mobjinfo[i].flags_extra |= MFX_MIRROREDCORPSE;
   }
 
-  mobjinfo[MT_PUFF].flags_extra |= MFX_FLIPPABLE;
-  mobjinfo[MT_BLOOD].flags_extra |= MFX_FLIPPABLE;
+  mobjinfo[MT_PUFF].flags_extra |= MFX_MIRROREDCORPSE;
+  mobjinfo[MT_BLOOD].flags_extra |= MFX_MIRROREDCORPSE;
 
   for (i = MT_MISC61; i <= MT_MISC69; ++i)
-     mobjinfo[i].flags_extra |= MFX_FLIPPABLE;
+     mobjinfo[i].flags_extra |= MFX_MIRROREDCORPSE;
 
-  mobjinfo[MT_DOGS].flags_extra |= MFX_FLIPPABLE;
+  mobjinfo[MT_DOGS].flags_extra |= MFX_MIRROREDCORPSE;
 
   for (i = S_SARG_RUN1; i <= S_SARG_PAIN2; ++i)
     states[i].flags |= STATEF_SKILL5FAST;

--- a/src/info.h
+++ b/src/info.h
@@ -1511,7 +1511,6 @@ typedef struct
 
     // mbf21
     int flags2;
-    int flags_extra; // Woof!
     int infighting_group;
     int projectile_group;
     int splash_group;
@@ -1520,6 +1519,7 @@ typedef struct
     int meleerange;
 
     // [Woof!]
+    int flags_extra;  // [EA] Woof!-exclusive extension
     int bloodcolor;   // [FG] colored blood and gibs
     // DEHEXTRA
     mobjtype_t droppeditem; // mobj to drop after death

--- a/src/info.h
+++ b/src/info.h
@@ -1511,6 +1511,7 @@ typedef struct
 
     // mbf21
     int flags2;
+    int flags_extra; // Woof!
     int infighting_group;
     int projectile_group;
     int splash_group;

--- a/src/p_enemy.c
+++ b/src/p_enemy.c
@@ -1771,7 +1771,7 @@ static boolean P_HealCorpse(mobj_t* actor, int radius, statenum_t healstate, sfx
 		              corpsehit->type, corpsehit->x>>FRACBITS, corpsehit->y>>FRACBITS);
 		  }
 
-		  corpsehit->flags2 &= ~MF2_COLOREDBLOOD;
+		  corpsehit->flags_extra &= ~MFX_COLOREDBLOOD;
 		  corpsehit->bloodcolor = 0;
 
                   corpsehit->health = info->spawnhealth;

--- a/src/p_inter.c
+++ b/src/p_inter.c
@@ -766,7 +766,7 @@ static void P_KillMobj(mobj_t *source, mobj_t *target, method_t mod)
   target->tics -= P_Random(pr_killtics)&3;
 
   // [crispy] randomly flip corpse, blood and death animation sprites
-  if (target->flags2 & MF2_FLIPPABLE)
+  if (target->flags_extra & MFX_FLIPPABLE)
   {
     if (Woof_Random() & 1)
       target->intflags |= MIF_FLIP;

--- a/src/p_inter.c
+++ b/src/p_inter.c
@@ -766,7 +766,7 @@ static void P_KillMobj(mobj_t *source, mobj_t *target, method_t mod)
   target->tics -= P_Random(pr_killtics)&3;
 
   // [crispy] randomly flip corpse, blood and death animation sprites
-  if (target->flags_extra & MFX_FLIPPABLE)
+  if (target->flags_extra & MFX_MIRROREDCORPSE)
   {
     if (Woof_Random() & 1)
       target->intflags |= MIF_FLIP;

--- a/src/p_map.c
+++ b/src/p_map.c
@@ -2048,7 +2048,7 @@ boolean PIT_ChangeSector(mobj_t *thing)
       thing->height = thing->radius = 0;
       if (thing->info->bloodcolor)
       {
-        thing->flags2 |= MF2_COLOREDBLOOD;
+        thing->flags_extra |= MFX_COLOREDBLOOD;
         thing->bloodcolor = V_BloodColor(thing->info->bloodcolor);
       }
       return true;      // keep checking
@@ -2088,7 +2088,7 @@ boolean PIT_ChangeSector(mobj_t *thing)
 
       if (thing->info->bloodcolor)
       {
-        mo->flags2 |= MF2_COLOREDBLOOD;
+        mo->flags_extra |= MFX_COLOREDBLOOD;
         mo->bloodcolor = V_BloodColor(thing->info->bloodcolor);
       }
 

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -898,7 +898,7 @@ mobj_t *P_SpawnMobj(fixed_t x, fixed_t y, fixed_t z, mobjtype_t type)
   mobj->friction    = ORIG_FRICTION;                        // phares 3/17/98
 
   // [crispy] randomly flip corpse, blood and death animation sprites
-  if (mobj->flags_extra & MFX_FLIPPABLE && !(mobj->flags & MF_SHOOTABLE))
+  if (mobj->flags_extra & MFX_MIRROREDCORPSE && !(mobj->flags & MF_SHOOTABLE))
   {
     if (Woof_Random() & 1)
       mobj->intflags |= MIF_FLIP;

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -842,6 +842,7 @@ mobj_t *P_SpawnMobj(fixed_t x, fixed_t y, fixed_t z, mobjtype_t type)
   mobj->height = info->height;                                      // phares
   mobj->flags  = info->flags;
   mobj->flags2 = info->flags2;
+  mobj->flags_extra = info->flags_extra;
 
   // killough 8/23/98: no friends, bouncers, or touchy things in old demos
   if (demo_version < DV_MBF)
@@ -897,7 +898,7 @@ mobj_t *P_SpawnMobj(fixed_t x, fixed_t y, fixed_t z, mobjtype_t type)
   mobj->friction    = ORIG_FRICTION;                        // phares 3/17/98
 
   // [crispy] randomly flip corpse, blood and death animation sprites
-  if (mobj->flags2 & MF2_FLIPPABLE && !(mobj->flags & MF_SHOOTABLE))
+  if (mobj->flags_extra & MFX_FLIPPABLE && !(mobj->flags & MF_SHOOTABLE))
   {
     if (Woof_Random() & 1)
       mobj->intflags |= MIF_FLIP;
@@ -1375,7 +1376,7 @@ void P_SpawnBlood(fixed_t x,fixed_t y,fixed_t z,int damage,mobj_t *bleeder)
   th->tics -= P_Random(pr_spawnblood)&3;
   if (bleeder->info->bloodcolor)
   {
-    th->flags2 |= MF2_COLOREDBLOOD;
+    th->flags_extra |= MFX_COLOREDBLOOD;
     th->bloodcolor = V_BloodColor(bleeder->info->bloodcolor);
   }
 

--- a/src/p_mobj.h
+++ b/src/p_mobj.h
@@ -220,9 +220,14 @@ typedef enum
     MF2_E4M8BOSS        = 0x00010000, // is an E4M8 boss
     MF2_RIP             = 0x00020000, // missile rips through solid
     MF2_FULLVOLSOUNDS   = 0x00040000, // full volume see / death sound
-    MF2_COLOREDBLOOD    = 0x00080000, // [FG] colored blood and gibs
-    MF2_FLIPPABLE       = 0x00100000, // [crispy] randomly flip corpse, blood and death animation sprites
 } mobjflag2_t;
+
+// [EA] Woof!-exclusive extension
+typedef enum
+{
+    MFX_COLOREDBLOOD    = 0x00000001, // [FG] colored blood and gibs
+    MFX_FLIPPABLE       = 0x00000002, // [crispy] randomly flip corpse, blood and death animation sprites
+} mobjflag_extra_t;
 
 // killough 9/15/98: Same, but internal flags, not intended for .deh
 // (some degree of opaqueness is good, to avoid compatibility woes)
@@ -306,6 +311,7 @@ typedef struct mobj_s
     state_t*            state;
     int                 flags;
     int                 flags2; // mbf21
+    int                 flags_extra; // Woof!
     int                 intflags;  // killough 9/15/98: internal flags
     int                 health;
 

--- a/src/p_mobj.h
+++ b/src/p_mobj.h
@@ -226,7 +226,7 @@ typedef enum
 typedef enum
 {
     MFX_COLOREDBLOOD    = 0x00000001, // [FG] colored blood and gibs
-    MFX_MIRROREDCORPSE       = 0x00000002, // [crispy] randomly flip corpse, blood and death animation sprites
+    MFX_MIRROREDCORPSE  = 0x00000002, // [crispy] randomly flip corpse, blood and death animation sprites
 } mobjflag_extra_t;
 
 // killough 9/15/98: Same, but internal flags, not intended for .deh

--- a/src/p_mobj.h
+++ b/src/p_mobj.h
@@ -226,7 +226,7 @@ typedef enum
 typedef enum
 {
     MFX_COLOREDBLOOD    = 0x00000001, // [FG] colored blood and gibs
-    MFX_FLIPPABLE       = 0x00000002, // [crispy] randomly flip corpse, blood and death animation sprites
+    MFX_MIRROREDCORPSE       = 0x00000002, // [crispy] randomly flip corpse, blood and death animation sprites
 } mobjflag_extra_t;
 
 // killough 9/15/98: Same, but internal flags, not intended for .deh

--- a/src/p_saveg.c
+++ b/src/p_saveg.c
@@ -331,7 +331,12 @@ static void saveg_read_mobj_t(mobj_t *str)
         str->flags2 = mobjinfo[str->type].flags2;
     }
 
-    str->flags_extra = saveg_read32();
+    if (saveg_compat > saveg_woof1500)
+    {
+        // Woof!-exclusive extension
+        // int flags_extra;
+        str->flags_extra = saveg_read32();
+    }
 
     // int intflags
     str->intflags = saveg_read32();

--- a/src/p_saveg.c
+++ b/src/p_saveg.c
@@ -331,6 +331,8 @@ static void saveg_read_mobj_t(mobj_t *str)
         str->flags2 = mobjinfo[str->type].flags2;
     }
 
+    str->flags_extra = saveg_read32();
+
     // int intflags
     str->intflags = saveg_read32();
 
@@ -524,6 +526,10 @@ static void saveg_write_mobj_t(mobj_t *str)
 
     // [Woof!]: mbf21: int flags2;
     saveg_write32(str->flags2);
+
+    // Woof!-exclusive extension
+    // int flags_extra;
+    saveg_write32(str->flags_extra);
 
     // int intflags;
     saveg_write32(str->intflags);

--- a/src/r_defs.h
+++ b/src/r_defs.h
@@ -383,6 +383,7 @@ typedef struct vissprite_s
   int patch;
   int mobjflags;
   int mobjflags2;
+  int mobjflags_extra; // Woof!
 
   // for color translation and shadow draw, maxbright frames as well
   lighttable_t *colormap[2];

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -437,7 +437,7 @@ void R_DrawVisSprite(vissprite_t *vis, int x1, int x2)
     colfunc = R_DrawFuzzColumn;    // killough 3/14/98
   else
     // [FG] colored blood and gibs
-    if (vis->mobjflags2 & MF2_COLOREDBLOOD)
+    if (vis->mobjflags_extra & MFX_COLOREDBLOOD)
       {
         colfunc = R_DrawTranslatedColumn;
         dc_translation = red2col[vis->color];
@@ -585,7 +585,7 @@ static void R_ProjectSprite (mobj_t* thing)
 
   // [crispy] randomly flip corpse, blood and death animation sprites
   if (STRICTMODE(flipcorpses) &&
-      (thing->flags2 & MF2_FLIPPABLE) &&
+      (thing->flags_extra & MFX_FLIPPABLE) &&
       !(thing->flags & MF_SHOOTABLE) &&
       (thing->intflags & MIF_FLIP))
     {

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -647,6 +647,7 @@ static void R_ProjectSprite (mobj_t* thing)
 
   vis->mobjflags = thing->flags;
   vis->mobjflags2 = thing->flags2;
+  vis->mobjflags_extra = thing->flags_extra;
   vis->scale = xscale;
   vis->gx = interpx;
   vis->gy = interpy;
@@ -857,6 +858,7 @@ void R_DrawPSprite (pspdef_t *psp)
   vis = &avis;
   vis->mobjflags = 0;
   vis->mobjflags2 = 0;
+  vis->mobjflags_extra = 0;
 
   // killough 12/98: fix psprite positioning problem
   vis->texturemid = (BASEYCENTER<<FRACBITS) /* + FRACUNIT/2 */ -

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -585,7 +585,7 @@ static void R_ProjectSprite (mobj_t* thing)
 
   // [crispy] randomly flip corpse, blood and death animation sprites
   if (STRICTMODE(flipcorpses) &&
-      (thing->flags_extra & MFX_FLIPPABLE) &&
+      (thing->flags_extra & MFX_MIRROREDCORPSE) &&
       !(thing->flags & MF_SHOOTABLE) &&
       (thing->intflags & MIF_FLIP))
     {

--- a/src/r_voxel.c
+++ b/src/r_voxel.c
@@ -1045,7 +1045,7 @@ void VX_DrawVoxel (vissprite_t * spr)
 		spr->colormap[0] = new_colormap;
 	}
 
-	if ((spr->mobjflags2 & MF2_COLOREDBLOOD) && (spr->colormap[0] != NULL))
+	if ((spr->mobjflags_extra & MFX_COLOREDBLOOD) && (spr->colormap[0] != NULL))
 	{
 		static const byte * prev_trans = NULL, * prev_map = NULL;
 		const byte * trans = red2col[spr->color], * map = spr->colormap[0];

--- a/src/r_voxel.c
+++ b/src/r_voxel.c
@@ -672,6 +672,7 @@ boolean VX_ProjectVoxel (mobj_t * thing)
 
 	vis->mobjflags = thing->flags;
 	vis->mobjflags2 = thing->flags2;
+	vis->mobjflags_extra = thing->flags_extra;
 	vis->scale = xscale;
 
 	vis->gx  = gx;


### PR DESCRIPTION
As per @rfomin on #2278.

![woof0025](https://github.com/user-attachments/assets/e8324136-4d17-481d-bd5b-e8763df807db)
