### PR TITLE
sndinfo: parse next token after assignment, no matter its format

### DIFF
--- a/src/s_sndinfo.c
+++ b/src/s_sndinfo.c
@@ -75,7 +75,7 @@ static void ParseSoundDefinition(scanner_t *s, sound_def_t **sound_defs)
         return;
     }
 
-    SC_MustGetToken(s, TK_RawString);
+    SC_GetNextToken(s, true);
     def.lump_name = M_StringDuplicate(SC_GetString(s));
     def.lumpnum = W_CheckNumForName(def.lump_name);
 


### PR DESCRIPTION
Fixes #2589