### PR TITLE
Added BEX mnemonic for beta pickup sprites

### DIFF
--- a/src/d_deh.c
+++ b/src/d_deh.c
@@ -246,6 +246,8 @@ char *s_GOTLAUNCHER = GOTLAUNCHER;
 char *s_GOTPLASMA = GOTPLASMA;
 char *s_GOTSHOTGUN = GOTSHOTGUN;
 char *s_GOTSHOTGUN2 = GOTSHOTGUN2;
+char *s_BETA_BONUS3 = BETA_BONUS3;
+char *s_BETA_BONUS4 = BETA_BONUS4;
 char *s_PD_BLUEO = PD_BLUEO;
 char *s_PD_REDO = PD_REDO;
 char *s_PD_YELLOWO = PD_YELLOWO;
@@ -646,6 +648,8 @@ static deh_strs deh_strlookup[] = {
     {&s_GOTPLASMA,          "GOTPLASMA"         },
     {&s_GOTSHOTGUN,         "GOTSHOTGUN"        },
     {&s_GOTSHOTGUN2,        "GOTSHOTGUN2"       },
+    {&s_BETA_BONUS3,        "BETA_BONUS3"       },
+    {&s_BETA_BONUS4,        "BETA_BONUS4"       },
     {&s_PD_BLUEO,           "PD_BLUEO"          },
     {&s_PD_REDO,            "PD_REDO"           },
     {&s_PD_YELLOWO,         "PD_YELLOWO"        },

--- a/src/d_deh.h
+++ b/src/d_deh.h
@@ -201,6 +201,10 @@ extern char *s_GOTSHOTGUN; // = GOTSHOTGUN;
 //#define GOTSHOTGUN2   "You got the super shotgun!"
 extern char *s_GOTSHOTGUN2; // = GOTSHOTGUN2;
 
+// [NS] Beta pickups.
+extern char *s_BETA_BONUS3;
+extern char *s_BETA_BONUS4;
+
 //
 // P_Doors.C
 //

--- a/src/d_englsh.h
+++ b/src/d_englsh.h
@@ -135,6 +135,10 @@
 #define GOTSHOTGUN  "You got the shotgun!"
 #define GOTSHOTGUN2 "You got the super shotgun!"
 
+// [NS] Beta pickups.
+#define BETA_BONUS3 "Picked up an evil sceptre."
+#define BETA_BONUS4 "Picked up an unholy bible."
+
 //
 // P_Doors.C
 //

--- a/src/p_inter.c
+++ b/src/p_inter.c
@@ -368,11 +368,11 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
       break;
 
     case SPR_BON3:      // killough 7/11/98: evil sceptre from beta version
-      pickupmsg(player, "Picked up an evil sceptre");
+      pickupmsg(player, "%s", s_BETA_BONUS3);
       break;
 
     case SPR_BON4:      // killough 7/11/98: unholy bible from beta version
-      pickupmsg(player, "Picked up an unholy bible");
+      pickupmsg(player, "%s", s_BETA_BONUS4);
       break;
 
     case SPR_SOUL:


### PR DESCRIPTION
Pulled from CrispyDoom

Issue requested here: https://github.com/MrAlaux/Nugget-Doom/issues/147

> The beta dagger/bible (from MBF) are useful for DEH mods to have collectible items that otherwise do nothing. ZDoom and Crispy Doom both use the string keys BETA_BONUS3 and BETA_BONUS4. Cheers!