### PR TITLE
Fix textscreen scaling

### DIFF
--- a/textscreen/txt_sdl.c
+++ b/textscreen/txt_sdl.c
@@ -133,7 +133,7 @@ static void UpdateLogicalPresentation(void)
         // Window width is the constraint.
         const int border_w = w % screen_image_w;
 
-        if (border_w >= 0 && border_w <= w / 5)
+        if (border_w >= 0 && border_w <= w / 6)
         {
             // Borders are small enough, so use integer scaling.
             mode = SDL_LOGICAL_PRESENTATION_INTEGER_SCALE;
@@ -144,7 +144,7 @@ static void UpdateLogicalPresentation(void)
         // Window height is the constraint.
         const int border_h = h % screen_image_h;
 
-        if (border_h >= 0 && border_h <= h / 5)
+        if (border_h >= 0 && border_h <= h / 6)
         {
             // Borders are small enough, so use integer scaling.
             mode = SDL_LOGICAL_PRESENTATION_INTEGER_SCALE;


### PR DESCRIPTION
Alternative to https://github.com/fabiangreffrath/woof/pull/2495

Details: https://github.com/fabiangreffrath/woof/pull/2496#issuecomment-3605420018

<details><summary>Old information</summary>

Test wad with an ENDOOM that uses a fine grid as a worst case test scenario:
[endoom_grid.zip](https://github.com/user-attachments/files/23893652/endoom_grid.zip)

2560x1440 images cropped to show scaling differences. Other resolutions will vary in appearance but will generally look the same.

<img width="621" height="882" alt="endoom_grid" src="https://github.com/user-attachments/assets/ed34f280-5a37-4be8-b014-f8dbe4cffd24" />

DOSBox uses a different font that doesn't tile perfectly.

ENDOOM will look like the third or fourth image depending on the user's `correct_aspect_ratio` config setting.

woof-setup will look like the first image because it's already forced to integer scaling and will have scaling artifacts otherwise:

- [woof-setup without aspect ratio correction](https://github.com/user-attachments/assets/dd77ca65-6ca8-4bb8-b5f2-59bdadfb7813) (this PR)
- [woof-setup with aspect ratio correction](https://github.com/user-attachments/assets/693715a7-f437-44a4-b79e-327cdfac4b14) (not used)

</details>
