### PR TITLE
Set a minimum version requirement for SDL3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,7 @@ check_c_source_compiles(
 set(CMAKE_FIND_FRAMEWORK NEVER)
 
 # Library requirements.
-find_package(SDL3 3.4 REQUIRED)
+find_package(SDL3 3.3 REQUIRED)
 find_package(OpenAL REQUIRED)
 find_package(libebur128 REQUIRED)
 find_package(SndFile 1.0.29 REQUIRED)


### PR DESCRIPTION
https://wiki.libsdl.org/SDL3/SDL_SetTexturePalette

> This function is available since SDL 3.4.0.

I ran into this when I was trying to build the master branch on Fedora, which has 3.2.24.