### PR TITLE
fix tracker music looping

### DIFF
--- a/src/i_xmp.c
+++ b/src/i_xmp.c
@@ -105,7 +105,15 @@ static int I_XMP_FillStream(byte *buffer, int buffer_samples)
 
     if (ret < 0)
     {
-        return 0;
+        if (stream_looping)
+        {
+            xmp_restart_module(context);
+            xmp_set_position(context, 0);
+        }
+        else
+        {
+            return 0;
+        }
     }
 
     return buffer_samples;
@@ -120,6 +128,7 @@ static void I_XMP_PlayStream(boolean looping)
 
     stream_looping = looping;
     xmp_start_player(context, SND_SAMPLERATE, 0);
+    xmp_set_player(context, XMP_PLAYER_VOLUME, 100);
 }
 
 static void I_XMP_CloseStream(void)


### PR DESCRIPTION
GZDoom uses the same approach: https://github.com/ZDoom/ZMusic/blob/a70ec38e4b83b15d6f2ae8a01521bf80ae51a7d1/source/streamsources/music_libxmp.cpp#L144-L149

DSDA-Doom: https://github.com/kraflab/dsda-doom/pull/721