### PR TITLE
Add option to pause demo loop while menu is open

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -456,6 +456,11 @@ static demoloop_t demoloop_point;
 //
 void D_PageTicker(void)
 {
+  if (menuactive && !netgame && menu_pause_demos)
+  {
+    return;
+  }
+
   // killough 12/98: don't advance internal demos if a single one is 
   // being played. The only time this matters is when using -loadgame with
   // -fastdemo, -playdemo, or -timedemo, and a consistency error occurs.

--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -256,6 +256,7 @@ extern  overlay_t automapoverlay;
 #define automap_off (!automapactive || automapoverlay)
 
 extern  boolean menuactive;    // Menu overlayed?
+extern  boolean menu_pause_demos;
 extern  int     paused;        // Game Pause?
 extern  boolean viewactive;
 extern  boolean nodrawers;

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -3129,35 +3129,11 @@ void G_Ticker(void)
   // killough 9/29/98: split up switch statement
   // into pauseable and unpauseable parts.
 
-  if (gamestate == GS_LEVEL)
-  {
-    P_Ticker();
-    ST_Ticker();
-    AM_Ticker();
-  }
-  else if (!(paused & 2))
-  {
-    switch (gamestate)
-    {
-      case GS_INTERMISSION:
-        WI_Ticker();
-        break;
-
-      case GS_FINALE:
-        F_Ticker();
-        break;
-
-      case GS_DEMOSCREEN:
-        if (!menuactive || netgame || !menu_pause_demos)
-        {
-          D_PageTicker();
-        }
-        break;
-
-      default:
-        break;
-    }
-  }
+  gamestate == GS_LEVEL ? P_Ticker(), ST_Ticker(), AM_Ticker() :
+    paused & 2 ? (void) 0 :
+      gamestate == GS_INTERMISSION ? WI_Ticker() :
+	gamestate == GS_FINALE ? F_Ticker() :
+	  gamestate == GS_DEMOSCREEN ? D_PageTicker() : (void) 0;
 }
 
 //

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -3012,7 +3012,7 @@ void G_Ticker(void)
   // P_Ticker() does not stop netgames if a menu is activated, so
   // we do not need to stop if a menu is pulled up during netgames.
 
-  if (paused & 2 || (!demoplayback && menuactive && !netgame))
+  if (paused & 2 || ((!demoplayback || menu_pause_demos) && menuactive && !netgame))
     basetic++;  // For revenant tracers and RNG -- we must maintain sync
   else
     {
@@ -3129,11 +3129,35 @@ void G_Ticker(void)
   // killough 9/29/98: split up switch statement
   // into pauseable and unpauseable parts.
 
-  gamestate == GS_LEVEL ? P_Ticker(), ST_Ticker(), AM_Ticker() :
-    paused & 2 ? (void) 0 :
-      gamestate == GS_INTERMISSION ? WI_Ticker() :
-	gamestate == GS_FINALE ? F_Ticker() :
-	  gamestate == GS_DEMOSCREEN ? D_PageTicker() : (void) 0;
+  if (gamestate == GS_LEVEL)
+  {
+    P_Ticker();
+    ST_Ticker();
+    AM_Ticker();
+  }
+  else if (!(paused & 2))
+  {
+    switch (gamestate)
+    {
+      case GS_INTERMISSION:
+        WI_Ticker();
+        break;
+
+      case GS_FINALE:
+        F_Ticker();
+        break;
+
+      case GS_DEMOSCREEN:
+        if (!menuactive || netgame || !menu_pause_demos)
+        {
+          D_PageTicker();
+        }
+        break;
+
+      default:
+        break;
+    }
+  }
 }
 
 //

--- a/src/mn_menu.c
+++ b/src/mn_menu.c
@@ -107,6 +107,7 @@ static boolean mouse_active_thermo;
 static boolean options_active;
 static boolean customskill_active;
 
+boolean menu_pause_demos;
 backdrop_t menu_backdrop;
 
 int bigfont_priority = -1;

--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -3384,6 +3384,8 @@ static setup_menu_t gen_settings6[] = {
     {"Invulnerability effect", S_CHOICE | S_STRICT, OFF_CNTR_X, M_SPC,
      {"invul_mode"}, .strings_id = str_invul_mode, .action = R_InvulMode},
 
+    {"Pause Demos in Menu", S_ONOFF, OFF_CNTR_X, M_SPC, {"menu_pause_demos"}},
+
     {"Demo progress bar", S_ONOFF, OFF_CNTR_X, M_SPC, {"demobar"}},
 
     {"On death action", S_CHOICE, OFF_CNTR_X, M_SPC, {"death_use_action"},
@@ -5137,6 +5139,8 @@ void MN_SetupResetMenu(void)
 void MN_BindMenuVariables(void)
 {
     BIND_NUM_MENU(resolution_scale, 0, UL);
+    BIND_BOOL_GENERAL(menu_pause_demos, false,
+        "Pause demo loop while menu is open");
     BIND_NUM_GENERAL(menu_backdrop, MENU_BG_DARK, MENU_BG_OFF, MENU_BG_TEXTURE,
         "Menu backdrop (0 = Off; 1 = Dark; 2 = Texture)");
     BIND_NUM_GENERAL(menu_help, MENU_HELP_AUTO, MENU_HELP_OFF, MENU_HELP_PAD,

--- a/src/p_tick.c
+++ b/src/p_tick.c
@@ -390,7 +390,7 @@ void P_Ticker (void)
   // 
   // All of this complicated mess is used to preserve demo sync.
 
-  if (paused || (menuactive && !demoplayback && !netgame &&
+  if (paused || (menuactive && (!demoplayback || menu_pause_demos) && !netgame &&
 		 players[consoleplayer].viewz != 1))
     return;
 


### PR DESCRIPTION
This will be part of a demos section in a future menu layout:

```
Demos                (a future "yellow" section title)
Pause Demos in Menu  [Off], On
Show Progress Bar    [Off], On
```
