### PR TITLE
SBARDEF: add "image crop" to some elements

### DIFF
--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -3912,7 +3912,7 @@ void MN_DrawStringCR(int cx, int cy, byte *cr1, byte *cr2, const char *ch)
         // desired color, colrngs[color]
         if (cr && cr2)
         {
-            V_DrawPatchTRTR(cx, cy, hu_font[c], cr, cr2);
+            V_DrawPatchTRTR(cx, cy, (crop_t){0}, hu_font[c], cr, cr2);
         }
         else
         {

--- a/src/st_carousel.c
+++ b/src/st_carousel.c
@@ -183,15 +183,15 @@ static void DrawIcon(int x, int y, sbarelem_t *elem, weapon_icon_t icon)
 
     if (cr && elem->tranmap)
     {
-        V_DrawPatchTRTL(x, y, patch, cr, elem->tranmap);
+        V_DrawPatchTRTL(x, y, (crop_t){0}, patch, cr, elem->tranmap);
     }
     else if (elem->tranmap)
     {
-        V_DrawPatchTL(x, y, patch, elem->tranmap);
+        V_DrawPatchTL(x, y, (crop_t){0}, patch, elem->tranmap);
     }
     else
     {
-        V_DrawPatchTranslated(x, y, patch, cr);
+        V_DrawPatchTR(x, y, (crop_t){0}, patch, cr);
     }
 }
 

--- a/src/st_sbardef.c
+++ b/src/st_sbardef.c
@@ -80,6 +80,18 @@ static const char *sbw_names[] =
     [sbw_title] = "level_title",
 };
 
+static crop_t ParseCrop(json_t *json)
+{
+    crop_t crop = {
+        .topoffset = JS_GetIntegerValue(json, "topoffset"),
+        .leftoffset = JS_GetIntegerValue(json, "leftoffset"),
+        .midoffset = JS_GetIntegerValue(json, "midoffset"),
+        .width = JS_GetIntegerValue(json, "width"),
+        .height = JS_GetIntegerValue(json, "height")
+    };
+    return crop;
+}
+
 static boolean ParseSbarElem(json_t *json, sbarelem_t *out);
 
 static boolean ParseSbarElemType(json_t *json, sbarelementtype_t type,
@@ -148,14 +160,7 @@ static boolean ParseSbarElemType(json_t *json, sbarelementtype_t type,
                     return false;
                 }
                 graphic->patch_name = M_StringDuplicate(patch);
-                crop_t crop = {
-                    .topoffset = JS_GetIntegerValue(json, "topoffset"),
-                    .leftoffset = JS_GetIntegerValue(json, "leftoffset"),
-                    .midoffset = JS_GetIntegerValue(json, "midoffset"),
-                    .width = JS_GetIntegerValue(json, "width"),
-                    .height = JS_GetIntegerValue(json, "height")
-                };
-                graphic->crop = crop;
+                graphic->crop = ParseCrop(json);
                 out->subtype.graphic = graphic;
             }
             break;
@@ -283,7 +288,15 @@ static boolean ParseSbarElemType(json_t *json, sbarelementtype_t type,
         case sbe_face:
             {
                 sbe_face_t *face = calloc(1, sizeof(*face));
+                face->crop = ParseCrop(json);
                 out->subtype.face = face;
+            }
+            break;
+        case sbe_facebackground:
+            {
+                sbe_facebackground_t *facebackground = calloc(1, sizeof(*facebackground));
+                facebackground->crop = ParseCrop(json);
+                out->subtype.facebackground = facebackground;
             }
             break;
 

--- a/src/st_sbardef.c
+++ b/src/st_sbardef.c
@@ -148,6 +148,14 @@ static boolean ParseSbarElemType(json_t *json, sbarelementtype_t type,
                     return false;
                 }
                 graphic->patch_name = M_StringDuplicate(patch);
+                crop_t crop = {
+                    .topoffset = JS_GetIntegerValue(json, "topoffset"),
+                    .leftoffset = JS_GetIntegerValue(json, "leftoffset"),
+                    .midoffset = JS_GetIntegerValue(json, "midoffset"),
+                    .width = JS_GetIntegerValue(json, "width"),
+                    .height = JS_GetIntegerValue(json, "height")
+                };
+                graphic->crop = crop;
                 out->subtype.graphic = graphic;
             }
             break;

--- a/src/st_sbardef.h
+++ b/src/st_sbardef.h
@@ -177,6 +177,9 @@ typedef struct
 {
     const char *patch_name;
     patch_t *patch;
+
+    // Woof!
+    crop_t crop;
 } sbe_graphic_t;
 
 typedef struct

--- a/src/st_sbardef.h
+++ b/src/st_sbardef.h
@@ -208,7 +208,16 @@ typedef struct
 
     // used for evil grin
     boolean oldweaponsowned[NUMWEAPONS];
+
+    // Woof!
+    crop_t crop;
 } sbe_face_t;
+
+typedef struct
+{
+    // Woof!
+    crop_t crop;
+} sbe_facebackground_t;
 
 typedef struct
 {
@@ -251,6 +260,7 @@ struct sbarelem_s
         sbe_animation_t *animation;
         sbe_number_t *number;
         sbe_face_t *face;
+        sbe_facebackground_t *facebackground;
 
         // Woof!
         sbe_widget_t *widget;

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -1232,24 +1232,16 @@ static void DrawPatch(int x, int y, crop_t crop, int maxheight,
         return;
     }
 
-    int width = crop.width ? crop.width : SHORT(patch->width);
-    int height;
-    if (maxheight)
-    {
-        height = maxheight;
-    }
-    else if (crop.height)
-    {
-        height = crop.height;
-    }
-    else
-    {
-        height = SHORT(patch->height);
-    }
+    int width = SHORT(patch->width);
+    int height = maxheight ? maxheight : SHORT(patch->height);
 
     if (alignment & sbe_h_middle)
     {
         x = x - width / 2 + SHORT(patch->leftoffset);
+        if (crop.midoffset)
+        {
+            x += width / 2 + crop.midoffset;
+        }
     }
     else if (alignment & sbe_h_right)
     {

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -1496,7 +1496,8 @@ static void DrawElem(int x, int y, sbarelem_t *elem, player_t *player)
 
         case sbe_facebackground:
             {
-                DrawPatch(x, y, (crop_t){0}, 0, elem->alignment,
+                sbe_facebackground_t *facebackground = elem->subtype.facebackground;
+                DrawPatch(x, y, facebackground->crop, 0, elem->alignment,
                           facebackpatches[displayplayer], elem->cr,
                           elem->tranmap);
             }
@@ -1505,7 +1506,7 @@ static void DrawElem(int x, int y, sbarelem_t *elem, player_t *player)
         case sbe_face:
             {
                 sbe_face_t *face = elem->subtype.face;
-                DrawPatch(x, y, (crop_t){0}, 0, elem->alignment,
+                DrawPatch(x, y, face->crop, 0, elem->alignment,
                           facepatches[face->faceindex], elem->cr,
                           elem->tranmap);
             }

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -1223,16 +1223,29 @@ static void ResetStatusBar(void)
     ST_ResetTitle();
 }
 
-static void DrawPatch(int x, int y, int maxheight, sbaralignment_t alignment,
-                      patch_t *patch, crange_idx_e cr, byte *tl)
+static void DrawPatch(int x, int y, crop_t crop, int maxheight,
+                      sbaralignment_t alignment, patch_t *patch,
+                      crange_idx_e cr, byte *tl)
 {
     if (!patch)
     {
         return;
     }
 
-    int width = SHORT(patch->width);
-    int height = maxheight ? maxheight : SHORT(patch->height);
+    int width = crop.width ? crop.width : SHORT(patch->width);
+    int height;
+    if (maxheight)
+    {
+        height = maxheight;
+    }
+    else if (crop.height)
+    {
+        height = crop.height;
+    }
+    else
+    {
+        height = SHORT(patch->height);
+    }
 
     if (alignment & sbe_h_middle)
     {
@@ -1265,15 +1278,15 @@ static void DrawPatch(int x, int y, int maxheight, sbaralignment_t alignment,
 
     if (outr && tl)
     {
-        V_DrawPatchTRTL(x, y, patch, outr, tl);
+        V_DrawPatchTRTL(x, y, crop, patch, outr, tl);
     }
     else if (tl)
     {
-        V_DrawPatchTL(x, y, patch, tl);
+        V_DrawPatchTL(x, y, crop, patch, tl);
     }
     else
     {
-        V_DrawPatchTranslated(x, y, patch, outr);
+        V_DrawPatchTR(x, y, crop, patch, outr);
     }
 }
 
@@ -1306,8 +1319,9 @@ static void DrawGlyphNumber(int x, int y, sbarelem_t *elem, patch_t *glyph)
 
     if (glyph)
     {
-        DrawPatch(x + number->xoffset, y, font->maxheight, elem->alignment,
-                  glyph, elem->crboom == CR_NONE ? elem->cr : elem->crboom,
+        DrawPatch(x + number->xoffset, y, (crop_t){0}, font->maxheight,
+                  elem->alignment, glyph,
+                  elem->crboom == CR_NONE ? elem->cr : elem->crboom,
                   elem->tranmap);
     }
 
@@ -1355,8 +1369,8 @@ static void DrawGlyphLine(int x, int y, sbarelem_t *elem, widgetline_t *line,
 
     if (glyph)
     {
-        DrawPatch(x + line->xoffset, y, font->maxheight, elem->alignment, glyph,
-                  elem->cr, elem->tranmap);
+        DrawPatch(x + line->xoffset, y, (crop_t){0}, font->maxheight,
+                  elem->alignment, glyph, elem->cr, elem->tranmap);
     }
 
     if (elem->alignment & sbe_h_middle)
@@ -1483,14 +1497,14 @@ static void DrawElem(int x, int y, sbarelem_t *elem, player_t *player)
         case sbe_graphic:
             {
                 sbe_graphic_t *graphic = elem->subtype.graphic;
-                DrawPatch(x, y, 0, elem->alignment, graphic->patch, elem->cr,
-                          elem->tranmap);
+                DrawPatch(x, y, graphic->crop, 0, elem->alignment,
+                          graphic->patch, elem->cr, elem->tranmap);
             }
             break;
 
         case sbe_facebackground:
             {
-                DrawPatch(x, y, 0, elem->alignment,
+                DrawPatch(x, y, (crop_t){0}, 0, elem->alignment,
                           facebackpatches[displayplayer], elem->cr,
                           elem->tranmap);
             }
@@ -1499,7 +1513,7 @@ static void DrawElem(int x, int y, sbarelem_t *elem, player_t *player)
         case sbe_face:
             {
                 sbe_face_t *face = elem->subtype.face;
-                DrawPatch(x, y, 0, elem->alignment,
+                DrawPatch(x, y, (crop_t){0}, 0, elem->alignment,
                           facepatches[face->faceindex], elem->cr,
                           elem->tranmap);
             }
@@ -1510,8 +1524,8 @@ static void DrawElem(int x, int y, sbarelem_t *elem, player_t *player)
                 sbe_animation_t *animation = elem->subtype.animation;
                 patch_t *patch =
                     animation->frames[animation->frame_index].patch;
-                DrawPatch(x, y, 0, elem->alignment, patch, elem->cr,
-                          elem->tranmap);
+                DrawPatch(x, y, (crop_t){0}, 0, elem->alignment, patch,
+                          elem->cr, elem->tranmap);
             }
             break;
 

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -245,6 +245,7 @@ typedef struct
     int x;
     int y1, y2;
     int height;
+    int topoffset;
 
     fixed_t frac;
     fixed_t step;
@@ -456,12 +457,12 @@ static void DrawMaskedColumn(patch_column_t *patchcol, const int ytop,
             }
 
             patchcol->y1 = y1lookup[columntop];
-            patchcol->frac = 0;
+            patchcol->frac = patchcol->topoffset << FRACBITS;
         }
         else
         {
             patchcol->frac = (-columntop) << FRACBITS;
-            patchcol->y1 = 0;
+            patchcol->y1 = patchcol->topoffset << FRACBITS;
         }
 
         if (columntop + column->length - 1 < 0)
@@ -595,6 +596,7 @@ static void DrawPatchInternal(int x, int y, crop_t crop, patch_t *patch,
     }
 
     patchcol.height = crop.height;
+    patchcol.topoffset = crop.topoffset;
 
     column_t *column;
     int texturecolumn;
@@ -602,7 +604,7 @@ static void DrawPatchInternal(int x, int y, crop_t crop, patch_t *patch,
     w = SHORT(patch->width);
     int leftoffset = crop.midoffset ? w / 2 + crop.midoffset : crop.leftoffset;
 
-    const int ytop = y - SHORT(patch->topoffset) + crop.topoffset;
+    const int ytop = y - SHORT(patch->topoffset);
     for (; patchcol.x <= x2; patchcol.x++, startfrac += xiscale)
     {
         texturecolumn = (startfrac >> FRACBITS) + leftoffset;

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -470,12 +470,12 @@ static void DrawMaskedColumn(patch_column_t *patchcol, const int ytop,
         }
         if (columntop + column->length - 1 < SCREENHEIGHT)
         {
-            patchcol->y2 = y2lookup[columntop + column->length - 1];
+            int y2 = columntop + column->length - 1;
             if (patchcol->height)
             {
-                int yh = y2lookup[ytop + patchcol->height - 1];
-                patchcol->y2 = MIN(patchcol->y2, yh);
+                y2 = MIN(y2, ytop + patchcol->height - 1);
             }
+            patchcol->y2 = y2lookup[y2];
         }
         else
         {
@@ -600,9 +600,9 @@ static void DrawPatchInternal(int x, int y, crop_t crop, patch_t *patch,
     int texturecolumn;
 
     w = SHORT(patch->width);
-    int leftoffset = crop.midoffset ? w / 2 - crop.midoffset : crop.leftoffset;
+    int leftoffset = crop.midoffset ? w / 2 + crop.midoffset : crop.leftoffset;
 
-    const int ytop = y - SHORT(patch->topoffset) - crop.topoffset;
+    const int ytop = y - SHORT(patch->topoffset) + crop.topoffset;
     for (; patchcol.x <= x2; patchcol.x++, startfrac += xiscale)
     {
         texturecolumn = (startfrac >> FRACBITS) + leftoffset;

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -244,6 +244,7 @@ typedef struct
 {
     int x;
     int y1, y2;
+    int height;
 
     fixed_t frac;
     fixed_t step;
@@ -470,6 +471,11 @@ static void DrawMaskedColumn(patch_column_t *patchcol, const int ytop,
         if (columntop + column->length - 1 < SCREENHEIGHT)
         {
             patchcol->y2 = y2lookup[columntop + column->length - 1];
+            if (patchcol->height)
+            {
+                int yh = y2lookup[ytop + patchcol->height - 1];
+                patchcol->y2 = MIN(patchcol->y2, yh);
+            }
         }
         else
         {
@@ -493,13 +499,21 @@ static void DrawMaskedColumn(patch_column_t *patchcol, const int ytop,
     }
 }
 
-static void DrawPatchInternal(int x, int y, patch_t *patch, boolean flipped)
+static void DrawPatchInternal(int x, int y, crop_t crop, patch_t *patch,
+                              boolean flipped)
 {
     int x1, x2, w;
     fixed_t iscale, xiscale, startfrac = 0;
     patch_column_t patchcol = {0};
 
-    w = SHORT(patch->width);
+    if (crop.width)
+    {
+        w = crop.width;
+    }
+    else
+    {
+        w = SHORT(patch->width);
+    }
 
     // calculate edges of the shape
     if (flipped)
@@ -580,28 +594,31 @@ static void DrawPatchInternal(int x, int y, patch_t *patch, boolean flipped)
         startfrac += xiscale * (patchcol.x - x1);
     }
 
+    patchcol.height = crop.height;
+
+    column_t *column;
+    int texturecolumn;
+
+    w = SHORT(patch->width);
+    int leftoffset = crop.midoffset ? w / 2 - crop.midoffset : crop.leftoffset;
+
+    const int ytop = y - SHORT(patch->topoffset) - crop.topoffset;
+    for (; patchcol.x <= x2; patchcol.x++, startfrac += xiscale)
     {
-        column_t *column;
-        int texturecolumn;
+        texturecolumn = (startfrac >> FRACBITS) + leftoffset;
 
-        const int ytop = y - SHORT(patch->topoffset);
-        for (; patchcol.x <= x2; patchcol.x++, startfrac += xiscale)
+        if (texturecolumn < 0)
         {
-            texturecolumn = startfrac >> FRACBITS;
-
-            if (texturecolumn < 0)
-            {
-                continue;
-            }
-            else if (texturecolumn >= w)
-            {
-                break;
-            }
-
-            column = (column_t *)((byte *)patch
-                                  + LONG(patch->columnofs[texturecolumn]));
-            DrawMaskedColumn(&patchcol, ytop, column);
+            continue;
         }
+        else if (texturecolumn >= w)
+        {
+            break;
+        }
+
+        column = (column_t *)((byte *)patch
+                              + LONG(patch->columnofs[texturecolumn]));
+        DrawMaskedColumn(&patchcol, ytop, column);
     }
 }
 
@@ -624,16 +641,17 @@ static void DrawPatchInternal(int x, int y, patch_t *patch, boolean flipped)
 // killough 11/98: Consolidated V_DrawPatch and V_DrawPatchFlipped into one
 //
 
-void V_DrawPatchGeneral(int x, int y, patch_t *patch, boolean flipped)
+void V_DrawPatchGeneral(int x, int y, crop_t crop,
+                        patch_t *patch, boolean flipped)
 {
     x += video.deltaw;
 
     drawcolfunc = DrawPatchColumn;
 
-    DrawPatchInternal(x, y, patch, flipped);
+    DrawPatchInternal(x, y, crop, patch, flipped);
 }
 
-void V_DrawPatchTranslated(int x, int y, patch_t *patch, byte *outr)
+void V_DrawPatchTR(int x, int y, crop_t crop, patch_t *patch, byte *outr)
 {
     x += video.deltaw;
 
@@ -647,20 +665,26 @@ void V_DrawPatchTranslated(int x, int y, patch_t *patch, byte *outr)
         drawcolfunc = DrawPatchColumn;
     }
 
-    DrawPatchInternal(x, y, patch, false);
+    DrawPatchInternal(x, y, crop, patch, false);
 }
 
-void V_DrawPatchTL(int x, int y, struct patch_s *patch, byte *tl)
+void V_DrawPatchTranslated(int x, int y, patch_t *patch, byte *outr)
+{
+    V_DrawPatchTR(x, y, (crop_t){0}, patch, outr);
+}
+
+void V_DrawPatchTL(int x, int y, crop_t crop, struct patch_s *patch, byte *tl)
 {
     x += video.deltaw;
 
     tranmap = tl;
     drawcolfunc = DrawPatchColumnTL;
 
-    DrawPatchInternal(x, y, patch, false);
+    DrawPatchInternal(x, y, crop, patch, false);
 }
 
-void V_DrawPatchTRTL(int x, int y, struct patch_s *patch, byte *outr, byte *tl)
+void V_DrawPatchTRTL(int x, int y, crop_t crop, struct patch_s *patch,
+                     byte *outr, byte *tl)
 {
     x += video.deltaw;
 
@@ -668,10 +692,11 @@ void V_DrawPatchTRTL(int x, int y, struct patch_s *patch, byte *outr, byte *tl)
     tranmap = tl;
     drawcolfunc = DrawPatchColumnTRTL;
 
-    DrawPatchInternal(x, y, patch, false);
+    DrawPatchInternal(x, y, crop, patch, false);
 }
 
-void V_DrawPatchTRTR(int x, int y, patch_t *patch, byte *outr1, byte *outr2)
+void V_DrawPatchTRTR(int x, int y, crop_t crop, patch_t *patch,
+                     byte *outr1, byte *outr2)
 {
     x += video.deltaw;
 
@@ -679,7 +704,7 @@ void V_DrawPatchTRTR(int x, int y, patch_t *patch, byte *outr1, byte *outr2)
     translation2 = outr2;
     drawcolfunc = DrawPatchColumnTRTR;
 
-    DrawPatchInternal(x, y, patch, false);
+    DrawPatchInternal(x, y, crop, patch, false);
 }
 
 void V_DrawPatchFullScreen(patch_t *patch)
@@ -697,7 +722,7 @@ void V_DrawPatchFullScreen(patch_t *patch)
 
     drawcolfunc = DrawPatchColumn;
 
-    DrawPatchInternal(x, 0, patch, false);
+    DrawPatchInternal(x, 0, (crop_t){0}, patch, false);
 }
 
 void V_ShadeScreen(void)

--- a/src/v_video.h
+++ b/src/v_video.h
@@ -157,20 +157,33 @@ void V_CopyRect(int srcx, int srcy, pixel_t *source, int width, int height,
 
 // killough 11/98: Consolidated V_DrawPatch and V_DrawPatchFlipped
 
-void V_DrawPatchGeneral(int x, int y, struct patch_s *patch, boolean flipped);
+typedef struct
+{
+    int topoffset;
+    int leftoffset;
+    int midoffset;
+    int width;
+    int height;    
+} crop_t;
 
-#define V_DrawPatch(x, y, p) V_DrawPatchGeneral(x, y, p, false)
+void V_DrawPatchGeneral(int x, int y, crop_t rect, struct patch_s *patch,
+                        boolean flipped);
 
-#define V_DrawPatchFlipped(x, y, p) V_DrawPatchGeneral(x, y, p, true)
+#define V_DrawPatch(x, y, p) V_DrawPatchGeneral(x, y, (crop_t){0}, p, false)
+
+#define V_DrawPatchFlipped(x, y, p) V_DrawPatchGeneral(x, y, (crop_t){0}, p, true)
 
 void V_DrawPatchTranslated(int x, int y, struct patch_s *patch, byte *outr);
 
-void V_DrawPatchTRTR(int x, int y, struct patch_s *patch, byte *outr1,
-                     byte *outr2);
+void V_DrawPatchTR(int x, int y, crop_t rect, struct patch_s *patch, byte *outr);
 
-void V_DrawPatchTL(int x, int y, struct patch_s *patch, byte *tl);
+void V_DrawPatchTRTR(int x, int y, crop_t rect, struct patch_s *patch,
+                     byte *outr1, byte *outr2);
 
-void V_DrawPatchTRTL(int x, int y, struct patch_s *patch, byte *outr, byte *tl);
+void V_DrawPatchTL(int x, int y, crop_t rect, struct patch_s *patch, byte *tl);
+
+void V_DrawPatchTRTL(int x, int y, crop_t rect, struct patch_s *patch,
+                     byte *outr, byte *tl);
 
 void V_DrawPatchFullScreen(struct patch_s *patch);
 


### PR DESCRIPTION
Example:
```json
"graphic": {
  "x": 160,
  "y": 168,
  "width": 60,
  "height": 0,
  "topoffset": 0,
  "leftoffset": 0,
  "midoffset": 30,
  "alignment": 1,
  "patch": "STBAR",
  "tranmap": null,
  "translation": null,
  "conditions": null,
  "children": null
}
```
<img width="1065" height="600" alt="woof0002" src="https://github.com/user-attachments/assets/6343b7ac-d48f-4911-b95f-cfbcdf23a4c7" />

Test file (third HUD): [sbardef.zip](https://github.com/user-attachments/files/21849278/sbardef.zip)
