### PR TITLE
Add UDMF Thing args

### DIFF
--- a/src/doomdata.h
+++ b/src/doomdata.h
@@ -192,9 +192,10 @@ typedef struct {
   fixed_t x;
   fixed_t y;
   fixed_t height;
-  short angle;
-  short type;
-  int options;
+  int32_t args[5];
+  int16_t angle;
+  int16_t type;
+  int32_t options;
 } mapthing_t;
 
 #endif // __DOOMDATA__

--- a/src/info.c
+++ b/src/info.c
@@ -4981,7 +4981,7 @@ mobjinfo_t original_mobjinfo[NUMMOBJTYPES] = {
 
   // [crispy] support MUSINFO lump (dynamic music changing)
   {   // MT_MUSICSOURCE
-    14164,   // doomednum
+    14165,   // doomednum
     S_TNT1,   // spawnstate
     1000,   // spawnhealth
     S_NULL,   // seestate

--- a/src/p_ambient.c
+++ b/src/p_ambient.c
@@ -204,14 +204,14 @@ void T_AmbientSoundAdapter(mobj_t *mobj)
     T_AmbientSound((ambient_t *)mobj);
 }
 
-void P_AddAmbientSoundThinker(mobj_t *mobj, int index)
+void P_AddAmbientSoundThinker(mobj_t *mobj)
 {
     if (!snd_ambient || !mobj)
     {
         return;
     }
 
-    const ambient_data_t *data = S_GetAmbientData(index);
+    const ambient_data_t *data = S_GetAmbientData(mobj->args[0]);
 
     if (!data || data->sfx_id == sfx_None || !S_sfx[data->sfx_id].length)
     {
@@ -257,7 +257,7 @@ void P_AddAmbientSoundThinker(mobj_t *mobj, int index)
 void P_InitAmbientSoundMobjInfo(void)
 {
     mobjinfo_t amb_mobjinfo = {
-        .doomednum = 14064,
+        .doomednum = 14065,
         .spawnstate = S_NULL,
         .spawnhealth = 1000,
         .seestate = S_NULL,

--- a/src/p_ambient.h
+++ b/src/p_ambient.h
@@ -47,7 +47,7 @@ void P_StopAmbientSound(ambient_t *ambient);
 void P_MarkAmbientSound(ambient_t *ambient, int handle);
 void P_EvictAmbientSound(ambient_t *ambient, int handle);
 void T_AmbientSoundAdapter(mobj_t *mobj);
-void P_AddAmbientSoundThinker(mobj_t *mobj, int index);
+void P_AddAmbientSoundThinker(mobj_t *mobj);
 void P_InitAmbientSoundMobjInfo(void);
 
 #endif

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -1190,7 +1190,6 @@ void P_SpawnMapThing (mapthing_t* mthing)
   int    i;
   mobj_t *mobj;
   fixed_t x, y, z;
-  int id = 0;
 
   switch(mthing->type)
     {
@@ -1295,12 +1294,12 @@ void P_SpawnMapThing (mapthing_t* mthing)
   // [crispy] support MUSINFO lump (dynamic music changing)
   if (mthing->type >= 14100 && mthing->type <= 14164)
   {
-      id = mthing->type - 14100;
+      mthing->args[0] = mthing->type - 14100;
       mthing->type = mobjinfo[MT_MUSICSOURCE].doomednum;
   }
   else if (mthing->type >= 14001 && mthing->type <= 14064)
   {
-      id = mthing->type - 14000;
+      mthing->args[0] = mthing->type - 14000;
       mthing->type = mobjinfo[zmt_ambientsound].doomednum;
   }
 
@@ -1364,6 +1363,13 @@ spawnit:
     mobj->z -= mthing->height;
   }
 
+  // UDMF thing args
+  mobj->args[0] = mthing->args[0];
+  mobj->args[1] = mthing->args[1];
+  mobj->args[2] = mthing->args[2];
+  mobj->args[3] = mthing->args[3];
+  mobj->args[4] = mthing->args[4];
+
   // killough 7/20/98: exclude friends
   if (!((mobj->flags ^ MF_COUNTKILL) & (MF_FRIEND | MF_COUNTKILL)))
     totalkills++;
@@ -1375,14 +1381,9 @@ spawnit:
   if (mthing->options & MTF_AMBUSH)
     mobj->flags |= MF_AMBUSH;
 
-  // [crispy] support MUSINFO lump (dynamic music changing)
-  if (i == MT_MUSICSOURCE)
+  if (i == zmt_ambientsound)
   {
-      mobj->health = 1000 + id;
-  }
-  else if (i == zmt_ambientsound)
-  {
-      P_AddAmbientSoundThinker(mobj, id);
+      P_AddAmbientSoundThinker(mobj);
   }
 }
 

--- a/src/p_mobj.h
+++ b/src/p_mobj.h
@@ -315,6 +315,9 @@ typedef struct mobj_s
     int                 intflags;  // killough 9/15/98: internal flags
     int                 health;
 
+    // UDMF extensions
+    int32_t args[5];
+
     // Movement direction, movement generation (zig-zagging).
     short               movedir;        // 0-7
     short               movecount;      // when 0, select a new dir

--- a/src/p_saveg.c
+++ b/src/p_saveg.c
@@ -176,6 +176,13 @@ static void saveg_read_mapthing_t(mapthing_t *str)
     // fixed_t height;
     str->height = saveg_read32();
 
+    // int args[5];
+    str->args[0] = saveg_read32();
+    str->args[1] = saveg_read32();
+    str->args[2] = saveg_read32();
+    str->args[3] = saveg_read32();
+    str->args[4] = saveg_read32();
+
     // short angle;
     str->angle = saveg_read16();
 
@@ -196,6 +203,13 @@ static void saveg_write_mapthing_t(mapthing_t *str)
 
     // fixed_t height;
     saveg_write32(str->height);
+
+    // int args[5];
+    saveg_write32(str->args[0]);
+    saveg_write32(str->args[1]);
+    saveg_write32(str->args[2]);
+    saveg_write32(str->args[3]);
+    saveg_write32(str->args[4]);
 
     // short angle;
     saveg_write16(str->angle);

--- a/src/p_udmf.c
+++ b/src/p_udmf.c
@@ -70,6 +70,10 @@ typedef struct
     double height;
     int angle;
     int options;
+
+    // Hexen
+    int special;
+    int args[5];
 } UDMF_Thing_t;
 
 typedef struct
@@ -317,21 +321,22 @@ static void UDMF_ParseLinedef(scanner_t *s)
         }
         else if (BASE_PROP(arg0))
         {
+            // Tag -> id/arg0 split means arg0 is always enabled
             line.args[0] = UDMF_ScanInt(s);
         }
-        else if (BASE_PROP(arg1))
+        else if (PROP(arg1, UDMF_HEXEN))
         {
             line.args[1] = UDMF_ScanInt(s);
         }
-        else if (BASE_PROP(arg2))
+        else if (PROP(arg2, UDMF_HEXEN))
         {
             line.args[2] = UDMF_ScanInt(s);
         }
-        else if (BASE_PROP(arg3))
+        else if (PROP(arg3, UDMF_HEXEN))
         {
             line.args[3] = UDMF_ScanInt(s);
         }
-        else if (BASE_PROP(arg4))
+        else if (PROP(arg4, UDMF_HEXEN))
         {
             line.args[4] = UDMF_ScanInt(s);
         }
@@ -523,6 +528,10 @@ static void UDMF_ParseThing(scanner_t *s)
         {
             thing.type = UDMF_ScanInt(s);
         }
+        else if (BASE_PROP(id))
+        {
+            thing.id = UDMF_ScanInt(s);
+        }
         else if (BASE_PROP(x))
         {
             thing.x = UDMF_ScanDouble(s);
@@ -578,6 +587,26 @@ static void UDMF_ParseThing(scanner_t *s)
         else if (PROP(friend, UDMF_MBF))
         {
             thing.options |= UDMF_ScanFlag(s, MTF_FRIEND);
+        }
+        else if (PROP(arg0, UDMF_HEXEN))
+        {
+            thing.args[0] = UDMF_ScanInt(s);
+        }
+        else if (PROP(arg1, UDMF_HEXEN))
+        {
+            thing.args[1] = UDMF_ScanInt(s);
+        }
+        else if (PROP(arg2, UDMF_HEXEN))
+        {
+            thing.args[2] = UDMF_ScanInt(s);
+        }
+        else if (PROP(arg3, UDMF_HEXEN))
+        {
+            thing.args[3] = UDMF_ScanInt(s);
+        }
+        else if (PROP(arg4, UDMF_HEXEN))
+        {
+            thing.args[4] = UDMF_ScanInt(s);
         }
         else
         {

--- a/src/p_udmf.c
+++ b/src/p_udmf.c
@@ -595,6 +595,10 @@ static void UDMF_ParseThing(scanner_t *s)
         {
             thing.options |= UDMF_ScanFlag(s, MTF_FRIEND);
         }
+        else if (PROP(special, UDMF_PARAM))
+        {
+            thing.special = UDMF_ScanInt(s);
+        }
         else if (PROP(arg0, UDMF_PARAM))
         {
             thing.args[0] = UDMF_ScanInt(s);

--- a/src/p_udmf.c
+++ b/src/p_udmf.c
@@ -20,6 +20,7 @@
 #include "doomdef.h"
 #include "doomstat.h"
 #include "doomtype.h"
+#include "i_printf.h"
 #include "i_system.h"
 #include "m_argv.h"
 #include "m_array.h"
@@ -253,9 +254,10 @@ static void UDMF_ParseNamespace(scanner_t *s)
     {
         udmf_features |= UDMF_DOOM | UDMF_BOOM | UDMF_MBF;
     }
-    else if (!strcasecmp(name, "hexen") && devparm)
+    else if (devparm && !strcasecmp(name, "hexen"))
     {
-        udmf_features |= UDMF_PARAM | UDMF_BOOM | UDMF_MBF;
+        I_Printf(VB_WARNING, "Loading development-only UDMF namespace: \"%s\"", name);
+        udmf_features |= UDMF_DOOM | UDMF_BOOM | UDMF_MBF | UDMF_PARAM;
     }
     else
     {
@@ -955,6 +957,12 @@ void UDMF_LoadThings(void)
         mt.angle = CLAMP(udmf_things[i].angle, 0, 360);
         mt.type = udmf_things[i].type;
         mt.options = udmf_things[i].options;
+
+        mt.args[0] = udmf_things[i].args[0];
+        mt.args[1] = udmf_things[i].args[1];
+        mt.args[2] = udmf_things[i].args[2];
+        mt.args[3] = udmf_things[i].args[3];
+        mt.args[4] = udmf_things[i].args[4];
 
         P_SpawnMapThing(&mt);
     }

--- a/src/p_udmf.c
+++ b/src/p_udmf.c
@@ -56,6 +56,9 @@ typedef enum
     UDMF_MBF21 = (1 << 6),
     UDMF_ID24 = (1 << 7),
 
+    // General behavior
+    UDMF_PARAM = (1 << 8),
+
     // Compatibility
     UDMF_COMP_NO_ARG0 = (1 << 31),
 } UDMF_Features_t;
@@ -250,6 +253,10 @@ static void UDMF_ParseNamespace(scanner_t *s)
     {
         udmf_features |= UDMF_DOOM | UDMF_BOOM | UDMF_MBF;
     }
+    else if (!strcasecmp(name, "hexen") && devparm)
+    {
+        udmf_features |= UDMF_PARAM | UDMF_BOOM | UDMF_MBF;
+    }
     else
     {
         I_Error("Unknown UDMF namespace: \"%s\".", name);
@@ -324,19 +331,19 @@ static void UDMF_ParseLinedef(scanner_t *s)
             // Tag -> id/arg0 split means arg0 is always enabled
             line.args[0] = UDMF_ScanInt(s);
         }
-        else if (PROP(arg1, UDMF_HEXEN))
+        else if (PROP(arg1, UDMF_PARAM))
         {
             line.args[1] = UDMF_ScanInt(s);
         }
-        else if (PROP(arg2, UDMF_HEXEN))
+        else if (PROP(arg2, UDMF_PARAM))
         {
             line.args[2] = UDMF_ScanInt(s);
         }
-        else if (PROP(arg3, UDMF_HEXEN))
+        else if (PROP(arg3, UDMF_PARAM))
         {
             line.args[3] = UDMF_ScanInt(s);
         }
-        else if (PROP(arg4, UDMF_HEXEN))
+        else if (PROP(arg4, UDMF_PARAM))
         {
             line.args[4] = UDMF_ScanInt(s);
         }
@@ -588,23 +595,23 @@ static void UDMF_ParseThing(scanner_t *s)
         {
             thing.options |= UDMF_ScanFlag(s, MTF_FRIEND);
         }
-        else if (PROP(arg0, UDMF_HEXEN))
+        else if (PROP(arg0, UDMF_PARAM))
         {
             thing.args[0] = UDMF_ScanInt(s);
         }
-        else if (PROP(arg1, UDMF_HEXEN))
+        else if (PROP(arg1, UDMF_PARAM))
         {
             thing.args[1] = UDMF_ScanInt(s);
         }
-        else if (PROP(arg2, UDMF_HEXEN))
+        else if (PROP(arg2, UDMF_PARAM))
         {
             thing.args[2] = UDMF_ScanInt(s);
         }
-        else if (PROP(arg3, UDMF_HEXEN))
+        else if (PROP(arg3, UDMF_PARAM))
         {
             thing.args[3] = UDMF_ScanInt(s);
         }
-        else if (PROP(arg4, UDMF_HEXEN))
+        else if (PROP(arg4, UDMF_PARAM))
         {
             thing.args[4] = UDMF_ScanInt(s);
         }

--- a/src/p_udmf.c
+++ b/src/p_udmf.c
@@ -254,7 +254,7 @@ static void UDMF_ParseNamespace(scanner_t *s)
     {
         udmf_features |= UDMF_DOOM | UDMF_BOOM | UDMF_MBF;
     }
-    else if (devparm && !strcasecmp(name, "hexen"))
+    else if (devparm && !strcasecmp(name, "dsda"))
     {
         I_Printf(VB_WARNING, "Loading development-only UDMF namespace: \"%s\"", name);
         udmf_features |= UDMF_DOOM | UDMF_BOOM | UDMF_MBF | UDMF_PARAM;

--- a/src/s_musinfo.c
+++ b/src/s_musinfo.c
@@ -123,11 +123,12 @@ void T_MusInfo(void)
         if (!musinfo.tics && musinfo.lastmapthing != musinfo.mapthing)
         {
             // [crispy] encode music lump number in mapthing health
-            int arraypt = musinfo.mapthing->health - 1000;
+            // UDMF extension
+            int musinfo_index = musinfo.mapthing->args[0];
 
-            if (arraypt >= 0 && arraypt < MAX_MUS_ENTRIES)
+            if (musinfo_index >= 0 && musinfo_index < MAX_MUS_ENTRIES)
             {
-                int lumpnum = musinfo.items[arraypt];
+                int lumpnum = musinfo.items[musinfo_index];
 
                 if (lumpnum > 0 && lumpnum < numlumps)
                 {


### PR DESCRIPTION
Another small addition towards the gradual goal of adding support for hexen-style mapping features.

This is a custom thing added by DSDA, Eternity and (G)ZDoom. Instead of determining the MUSINFO/SNDINFO index solely by the Thing's DoomEdNum, thing 65 will use the arg0. There are some additional args that are used on (G)ZDoom's UDMF namespace, specifically -- these can be added at a later moment, if they are at all desired.

I have also tested the Ancient Aliens MAP01 music changer sequence, as well as `examples/ambient_showcase.wad`, and both still work just the same

Test map: [UDMF_MUSINFO.zip](https://github.com/user-attachments/files/22710798/UDMF_MUSINFO.zip) -- uses both classic Music Changers on one side and the Custom Music Changer on the other, both sides should change to the exact same tracks, in order.

<img width="1203" height="737" alt="image" src="https://github.com/user-attachments/assets/fc6577d9-bc36-418e-9dc7-0b020c1b863e" />
