### PR TITLE
Revert "workaround for zdbsp's incorrect sidedef removal (#2489)"

### DIFF
--- a/src/nano_bsp.c
+++ b/src/nano_bsp.c
@@ -154,8 +154,16 @@ void DumpNode (nanode_t * N, int lev)
 void BSP_CalcOffset (seg_t * seg)
 {
 	line_t * ld = seg->linedef;
-	int side = P_GetSidedefNum(seg, ld);
-	seg->offset = P_GetOffset(seg->v1, side ? ld->v2 : ld->v1);
+
+	// compute which side of the linedef the seg is on
+	int side;
+
+	if (abs (ld->dx) > abs (ld->dy))
+		side = ((ld->dx < 0) == (seg->v2->x - seg->v1->x < 0)) ? 0 : 1;
+	else
+		side = ((ld->dy < 0) == (seg->v2->y - seg->v1->y < 0)) ? 0 : 1;
+
+	seg->offset = P_GetOffset (seg->v1, side ? ld->v2 : ld->v1);
 }
 
 void BSP_BoundingBox (seg_t * soup, fixed_t * bbox)

--- a/src/p_extnodes.h
+++ b/src/p_extnodes.h
@@ -25,8 +25,6 @@
 #include "doomdata.h"
 
 struct vertex_s;
-struct seg_s;
-struct line_s;
 
 typedef enum
 {
@@ -48,7 +46,6 @@ extern const char *const node_format_names[];
 extern mapformat_t P_CheckMapFormat(int lumpnum);
 extern nodeformat_t P_CheckDoomNodeFormat(int lumpnum);
 extern nodeformat_t P_CheckUDMFNodeFormat(int lumpnum);
-extern int P_GetSidedefNum(struct seg_s * li, struct line_s * ldef);
 extern int P_GetOffset(struct vertex_s *v1, struct vertex_s *v2);
 
 extern void P_LoadSegs_DEEP(int lump);

--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -230,9 +230,7 @@ void P_LoadSegs (int lump)
       linedef = (unsigned short)SHORT(ml->linedef); // [FG] extended nodes
       ldef = &lines[linedef];
       li->linedef = ldef;
-      // ignored
-      // side = SHORT(ml->side);
-      side = P_GetSidedefNum(li, ldef);
+      side = SHORT(ml->side);
 
       // Andrey Budko: check for wrong indexes
       if ((unsigned)ldef->sidenum[side] >= (unsigned)numsides)


### PR DESCRIPTION
As it were, the workaround was not perfect, and errors on some maps with extended nodes, which were not caught in my initial testing. It appears that in some cases the ZDBSP handling of the built elements is even more inconsistent than previously expected, and the sidedef issue will need fixing upstream with existing levels left as-is -- unless the seg-line sidedef detection function is perhaps improved upon.

<img width="641" height="25" alt="image" src="https://github.com/user-attachments/assets/41851133-95a3-4fdc-acf1-fef793375a9c" />
