### PR TITLE
port PrBoom+ complevel check for scroller precision

### DIFF
--- a/src/p_spec.c
+++ b/src/p_spec.c
@@ -3092,8 +3092,8 @@ static void Add_WallScroller(int64_t dx, int64_t dy, const line_t *l,
   // CPhipps - Import scroller calc overflow fix, compatibility optioned
   if (demo_version >= DV_MBF)
   {
-    x = (fixed_t)((dy * -l->dy - dx * l->dx) / d);  // killough 10/98:
-    y = (fixed_t)((dy * l->dx - dx * l->dy) / d);   // Use long long arithmetic
+    x = (fixed_t) (((int64_t) dy * -l->dy - (int64_t) dx * l->dx) / d); // killough 10/98:
+    y = (fixed_t) (((int64_t) dy * l->dx - (int64_t) dx * l->dy) / d);  // Use long long arithmetic
   }
   else
   {


### PR DESCRIPTION
I've been working on UDMF-related scroller code, and noticed a minor discrepancy between Woof and DSDA.

Boom:
https://github.com/doom-cross-port-collab/boom/blob/2a11d37040be9ac40a61f4c7b7f4541bef2411bf/src/p_spec.c#L2674-L2675

MBF:
https://github.com/doom-cross-port-collab/mbf/blob/8f705abd36ed2edc3ba64abb855f05a12dd71bc9/src/p_spec.c#L2594-L2595

DSDA:
https://github.com/kraflab/dsda-doom/blob/079e9a8c04a24ab3dd1c626da10d482e84737d11/prboom2/src/p_spec.c#L3716-L3726