### PR TITLE
SNDINFO: warning instead of error out

### DIFF
--- a/src/m_scanner.c
+++ b/src/m_scanner.c
@@ -33,6 +33,7 @@
 #include <string.h>
 
 #include "doomtype.h"
+#include "i_printf.h"
 #include "i_system.h"
 #include "m_misc.h"
 
@@ -589,7 +590,7 @@ boolean SC_CheckToken(scanner_t *s, char token)
     return false;
 }
 
-void SC_Error(scanner_t *s, const char *msg, ...)
+void SC_PrintMsg(scmsg_t type, scanner_t *s, const char *msg, ...)
 {
     char buffer[1024];
     va_list args;
@@ -597,8 +598,16 @@ void SC_Error(scanner_t *s, const char *msg, ...)
     M_vsnprintf(buffer, sizeof(buffer), msg, args);
     va_end(args);
 
-    I_Error("%s(%d:%d): %s", s->scriptname, s->state.tokenline,
-            s->state.tokenlinepos + 1, buffer);
+    if (type == SC_ERROR)
+    {
+        I_Error("%s(%d:%d): %s", s->scriptname, s->state.tokenline,
+                s->state.tokenlinepos + 1, buffer);
+    }
+    else
+    {
+        I_Printf(VB_ERROR, "%s(%d:%d): %s", s->scriptname, s->state.tokenline,
+                 s->state.tokenlinepos + 1, buffer);
+    }
 }
 
 void SC_MustGetToken(scanner_t *s, char token)

--- a/src/m_scanner.h
+++ b/src/m_scanner.h
@@ -72,6 +72,14 @@ boolean SC_SameLine(scanner_t *s);
 boolean SC_CheckStringOrIdent(scanner_t *s);
 void SC_MustGetStringOrIdent(scanner_t *s);
 
-void SC_Error(scanner_t *s, const char *msg, ...) PRINTF_ATTR(2, 3);
+typedef enum
+{
+    SC_ERROR,
+    SC_WARNING
+} scmsg_t;
+
+void SC_PrintMsg(scmsg_t type, scanner_t *s, const char *msg, ...) PRINTF_ATTR(3, 4);
+#define SC_Error(s, ...) SC_PrintMsg(SC_ERROR, s, __VA_ARGS__)
+#define SC_Warning(s, ...) SC_PrintMsg(SC_WARNING, s, __VA_ARGS__)
 
 #endif

--- a/src/s_sndinfo.c
+++ b/src/s_sndinfo.c
@@ -70,7 +70,9 @@ static void ParseSoundDefinition(scanner_t *s, sound_def_t **sound_defs)
 
     if (!SC_SameLine(s))
     {
-        SC_Error(s, "expected lump name");
+        SC_Warning(s, "expected lump name");
+        free(def.sound_name);
+        return;
     }
 
     SC_MustGetToken(s, TK_RawString);
@@ -79,7 +81,14 @@ static void ParseSoundDefinition(scanner_t *s, sound_def_t **sound_defs)
 
     if (def.lumpnum < 0)
     {
-        SC_Error(s, "lump not found: %s", def.lump_name);
+        SC_Warning(s, "lump not found: %s", def.lump_name);
+        free(def.sound_name);
+        free(def.lump_name);
+        if (SC_SameLine(s))
+        {
+            SC_GetNextLineToken(s);
+        }
+        return;
     }
 
     // If there are multiple sound definitions with the same sound name, only


### PR DESCRIPTION
Fixes aaliens_v1_5_umapinfo.wad (Bethesda version from Skillsaw, [dropbox](https://www.dropbox.com/scl/fi/w0eb5tgsx02ektzgp4mnw/aaliens_v1_5_umapinfo.wad?rlkey=omwn10xq0cq61w9qqymbadheq&st=hn91q7fd&dl=0)).

@ceski-1 Should we always print warning instead of calling `I_Error` for SNDINFO parsing? I can add warning mode to `m_scanner`.