### PR TITLE
Use correct DeepBSPV4 node count

### DIFF
--- a/src/p_extnodes.c
+++ b/src/p_extnodes.c
@@ -418,7 +418,7 @@ void P_LoadNodes_DEEP(int lump)
     byte *data;
     int i;
 
-    numnodes = W_LumpLength(lump) / sizeof(mapnode_deep_t);
+    numnodes = (W_LumpLength(lump) - 8) / sizeof(mapnode_deep_t);
     nodes = Z_Malloc(numnodes * sizeof(node_t), PU_LEVEL, 0);
     data = W_CacheLumpNum(lump, PU_STATIC);
 


### PR DESCRIPTION
The direct use of W_LumpLength does not account for the length of the DeepBSPV4 header.

Crispy, DSDA, EE, etc all already account for this one.

The issue is not present in ZDoom nodes.