### PR TITLE
Add range check for window events

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -532,7 +532,9 @@ static void ProcessEvent(SDL_Event *ev)
             break;
 
         default:
-            if (ev->window.windowID == SDL_GetWindowID(screen))
+            if (ev->type >= SDL_EVENT_WINDOW_FIRST
+                && ev->type <= SDL_EVENT_WINDOW_LAST
+                && ev->window.windowID == SDL_GetWindowID(screen))
             {
                 HandleWindowEvent(&ev->window);
             }


### PR DESCRIPTION
Caught this while working on similar events for textscreen. Follows the [SDL3 migration guide](https://github.com/libsdl-org/SDL/blob/main/docs/README-migration.md#sdl_eventsh) recommendations and avoids undefined behavior. This affects when `HandleWindowEvent` is called. That means it affects when `I_ResetDRS` is called at the end of that function.