### PR TITLE
Rework ENDOOM options

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1641,26 +1641,14 @@ void D_SetBloodColor(void)
 // killough 8/1/98: change back to ENDOOM
 
 typedef enum {
-  EXIT_SEQUENCE_OFF,          // Skip sound, skip ENDOOM.
-  EXIT_SEQUENCE_SOUND_ONLY,   // Play sound, skip ENDOOM.
-  EXIT_SEQUENCE_ENDOOM_ONLY,  // Skip sound, show ENDOOM.
-  EXIT_SEQUENCE_FULL          // Play sound, show ENDOOM.
-} exit_sequence_t;
+  ENDOOM_OFF,
+  ENDOOM_PWAD_ONLY,
+  ENDOOM_ALWAYS
+} endoom_t;
 
-static exit_sequence_t exit_sequence;
-static boolean endoom_pwad_only;
-
-boolean D_EndDoomEnabled(void)
-{
-  return (exit_sequence == EXIT_SEQUENCE_FULL
-          || exit_sequence == EXIT_SEQUENCE_ENDOOM_ONLY);
-}
-
-boolean D_QuitSoundEnabled(void)
-{
-  return (exit_sequence == EXIT_SEQUENCE_FULL
-          || exit_sequence == EXIT_SEQUENCE_SOUND_ONLY);
-}
+boolean quit_prompt;
+boolean quit_sound;
+static endoom_t show_endoom;
 
 static void D_ShowEndDoom(void)
 {
@@ -1679,12 +1667,13 @@ boolean D_AllowEndDoom(void)
     return false; // Alt-F4 or pressed the close button.
   }
 
-  if (!D_EndDoomEnabled())
+  if (show_endoom == ENDOOM_OFF)
   {
-    return false; // Exit sequence is set to "Off" or "Sound Only".
+    return false; // ENDOOM disabled.
   }
 
-  if (W_IsIWADLump(W_CheckNumForName("ENDOOM")) && endoom_pwad_only)
+  if (W_IsIWADLump(W_CheckNumForName("ENDOOM"))
+      && show_endoom == ENDOOM_PWAD_ONLY)
   {
     return false; // User prefers PWAD ENDOOM only.
   }
@@ -2699,9 +2688,10 @@ void D_DoomMain(void)
 
 void D_BindMiscVariables(void)
 {
-  BIND_NUM_GENERAL(exit_sequence, 0, 0, EXIT_SEQUENCE_FULL,
-    "Exit sequence (0 = Off; 1 = Sound Only; 2 = ENDOOM Only; 3 = Full)");
-  BIND_BOOL_GENERAL(endoom_pwad_only, false, "Show only ENDOOM from PWAD");
+  BIND_BOOL_GENERAL(quit_prompt, true, "Show quit prompt");
+  BIND_BOOL_GENERAL(quit_sound, false, "Play quit sound");
+  BIND_NUM_GENERAL(show_endoom, ENDOOM_OFF, ENDOOM_OFF, ENDOOM_ALWAYS,
+    "Show ENDOOM screen (0 = Off; 1 = PWAD Only; 2 = Always)");
   BIND_BOOL_GENERAL(demobar, false, "Show demo progress bar");
   BIND_NUM_GENERAL(screen_melt, wipe_Melt, wipe_None, wipe_Fizzle,
     "Screen wipe effect (0 = None; 1 = Melt; 2 = Crossfade; 3 = Fizzlefade)");

--- a/src/d_main.h
+++ b/src/d_main.h
@@ -45,9 +45,9 @@ extern boolean clcoopspawns; // checkparm of -coop_spawns
 void D_SetMaxHealth(void);
 void D_SetBloodColor(void);
 
+extern boolean quit_prompt;
+extern boolean quit_sound;
 extern boolean fast_exit;
-boolean D_EndDoomEnabled(void);
-boolean D_QuitSoundEnabled(void);
 boolean D_AllowEndDoom(void);
 
 // Called by IO functions when input is detected.

--- a/src/mn_menu.c
+++ b/src/mn_menu.c
@@ -1501,7 +1501,7 @@ static void M_QuitResponse(int ch)
     {
         return;
     }
-    if (D_QuitSoundEnabled() &&
+    if (quit_sound &&
         (!netgame || demoplayback) && // killough 12/98
         !nosfxparm)                   // avoid delay if no sound card
     {
@@ -1535,7 +1535,14 @@ static void M_QuitDOOM(int choice)
                 *endmsg[gametic % (NUM_QUITMESSAGES - 1) + 1], s_DOSY);
     }
 
-    M_StartMessage(endstring, M_QuitResponse, true);
+    if (quit_prompt)
+    {
+        M_StartMessage(endstring, M_QuitResponse, true);
+    }
+    else
+    {
+        M_QuitResponse('y');
+    }
 }
 
 /////////////////////////////
@@ -2549,8 +2556,11 @@ boolean M_ShortcutResponder(const event_t *ev)
 
     if (M_InputActivated(input_quit)) // Quit DOOM
     {
-        M_PauseSound();
-        M_StartSound(sfx_swtchn);
+        if (quit_prompt)
+        {
+            M_PauseSound();
+            M_StartSound(sfx_swtchn);
+        }
         M_QuitDOOM(0);
         return true;
     }

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -395,7 +395,7 @@ enum
     str_gyro_accel,
 
     str_default_complevel,
-    str_exit_sequence,
+    str_endoom,
     str_death_use_action,
     str_widescreen,
     str_bobbing_pct,
@@ -3327,10 +3327,6 @@ static void SmoothLight(void)
     setsizeneeded = true; // run R_ExecuteSetViewSize
 }
 
-static const char *exit_sequence_strings[] = {
-    "Off", "Sound Only", "ENDOOM Only", "Full"
-};
-
 static const char *fuzzmode_strings[] = {
     "Blocky", "Refraction", "Shadow", "Original"
 };
@@ -3373,7 +3369,7 @@ static const char *screen_melt_strings[] = {"Off", "Melt", "Crossfade", "Fizzle"
 
 static const char *invul_mode_strings[] = {"Vanilla", "MBF", "Gray"};
 
-static void UpdatePwadEndoomItem(void);
+static const char *endoom_strings[] = {"Off", "PWAD Only", "Always"};
 
 static setup_menu_t gen_settings6[] = {
 
@@ -3406,10 +3402,12 @@ static setup_menu_t gen_settings6[] = {
     {"Game speed", S_NUM | S_STRICT | S_PCT, OFF_CNTR_X, M_SPC,
      {"realtic_clock_rate"}, .action = G_SetTimeScale},
 
-    {"Exit Sequence", S_CHOICE, OFF_CNTR_X, M_SPC, {"exit_sequence"},
-    .strings_id = str_exit_sequence, .action = UpdatePwadEndoomItem},
+    {"Show Quit Prompt", S_ONOFF, OFF_CNTR_X, M_SPC, {"quit_prompt"}},
 
-    {"PWAD ENDOOM Only", S_ONOFF, OFF_CNTR_X, M_SPC, {"endoom_pwad_only"}},
+    {"Play Quit Sound", S_ONOFF, OFF_CNTR_X, M_SPC, {"quit_sound"}},
+
+    {"Show ENDOOM Screen", S_CHOICE, OFF_CNTR_X, M_SPC, {"show_endoom"},
+     .strings_id = str_endoom},
 
     MI_END
 };
@@ -3418,11 +3416,6 @@ static setup_menu_t *gen_settings[] = {
     gen_settings1, gen_settings2, gen_settings3, gen_settings4,
     gen_settings5, gen_settings6, NULL
 };
-
-static void UpdatePwadEndoomItem(void)
-{
-    DisableItem(!D_EndDoomEnabled(), gen_settings6, "endoom_pwad_only");
-}
 
 void MN_UpdateDynamicResolutionItem(void)
 {
@@ -5036,7 +5029,7 @@ static const char **selectstrings[] = {
     [str_gyro_sens] = NULL,
     [str_gyro_accel] = NULL,
     [str_default_complevel] = default_complevel_strings,
-    [str_exit_sequence] = exit_sequence_strings,
+    [str_endoom] = endoom_strings,
     [str_death_use_action] = death_use_action_strings,
     [str_widescreen] = widescreen_strings,
     [str_bobbing_pct] = bobbing_pct_strings,
@@ -5139,7 +5132,6 @@ void MN_SetupResetMenu(void)
     UpdateWeaponSlotItems();
     MN_UpdateEqualizerItems();
     UpdateGainItems();
-    UpdatePwadEndoomItem();
 }
 
 void MN_BindMenuVariables(void)


### PR DESCRIPTION
I have some small changes I'd like to start making PRs for ahead of any major menu work. This is one example.

This makes the ENDOOM options a little easier to follow. Originally, "Exit Sequence" was made in an attempt to simplify the menu items for ENDOOM down to just one. But due to user request this became two options with the addition of "PWAD ENDOOM Only", which made the original effort pointless and left the options somewhat confusing. This PR restores `show_endoom` and adds `quit_sound` to complement it. The same functionality, but easier to follow.

Additionally, `quit_prompt` was added for convenience. I find it useful and it will fit well in a future menu layout. But does it justify a menu option? I can remove this if it seems like too much.

```
Quit Game           (a future "yellow" section title)
Show Quit Prompt    Off, [On]
Play Quit Sound     [Off], On
Show ENDOOM Screen  [Off], PWAD Only, Always
```