### PR TITLE
Smoother volume ramping for ambient sounds

### DIFF
--- a/src/i_3dsound.c
+++ b/src/i_3dsound.c
@@ -227,7 +227,7 @@ static boolean CalcVolumePriority(int dist, sfxparams_t *params)
     {
         return true;
     }
-    else if (dist >= params->clipping_dist + params->keep_alive_dist)
+    else if (dist >= params->active_dist)
     {
         return false;
     }

--- a/src/i_3dsound.c
+++ b/src/i_3dsound.c
@@ -210,15 +210,33 @@ static void CalcDistance(const mobj_t *listener, const mobj_t *source,
     }
 }
 
+static void UpdatePriority(sfxparams_t *params)
+{
+    // Decrease priority with volume attenuation.
+    params->priority += (127 - params->volume);
+
+    if (params->priority > 255)
+    {
+        params->priority = 255;
+    }
+}
+
 static boolean CalcVolumePriority(int dist, sfxparams_t *params)
 {
     if (dist == 0)
     {
         return true;
     }
-    else if (dist >= params->clipping_dist)
+    else if (dist >= params->clipping_dist + params->keep_alive_dist)
     {
         return false;
+    }
+    else if (dist >= params->clipping_dist)
+    {
+        // Special case for zero-volume sounds that are allowed to stay active.
+        params->volume = 0;
+        UpdatePriority(params);
+        return true;
     }
     else if (dist > params->close_dist)
     {
@@ -228,14 +246,7 @@ static boolean CalcVolumePriority(int dist, sfxparams_t *params)
                          / (params->clipping_dist - params->close_dist);
     }
 
-    // Decrease priority with volume attenuation.
-    params->priority += (127 - params->volume);
-
-    if (params->priority > 255)
-    {
-        params->priority = 255;
-    }
-
+    UpdatePriority(params);
     return (params->volume > 0);
 }
 

--- a/src/i_3dsound.c
+++ b/src/i_3dsound.c
@@ -227,7 +227,7 @@ static boolean CalcVolumePriority(int dist, sfxparams_t *params)
     {
         return true;
     }
-    else if (dist >= params->active_dist)
+    else if (dist >= params->stop_dist)
     {
         return false;
     }

--- a/src/i_mbfsound.c
+++ b/src/i_mbfsound.c
@@ -107,7 +107,7 @@ static boolean I_MBF_AdjustSoundParams(const mobj_t *listener,
     {
         return true;
     }
-    else if (dist >= params->active_dist)
+    else if (dist >= params->stop_dist)
     {
         return false;
     }

--- a/src/i_mbfsound.c
+++ b/src/i_mbfsound.c
@@ -107,7 +107,7 @@ static boolean I_MBF_AdjustSoundParams(const mobj_t *listener,
     {
         return true;
     }
-    else if (dist >= params->clipping_dist + params->keep_alive_dist)
+    else if (dist >= params->active_dist)
     {
         return false;
     }

--- a/src/p_ambient.c
+++ b/src/p_ambient.c
@@ -53,7 +53,7 @@ void P_GetAmbientSoundParams(ambient_t *ambient, sfxparams_t *params)
 {
     params->close_dist = ambient->data.close_dist;
     params->clipping_dist = ambient->data.clipping_dist;
-    params->active_dist = params->clipping_dist + AMB_KEEP_ALIVE_DIST;
+    params->stop_dist = params->clipping_dist + AMB_KEEP_ALIVE_DIST;
     params->volume_scale = ambient->data.volume_scale;
 }
 

--- a/src/p_ambient.c
+++ b/src/p_ambient.c
@@ -53,7 +53,7 @@ void P_GetAmbientSoundParams(ambient_t *ambient, sfxparams_t *params)
 {
     params->close_dist = ambient->data.close_dist;
     params->clipping_dist = ambient->data.clipping_dist;
-    params->keep_alive_dist = AMB_KEEP_ALIVE_DIST;
+    params->active_dist = params->clipping_dist + AMB_KEEP_ALIVE_DIST;
     params->volume_scale = ambient->data.volume_scale;
 }
 

--- a/src/p_ambient.c
+++ b/src/p_ambient.c
@@ -30,6 +30,7 @@
 #include "z_zone.h"
 
 #define AMB_UPDATE_TICS 7 // 200 ms
+#define AMB_KEEP_ALIVE_DIST 330 // 23.57 mu/tic (SR50) * 2 (wallrun) * 7 tics
 
 int zmt_ambientsound = ZMT_UNDEFINED;
 
@@ -52,6 +53,7 @@ void P_GetAmbientSoundParams(ambient_t *ambient, sfxparams_t *params)
 {
     params->close_dist = ambient->data.close_dist;
     params->clipping_dist = ambient->data.clipping_dist;
+    params->keep_alive_dist = AMB_KEEP_ALIVE_DIST;
     params->volume_scale = ambient->data.volume_scale;
 }
 

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -51,6 +51,7 @@ typedef struct channel_s
     ambient_t *ambient;   // Ambient sound source using this channel.
     int close_dist;       // Sounds at or under this distance are full volume.
     int clipping_dist;    // Sounds at or over this distance are zero volume.
+    int keep_alive_dist;  // Additional distance allowed for zero-volume sounds.
     int volume_scale;     // volume scale value for effect -- haleyjd 05/29/06
     int handle;           // handle of the sound being played
     int o_priority;       // haleyjd 09/27/06: stored priority value
@@ -471,6 +472,7 @@ static boolean StartSoundEx(const mobj_t *origin, int sfx_id,
     {
         params.close_dist = S_CLOSE_DIST;
         params.clipping_dist = S_CLIPPING_DIST;
+        params.keep_alive_dist = 0;
         params.volume_scale = 127;
     }
 
@@ -523,6 +525,7 @@ static boolean StartSoundEx(const mobj_t *origin, int sfx_id,
         channels[cnum].ambient = ambient;
         channels[cnum].close_dist = params.close_dist;
         channels[cnum].clipping_dist = params.clipping_dist;
+        channels[cnum].keep_alive_dist = params.keep_alive_dist;
         channels[cnum].volume_scale = params.volume_scale;
         channels[cnum].o_priority = o_priority;    // original priority
         channels[cnum].priority = params.priority; // scaled priority
@@ -869,6 +872,7 @@ void S_UpdateSounds(const mobj_t *listener)
                     sfxparams_t params;
                     params.close_dist = c->close_dist;
                     params.clipping_dist = c->clipping_dist;
+                    params.keep_alive_dist = c->keep_alive_dist;
                     params.volume_scale = c->volume_scale;
                     params.priority = c->o_priority; // haleyjd 09/27/06: priority
 

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -51,7 +51,7 @@ typedef struct channel_s
     ambient_t *ambient;   // Ambient sound source using this channel.
     int close_dist;       // Sounds at or under this distance are full volume.
     int clipping_dist;    // Sounds at or over this distance are zero volume.
-    int active_dist;      // Sounds at or over this distance are stopped.
+    int stop_dist;        // Sounds at or over this distance are stopped.
     int volume_scale;     // volume scale value for effect -- haleyjd 05/29/06
     int handle;           // handle of the sound being played
     int o_priority;       // haleyjd 09/27/06: stored priority value
@@ -472,7 +472,7 @@ static boolean StartSoundEx(const mobj_t *origin, int sfx_id,
     {
         params.close_dist = S_CLOSE_DIST;
         params.clipping_dist = S_CLIPPING_DIST;
-        params.active_dist = params.clipping_dist;
+        params.stop_dist = params.clipping_dist;
         params.volume_scale = 127;
     }
 
@@ -525,7 +525,7 @@ static boolean StartSoundEx(const mobj_t *origin, int sfx_id,
         channels[cnum].ambient = ambient;
         channels[cnum].close_dist = params.close_dist;
         channels[cnum].clipping_dist = params.clipping_dist;
-        channels[cnum].active_dist = params.active_dist;
+        channels[cnum].stop_dist = params.stop_dist;
         channels[cnum].volume_scale = params.volume_scale;
         channels[cnum].o_priority = o_priority;    // original priority
         channels[cnum].priority = params.priority; // scaled priority
@@ -872,7 +872,7 @@ void S_UpdateSounds(const mobj_t *listener)
                     sfxparams_t params;
                     params.close_dist = c->close_dist;
                     params.clipping_dist = c->clipping_dist;
-                    params.active_dist = c->active_dist;
+                    params.stop_dist = c->stop_dist;
                     params.volume_scale = c->volume_scale;
                     params.priority = c->o_priority; // haleyjd 09/27/06: priority
 

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -51,7 +51,7 @@ typedef struct channel_s
     ambient_t *ambient;   // Ambient sound source using this channel.
     int close_dist;       // Sounds at or under this distance are full volume.
     int clipping_dist;    // Sounds at or over this distance are zero volume.
-    int keep_alive_dist;  // Additional distance allowed for zero-volume sounds.
+    int active_dist;      // Sounds at or over this distance are stopped.
     int volume_scale;     // volume scale value for effect -- haleyjd 05/29/06
     int handle;           // handle of the sound being played
     int o_priority;       // haleyjd 09/27/06: stored priority value
@@ -472,7 +472,7 @@ static boolean StartSoundEx(const mobj_t *origin, int sfx_id,
     {
         params.close_dist = S_CLOSE_DIST;
         params.clipping_dist = S_CLIPPING_DIST;
-        params.keep_alive_dist = 0;
+        params.active_dist = params.clipping_dist;
         params.volume_scale = 127;
     }
 
@@ -525,7 +525,7 @@ static boolean StartSoundEx(const mobj_t *origin, int sfx_id,
         channels[cnum].ambient = ambient;
         channels[cnum].close_dist = params.close_dist;
         channels[cnum].clipping_dist = params.clipping_dist;
-        channels[cnum].keep_alive_dist = params.keep_alive_dist;
+        channels[cnum].active_dist = params.active_dist;
         channels[cnum].volume_scale = params.volume_scale;
         channels[cnum].o_priority = o_priority;    // original priority
         channels[cnum].priority = params.priority; // scaled priority
@@ -872,7 +872,7 @@ void S_UpdateSounds(const mobj_t *listener)
                     sfxparams_t params;
                     params.close_dist = c->close_dist;
                     params.clipping_dist = c->clipping_dist;
-                    params.keep_alive_dist = c->keep_alive_dist;
+                    params.active_dist = c->active_dist;
                     params.volume_scale = c->volume_scale;
                     params.priority = c->o_priority; // haleyjd 09/27/06: priority
 

--- a/src/sounds.h
+++ b/src/sounds.h
@@ -27,6 +27,7 @@ typedef struct sfxparams_s
 {
   int close_dist;
   int clipping_dist;
+  int keep_alive_dist;
   int volume_scale;
   int volume;
   int separation;

--- a/src/sounds.h
+++ b/src/sounds.h
@@ -27,7 +27,7 @@ typedef struct sfxparams_s
 {
   int close_dist;
   int clipping_dist;
-  int active_dist;
+  int stop_dist;
   int volume_scale;
   int volume;
   int separation;

--- a/src/sounds.h
+++ b/src/sounds.h
@@ -27,7 +27,7 @@ typedef struct sfxparams_s
 {
   int close_dist;
   int clipping_dist;
-  int keep_alive_dist;
+  int active_dist;
   int volume_scale;
   int volume;
   int separation;


### PR DESCRIPTION
Just a small improvement to the initial volume ramping for ambient sounds. Additional details in commit comment.

Test wad: map03 of ambient_test.wad from https://github.com/fabiangreffrath/woof/pull/2280

Steps to reproduce: SR50 towards the ambient sound. The volume ramping is smoother with this PR.