### PR TITLE
add option to mute audio when the window is unfocused

### DIFF
--- a/src/mn_setup.c
+++ b/src/mn_setup.c
@@ -2582,8 +2582,6 @@ static setup_menu_t gen_settings2[] = {
 
     MI_GAP,
 
-    {"Mute When Unfocused", S_ONOFF, CNTR_X, M_SPC, {"mute_unfocused"}},
-
     {"Sound Module", S_CHOICE, CNTR_X, M_SPC, {"snd_module"},
      .strings_id = str_sound_module, .action = SetSoundModule},
 


### PR DESCRIPTION
as featured in inter-doom, cherry, uzdoom, doom retro, and probably more.

config-only `mute_unfocused` key, enabled by default.