### PR TITLE
Fix Brightmaps menu setting not brighmapping wall textures

### DIFF
--- a/src/r_segs.c
+++ b/src/r_segs.c
@@ -173,7 +173,9 @@ void R_RenderMaskedSegRange(drawseg_t *ds, int x1, int x2)
             // [crispy] brightmaps for two sided mid-textures
             dc_brightmap = texturebrightmap[texnum];
             dc_colormap[0] = walllights[index];
-            dc_colormap[1] = STRICTMODE(brightmaps) ? fullcolormap : dc_colormap[0];
+            dc_colormap[1] = (STRICTMODE(brightmaps) || force_brightmaps)
+                              ? fullcolormap
+                              : dc_colormap[0];
           }
 
         // killough 3/2/98:
@@ -386,8 +388,10 @@ static void R_RenderSegLoop (void)
 
           // calculate lighting
           dc_colormap[0] = walllights[index];
-          dc_colormap[1] = (!fixedcolormap && STRICTMODE(brightmaps)) ?
-                           fullcolormap : dc_colormap[0];
+          dc_colormap[1] = (!fixedcolormap &&
+                            (STRICTMODE(brightmaps) || force_brightmaps))
+                            ? fullcolormap
+                            : dc_colormap[0];
           dc_x = rw_x;
           dc_iscale = 0xffffffffu / (unsigned)rw_scale;
         }


### PR DESCRIPTION
Thanks to @DeathEgg, for reporting and helping test this bug, on their WIP Chex Nexus mod.

If the "Brightmaps" option setting is set to "Off" in the menu, and a `BRGHTMPS` lump is provided on a PWAD, wall textures will _not_ be brightmapped as intended.

Current `master`, menu setting is "Off", `BRGHTMPS` lump included:
<img width="1917" height="1080" alt="woof0500" src="https://github.com/user-attachments/assets/038acb69-7603-4afa-9c83-84815066d53d" />

This branch, menu setting is "Off", `BRGHTMPS` lump included:
<img width="1917" height="1080" alt="woof0502" src="https://github.com/user-attachments/assets/f4426078-5629-4897-a354-229490e95b62" />
