### PR TITLE
speed up UDMF parsing

### DIFF
--- a/src/deh_frame.c
+++ b/src/deh_frame.c
@@ -46,9 +46,8 @@ static void SetDefinedCodepointerArgs(int frame_number, int arg)
     }
     else
     {
-        args = &flag;
+        hashmap_put(defined_args, frame_number, &flag);
     }
-    hashmap_put(defined_args, frame_number, args);
 }
 
 byte DEH_GetDefinedCodepointerArgs(int frame_number)

--- a/src/m_scanner.c
+++ b/src/m_scanner.c
@@ -66,7 +66,7 @@ struct scanner_s
     parserstate_t state;
     parserstate_t nextstate, prevstate;
 
-    char *data;
+    const char *data;
     size_t length;
 
     int line;
@@ -849,8 +849,7 @@ scanner_t *SC_Open(const char *scriptname, const char *data, int length)
     s->neednext = true;
 
     s->length = length;
-    s->data = malloc(length);
-    memcpy(s->data, data, length);
+    s->data = data;
 
     CheckForWhitespace(s);
     s->state.scanpos = s->scanpos;
@@ -876,7 +875,6 @@ void SC_Close(scanner_t *s)
     {
         free((char *)s->scriptname);
     }
-    free(s->data);
     free(s);
 }
 

--- a/src/p_udmf.c
+++ b/src/p_udmf.c
@@ -201,9 +201,7 @@ inline static int UDMF_ScanInt(scanner_t *s)
 {
     int x = 0;
     SC_MustGetToken(s, '=');
-    boolean neg = SC_CheckToken(s, '-');
-    SC_MustGetToken(s, TK_IntConst);
-    x = neg ? -SC_GetNumber(s) : SC_GetNumber(s);
+    x = SC_GetNegativeInteger(s);
     SC_MustGetToken(s, ';');
     return x;
 }
@@ -213,9 +211,7 @@ inline static double UDMF_ScanDouble(scanner_t *s)
 {
     double x = 0;
     SC_MustGetToken(s, '=');
-    boolean neg = SC_CheckToken(s, '-');
-    SC_MustGetToken(s, TK_FloatConst);
-    x = neg ? -SC_GetDecimal(s) : SC_GetDecimal(s);
+    x = SC_GetNegativeDecimal(s);
     SC_MustGetToken(s, ';');
     return x;
 }
@@ -244,25 +240,25 @@ inline static void UDMF_ScanLumpName(scanner_t *s, char *x)
 }
 
 // Property is valid in all namespaces
-#define BASE_PROP(keyword) (!strcasecmp(prop, #keyword))
+#define BASE_PROP(keyword) (!strcmp(prop, #keyword))
 
 // Property is valid in the current namespace
 #define PROP(keyword, flags) \
-    (!strcasecmp(prop, #keyword) && (udmf_flags & (flags)))
+    ((udmf_flags & (flags)) && !strcmp(prop, #keyword))
 
 // Parse specific string properties
 inline static int32_t UDMF_ScanSectorScroll(scanner_t *s)
 {
-    const char *buf;
     int32_t mode = 0;
     SC_MustGetToken(s, '=');
     SC_MustGetToken(s, TK_StringConst);
-    buf = SC_GetString(s);
-    if (!strcasecmp(buf, "visual"))
+    const char *buf = SC_GetString(s);
+    M_StringToLower((char *)buf);
+    if (!strcmp(buf, "visual"))
       mode = SCROLL_TEXTURE;
-    else if (!strcasecmp(buf, "physical"))
+    else if (!strcmp(buf, "physical"))
       mode = SCROLL_CARRY;
-    else if (!strcasecmp(buf, "both"))
+    else if (!strcmp(buf, "both"))
       mode = SCROLL_ALL;
     SC_MustGetToken(s, ';');
     return mode;
@@ -347,6 +343,7 @@ static void UDMF_ParseVertex(scanner_t *s)
     {
         SC_MustGetToken(s, TK_Identifier);
         const char *prop = SC_GetString(s);
+        M_StringToLower((char *)prop);
         if (BASE_PROP(x))
         {
             vertex.x = UDMF_ScanDouble(s);
@@ -380,6 +377,7 @@ static void UDMF_ParseLinedef(scanner_t *s)
     {
         SC_MustGetToken(s, TK_Identifier);
         const char *prop = SC_GetString(s);
+        M_StringToLower((char *)prop);
         if (BASE_PROP(v1))
         {
             line.v1_id = UDMF_ScanInt(s);
@@ -509,6 +507,7 @@ static void UDMF_ParseSidedef(scanner_t *s)
     {
         SC_MustGetToken(s, TK_Identifier);
         const char *prop = SC_GetString(s);
+        M_StringToLower((char *)prop);
         if (BASE_PROP(offsetx))
         {
             side.offsetx = UDMF_ScanInt(s);
@@ -654,6 +653,7 @@ static void UDMF_ParseSector(scanner_t *s)
     {
         SC_MustGetToken(s, TK_Identifier);
         const char *prop = SC_GetString(s);
+        M_StringToLower((char *)prop);
         if (BASE_PROP(heightfloor))
         {
             sector.heightfloor = UDMF_ScanInt(s);
@@ -795,6 +795,7 @@ static void UDMF_ParseThing(scanner_t *s)
     {
         SC_MustGetToken(s, TK_Identifier);
         const char *prop = SC_GetString(s);
+        M_StringToLower((char *)prop);
         if (BASE_PROP(type))
         {
             thing.type = UDMF_ScanInt(s);
@@ -906,33 +907,33 @@ static void UDMF_ParseTextMap(int lumpnum)
         SC_Open("TEXTMAP", W_CacheLumpNum(lumpnum + UDMF_TEXTMAP, PU_CACHE),
                 W_LumpLength(lumpnum + UDMF_TEXTMAP));
 
-    const char *toplevel = NULL;
     while (SC_TokensLeft(s))
     {
         SC_MustGetToken(s, TK_Identifier);
-        toplevel = SC_GetString(s);
+        const char *toplevel = SC_GetString(s);
+        M_StringToLower((char *)toplevel);
 
-        if (!strcasecmp(toplevel, "namespace"))
+        if (!strcmp(toplevel, "namespace"))
         {
             UDMF_ParseNamespace(s);
         }
-        else if (!strcasecmp(toplevel, "vertex"))
+        else if (!strcmp(toplevel, "vertex"))
         {
             UDMF_ParseVertex(s);
         }
-        else if (!strcasecmp(toplevel, "linedef"))
+        else if (!strcmp(toplevel, "linedef"))
         {
             UDMF_ParseLinedef(s);
         }
-        else if (!strcasecmp(toplevel, "sidedef"))
+        else if (!strcmp(toplevel, "sidedef"))
         {
             UDMF_ParseSidedef(s);
         }
-        else if (!strcasecmp(toplevel, "sector"))
+        else if (!strcmp(toplevel, "sector"))
         {
             UDMF_ParseSector(s);
         }
-        else if (!strcasecmp(toplevel, "thing"))
+        else if (!strcmp(toplevel, "thing"))
         {
             UDMF_ParseThing(s);
         }


### PR DESCRIPTION
Speed up UDMF parsing by 1.5x by using `strcmp` instead of `strcasecmp`.

It's twice as slow as parsing the binary map format. We could speed it up further by using a hash map for property names and writing a specific, simplified scanner, but I think it would still be 1.5 times slower than the binary format.