### PR TITLE
Return earlier if screen size wasn't changed

### DIFF
--- a/src/mn_menu.c
+++ b/src/mn_menu.c
@@ -1814,8 +1814,6 @@ static void M_ChangeMessages(int choice)
 // hud_active controlled soley by F5=key_detail (key_hud)
 // hud_displayed is toggled by + or = in fullscreen
 // hud_displayed is cleared by -
-// [Woof!] Return early and do not play sound
-// if the screen size was not actually changed.
 
 static void M_SizeDisplay(int choice)
 {


### PR DESCRIPTION
Essentially, this PR is a micro-optimization that fixes a minor oversight inherited from the [vanilla menu](https://github.com/chocolate-doom/chocolate-doom/blob/master/src/doom/m_menu.c#L1176-L1198): even when the screen size is already at its minimum or maximum, attempting to make it smaller or larger still plays the `sfx_stnmov` sound and calls `R_SetViewSize()`, creating the illusion that something is happening, and wasting a few unnecessary microseconds on the function call.