### PR TITLE
sndinfo: skip `$random` and everything between `{` and `}`

### DIFF
--- a/src/s_sndinfo.c
+++ b/src/s_sndinfo.c
@@ -312,6 +312,8 @@ static boolean SkipRandomSoundCommand(scanner_t *s)
 {
     int brackets_found = 0;
 
+    SC_Warning(s, "skip $random record");
+
     while (SC_TokensLeft(s))
     {
         SC_CheckToken(s, TK_RawString);


### PR DESCRIPTION
Fixes #2400