### PR TITLE
Fix ID24 inventory-reset exits missing from UMAPINFO 0-tag check

### DIFF
--- a/src/g_umapinfo.c
+++ b/src/g_umapinfo.c
@@ -516,7 +516,9 @@ static void ParseStandardProperty(scanner_t *s, mapentry_t *mape)
             tag = SC_GetNumber(s);
             // allow no 0-tag specials here, unless a level exit.
             if (tag != 0 || special == 11 || special == 51 || special == 52
-                || special == 124)
+                || special == 124 || special == 2069 || special == 2070
+                || special == 2071 || special == 2072 || special == 2073
+                || special == 2074)
             {
                 bossaction_t bossaction = {type, special, tag};
                 array_push(mape->bossactions, bossaction);

--- a/src/p_switch.c
+++ b/src/p_switch.c
@@ -440,6 +440,13 @@ P_UseSpecialLine
         P_ChangeSwitchTexture(line,0);
       return true;
 
+    // S1 - Exit to the next map and reset inventory.
+    case 2070:
+      if (demo_version < DV_ID24)
+        return false;
+      reset_inventory = true;
+      // fallthrough
+
     case 11:
       // Exit level
 
@@ -519,6 +526,13 @@ P_UseSpecialLine
       if (EV_DoDoor(line,doorClose))
         P_ChangeSwitchTexture(line,0);
       return true;
+
+    // SR - Exit to the secret map and reset inventory.
+    case 2073:
+      if (demo_version < DV_ID24)
+        return false;
+      reset_inventory = true;
+      // fallthrough
 
     case 51:
       // Secret EXIT
@@ -1044,24 +1058,6 @@ P_UseSpecialLine
           // 1/29/98 jff end of added SR linedef types
 
         }
-      if (demo_version >= DV_ID24)
-        switch (line->special)
-        {
-          // S1 - Exit to the next map and reset inventory.
-          case 2070:
-            reset_inventory = true;
-            P_ChangeSwitchTexture(line, 0);
-            G_ExitLevel();
-            return true;
-
-          // SR - Exit to the secret map and reset inventory.
-          case 2073:
-            reset_inventory = true;
-            P_ChangeSwitchTexture(line, 0);
-            G_SecretExitLevel();
-            return true;
-        }
-      break;
 
     // Buttons (retriggerable switches)
     case 42:


### PR DESCRIPTION
UMAPINFO's 0-tag check for exits lacked ID24's exit specials. ID24's S-triggered exits now match the same formatting for the other exits.