### PR TITLE
Search tx namespace if texture patches arent found in global namespace

### DIFF
--- a/src/r_data.c
+++ b/src/r_data.c
@@ -595,6 +595,11 @@ void R_InitTextures (void)
     {
       strncpy (name,name_p+i*8, 8);
       patchlookup[i] = W_CheckNumForName(name);
+
+      // [EB] some wads use the texture namespace but then still use those in pnames
+      if (patchlookup[i] == -1)
+        patchlookup[i] = (W_CheckNumForName)(name, ns_textures);
+
       if (patchlookup[i] == -1)
         {
           // killough 4/17/98:


### PR DESCRIPTION
Before support was added for the TX_ markers, a patch placed between them would be found in the global namespace, and would be loaded for lookup by PNAMES if it was listed there. When support for TX_ was added, these patches stopped being found, which causes some wads not to load.

I don't off the top of my head know of a Woof compatible wad with this issue, but it is a regression and can be seen in Odamex with dietdbab.wad, which stopped working in 11.1.1 because of this exact problem.