### PR TITLE
improvements to the SNDINFO parser

### DIFF
--- a/src/m_scanner.h
+++ b/src/m_scanner.h
@@ -42,7 +42,7 @@ enum
     TK_BoolConst,       // Ex: true
     TK_FloatConst,      // Ex: 1.5
 
-    TK_LumpName,
+    TK_RawString,
 
     TK_AnnotateStart,   // Block comment start
     TK_AnnotateEnd,     // Block comment end
@@ -71,8 +71,6 @@ void SC_Rewind(scanner_t *s); // Only can rewind one step.
 boolean SC_SameLine(scanner_t *s);
 boolean SC_CheckStringOrIdent(scanner_t *s);
 void SC_MustGetStringOrIdent(scanner_t *s);
-
-void SC_GetNextTokenLumpName(scanner_t *s);
 
 void SC_Error(scanner_t *s, const char *msg, ...) PRINTF_ATTR(2, 3);
 

--- a/src/r_bmaps.c
+++ b/src/r_bmaps.c
@@ -121,7 +121,7 @@ static boolean ParseProperty(scanner_t *s, elem_t *elem)
 
     int game = DOOM1AND2;
 
-    SC_GetNextTokenLumpName(s);
+    SC_MustGetToken(s, TK_RawString);
     name = M_StringDuplicate(SC_GetString(s));
     SC_MustGetToken(s, TK_Identifier);
     idx = GetBrightmap(SC_GetString(s));
@@ -270,7 +270,7 @@ void R_ParseBrightmaps(int lumpnum)
     {
         if (!SC_CheckToken(s, TK_Identifier))
         {
-            SC_GetNextToken(s, true);
+            SC_GetNextLineToken(s);
             continue;
         }
         if (!strcasecmp("BRIGHTMAP", SC_GetString(s)))

--- a/src/s_musinfo.c
+++ b/src/s_musinfo.c
@@ -79,7 +79,7 @@ void S_ParseMusInfo(const char *mapid)
             // Check number in range
             if (num > 0 && num < MAX_MUS_ENTRIES)
             {
-                SC_GetNextTokenLumpName(s);
+                SC_MustGetToken(s, TK_RawString);
                 lumpnum = W_CheckNumForName(SC_GetString(s));
                 if (lumpnum > 0)
                 {

--- a/src/s_sndinfo.c
+++ b/src/s_sndinfo.c
@@ -73,13 +73,13 @@ static void ParseSoundDefinition(scanner_t *s, sound_def_t **sound_defs)
         SC_Error(s, "expected lump name");
     }
 
-    SC_GetNextTokenLumpName(s);
+    SC_MustGetToken(s, TK_RawString);
     def.lump_name = M_StringDuplicate(SC_GetString(s));
     def.lumpnum = W_CheckNumForName(def.lump_name);
 
     if (def.lumpnum < 0)
     {
-        SC_Error(s, "SNDINFO: lump not found: %s", def.lump_name);
+        SC_Error(s, "lump not found: %s", def.lump_name);
     }
 
     // If there are multiple sound definitions with the same sound name, only
@@ -131,7 +131,7 @@ static void ParseAmbientSoundCommand(scanner_t *s, char ***sound_names,
     const int array_index = index - 1;
 
     // Sound name
-    SC_GetNextTokenLumpName(s);
+    SC_MustGetToken(s, TK_RawString);
     char *sound_name = M_StringDuplicate(SC_GetString(s));
 
     // Type is optional, but mode is required.
@@ -339,7 +339,7 @@ void S_ParseSndInfo(int lumpnum)
 
     while (SC_TokensLeft(s))
     {
-        SC_GetNextTokenLumpName(s);
+        SC_CheckToken(s, TK_RawString);
         const char *string = SC_GetString(s);
         if (string[0] != '$')
         {


### PR DESCRIPTION
* Use `SC_GetNextTokenLumpName` for sound logical name and lumps.

* Always error out using `SC_Error`.

Fix the parsing of SNDINFO in Eviternity 2. It has a `16inch/fire` logical sound name, which is not an identifier. Unfortunately, Doom lump names can contain any character, so I created `SC_GetNextTokenLumpName` for cases like this (MUSINFO is the same).

SNDINFO is a legacy standard. Perhaps we should create a USNDINFO for the MBF25 with proper syntax, such as always putting lump names in quotation marks.