### PR TITLE
Fix aggressive monsters check

### DIFF
--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -868,7 +868,7 @@ mobj_t *P_SpawnMobj(fixed_t x, fixed_t y, fixed_t z, mobjtype_t type)
 
   mobj->health = info->spawnhealth;
 
-  if (gameskill != sk_nightmare || !aggromonsters)
+  if (gameskill != sk_nightmare && !aggromonsters)
     mobj->reactiontime = info->reactiontime;
 
   if (type != zmt_ambientsound)


### PR DESCRIPTION
Dehacked lump to exaggerate the `Reaction Time` property: [reflexes.txt](https://github.com/user-attachments/files/21815528/reflexes.txt)

Thanks to @MrAlaux for pointing this out -- the check for Aggressive Monsters, aka Nightmare reflexes, was using incorrect boolean logic. See, the check for Fast Monsters:
https://github.com/fabiangreffrath/woof/blob/de260b9e496ecc08311aea5be5663e3eda2040d8/src/p_enemy.c#L1193