### PR TITLE
skip `P_Dirty_Line` and `P_ChangeSwitchTexture` when `bossaction` is true

### DIFF
--- a/src/p_spec.c
+++ b/src/p_spec.c
@@ -1287,7 +1287,7 @@ void P_CrossSpecialLine(line_t *line, int side, mobj_t *thing, boolean bossactio
           {
           case WalkOnce:
             if (linefunc(line))
-              dirty_line(line)->special = 0;    // clear special if a walk once type
+              !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;    // clear special if a walk once type
             return;
           case WalkMany:
             linefunc(line);
@@ -1343,122 +1343,122 @@ void P_CrossSpecialLine(line_t *line, int side, mobj_t *thing, boolean bossactio
     case 2:
       // Open Door
       if (EV_DoDoor(line,doorOpen) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 3:
       // Close Door
       if (EV_DoDoor(line,doorClose) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 4:
       // Raise Door
       if (EV_DoDoor(line,doorNormal) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 5:
       // Raise Floor
       if (EV_DoFloor(line,raiseFloor) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 6:
       // Fast Ceiling Crush & Raise
       if (EV_DoCeiling(line,fastCrushAndRaise) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 8:
       // Build Stairs
       if (EV_BuildStairs(line,build8) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 10:
       // PlatDownWaitUp
       if (EV_DoPlat(line,downWaitUpStay,0) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 12:
       // Light Turn On - brightest near
       if (EV_LightTurnOn(line,0) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 13:
       // Light Turn On 255
       if (EV_LightTurnOn(line,255) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 16:
       // Close Door 30
       if (EV_DoDoor(line,close30ThenOpen) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 17:
       // Start Light Strobing
       if (EV_StartLightStrobing(line) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 19:
       // Lower Floor
       if (EV_DoFloor(line,lowerFloor) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 22:
       // Raise floor to nearest height and change texture
       if (EV_DoPlat(line,raiseToNearestAndChange,0) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 25:
       // Ceiling Crush and Raise
       if (EV_DoCeiling(line,crushAndRaise) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 30:
       // Raise floor to shortest texture height
       //  on either side of lines.
       if (EV_DoFloor(line,raiseToTexture) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 35:
       // Lights Very Dark
       if (EV_LightTurnOn(line,35) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 36:
       // Lower Floor (TURBO)
       if (EV_DoFloor(line,turboLower) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 37:
       // LowerAndChange
       if (EV_DoFloor(line,lowerAndChange) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 38:
       // Lower Floor To Lowest
       if (EV_DoFloor(line, lowerFloorToLowest) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 39:
       // TELEPORT! //jff 02/09/98 fix using up with wrong side crossing
       if (EV_Teleport(line, side, thing) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 40:
@@ -1467,17 +1467,17 @@ void P_CrossSpecialLine(line_t *line, int side, mobj_t *thing, boolean bossactio
         {
           EV_DoCeiling( line, raiseToHighest );
           EV_DoFloor( line, lowerFloorToLowest ); //jff 02/12/98 doesn't work
-          dirty_line(line)->special = 0;
+          !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
         }
       else
         if (EV_DoCeiling(line, raiseToHighest))
-          dirty_line(line)->special = 0;
+          !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 44:
       // Ceiling Crush
       if (EV_DoCeiling(line, lowerAndCrush) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     // W1 - Exit to the next map and reset inventory.
@@ -1498,79 +1498,79 @@ void P_CrossSpecialLine(line_t *line, int side, mobj_t *thing, boolean bossactio
     case 53:
       // Perpetual Platform Raise
       if (EV_DoPlat(line,perpetualRaise,0) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 54:
       // Platform Stop
       if (EV_StopPlat(line) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 56:
       // Raise Floor Crush
       if (EV_DoFloor(line,raiseFloorCrush) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 57:
       // Ceiling Crush Stop
       if (EV_CeilingCrushStop(line) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 58:
       // Raise Floor 24
       if (EV_DoFloor(line,raiseFloor24) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 59:
       // Raise Floor 24 And Change
       if (EV_DoFloor(line,raiseFloor24AndChange) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 100:
       // Build Stairs Turbo 16
       if (EV_BuildStairs(line,turbo16) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 104:
       // Turn lights off in sector(tag)
       if (EV_TurnTagLightsOff(line) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 108:
       // Blazing Door Raise (faster than TURBO!)
       if (EV_DoDoor(line,blazeRaise) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 109:
       // Blazing Door Open (faster than TURBO!)
       if (EV_DoDoor (line,blazeOpen) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 110:
       // Blazing Door Close (faster than TURBO!)
       if (EV_DoDoor (line,blazeClose) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 119:
       // Raise floor to nearest surr. floor
       if (EV_DoFloor(line,raiseFloorToNearest) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 121:
       // Blazing PlatDownWaitUpStay
       if (EV_DoPlat(line,blazeDWUS,0) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     // W1 - Exit to the secret map and reset inventory.
@@ -1592,19 +1592,19 @@ void P_CrossSpecialLine(line_t *line, int side, mobj_t *thing, boolean bossactio
       // TELEPORT MonsterONLY
       if (!thing->player &&
           (EV_Teleport(line, side, thing) || demo_compatibility))
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 130:
       // Raise Floor Turbo
       if (EV_DoFloor(line,raiseFloorTurbo) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
     case 141:
       // Silent Ceiling Crush & Raise
       if (EV_DoCeiling(line,silentCrushAndRaise) || demo_compatibility)
-        dirty_line(line)->special = 0;
+        !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       break;
 
       // Regular walk many retriggerable
@@ -1780,7 +1780,7 @@ void P_CrossSpecialLine(line_t *line, int side, mobj_t *thing, boolean bossactio
 
 
     case 2076:
-      dirty_line(line)->special = 0;
+      !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
       // fallthrough
 
     case 2077:
@@ -1814,55 +1814,55 @@ void P_CrossSpecialLine(line_t *line, int side, mobj_t *thing, boolean bossactio
             // Raise Floor 512
             // 142 W1  EV_DoFloor(raiseFloor512)
             if (EV_DoFloor(line,raiseFloor512))
-              dirty_line(line)->special = 0;
+              !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
             break;
 
           case 143:
             // Raise Floor 24 and change
             // 143 W1  EV_DoPlat(raiseAndChange,24)
             if (EV_DoPlat(line,raiseAndChange,24))
-              dirty_line(line)->special = 0;
+              !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
             break;
 
           case 144:
             // Raise Floor 32 and change
             // 144 W1  EV_DoPlat(raiseAndChange,32)
             if (EV_DoPlat(line,raiseAndChange,32))
-              dirty_line(line)->special = 0;
+              !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
             break;
 
           case 145:
             // Lower Ceiling to Floor
             // 145 W1  EV_DoCeiling(lowerToFloor)
             if (EV_DoCeiling( line, lowerToFloor ))
-              dirty_line(line)->special = 0;
+              !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
             break;
 
           case 146:
             // Lower Pillar, Raise Donut
             // 146 W1  EV_DoDonut()
             if (EV_DoDonut(line))
-              dirty_line(line)->special = 0;
+              !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
             break;
 
           case 199:
             // Lower ceiling to lowest surrounding ceiling
             // 199 W1 EV_DoCeiling(lowerToLowest)
             if (EV_DoCeiling(line,lowerToLowest))
-              dirty_line(line)->special = 0;
+              !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
             break;
 
           case 200:
             // Lower ceiling to highest surrounding floor
             // 200 W1 EV_DoCeiling(lowerToMaxFloor)
             if (EV_DoCeiling(line,lowerToMaxFloor))
-              dirty_line(line)->special = 0;
+              !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
             break;
 
           case 207:
             // killough 2/16/98: W1 silent teleporter (normal kind)
             if (EV_SilentTeleport(line, side, thing))
-              dirty_line(line)->special = 0;
+              !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
             break;
 
             //jff 3/16/98 renumber 215->153
@@ -1870,70 +1870,70 @@ void P_CrossSpecialLine(line_t *line, int side, mobj_t *thing, boolean bossactio
             // Texture/Type Change Only (Trig)
             // 153 W1 Change Texture/Type Only
             if (EV_DoChange(line,trigChangeOnly))
-              dirty_line(line)->special = 0;
+              !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
             break;
 
           case 239: //jff 3/15/98 create texture change no motion type
             // Texture/Type Change Only (Numeric)
             // 239 W1 Change Texture/Type Only
             if (EV_DoChange(line,numChangeOnly))
-              dirty_line(line)->special = 0;
+              !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
             break;
 
           case 219:
             // Lower floor to next lower neighbor
             // 219 W1 Lower Floor Next Lower Neighbor
             if (EV_DoFloor(line,lowerFloorToNearest))
-              dirty_line(line)->special = 0;
+              !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
             break;
 
           case 227:
             // Raise elevator next floor
             // 227 W1 Raise Elevator next floor
             if (EV_DoElevator(line,elevateUp))
-              dirty_line(line)->special = 0;
+              !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
             break;
 
           case 231:
             // Lower elevator next floor
             // 231 W1 Lower Elevator next floor
             if (EV_DoElevator(line,elevateDown))
-              dirty_line(line)->special = 0;
+              !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
             break;
 
           case 235:
             // Elevator to current floor
             // 235 W1 Elevator to current floor
             if (EV_DoElevator(line,elevateCurrent))
-              dirty_line(line)->special = 0;
+              !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
             break;
 
           case 243: //jff 3/6/98 make fit within DCK's 256 linedef types
             // killough 2/16/98: W1 silent teleporter (linedef-linedef kind)
             if (EV_SilentLineTeleport(line, side, thing, false))
-              dirty_line(line)->special = 0;
+              !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
             break;
 
           case 262: //jff 4/14/98 add silent line-line reversed
             if (EV_SilentLineTeleport(line, side, thing, true))
-              dirty_line(line)->special = 0;
+              !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
             break;
 
           case 264: //jff 4/14/98 add monster-only silent line-line reversed
             if (!thing->player &&
                 EV_SilentLineTeleport(line, side, thing, true))
-              dirty_line(line)->special = 0;
+              !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
             break;
 
           case 266: //jff 4/14/98 add monster-only silent line-line
             if (!thing->player &&
                 EV_SilentLineTeleport(line, side, thing, false))
-              dirty_line(line)->special = 0;
+              !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
             break;
 
           case 268: //jff 4/14/98 add monster-only silent
             if (!thing->player && EV_SilentTeleport(line, side, thing))
-              dirty_line(line)->special = 0;
+              !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;;
             break;
 
             //jff 1/29/98 end of added W1 linedef types

--- a/src/p_switch.c
+++ b/src/p_switch.c
@@ -331,7 +331,7 @@ P_UseSpecialLine
         case PushOnce:
           if (!side)
             if (linefunc(line))
-              dirty_line(line)->special = 0;
+              !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ; // fix UMAPINFO bossaction savegame crash
           return true;
         case PushMany:
           if (!side)
@@ -339,11 +339,11 @@ P_UseSpecialLine
           return true;
         case SwitchOnce:
           if (linefunc(line))
-            P_ChangeSwitchTexture(line,0);
+            !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
           return true;
         case SwitchMany:
           if (linefunc(line))
-            P_ChangeSwitchTexture(line,1);
+            !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
           return true;
         default:  // if not a switch/push type, do nothing here
           return false;
@@ -431,13 +431,13 @@ P_UseSpecialLine
     case 7:
       // Build Stairs
       if (EV_BuildStairs(line,build8))
-        P_ChangeSwitchTexture(line,0);
+        !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
       return true;
 
     case 9:
       // Change Donut
       if (EV_DoDonut(line))
-        P_ChangeSwitchTexture(line,0);
+        !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
       return true;
 
     // S1 - Exit to the next map and reset inventory.
@@ -457,74 +457,74 @@ P_UseSpecialLine
         return false;
       }
 
-      P_ChangeSwitchTexture(line,0);
+      !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
       G_ExitLevel();
       return true;
 
     case 14:
       // Raise Floor 32 and change texture
       if (EV_DoPlat(line,raiseAndChange,32))
-        P_ChangeSwitchTexture(line,0);
+        !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
       return true;
 
     case 15:
       // Raise Floor 24 and change texture
       if (EV_DoPlat(line,raiseAndChange,24))
-        P_ChangeSwitchTexture(line,0);
+        !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
       return true;
 
     case 18:
       // Raise Floor to next highest floor
       if (EV_DoFloor(line, raiseFloorToNearest))
-        P_ChangeSwitchTexture(line,0);
+        !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
       return true;
 
     case 20:
       // Raise Plat next highest floor and change texture
       if (EV_DoPlat(line,raiseToNearestAndChange,0))
-        P_ChangeSwitchTexture(line,0);
+        !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
       return true;
 
     case 21:
       // PlatDownWaitUpStay
       if (EV_DoPlat(line,downWaitUpStay,0))
-        P_ChangeSwitchTexture(line,0);
+        !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
       return true;
 
     case 23:
       // Lower Floor to Lowest
       if (EV_DoFloor(line,lowerFloorToLowest))
-        P_ChangeSwitchTexture(line,0);
+        !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
       return true;
 
     case 29:
       // Raise Door
       if (EV_DoDoor(line, doorNormal))
-        P_ChangeSwitchTexture(line,0);
+        !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
       return true;
 
     case 41:
       // Lower Ceiling to Floor
       if (EV_DoCeiling(line,lowerToFloor))
-        P_ChangeSwitchTexture(line,0);
+        !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
       return true;
 
     case 71:
       // Turbo Lower Floor
       if (EV_DoFloor(line,turboLower))
-        P_ChangeSwitchTexture(line,0);
+        !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
       return true;
 
     case 49:
       // Ceiling Crush And Raise
       if (EV_DoCeiling(line,crushAndRaise))
-        P_ChangeSwitchTexture(line,0);
+        !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
       return true;
 
     case 50:
       // Close Door
       if (EV_DoDoor(line,doorClose))
-        P_ChangeSwitchTexture(line,0);
+        !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
       return true;
 
     // SR - Exit to the secret map and reset inventory.
@@ -544,68 +544,68 @@ P_UseSpecialLine
         return false;
       }
 
-      P_ChangeSwitchTexture(line,0);
+      !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
       G_SecretExitLevel();
       return true;
 
     case 55:
       // Raise Floor Crush
       if (EV_DoFloor(line,raiseFloorCrush))
-        P_ChangeSwitchTexture(line,0);
+        !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
       return true;
 
     case 101:
       // Raise Floor
       if (EV_DoFloor(line,raiseFloor))
-        P_ChangeSwitchTexture(line,0);
+        !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
       return true;
 
     case 102:
       // Lower Floor to Surrounding floor height
       if (EV_DoFloor(line,lowerFloor))
-        P_ChangeSwitchTexture(line,0);
+        !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
       return true;
 
     case 103:
       // Open Door
       if (EV_DoDoor(line,doorOpen))
-        P_ChangeSwitchTexture(line,0);
+        !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
       return true;
 
     case 111:
       // Blazing Door Raise (faster than TURBO!)
       if (EV_DoDoor (line,blazeRaise))
-        P_ChangeSwitchTexture(line,0);
+        !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
       return true;
 
     case 112:
       // Blazing Door Open (faster than TURBO!)
       if (EV_DoDoor (line,blazeOpen))
-        P_ChangeSwitchTexture(line,0);
+        !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
       return true;
 
     case 113:
       // Blazing Door Close (faster than TURBO!)
       if (EV_DoDoor (line,blazeClose))
-        P_ChangeSwitchTexture(line,0);
+        !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
       return true;
 
     case 122:
       // Blazing PlatDownWaitUpStay
       if (EV_DoPlat(line,blazeDWUS,0))
-        P_ChangeSwitchTexture(line,0);
+        !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
       return true;
 
     case 127:
       // Build Stairs Turbo 16
       if (EV_BuildStairs(line,turbo16))
-        P_ChangeSwitchTexture(line,0);
+        !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
       return true;
 
     case 131:
       // Raise Floor Turbo
       if (EV_DoFloor(line,raiseFloorTurbo))
-        P_ChangeSwitchTexture(line,0);
+        !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
       return true;
 
     case 133:
@@ -615,13 +615,13 @@ P_UseSpecialLine
     case 137:
       // BlzOpenDoor YELLOW
       if (EV_DoLockedDoor (line,blazeOpen,thing))
-        P_ChangeSwitchTexture(line,0);
+        !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
       return true;
 
     case 140:
       // Raise Floor 512
       if (EV_DoFloor(line,raiseFloor512))
-        P_ChangeSwitchTexture(line,0);
+        !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
       return true;
 
     // ID24 Music Changers
@@ -631,7 +631,7 @@ P_UseSpecialLine
       return true;
 
     case 2078:
-      dirty_line(line)->special = 0;
+      !bossaction ? (dirty_line(line)->special = 0) : (line->special = 0) ;
       // fallthrough
 
     case 2079:
@@ -658,56 +658,56 @@ P_UseSpecialLine
             // Raise Floor to shortest lower texture
             // 158 S1  EV_DoFloor(raiseToTexture), CSW(0)
             if (EV_DoFloor(line,raiseToTexture))
-              P_ChangeSwitchTexture(line,0);
+              !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
             return true;
 
           case 159:
             // Raise Floor to shortest lower texture
             // 159 S1  EV_DoFloor(lowerAndChange)
             if (EV_DoFloor(line,lowerAndChange))
-              P_ChangeSwitchTexture(line,0);
+              !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
             return true;
 
           case 160:
             // Raise Floor 24 and change
             // 160 S1  EV_DoFloor(raiseFloor24AndChange)
             if (EV_DoFloor(line,raiseFloor24AndChange))
-              P_ChangeSwitchTexture(line,0);
+              !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
             return true;
 
           case 161:
             // Raise Floor 24
             // 161 S1  EV_DoFloor(raiseFloor24)
             if (EV_DoFloor(line,raiseFloor24))
-              P_ChangeSwitchTexture(line,0);
+              !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
             return true;
 
           case 162:
             // Moving floor min n to max n
             // 162 S1  EV_DoPlat(perpetualRaise,0)
             if (EV_DoPlat(line,perpetualRaise,0))
-              P_ChangeSwitchTexture(line,0);
+              !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
             return true;
 
           case 163:
             // Stop Moving floor
             // 163 S1  EV_DoPlat(perpetualRaise,0)
             EV_StopPlat(line);
-            P_ChangeSwitchTexture(line,0);
+            !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
             return true;
 
           case 164:
             // Start fast crusher
             // 164 S1  EV_DoCeiling(fastCrushAndRaise)
             if (EV_DoCeiling(line,fastCrushAndRaise))
-              P_ChangeSwitchTexture(line,0);
+              !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
             return true;
 
           case 165:
             // Start slow silent crusher
             // 165 S1  EV_DoCeiling(silentCrushAndRaise)
             if (EV_DoCeiling(line,silentCrushAndRaise))
-              P_ChangeSwitchTexture(line,0);
+              !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
             return true;
 
           case 166:
@@ -715,133 +715,133 @@ P_UseSpecialLine
             // 166 S1 EV_DoCeiling(raiseToHighest), EV_DoFloor(lowerFloortoLowest)
             if (EV_DoCeiling(line, raiseToHighest) ||
                 EV_DoFloor(line, lowerFloorToLowest))
-              P_ChangeSwitchTexture(line,0);
+              !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
             return true;
 
           case 167:
             // Lower floor and Crush
             // 167 S1 EV_DoCeiling(lowerAndCrush)
             if (EV_DoCeiling(line, lowerAndCrush))
-              P_ChangeSwitchTexture(line,0);
+              !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
             return true;
 
           case 168:
             // Stop crusher
             // 168 S1 EV_CeilingCrushStop()
             if (EV_CeilingCrushStop(line))
-              P_ChangeSwitchTexture(line,0);
+              !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
             return true;
 
           case 169:
             // Lights to brightest neighbor sector
             // 169 S1  EV_LightTurnOn(0)
             EV_LightTurnOn(line,0);
-            P_ChangeSwitchTexture(line,0);
+            !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
             return true;
 
           case 170:
             // Lights to near dark
             // 170 S1  EV_LightTurnOn(35)
             EV_LightTurnOn(line,35);
-            P_ChangeSwitchTexture(line,0);
+            !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
             return true;
 
           case 171:
             // Lights on full
             // 171 S1  EV_LightTurnOn(255)
             EV_LightTurnOn(line,255);
-            P_ChangeSwitchTexture(line,0);
+            !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
             return true;
 
           case 172:
             // Start Lights Strobing
             // 172 S1  EV_StartLightStrobing()
             EV_StartLightStrobing(line);
-            P_ChangeSwitchTexture(line,0);
+            !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
             return true;
 
           case 173:
             // Lights to Dimmest Near
             // 173 S1  EV_TurnTagLightsOff()
             EV_TurnTagLightsOff(line);
-            P_ChangeSwitchTexture(line,0);
+            !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
             return true;
 
           case 174:
             // Teleport
             // 174 S1  EV_Teleport(side,thing)
             if (EV_Teleport(line,side,thing))
-              P_ChangeSwitchTexture(line,0);
+              !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
             return true;
 
           case 175:
             // Close Door, Open in 30 secs
             // 175 S1  EV_DoDoor(close30ThenOpen)
             if (EV_DoDoor(line,close30ThenOpen))
-              P_ChangeSwitchTexture(line,0);
+              !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
             return true;
 
           case 189: //jff 3/15/98 create texture change no motion type
             // Texture Change Only (Trigger)
             // 189 S1 Change Texture/Type Only
             if (EV_DoChange(line,trigChangeOnly))
-              P_ChangeSwitchTexture(line,0);
+              !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
             return true;
 
           case 203:
             // Lower ceiling to lowest surrounding ceiling
             // 203 S1 EV_DoCeiling(lowerToLowest)
             if (EV_DoCeiling(line,lowerToLowest))
-              P_ChangeSwitchTexture(line,0);
+              !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
             return true;
 
           case 204:
             // Lower ceiling to highest surrounding floor
             // 204 S1 EV_DoCeiling(lowerToMaxFloor)
             if (EV_DoCeiling(line,lowerToMaxFloor))
-              P_ChangeSwitchTexture(line,0);
+              !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
             return true;
 
           case 209:
             // killough 1/31/98: silent teleporter
             //jff 209 S1 SilentTeleport
             if (EV_SilentTeleport(line, side, thing))
-              P_ChangeSwitchTexture(line,0);
+              !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
             return true;
 
           case 241: //jff 3/15/98 create texture change no motion type
             // Texture Change Only (Numeric)
             // 241 S1 Change Texture/Type Only
             if (EV_DoChange(line,numChangeOnly))
-              P_ChangeSwitchTexture(line,0);
+              !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
             return true;
 
           case 221:
             // Lower floor to next lowest floor
             // 221 S1 Lower Floor To Nearest Floor
             if (EV_DoFloor(line,lowerFloorToNearest))
-              P_ChangeSwitchTexture(line,0);
+              !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
             return true;
 
           case 229:
             // Raise elevator next floor
             // 229 S1 Raise Elevator next floor
             if (EV_DoElevator(line,elevateUp))
-              P_ChangeSwitchTexture(line,0);
+              !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
             return true;
 
           case 233:
             // Lower elevator next floor
             // 233 S1 Lower Elevator next floor
             if (EV_DoElevator(line,elevateDown))
-              P_ChangeSwitchTexture(line,0);
+              !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
             return true;
 
           case 237:
             // Elevator to current floor
             // 237 S1 Elevator to current floor
             if (EV_DoElevator(line,elevateCurrent))
-              P_ChangeSwitchTexture(line,0);
+              !bossaction ? P_ChangeSwitchTexture(line,0) : (line->special = 0) ;
             return true;
 
 
@@ -854,42 +854,42 @@ P_UseSpecialLine
             // Texture Change Only (Numeric)
             // 78 SR Change Texture/Type Only
             if (EV_DoChange(line,numChangeOnly))
-              P_ChangeSwitchTexture(line,1);
+              !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
             return true;
 
           case 176:
             // Raise Floor to shortest lower texture
             // 176 SR  EV_DoFloor(raiseToTexture), CSW(1)
             if (EV_DoFloor(line,raiseToTexture))
-              P_ChangeSwitchTexture(line,1);
+              !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
             return true;
 
           case 177:
             // Raise Floor to shortest lower texture
             // 177 SR  EV_DoFloor(lowerAndChange)
             if (EV_DoFloor(line,lowerAndChange))
-              P_ChangeSwitchTexture(line,1);
+              !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
             return true;
 
           case 178:
             // Raise Floor 512
             // 178 SR  EV_DoFloor(raiseFloor512)
             if (EV_DoFloor(line,raiseFloor512))
-              P_ChangeSwitchTexture(line,1);
+              !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
             return true;
 
           case 179:
             // Raise Floor 24 and change
             // 179 SR  EV_DoFloor(raiseFloor24AndChange)
             if (EV_DoFloor(line,raiseFloor24AndChange))
-              P_ChangeSwitchTexture(line,1);
+              !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
             return true;
 
           case 180:
             // Raise Floor 24
             // 180 SR  EV_DoFloor(raiseFloor24)
             if (EV_DoFloor(line,raiseFloor24))
-              P_ChangeSwitchTexture(line,1);
+              !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
             return true;
 
           case 181:
@@ -897,35 +897,35 @@ P_UseSpecialLine
             // 181 SR  EV_DoPlat(perpetualRaise,0)
 
             EV_DoPlat(line,perpetualRaise,0);
-            P_ChangeSwitchTexture(line,1);
+            !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
             return true;
 
           case 182:
             // Stop Moving floor
             // 182 SR  EV_DoPlat(perpetualRaise,0)
             EV_StopPlat(line);
-            P_ChangeSwitchTexture(line,1);
+            !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
             return true;
 
           case 183:
             // Start fast crusher
             // 183 SR  EV_DoCeiling(fastCrushAndRaise)
             if (EV_DoCeiling(line,fastCrushAndRaise))
-              P_ChangeSwitchTexture(line,1);
+              !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
             return true;
 
           case 184:
             // Start slow crusher
             // 184 SR  EV_DoCeiling(crushAndRaise)
             if (EV_DoCeiling(line,crushAndRaise))
-              P_ChangeSwitchTexture(line,1);
+              !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
             return true;
 
           case 185:
             // Start slow silent crusher
             // 185 SR  EV_DoCeiling(silentCrushAndRaise)
             if (EV_DoCeiling(line,silentCrushAndRaise))
-              P_ChangeSwitchTexture(line,1);
+              !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
             return true;
 
           case 186:
@@ -933,140 +933,140 @@ P_UseSpecialLine
             // 186 SR EV_DoCeiling(raiseToHighest), EV_DoFloor(lowerFloortoLowest)
             if (EV_DoCeiling(line, raiseToHighest) ||
                 EV_DoFloor(line, lowerFloorToLowest))
-              P_ChangeSwitchTexture(line,1);
+              !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
             return true;
 
           case 187:
             // Lower floor and Crush
             // 187 SR EV_DoCeiling(lowerAndCrush)
             if (EV_DoCeiling(line, lowerAndCrush))
-              P_ChangeSwitchTexture(line,1);
+              !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
             return true;
 
           case 188:
             // Stop crusher
             // 188 SR EV_CeilingCrushStop()
             if (EV_CeilingCrushStop(line))
-              P_ChangeSwitchTexture(line,1);
+              !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
             return true;
 
           case 190: //jff 3/15/98 create texture change no motion type
             // Texture Change Only (Trigger)
             // 190 SR Change Texture/Type Only
             if (EV_DoChange(line,trigChangeOnly))
-              P_ChangeSwitchTexture(line,1);
+              !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
             return true;
 
           case 191:
             // Lower Pillar, Raise Donut
             // 191 SR  EV_DoDonut()
             if (EV_DoDonut(line))
-              P_ChangeSwitchTexture(line,1);
+              !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
             return true;
 
           case 192:
             // Lights to brightest neighbor sector
             // 192 SR  EV_LightTurnOn(0)
             EV_LightTurnOn(line,0);
-            P_ChangeSwitchTexture(line,1);
+            !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
             return true;
 
           case 193:
             // Start Lights Strobing
             // 193 SR  EV_StartLightStrobing()
             EV_StartLightStrobing(line);
-            P_ChangeSwitchTexture(line,1);
+            !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
             return true;
 
           case 194:
             // Lights to Dimmest Near
             // 194 SR  EV_TurnTagLightsOff()
             EV_TurnTagLightsOff(line);
-            P_ChangeSwitchTexture(line,1);
+            !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
             return true;
 
           case 195:
             // Teleport
             // 195 SR  EV_Teleport(side,thing)
             if (EV_Teleport(line,side,thing))
-              P_ChangeSwitchTexture(line,1);
+              !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
             return true;
 
           case 196:
             // Close Door, Open in 30 secs
             // 196 SR  EV_DoDoor(close30ThenOpen)
             if (EV_DoDoor(line,close30ThenOpen))
-              P_ChangeSwitchTexture(line,1);
+              !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
             return true;
 
           case 205:
             // Lower ceiling to lowest surrounding ceiling
             // 205 SR EV_DoCeiling(lowerToLowest)
             if (EV_DoCeiling(line,lowerToLowest))
-              P_ChangeSwitchTexture(line,1);
+              !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
             return true;
 
           case 206:
             // Lower ceiling to highest surrounding floor
             // 206 SR EV_DoCeiling(lowerToMaxFloor)
             if (EV_DoCeiling(line,lowerToMaxFloor))
-              P_ChangeSwitchTexture(line,1);
+              !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
             return true;
 
           case 210:
             // killough 1/31/98: silent teleporter
             //jff 210 SR SilentTeleport
             if (EV_SilentTeleport(line, side, thing))
-              P_ChangeSwitchTexture(line,1);
+              !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
             return true;
 
           case 211: //jff 3/14/98 create instant toggle floor type
             // Toggle Floor Between C and F Instantly
             // 211 SR Toggle Floor Instant
             if (EV_DoPlat(line,toggleUpDn,0))
-              P_ChangeSwitchTexture(line,1);
+              !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
             return true;
 
           case 222:
             // Lower floor to next lowest floor
             // 222 SR Lower Floor To Nearest Floor
             if (EV_DoFloor(line,lowerFloorToNearest))
-              P_ChangeSwitchTexture(line,1);
+              !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
             return true;
 
           case 230:
             // Raise elevator next floor
             // 230 SR Raise Elevator next floor
             if (EV_DoElevator(line,elevateUp))
-              P_ChangeSwitchTexture(line,1);
+              !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
             return true;
 
           case 234:
             // Lower elevator next floor
             // 234 SR Lower Elevator next floor
             if (EV_DoElevator(line,elevateDown))
-              P_ChangeSwitchTexture(line,1);
+              !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
             return true;
 
           case 238:
             // Elevator to current floor
             // 238 SR Elevator to current floor
             if (EV_DoElevator(line,elevateCurrent))
-              P_ChangeSwitchTexture(line,1);
+              !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
             return true;
 
           case 258:
             // Build stairs, step 8
             // 258 SR EV_BuildStairs(build8)
             if (EV_BuildStairs(line,build8))
-              P_ChangeSwitchTexture(line,1);
+              !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
             return true;
 
           case 259:
             // Build stairs, step 16
             // 259 SR EV_BuildStairs(turbo16)
             if (EV_BuildStairs(line,turbo16))
-              P_ChangeSwitchTexture(line,1);
+              !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
             return true;
 
           // 1/29/98 jff end of added SR linedef types
@@ -1078,115 +1078,115 @@ P_UseSpecialLine
     case 42:
       // Close Door
       if (EV_DoDoor(line,doorClose))
-        P_ChangeSwitchTexture(line,1);
+        !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
       return true;
 
     case 43:
       // Lower Ceiling to Floor
       if (EV_DoCeiling(line,lowerToFloor))
-        P_ChangeSwitchTexture(line,1);
+        !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
       return true;
 
     case 45:
       // Lower Floor to Surrounding floor height
       if (EV_DoFloor(line,lowerFloor))
-        P_ChangeSwitchTexture(line,1);
+        !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
       return true;
 
     case 60:
       // Lower Floor to Lowest
       if (EV_DoFloor(line,lowerFloorToLowest))
-        P_ChangeSwitchTexture(line,1);
+        !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
       return true;
 
     case 61:
       // Open Door
       if (EV_DoDoor(line,doorOpen))
-        P_ChangeSwitchTexture(line,1);
+        !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
       return true;
 
     case 62:
       // PlatDownWaitUpStay
       if (EV_DoPlat(line,downWaitUpStay,1))
-        P_ChangeSwitchTexture(line,1);
+        !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
       return true;
 
     case 63:
       // Raise Door
       if (EV_DoDoor(line, doorNormal))
-        P_ChangeSwitchTexture(line,1);
+        !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
       return true;
 
     case 64:
       // Raise Floor to ceiling
       if (EV_DoFloor(line,raiseFloor))
-        P_ChangeSwitchTexture(line,1);
+        !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
       return true;
 
     case 66:
       // Raise Floor 24 and change texture
       if (EV_DoPlat(line,raiseAndChange,24))
-        P_ChangeSwitchTexture(line,1);
+        !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
       return true;
 
     case 67:
       // Raise Floor 32 and change texture
       if (EV_DoPlat(line,raiseAndChange,32))
-        P_ChangeSwitchTexture(line,1);
+        !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
       return true;
 
     case 65:
       // Raise Floor Crush
       if (EV_DoFloor(line,raiseFloorCrush))
-        P_ChangeSwitchTexture(line,1);
+        !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
       return true;
 
     case 68:
       // Raise Plat to next highest floor and change texture
       if (EV_DoPlat(line,raiseToNearestAndChange,0))
-        P_ChangeSwitchTexture(line,1);
+        !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
       return true;
 
     case 69:
       // Raise Floor to next highest floor
       if (EV_DoFloor(line, raiseFloorToNearest))
-        P_ChangeSwitchTexture(line,1);
+        !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
       return true;
 
     case 70:
       // Turbo Lower Floor
       if (EV_DoFloor(line,turboLower))
-        P_ChangeSwitchTexture(line,1);
+        !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
       return true;
 
     case 114:
       // Blazing Door Raise (faster than TURBO!)
       if (EV_DoDoor (line,blazeRaise))
-        P_ChangeSwitchTexture(line,1);
+        !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
       return true;
 
     case 115:
       // Blazing Door Open (faster than TURBO!)
       if (EV_DoDoor (line,blazeOpen))
-        P_ChangeSwitchTexture(line,1);
+        !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
       return true;
 
     case 116:
       // Blazing Door Close (faster than TURBO!)
       if (EV_DoDoor (line,blazeClose))
-        P_ChangeSwitchTexture(line,1);
+        !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
       return true;
 
     case 123:
       // Blazing PlatDownWaitUpStay
       if (EV_DoPlat(line,blazeDWUS,0))
-        P_ChangeSwitchTexture(line,1);
+        !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
       return true;
 
     case 132:
       // Raise Floor Turbo
       if (EV_DoFloor(line,raiseFloorTurbo))
-        P_ChangeSwitchTexture(line,1);
+        !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
       return true;
 
     case 99:
@@ -1196,19 +1196,19 @@ P_UseSpecialLine
     case 136:
       // BlzOpenDoor YELLOW
       if (EV_DoLockedDoor (line,blazeOpen,thing))
-        P_ChangeSwitchTexture(line,1);
+        !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
       return true;
 
     case 138:
       // Light Turn On
       EV_LightTurnOn(line,255);
-      P_ChangeSwitchTexture(line,1);
+      !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
       return true;
 
     case 139:
       // Light Turn Off
       EV_LightTurnOn(line,35);
-      P_ChangeSwitchTexture(line,1);
+      !bossaction ? P_ChangeSwitchTexture(line,1) : (line->special = 0) ;
       return true;
   }
   return !bossaction;


### PR DESCRIPTION
Fixes #2569 but could use a review. Recorded demos appear to still sync, including ones that utilize UMAPINFO bossactions. Tested to confirm that the bossactions still occur, that one-time linedef actions' activated or not-activated states persist properly across saves, and that switch texture state properly persists across saves. However, there are some unnecessary checks that may warrant discussion. For example, bossactions can't occur on locked doors or teleports, but I added the safeguards there anyway just in case a future spec changes this.