### PR TITLE
I_Error: print function name only with debug build, remove "not a crash" note

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -205,6 +205,13 @@ target_link_libraries(woof PRIVATE
     sha1
     md5)
 
+target_compile_definitions(woof PUBLIC
+    $<$<CONFIG:Debug>:WOOF_DEBUG>
+    $<$<CONFIG:RelWithDebInfo>:WOOF_DEBUG>
+    $<$<CONFIG:Release>:WOOF_RELEASE>
+    $<$<CONFIG:MinSizeRel>:WOOF_RELEASE>
+)
+
 # Some platforms require standard libraries to be linked against.
 if(HAVE_LIBM)
     target_link_libraries(woof PRIVATE m)

--- a/src/i_system.c
+++ b/src/i_system.c
@@ -54,12 +54,14 @@ void I_ErrorOrSuccess(int err_code, const char *prefix, const char *error,
     char *curmsg = errmsg + strlen(errmsg);
     char *msgptr = curmsg;
 
+#ifdef WOOF_DEBUG
     if (prefix)
     {
         int offset = M_snprintf(msgptr, len, "%s: ", prefix);
         msgptr += offset;
         len -= offset;
     }
+#endif
 
     va_list argptr;
     va_start(argptr, error);
@@ -79,14 +81,6 @@ void I_ErrorOrSuccess(int err_code, const char *prefix, const char *error,
 
 void I_ErrorMsg()
 {
-    const char note[] = "\nNote: This is an error message and not a \"crash\"!";
-
-    if (*errmsg && exit_code != 0
-        && sizeof(errmsg) - strlen(errmsg) > strlen(note))
-    {
-        strcat(errmsg, note);
-    }
-
     //!
     // @category obscure
     //


### PR DESCRIPTION
Discussion: https://github.com/fabiangreffrath/woof/pull/2327#discussion_r2217354000

I think users would always call any program exit a "crash", especially on Windows. There is popular "crash to the desktop" (CTD) terminology.