### PR TITLE
Always use direct vertical aiming when free look is enabled

### DIFF
--- a/src/g_game.c
+++ b/src/g_game.c
@@ -4892,8 +4892,6 @@ void G_BindCompVariables(void)
              "Fix blockmap bug (improves hit detection)");
   M_BindBool("checksight12", &checksight12, NULL, false, ss_comp, wad_no,
              "Fast blockmap-based line-of-sight calculation");
-  M_BindBool("direct_vertical_aiming", &default_direct_vertical_aiming, &direct_vertical_aiming,
-             false, ss_comp, wad_no, "Direct vertical aiming");
   M_BindBool("pistolstart", &default_pistolstart, &pistolstart,
              false, ss_comp, wad_no, "Pistol start");
 

--- a/src/i_input.c
+++ b/src/i_input.c
@@ -552,6 +552,7 @@ static void CloseGamepad(void)
         DisableGamepadEvents();
         UpdatePlatform();
         I_ResetGamepad();
+        MN_UpdateFreeLook(false);
     }
 }
 
@@ -581,6 +582,7 @@ void I_OpenGamepad(int device_index)
         UpdatePlatform();
         EnableGamepadEvents();
         SDL_GameControllerSetPlayerIndex(gamepad, 0);
+        MN_UpdateFreeLook(false);
 
         if (gyro_supported)
         {

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -2187,9 +2187,6 @@ setup_menu_t comp_settings1[] = {
 
     {"Compatibility-breaking Features", S_SKIP | S_TITLE, M_X, M_SPC},
 
-    {"Direct Vertical Aiming", S_ONOFF | S_STRICT, M_X, M_SPC,
-     {"direct_vertical_aiming"}, .action = P_UpdateDirectVerticalAiming},
-
     {"Auto Strafe 50", S_ONOFF | S_STRICT, M_X, M_SPC, {"autostrafe50"},
      .action = G_UpdateSideMove},
 
@@ -2785,7 +2782,7 @@ void MN_DrawEqualizer(void)
 
 void MN_UpdateFreeLook(boolean condition)
 {
-    P_UpdateDirectVerticalAiming();
+    P_UpdateDirectVerticalAiming(mouselook || (padlook && I_UseGamepad()));
 
     if (condition)
     {

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -48,13 +48,12 @@
 #include "v_video.h"
 #include "z_zone.h"
 
-boolean direct_vertical_aiming, default_direct_vertical_aiming;
+boolean direct_vertical_aiming;
 int max_pitch_angle = 32 * ANG1, default_max_pitch_angle;
 
-void P_UpdateDirectVerticalAiming(void)
+void P_UpdateDirectVerticalAiming(boolean condition)
 {
-  direct_vertical_aiming = (CRITICAL(default_direct_vertical_aiming) &&
-                            (mouselook || padlook));
+  direct_vertical_aiming = CRITICAL(condition);
   max_pitch_angle = default_max_pitch_angle * ANG1;
 }
 

--- a/src/p_mobj.h
+++ b/src/p_mobj.h
@@ -425,9 +425,9 @@ extern int itemrespawntime[];
 extern int iquehead;
 extern int iquetail;
 
-extern boolean direct_vertical_aiming, default_direct_vertical_aiming;
+extern boolean direct_vertical_aiming;
 extern int max_pitch_angle, default_max_pitch_angle;
-void P_UpdateDirectVerticalAiming(void);
+void P_UpdateDirectVerticalAiming(boolean condition);
 
 extern boolean checksight12;
 void P_UpdateCheckSight(void);


### PR DESCRIPTION
Free look is allowed for single player, multiplayer, and demo recording. That hasn't changed. Direct vertical aiming has historically been a confusing option and overlooked by users who wonder why they can look up/down but can't aim up/down. This PR removes the "Direct Vertical Aiming" menu option and automatically enables it in single player when free look is enabled. Direct vertical aiming is still disabled for multiplayer and demo recording.