### PR TITLE
Rewrite id24 DEMOLOOP parser

### DIFF
--- a/src/d_demoloop.c
+++ b/src/d_demoloop.c
@@ -254,6 +254,12 @@ static void D_GetDefaultDemoLoop(GameMode_t mode)
 
             demoloop = demoloop_commercial;
             demoloop_count = arrlen(demoloop_commercial);
+
+            if (W_CheckNumForName(demoloop_commercial[6].primary_lump) < 0)
+            {
+                // Ignore missing DEMO4.
+                demoloop_count--;
+            }
             break;
 
         case indetermined:

--- a/src/d_demoloop.c
+++ b/src/d_demoloop.c
@@ -18,6 +18,8 @@
 //    graphic-and-music, or DEMO lump.
 //
 
+#include <math.h>
+
 #include "doomdef.h"
 #include "doomstat.h"
 
@@ -26,6 +28,7 @@
 #include "m_json.h"
 #include "m_misc.h"
 #include "sounds.h"
+#include "w_wad.h"
 
 #include "d_demoloop.h"
 
@@ -68,41 +71,113 @@ static demoloop_entry_t demoloop_commercial[] = {
 demoloop_t demoloop = NULL;
 int        demoloop_count = 0;
 
-void D_ParseDemoLoopEntry(json_t *entry)
+static void D_ParseOutroWipe(json_t *json, demoloop_entry_t *entry)
 {
-    const char* primary_buffer   = JS_GetStringValue(entry, "primarylump");
-    const char* secondary_buffer = JS_GetStringValue(entry, "secondarylump");
-    double      seconds          = JS_GetNumberValue(entry, "duration");
-    int         type             = JS_GetIntegerValue(entry, "type");
-    int         outro_wipe       = JS_GetIntegerValue(entry, "outro_wipe");
+    entry->outro_wipe = JS_GetIntegerValue(json, "outrowipe");
 
-    // We don't want a malformed entry to creep in, and break the titlescreen.
-    // If one such entry does exist, skip it.
-    // TODO: modify later to check locally for lump type.
-    if (primary_buffer == NULL || secondary_buffer == NULL || type < TYPE_ART
-        || type > TYPE_DEMO)
+    if (entry->outro_wipe != WIPE_IMMEDIATE && entry->outro_wipe != WIPE_MELT)
     {
-        return;
+        I_Printf(VB_WARNING, "DEMOLOOP: invalid outrowipe, using screen melt");
+        entry->outro_wipe = WIPE_MELT;
+    }
+}
+
+static void D_ParseDuration(json_t *json, demoloop_entry_t *entry)
+{
+    const double duration_seconds = JS_GetNumberValue(json, "duration");
+    double duration_tics = duration_seconds * TICRATE;
+    duration_tics = CLAMP(duration_tics, 0, INT_MAX);
+    entry->duration = lround(duration_tics);
+}
+
+static boolean D_ParseSecondaryLump(json_t *json, demoloop_entry_t *entry)
+{
+    const char *secondary_lump = JS_GetStringValue(json, "secondarylump");
+
+    if (secondary_lump == NULL || secondary_lump[0] == '\0')
+    {
+        // Secondary lump is optional.
+        entry->secondary_lump[0] = '\0';
+    }
+    else
+    {
+        M_CopyLumpName(entry->secondary_lump, secondary_lump);
+
+        if (W_CheckNumForName(entry->secondary_lump) < 0)
+        {
+            I_Printf(VB_WARNING, "DEMOLOOP: invalid secondarylump");
+            return false;
+        }
     }
 
-    // Similarly, but this time it isn't game-breaking.
-    // Let it gracefully default to "closest vanilla behavior".
-    if (outro_wipe <= WIPE_NONE || outro_wipe > WIPE_MELT)
+    return true;
+}
+
+static boolean D_ParsePrimaryLump(json_t *json, demoloop_entry_t *entry)
+{
+    const char *primary_lump = JS_GetStringValue(json, "primarylump");
+
+    if (primary_lump == NULL || primary_lump[0] == '\0')
     {
-        outro_wipe = WIPE_MELT;
+        I_Printf(VB_WARNING, "DEMOLOOP: undefined primarylump");
+        return false;
     }
 
-    demoloop_entry_t current_entry = {0};
+    M_CopyLumpName(entry->primary_lump, primary_lump);
 
-    // Remove pointer reference to in-memory JSON data.
-    M_CopyLumpName(current_entry.primary_lump, primary_buffer);
-    M_CopyLumpName(current_entry.secondary_lump, secondary_buffer);
-    // Providing the time in seconds is much more intuitive for the end users.
-    current_entry.duration   = seconds * TICRATE;
-    current_entry.type       = type;
-    current_entry.outro_wipe = outro_wipe;
+    if (W_CheckNumForName(entry->primary_lump) < 0)
+    {
+        if (!strcasecmp(entry->primary_lump, "TITLEPIC")
+            && W_CheckNumForName("DMENUPIC") >= 0)
+        {
+            // Workaround for Doom 3: BFG Edition.
+            M_CopyLumpName(entry->primary_lump, "DMENUPIC");
+        }
+        else
+        {
+            I_Printf(VB_WARNING, "DEMOLOOP: invalid primarylump");
+            return false;
+        }
+    }
 
-    array_push(demoloop, current_entry);
+    return true;
+}
+
+static boolean D_ParseDemoLoopEntry(json_t *json)
+{
+    demoloop_entry_t entry = {0};
+
+    entry.type = JS_GetIntegerValue(json, "type");
+
+    switch (entry.type)
+    {
+        case TYPE_ART:
+            if (!D_ParsePrimaryLump(json, &entry)
+                || !D_ParseSecondaryLump(json, &entry))
+            {
+                return false;
+            }
+            D_ParseDuration(json, &entry);
+            D_ParseOutroWipe(json, &entry);
+            break;
+
+        case TYPE_DEMO:
+            if (!D_ParsePrimaryLump(json, &entry))
+            {
+                return false;
+            }
+            entry.secondary_lump[0] = '\0';
+            entry.duration = 0;
+            D_ParseOutroWipe(json, &entry);
+            break;
+
+        default:
+            I_Printf(VB_WARNING, "DEMOLOOP: invalid type");
+            return false;
+    }
+
+    array_push(demoloop, entry);
+    return true;
 }
 
 static void D_ParseDemoLoop(void)
@@ -136,7 +211,12 @@ static void D_ParseDemoLoop(void)
     json_t *entry;
     JS_ArrayForEach(entry, entry_list)
     {
-        D_ParseDemoLoopEntry(entry);
+        if (!D_ParseDemoLoopEntry(entry))
+        {
+            array_free(demoloop);
+            JS_Close("DEMOLOOP");
+            return;
+        }
     }
     demoloop_count = array_size(demoloop);
 
@@ -184,7 +264,20 @@ static void D_GetDefaultDemoLoop(GameMode_t mode)
             break;
     }
 
-    return;
+    if (demoloop && W_CheckNumForName("TITLEPIC") < 0
+        && W_CheckNumForName("DMENUPIC") >= 0)
+    {
+        for (int i = 0; i < demoloop_count; i++)
+        {
+            demoloop_entry_t *entry = &demoloop[i];
+
+            if (!strcasecmp(entry->primary_lump, "TITLEPIC"))
+            {
+                // Workaround for Doom 3: BFG Edition.
+                M_CopyLumpName(entry->primary_lump, "DMENUPIC");
+            }
+        }
+    }
 }
 
 void D_SetupDemoLoop(void)

--- a/src/d_demoloop.h
+++ b/src/d_demoloop.h
@@ -21,18 +21,17 @@
 #ifndef _D_DEMOLOOP_
 #define _D_DEMOLOOP_
 
-// Screen graphic or DEMO lump, NONE is used for fault tolerance.
+// Screen graphic or DEMO lump.
 typedef enum
 {
     TYPE_ART,
     TYPE_DEMO,
 } dl_type_t;
 
-// Immediate switch or screen melt, NONE is used for fault tolerance.
+// Immediate switch or screen melt.
 // TODO: reimplement more cleanly at a later, more relevant moment
 typedef enum
 {
-    WIPE_NONE = -1,
     WIPE_IMMEDIATE,
     WIPE_MELT,
 } dl_wipe_t;

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -502,20 +502,12 @@ void D_DoAdvanceDemo(void)
     usergame = false; // no save / end game here
     paused = false;
     gameaction = ga_nothing;
+    gamestate = GS_DEMOSCREEN;
 
     D_AdvanceDemoLoop();
     switch (demoloop_point->type)
     {
         case TYPE_ART:
-            gamestate = GS_DEMOSCREEN;
-
-            // Needed to support the Doom 3: BFG Edition variant
-            if (W_CheckNumForName(demoloop_point->primary_lump) < 0
-                && !strcasecmp(demoloop_point->primary_lump, "TITLEPIC"))
-            {
-                M_CopyLumpName(demoloop_point->primary_lump, "DMENUPIC");
-            }
-
             if (W_CheckNumForName(demoloop_point->primary_lump) >= 0)
             {
                 pagename = demoloop_point->primary_lump;
@@ -525,24 +517,18 @@ void D_DoAdvanceDemo(void)
                 {
                     S_ChangeMusInfoMusic(music, false);
                 }
-                break;
             }
-            // fallthrough
+            break;
 
         case TYPE_DEMO:
-            gamestate = GS_DEMOSCREEN;
-
             if (W_CheckNumForName(demoloop_point->primary_lump) >= 0)
             {
                 G_DeferedPlayDemo(demoloop_point->primary_lump);
-                break;
             }
-            // fallthrough
+            break;
 
         default:
-            I_Printf(VB_WARNING,
-                     "D_DoAdvanceDemo: Invalid demoloop[%d] entry, skipping",
-                     demosequence);
+            I_Printf(VB_DEBUG, "D_DoAdvanceDemo: unhandled demoloop type");
             break;
     }
 }


### PR DESCRIPTION
Alternative to https://github.com/fabiangreffrath/woof/pull/2355

DEMOLOOP lump validation occurs at initialization. If there are parsing errors, then DEMOLOOP will be ignored and the default demo loop for the current gamemode will be used instead.

Test wad: [demoloop_test.zip](https://github.com/user-attachments/files/21746132/demoloop_test.zip)