### PR TITLE
print backtrace in I_Error function

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -242,6 +242,11 @@ endif()
 target_compile_definitions(woof PRIVATE
     $<IF:$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>,WOOF_DEBUG,WOOF_RELEASE>)
 
+if(WIN32)
+    target_link_libraries(woof PRIVATE
+        $<IF:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>,Dbghelp>)
+endif()
+
 # Optional features.
 #
 # Our defines are not namespaced, so we pass them at compile-time instead of

--- a/src/i_system.c
+++ b/src/i_system.c
@@ -44,6 +44,84 @@ ticcmd_t *I_BaseTiccmd(void)
 // I_Error
 //
 
+#ifdef WOOF_DEBUG
+
+#if defined(_WIN32)
+#include <dbghelp.h>
+
+static void PrintBacktrace(void)
+{
+    HANDLE process = GetCurrentProcess();
+
+    boolean symbol_available = false;
+
+    if (SymInitialize(process, NULL, TRUE))
+    {
+        SymSetOptions(SYMOPT_UNDNAME);
+        symbol_available = true;
+    }
+
+    // Capture stack frames
+    void *stack[100];
+    USHORT frames = CaptureStackBackTrace(2, 100, stack, NULL);
+
+    // Print backtrace
+    I_Printf(VB_INFO, "Backtrace (frames %d):", frames);
+    for (USHORT i = 0; i < frames; i++)
+    {
+        DWORD64 address = (DWORD64)stack[i];
+
+        // Buffer for symbol info
+        char buffer[sizeof(SYMBOL_INFO) + 256 * sizeof(char)];
+        PSYMBOL_INFO symbol = (PSYMBOL_INFO)buffer;
+        symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
+        symbol->MaxNameLen = 256;
+
+        // Try to resolve symbol
+        DWORD64 displacement = 0;
+        if (symbol_available
+            && SymFromAddr(process, address, &displacement, symbol))
+        {
+            I_Printf(VB_INFO, " [%2d] %s (0x%llX)", i, symbol->Name, address);
+        }
+        else
+        {
+            I_Printf(VB_INFO, " [%2d] 0x%llX\n", i, address);
+        }
+    }
+}
+
+#else  // POSIX
+
+#include <execinfo.h>
+#include <unistd.h>
+
+static void PrintBacktrace(void)
+{
+    void *stack[100];
+    int size = backtrace(stack, 100);
+    char **symbols = backtrace_symbols(stack, size);
+
+    if (!symbols)
+    {
+        perror("backtrace_symbols");
+        return;
+    }
+
+    // Skip two frames
+    I_Printf(VB_INFO, "Backtrace (frames %d):\n", size - 2);
+    for (int i = 2; i < size; i++)
+    {
+        I_Printf(VB_INFO, " [%2d] %s\n", i - 1, symbols[i]);
+    }
+
+    free(symbols);
+}
+
+#endif
+
+#endif // WOOF_DEBUG
+
 static char errmsg[2048];    // buffer of error message -- killough
 static int exit_code;
 
@@ -75,6 +153,10 @@ void I_ErrorOrSuccess(int err_code, const char *prefix, const char *error,
     {
         exit_code = err_code;
     }
+
+#ifdef WOOF_DEBUG
+    PrintBacktrace();
+#endif
 
     I_SafeExit(exit_code);
 }


### PR DESCRIPTION
This will make `I_Error` much more useful. Example:
```
I_InitWindowIcon: backtrace?
Backtrace (frames 9):
 [ 0] I_InitWindowIcon (0x7FF61E9E6CAC)
 [ 1] I_InitGraphicsMode (0x7FF61E9E690E)
 [ 2] I_InitGraphics (0x7FF61E9E67F9)
 [ 3] D_DoomMain (0x7FF61E9B4981)
 [ 4] SDL_main (0x7FF61E9D69ED)
 [ 5] SDL_RunApp_REAL (0x7FFF6F89F1B9)
 [ 6] __scrt_common_main_seh (0x7FF61EAAF234)
 [ 7] BaseThreadInitThunk (0x7FFF9EAC7374)
 [ 8] RtlUserThreadStart (0x7FFF9EC1CC91)
```