### PR TITLE
match PrBoom A_FireOldBFG autoaim behavior

### DIFF
--- a/src/p_pspr.c
+++ b/src/p_pspr.c
@@ -830,7 +830,7 @@ void A_FireOldBFG(player_t *player, pspdef_t *psp)
 #ifdef MBF_STRICT
       if (autoaim || !beta_emulation)
 #else
-      if (autoaim)
+      if (autoaim || direct_vertical_aiming)
 #endif
 	{
 	  // killough 8/2/98: make autoaiming prefer enemies


### PR DESCRIPTION
It looks like `!beta_emulation` has been commented off since Andrey Budko originally ported back the beta emulation code to PrBoom: (https://github.com/kraflab/dsda-doom/commit/29d94db2d74ab11c123db9fd0fba0dbe6f3b8193) should we still try and allow autoaim outside of demo playback/recording?