### PR TITLE
Do not warn about unknown EdNum, if level editor camera is found

### DIFF
--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -1317,10 +1317,13 @@ void P_SpawnMapThing (mapthing_t* mthing)
               VB_DEBUG,
               "P_SpawnMapThing: Found level editor camera spawn at (%i, %i)",
               FixedToInt(mthing->x), FixedToInt(mthing->y));
-          return;
       }
-      I_Printf(VB_WARNING, "P_SpawnMapThing: Unknown Thing type %i at (%i, %i)",
-               mthing->type, FixedToInt(mthing->x), FixedToInt(mthing->y));
+      else
+      {
+          I_Printf(VB_WARNING,
+                   "P_SpawnMapThing: Unknown Thing type %i at (%i, %i)",
+                   mthing->type, FixedToInt(mthing->x), FixedToInt(mthing->y));
+      }
       return;
   }
 


### PR DESCRIPTION
32000 is the default Editor number used by UDB and other editors, to define a "spawn point" for the '3D View Mode' camera's position, some mappers end up leaving them in their finalized maps, this PR suppresses the warning if both a) No matching internal MObj index is found for the given EdNum AND b) the EdNum is question is 32000, as there still remains the possibility that someone may unknowingly override this otherwise "standard" EdNum.

Also fixes missing fixed_t conversion from the base spec UDMF PR.

Tested on MAP01 of [Vae Victus](https://doomwiki.org/wiki/Vae_Victus):

<img width="635" height="67" alt="image" src="https://github.com/user-attachments/assets/056abef7-cd82-4f08-8cb8-ba0161513e3b" />
