### PR TITLE
Use actual "21:9" aspect ratio values internally

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1237,8 +1237,8 @@ static double CurrentAspectRatio(void)
             h = 9;
             break;
         case RATIO_21_9:
-            w = 21;
-            h = 9;
+            w = 64; // Marketing!
+            h = 27; // https://en.wikipedia.org/wiki/21%3A9_aspect_ratio
             break;
         case RATIO_32_9:
             w = 32;


### PR DESCRIPTION
As far as I am aware, there are up to three possible real aspect ratios, in current "21:9"-branded monitors/screens:
* 64/27 => 2.370370370....
* 43/18 => 2.388888888....
* 12/5  => 2.4

As per the existing "4:3 (aka (4/3)^1) and 16:9 (aka (4/3)^2)" pattern of aspect ratios,  64:27 (aka (4/3)^3), is the only technically "true" version of 21:9, and AFAICT appears to be the most common one.

Using an internal 21:9 (2.333333333...) will always be slightly incorrect on any of the aforementioned ratios (and doesn't appear to have ever actually been sold as a real aspect in a real monitor?), meaning that 21:9 users will always use "Auto" mode no matter what, and anyone using it to test graphics or visuals for "21:9" for it will get a resolution that is just slightly too short -- this is also the reason why many "21:9" widescreen assets happen to be 560px wide instead of a more proper 576px wide, as Nash Muhandes used the shorter ratio when the widescreening efforts started out originally.

<hr>

Up-for-consideration, but not crucial:
* should the "21:9"-containing strings hold a bracketed "64:27" next to it? i.e the Resolution Scale setting could show "21:9 (64:27)" instead of just "21:9", same for the config file helper string?
* if the above is possible could we plausibly allow for _both_ "21:9 (64:27)" and "21:9 (43:18)"? i.e adding a new, though only subtly different scale option? would there be major user confusion? would it even be worth adding?