### PR TITLE
Fix potential vulnerable clone function

### DIFF
--- a/src/m_scanner.c
+++ b/src/m_scanner.c
@@ -220,7 +220,7 @@ static void Unescape(char *str)
         {
             *str++ = c;
         }
-        else
+        else if (*p)
         {
             switch (*p)
             {
@@ -241,6 +241,10 @@ static void Unescape(char *str)
                     break;
             }
             p++;
+        }
+        else
+        {
+            /* Trailing backslash */
         }
     }
     *str = 0;


### PR DESCRIPTION
### Summary

Our tool detected a potential out-of-bound read vulnerability in `src/m_scanner.c` which was cloned from [GNUAspell/aspell](https://github.com/GNUAspell/aspell) but did not receive the security patch. The original issue was reported and fixed under [CVE-2019-17544](https://nvd.nist.gov/vuln/detail/CVE-2019-17544).

### Proposed Fix

Apply the same patch to eliminate the vulnerability.

### Reference

https://nvd.nist.gov/vuln/detail/CVE-2019-17544
https://github.com/GNUAspell/aspell/commit/80fa26c74279fced8d778351cff19d1d8f44fe4e