### PR TITLE
enable the demo progress bar by default

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -2463,7 +2463,7 @@ void D_BindMiscVariables(void)
   BIND_BOOL_GENERAL(quit_sound, false, "Play quit sound");
   BIND_NUM_GENERAL(show_endoom, ENDOOM_OFF, ENDOOM_OFF, ENDOOM_ALWAYS,
     "Show ENDOOM screen (0 = Off; 1 = PWAD Only; 2 = Always)");
-  BIND_BOOL_GENERAL(demobar, false, "Show demo progress bar");
+  BIND_BOOL_GENERAL(demobar, true, "Show demo progress bar");
   BIND_NUM_GENERAL(screen_melt, wipe_Melt, wipe_None, wipe_Fizzle,
     "Screen wipe effect (0 = None; 1 = Melt; 2 = Crossfade; 3 = Fizzlefade)");
   BIND_NUM_GENERAL(palette_changes, PAL_CHANGE_ON, PAL_CHANGE_OFF, PAL_CHANGE_REDUCED,


### PR DESCRIPTION
DSDA-Doom has it enabled by default as well.