### PR TITLE
implement support for GAMEVERS and gameversion 1.666

### DIFF
--- a/base/all-all/compdb.lmp
+++ b/base/all-all/compdb.lmp
@@ -20,7 +20,7 @@
       {
         "name": "doomsday_of_uac_e1m8",
         "md5": "32fc3115a3162b623f0d0f4e7dee6861",
-        "complevel": "1.9"
+        "complevel": "1.666"
       },
       {
         "name": "hell_revealed_map19",

--- a/src/doomdef.h
+++ b/src/doomdef.h
@@ -58,6 +58,7 @@ typedef enum {
 typedef enum
 {
     exe_indetermined = -1,
+    exe_doom_1_666,  // Doom 1.666
     exe_doom_1_9,    // Doom 1.9: for shareware, registered and commercial
     exe_ultimate,    // Ultimate Doom (retail)
     exe_final,       // Final Doom

--- a/src/doomstat.c
+++ b/src/doomstat.c
@@ -29,6 +29,7 @@ GameMission_t gamemission = doom;
 GameVersion_t gameversion = exe_doom_1_9;
 
 GameVersions_t gameversions[] = {
+    {"Doom 1.666",    "1.666",    exe_doom_1_666},
     {"Doom 1.9",      "1.9",      exe_doom_1_9},
     {"Ultimate Doom", "ultimate", exe_ultimate},
     {"Final Doom",    "final",    exe_final},

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -3532,6 +3532,8 @@ demo_version_t G_GetNamedComplevel(const char *arg)
     } named_complevel[] = {
         {"vanilla",  DV_VANILLA, exe_indetermined},
         {"doom2",    DV_VANILLA, exe_doom_1_9    },
+        {"1.666",    DV_VANILLA, exe_doom_1_666  },
+        {"1",        DV_VANILLA, exe_doom_1_666  },
         {"1.9",      DV_VANILLA, exe_doom_1_9    },
         {"2",        DV_VANILLA, exe_doom_1_9    },
         {"ultimate", DV_VANILLA, exe_ultimate    },
@@ -3621,6 +3623,38 @@ const char *G_GetCurrentComplevelName(void)
         default:
             return "Unknown";
     }
+}
+
+static GameVersion_t GetWadGameVersion(void)
+{
+    int lumpnum = W_CheckNumForName("GAMEVERS");
+
+    if (lumpnum < 0)
+    {
+        return exe_indetermined;
+    }
+
+    int length = W_LumpLength(lumpnum);
+    char *data = W_CacheLumpNum(lumpnum, PU_CACHE);
+
+    if (length >= 5 && !strncasecmp("1.666", data, 5))
+    {
+        return exe_doom_1_666;
+    }
+    else if (length >= 3 && !strncasecmp("1.9", data, 3))
+    {
+        return exe_doom_1_9;
+    }
+    else if (length >= 8 && !strncasecmp("ultimate", data, 8))
+    {
+        return exe_ultimate;
+    }
+    else if (length >= 5 && !strncasecmp("final", data, 5))
+    {
+        return exe_final;
+    }
+
+    return exe_indetermined;
 }
 
 static demo_version_t GetWadDemover(void)
@@ -3821,6 +3855,12 @@ void G_ReloadDefaults(boolean keep_demover)
     if (demover == DV_NONE)
     {
       demover = GetWadDemover();
+      if (demover == DV_VANILLA)
+      {
+        GameVersion_t gamever = GetWadGameVersion();
+        if (gamever != exe_indetermined)
+          gameversion = gamever;
+      }
     }
 
     if (demover == DV_NONE)


### PR DESCRIPTION
I've looked at Chocolate Doom and it seems we don't need any playsim changes.