### PR TITLE
update sdl3 version, use SDL_SCALEMODE_PIXELART

### DIFF
--- a/cmake/ports/fluidsynth/portfile.cmake
+++ b/cmake/ports/fluidsynth/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO FluidSynth/fluidsynth
-    REF c5125b5dfee828ea715618d620651b6d135a39cb
-    SHA512 e01a2c4c6d7c3c22b298202e6e6d824dd4afa0b5ba59d556da9a3e89b704751fc904ec8e549cecaf25a8f1da46b630a595f4838cf50d10451e9099433cc65e4e
+    REF 09496178458aaa439c66cf50e27c3df1f8b033e7
+    SHA512 761c381ba9918405c8734b1ea22ae3946b8be47c24c32f08520f826622fecb79ef3b3be16abba9af116fb0dd7abd5c82f690be3453efb3cec215fec7322473c2
     HEAD_REF master
 )
 # Do not use or install FindSndFileLegacy.cmake and its deps

--- a/cmake/ports/sdl3/portfile.cmake
+++ b/cmake/ports/sdl3/portfile.cmake
@@ -1,0 +1,69 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO libsdl-org/SDL
+    REF 61e41c61dc5ab029b3912ec8c42d06386169feff
+    SHA512 338ac7e16f2bc05645615a35726c137edc1943a8b0210c9cba75b898071b22950e99666390095f0ea10f891ed156e4bfeeddf898e47dafc8dc8fb33ec8283f9f
+    HEAD_REF main
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" SDL_STATIC)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" SDL_SHARED)
+string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" FORCE_STATIC_VCRT)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        alsa     SDL_ALSA
+        ibus     SDL_IBUS
+        vulkan   SDL_VULKAN
+        wayland  SDL_WAYLAND
+        x11      SDL_X11
+)
+
+if ("x11" IN_LIST FEATURES)
+    message(WARNING "You will need to install Xorg dependencies to use feature x11:\nsudo apt install libx11-dev libxft-dev libxext-dev\n")
+endif()
+if ("wayland" IN_LIST FEATURES)
+    message(WARNING "You will need to install Wayland dependencies to use feature wayland:\nsudo apt install libwayland-dev libxkbcommon-dev libegl1-mesa-dev\n")
+endif()
+if ("ibus" IN_LIST FEATURES)
+    message(WARNING "You will need to install ibus dependencies to use feature ibus:\nsudo apt install libibus-1.0-dev\n")
+endif()
+# option for not need to show windows
+list(APPEND FEATURE_OPTIONS -DSDL_UNIX_CONSOLE_BUILD=ON)
+if (VCPKG_TARGET_IS_LINUX AND NOT "x11" IN_LIST FEATURES AND NOT "wayland" IN_LIST FEATURES)
+    message(WARNING "The selected features don't allow sdl3 to create windows, which is usually unintentional. You can get windowing support by installing the x11 and/or wayland features.")
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DSDL_STATIC=${SDL_STATIC}
+        -DSDL_SHARED=${SDL_SHARED}
+        -DSDL_FORCE_STATIC_VCRT=${FORCE_STATIC_VCRT}
+        -DSDL_LIBC=ON
+        -DSDL_TEST_LIBRARY=OFF
+        -DSDL_TESTS=OFF
+        -DSDL_INSTALL_CMAKEDIR_ROOT=share/${PORT}
+        # Specifying the revision skips the need to use git to determine a version
+        -DSDL_REVISION=vcpkg
+        -DCMAKE_DISABLE_FIND_PACKAGE_LibUSB=1
+    MAYBE_UNUSED_VARIABLES
+        SDL_FORCE_STATIC_VCRT
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt"
+    COMMENT "Some configurations may use code licensed under the MIT and Apache-2.0 licenses."
+)

--- a/cmake/ports/sdl3/usage
+++ b/cmake/ports/sdl3/usage
@@ -1,0 +1,4 @@
+sdl3 provides CMake targets:
+
+  find_package(SDL3 CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE SDL3::SDL3)

--- a/cmake/ports/sdl3/vcpkg.json
+++ b/cmake/ports/sdl3/vcpkg.json
@@ -1,0 +1,63 @@
+{
+  "name": "sdl3",
+  "version": "3.2.20",
+  "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
+  "homepage": "https://www.libsdl.org",
+  "license": "Zlib AND MIT AND Apache-2.0",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "dbus",
+      "default-features": false,
+      "platform": "linux"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    {
+      "name": "ibus",
+      "platform": "linux"
+    },
+    {
+      "name": "wayland",
+      "platform": "linux"
+    },
+    {
+      "name": "x11",
+      "platform": "linux"
+    }
+  ],
+  "features": {
+    "alsa": {
+      "description": "Support for alsa audio",
+      "dependencies": [
+        {
+          "name": "alsa",
+          "platform": "linux"
+        }
+      ]
+    },
+    "ibus": {
+      "description": "Build with ibus IME support",
+      "supports": "linux"
+    },
+    "vulkan": {
+      "description": "Vulkan functionality for SDL"
+    },
+    "wayland": {
+      "description": "Build with Wayland support",
+      "supports": "linux"
+    },
+    "x11": {
+      "description": "Build with X11 support",
+      "supports": "!windows"
+    }
+  }
+}


### PR DESCRIPTION
I've got slightly better performance with the SDL_SCALEMODE_PIXELART, and the results seem to be roughly the same as with the old method. It works with all video backends except d3d9 (users who need d3d9 probably don't want "smooth scaling" anyway).

Resolution scale 200%, Going Down lift (beginning of MAP02).
"pixel art" mode:
<img width="160" height="328" alt="image" src="https://github.com/user-attachments/assets/7d447cf7-dec6-466e-851e-438ceec49075" />

old method:
<img width="160" height="338" alt="image" src="https://github.com/user-attachments/assets/4787b3b2-d319-4141-af6f-0bb9e6adcd32" />

"smooth scaling" off:
<img width="160" height="338" alt="image" src="https://github.com/user-attachments/assets/dc768af2-1e9c-415c-ab54-de59b7c0b327" />


