### PR TITLE
Adjust strict mode handling to better match DSDA-Doom

### DIFF
--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -318,8 +318,7 @@ extern  int       playback_skiptics;
 
 extern  boolean   frozen_mode;
 
-extern  boolean   strictmode, default_strictmode;
-extern  boolean   force_strictmode;
+extern  boolean   strictmode;
 
 #define STRICTMODE(x) (strictmode ? 0 : (x))
 

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -174,8 +174,7 @@ boolean reset_inventory = false;
 
 static boolean  pistolstart, default_pistolstart;
 
-boolean         strictmode, default_strictmode;
-boolean         force_strictmode;
+boolean         strictmode;
 boolean         critical;
 
 // [crispy] store last cmd to track joins
@@ -3721,6 +3720,48 @@ static void G_BoomComp()
   comp[comp_reservedlineflag] = 0;
 }
 
+static void CheckDemoParams(boolean specified_complevel)
+{
+  const boolean use_recordfrom = (M_CheckParmWithArgs("-recordfrom", 2)
+                                  || M_CheckParmWithArgs("-recordfromto", 2));
+
+  if (use_recordfrom || M_CheckParmWithArgs("-record", 1))
+  {
+    //!
+    // @category demo
+    // @help
+    //
+    // Lifts strict mode restrictions according to DSDA rules.
+    //
+
+    strictmode = !M_ParmExists("-tas");
+
+    if (!specified_complevel)
+    {
+      I_Error("You must specify a compatibility level when recording a demo!\n"
+              "Example: %s -iwad DOOM.WAD -complevel ultimate -skill 4 -record demo",
+              PROJECT_SHORTNAME);
+    }
+
+    if (!use_recordfrom && !M_ParmExists("-skill") && !M_ParmExists("-uv")
+        && !M_ParmExists("-nm"))
+    {
+      I_Error("You must specify a skill level when recording a demo!\n"
+              "Example: %s -iwad DOOM.WAD -complevel ultimate -skill 4 -record demo",
+              PROJECT_SHORTNAME);
+    }
+
+    if (M_ParmExists("-pistolstart"))
+    {
+      I_Error("The -pistolstart option is not allowed when recording a demo!");
+    }
+  }
+  else
+  {
+    strictmode = false;
+  }
+}
+
 // killough 3/1/98: function to reload all the default parameter
 // settings before a new game begins
 
@@ -3818,6 +3859,8 @@ void G_ReloadDefaults(boolean keep_demover)
       }
     }
 
+    CheckDemoParams(p > 0);
+
     if (demover == DV_NONE)
     {
       demover = GetWadDemover();
@@ -3833,21 +3876,6 @@ void G_ReloadDefaults(boolean keep_demover)
       demo_version = demover;
       force_complevel = GetComplevel(demo_version);
     }
-  }
-
-  strictmode = default_strictmode;
-
-  //!
-  // @category demo
-  // @help
-  //
-  // Sets compatibility and cosmetic settings according to DSDA rules.
-  //
-
-  if (M_CheckParm("-strict"))
-  {
-    strictmode = true;
-    force_strictmode = true;
   }
 
   G_UpdateSideMove();
@@ -4858,8 +4886,6 @@ void G_BindCompVariables(void)
             "Default compatibility level (0 = Vanilla; 1 = Boom; 2 = MBF; 3 = MBF21)");
   M_BindBool("autostrafe50", &autostrafe50, NULL, false, ss_comp, wad_no,
              "Automatic strafe50 (SR50)");
-  M_BindBool("strictmode", &default_strictmode, &strictmode,
-             false, ss_comp, wad_no, "Strict mode");
   M_BindBool("hangsolid", &hangsolid, NULL, false, ss_comp, wad_no,
              "Enable walking under solid hanging bodies");
   M_BindBool("blockmapfix", &blockmapfix, NULL, false, ss_comp, wad_no,

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -375,7 +375,7 @@ static boolean ItemDisabled(int flags)
         force_complevel != CL_NONE ? force_complevel : default_complevel;
 
     if ((flags & S_DISABLE)
-        || (flags & S_STRICT && (default_strictmode || force_strictmode))
+        || (flags & S_STRICT && strictmode)
         || (flags & S_BOOM && complevel < CL_BOOM)
         || (flags & S_MBF && complevel < CL_MBF)
         || (flags & S_VANILLA && complevel != CL_VANILLA))
@@ -2182,8 +2182,6 @@ setup_menu_t comp_settings1[] = {
     {"Default Compatibility Level", S_CHOICE | S_LEVWARN, M_X, M_SPC,
      {"default_complevel"}, .strings_id = str_default_complevel,
      .action = UpdateDefaultCompatibilityLevel},
-
-    {"Strict Mode", S_ONOFF | S_LEVWARN, M_X, M_SPC, {"strictmode"}},
 
     MI_GAP,
 
@@ -4933,7 +4931,6 @@ void MN_InitMenuStrings(void)
 
 void MN_SetupResetMenu(void)
 {
-    DisableItem(force_strictmode, comp_settings1, "strictmode");
     DisableItem(force_complevel != CL_NONE, comp_settings1, "default_complevel");
     DisableItem(M_ParmExists("-pistolstart"), comp_settings1, "pistolstart");
     DisableItem(M_ParmExists("-uncapped") || M_ParmExists("-nouncapped"),

--- a/src/params.h
+++ b/src/params.h
@@ -53,7 +53,7 @@ static const char *params[] = {
 "-levelstat",
 "-longtics",
 "-shorttics",
-"-strict",
+"-tas",
 "-nogui",
 };
 
@@ -135,8 +135,7 @@ Demo options: \n\
   -record <demo>    Record a demo named demo.lmp.\n\
   -shorttics        Play with low turning resolution to emulate demo\n\
                     recording.\n\
-  -strict           Sets compatibility and cosmetic settings according to DSDA\n\
-                    rules.\n\
+  -tas              Lifts strict mode restrictions according to DSDA rules.\n\
 \n\
 Compatibility: \n\
   -cl <version>         Alias to -complevel.\n\


### PR DESCRIPTION
Fixes https://github.com/fabiangreffrath/woof/issues/2321

Changes:
- Strict mode is only applicable to demo recording.
- Strict mode is enabled by default when recording a demo.
- Added `-tas` parameter to disable strict mode when recording a demo.
- Removed `-strict` parameter.
- Removed "Strict Mode" menu item.
- Added error messages if the following demo recording requirements are not met:
  - `-skill` must be specified to record a demo.
  - `-complevel` must be specified to record a demo.
  - `-pistolstart` is not allowed when recording a demo.

Working with this part of the code is precarious, so please let me know if this looks right:
- In `D_DoomMain()`, the first `G_ReloadDefaults(false)` call occurs [here](https://github.com/fabiangreffrath/woof/blob/master/src/d_main.c#L2360).
- Further down in `D_DoomMain()`, recording decisions start [here](https://github.com/fabiangreffrath/woof/blob/master/src/d_main.c#L2551).
- Therefore, it makes sense to validate demo recording parameters after the complevel check in `G_ReloadDefaults()` [here](https://github.com/fabiangreffrath/woof/blob/master/src/g_game.c#L3820).
- DSDA-Doom handles the related checks [here](https://github.com/kraflab/dsda-doom/blob/master/prboom2/src/dsda/demo.c#L269).