### PR TITLE
Allow non-power-of-2 textures

### DIFF
--- a/src/r_data.c
+++ b/src/r_data.c
@@ -29,6 +29,7 @@
 #include "d_think.h"
 #include "doomdef.h"
 #include "doomstat.h"
+#include "doomtype.h"
 #include "i_printf.h"
 #include "i_system.h"
 #include "info.h"
@@ -497,14 +498,27 @@ static void R_GenerateLookup(int texnum, int *const errors)
 
 //
 // R_GetColumn
+// [EA] Updated to support Non-power-of-2 textures, everywhere
 //
-
 byte *R_GetColumn(int tex, int col)
 {
+  short width = texturewidth[tex];
+  int mask = texturewidthmask[tex];
   int ofs;
 
-  while (col < 0)
-    col &= texturewidth[tex];
+  if (mask + 1 == width)
+  {
+    col &= mask;
+  }
+  else
+  {
+    while (col < 0)
+    {
+      col += width;
+    }
+    col %= width;
+  }
+
   ofs  = texturecolumnofs2[tex][col];
 
   if (!texturecomposite2[tex])
@@ -514,7 +528,7 @@ byte *R_GetColumn(int tex, int col)
 }
 
 // [FG] wrapping column getter function for composited translucent mid-textures on 2S walls
-byte *R_GetColumnMod(int tex, int col)
+byte *R_GetColumnMasked(int tex, int col)
 {
   int ofs;
 
@@ -528,23 +542,6 @@ byte *R_GetColumnMod(int tex, int col)
     R_GenerateComposite(tex);
 
   return texturecomposite[tex] + ofs;
-}
-
-// [FG] wrapping column getter function for non-power-of-two wide sky textures
-byte *R_GetColumnMod2(int tex, int col)
-{
-  int ofs;
-
-  while (col < 0)
-    col += texturewidth[tex];
-
-  col %= texturewidth[tex];
-  ofs  = texturecolumnofs2[tex][col];
-
-  if (!texturecomposite2[tex])
-    R_GenerateComposite(tex);
-
-  return texturecomposite2[tex] + ofs;
 }
 
 //

--- a/src/r_data.c
+++ b/src/r_data.c
@@ -503,7 +503,8 @@ byte *R_GetColumn(int tex, int col)
 {
   int ofs;
 
-  col &= texturewidthmask[tex];
+  while (col < 0)
+    col &= texturewidth[tex];
   ofs  = texturecolumnofs2[tex][col];
 
   if (!texturecomposite2[tex])

--- a/src/r_data.c
+++ b/src/r_data.c
@@ -500,6 +500,7 @@ static void R_GenerateLookup(int texnum, int *const errors)
 // R_GetColumn
 // [EA] Updated to support Non-power-of-2 textures, everywhere
 //
+
 byte *R_GetColumn(int tex, int col)
 {
   short width = texturewidth[tex];

--- a/src/r_data.c
+++ b/src/r_data.c
@@ -503,8 +503,8 @@ static void R_GenerateLookup(int texnum, int *const errors)
 
 byte *R_GetColumn(int tex, int col)
 {
-  short width = texturewidth[tex];
-  int mask = texturewidthmask[tex];
+  const int width = texturewidth[tex];
+  const int mask = texturewidthmask[tex];
   int ofs;
 
   if (mask + 1 == width)

--- a/src/r_data.h
+++ b/src/r_data.h
@@ -25,8 +25,7 @@
 
 // Retrieve column data for span blitting.
 byte *R_GetColumn(int tex, int col);
-byte *R_GetColumnMod(int tex, int col);
-byte *R_GetColumnMod2(int tex, int col);
+byte *R_GetColumnMasked(int tex, int col);
 
 // I/O, setting up the stuff.
 void R_InitData (void);

--- a/src/r_plane.c
+++ b/src/r_plane.c
@@ -448,7 +448,7 @@ static void DrawSkyTex(visplane_t *pl, skytex_t *skytex)
         {
             int col = (an + xtoskyangle[x]) >> ANGLETOSKYSHIFT;
             col = FixedToInt(FixedMul(IntToFixed(col), skytex->scalex));
-            dc_source = R_GetColumnMod2(texture, col);
+            dc_source = R_GetColumn(texture, col);
             colfunc();
         }
     }
@@ -599,7 +599,7 @@ static void do_draw_mbf_sky(visplane_t *pl)
 
         if (dc_yl != USHRT_MAX && dc_yl <= dc_yh)
         {
-            dc_source = R_GetColumnMod2(texture, ((an + xtoskyangle[x]) ^ flip)
+            dc_source = R_GetColumn(texture, ((an + xtoskyangle[x]) ^ flip)
                                                      >> ANGLETOSKYSHIFT);
             colfunc();
         }

--- a/src/r_segs.c
+++ b/src/r_segs.c
@@ -422,7 +422,7 @@ static void R_RenderSegLoop (void)
                   dc_yl = yl;
                   dc_yh = mid;
                   dc_texturemid = rw_toptexturemid;
-                  dc_source = R_GetColumn(toptexture, texturecolumn);
+                  dc_source = R_GetColumn(toptexture,texturecolumn);
                   dc_texheight = textureheight[toptexture]>>FRACBITS;//killough
                   dc_brightmap = texturebrightmap[toptexture];
                   colfunc ();

--- a/src/r_segs.c
+++ b/src/r_segs.c
@@ -206,7 +206,7 @@ void R_RenderMaskedSegRange(drawseg_t *ds, int x1, int x2)
         // when forming multipatched textures (see r_data.c).
 
         // draw the texture
-        col = (column_t *)(R_GetColumnMasked(texnum, maskedtexturecol[dc_x] - 3));
+        col = (column_t *)(R_GetColumnMasked(texnum, maskedtexturecol[dc_x]) - 3);
         R_DrawMaskedColumn (col);
         maskedtexturecol[dc_x] = INT_MAX; // [FG] 32-bit integer math
       }

--- a/src/r_segs.c
+++ b/src/r_segs.c
@@ -206,8 +206,7 @@ void R_RenderMaskedSegRange(drawseg_t *ds, int x1, int x2)
         // when forming multipatched textures (see r_data.c).
 
         // draw the texture
-        col = (column_t *)((byte *)
-                           R_GetColumnMod(texnum,maskedtexturecol[dc_x]) - 3);
+        col = (column_t *)(R_GetColumnMasked(texnum, maskedtexturecol[dc_x] - 3));
         R_DrawMaskedColumn (col);
         maskedtexturecol[dc_x] = INT_MAX; // [FG] 32-bit integer math
       }
@@ -423,7 +422,7 @@ static void R_RenderSegLoop (void)
                   dc_yl = yl;
                   dc_yh = mid;
                   dc_texturemid = rw_toptexturemid;
-                  dc_source = R_GetColumn(toptexture,texturecolumn);
+                  dc_source = R_GetColumn(toptexture, texturecolumn);
                   dc_texheight = textureheight[toptexture]>>FRACBITS;//killough
                   dc_brightmap = texturebrightmap[toptexture];
                   colfunc ();


### PR DESCRIPTION
Closes #2298

After looking at the implementations present on KEX/Eternity/Odamex, this is the simplest change needed to enable this feature, without touching masked segs. It still uses the `widthmask` on PO2 textures, as seen on [Eternity](https://github.com/team-eternity/eternity/blob/00782357f867cceabf737892f3420fe3044f118c/source/r_textur.cpp#L1649-L1652) and [Odamex](https://github.com/odamex/odamex/blob/e8d0828d759d8679d933e7927114c0903d65ce2a/common/r_data.cpp#L461-L464) (though the performance cost is possibly negligible).

Example 386px texture (HOMS unrelated):
![woof0144](https://github.com/user-attachments/assets/dfa39c74-55c8-4bc3-b9e7-a3575516c8e6)
