### PR TITLE
let all message and announce widgets share the same duration counter

### DIFF
--- a/src/st_sbardef.h
+++ b/src/st_sbardef.h
@@ -287,7 +287,6 @@ typedef struct sbe_widget_s
     int height;
 
     int duration;
-    int *duration_left;
 
     boolean vertical;
 } sbe_widget_t;

--- a/src/st_sbardef.h
+++ b/src/st_sbardef.h
@@ -287,7 +287,7 @@ typedef struct sbe_widget_s
     int height;
 
     int duration;
-    int duration_left;
+    int *duration_left;
 
     boolean vertical;
 } sbe_widget_t;

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -1396,10 +1396,6 @@ static void ResetElem(sbarelem_t *elem, player_t *player)
             }
             break;
 
-        case sbe_widget:
-            elem->subtype.widget->duration_left = 0;
-            break;
-
         case sbe_string:
             {
                 sbe_string_t *string = elem->subtype.string;

--- a/src/st_widgets.c
+++ b/src/st_widgets.c
@@ -96,26 +96,25 @@ static void UpdateMessage(sbe_widget_t *widget, player_t *player)
     static boolean overwrite = true;
     static boolean messages_enabled = true;
 
-    widget->duration_left = &message_duration_left;
     if (messages_enabled)
     {
         if (message_string[0])
         {
-            *widget->duration_left = widget->duration;
+            message_duration_left = widget->duration;
             M_StringCopy(string, message_string, sizeof(string));
             message_string[0] = '\0';
             overwrite = false;
         }
         else if (player->message && player->message[0] && overwrite)
         {
-            *widget->duration_left = widget->duration;
+            message_duration_left = widget->duration;
             M_StringCopy(string, player->message, sizeof(string));
             player->message[0] = '\0';
         }
         else if (message_review)
         {
             message_review = false;
-            *widget->duration_left = widget->duration;
+            message_duration_left = widget->duration;
         }
     }
 
@@ -124,14 +123,14 @@ static void UpdateMessage(sbe_widget_t *widget, player_t *player)
         messages_enabled = show_messages;
     }
 
-    if (*widget->duration_left == 0)
+    if (message_duration_left == 0)
     {
         overwrite = true;
     }
     else
     {
         ST_AddLine(widget, string);
-        *widget->duration_left -= 1;
+        --message_duration_left;
     }
 }
 
@@ -157,11 +156,10 @@ static void UpdateAnnounceMessage(sbe_widget_t *widget, player_t *player)
 
     static char string[HU_MAXLINELENGTH];
 
-    widget->duration_left = &announce_duration_left;
     if (announce_string[0])
     {
         state = announce_map;
-        *widget->duration_left = widget->duration;
+        announce_duration_left = widget->duration;
         M_StringCopy(string, announce_string, sizeof(string));
         announce_string[0] = '\0';
     }
@@ -169,20 +167,20 @@ static void UpdateAnnounceMessage(sbe_widget_t *widget, player_t *player)
     {
         author_string[0] = '\0';
         state = announce_secret;
-        *widget->duration_left = widget->duration;
+        announce_duration_left = widget->duration;
         M_snprintf(string, sizeof(string), GOLD_S "%s" ORIG_S,
             player->secretmessage);
         player->secretmessage = NULL;
     }
 
-    if (*widget->duration_left > 0)
+    if (announce_duration_left > 0)
     {
         ST_AddLine(widget, string);
         if (author_string[0])
         {
             ST_AddLine(widget, author_string);
         }
-        *widget->duration_left -= 1;
+        --announce_duration_left;
     }
     else
     {

--- a/src/st_widgets.c
+++ b/src/st_widgets.c
@@ -84,6 +84,7 @@ static void SetLine(sbe_widget_t *widget, const char *string)
 }
 
 static char message_string[HU_MAXLINELENGTH];
+static int message_duration_left;
 
 static boolean message_review;
 
@@ -95,25 +96,26 @@ static void UpdateMessage(sbe_widget_t *widget, player_t *player)
     static boolean overwrite = true;
     static boolean messages_enabled = true;
 
+    widget->duration_left = &message_duration_left;
     if (messages_enabled)
     {
         if (message_string[0])
         {
-            widget->duration_left = widget->duration;
+            *widget->duration_left = widget->duration;
             M_StringCopy(string, message_string, sizeof(string));
             message_string[0] = '\0';
             overwrite = false;
         }
         else if (player->message && player->message[0] && overwrite)
         {
-            widget->duration_left = widget->duration;
+            *widget->duration_left = widget->duration;
             M_StringCopy(string, player->message, sizeof(string));
             player->message[0] = '\0';
         }
         else if (message_review)
         {
             message_review = false;
-            widget->duration_left = widget->duration;
+            *widget->duration_left = widget->duration;
         }
     }
 
@@ -122,18 +124,19 @@ static void UpdateMessage(sbe_widget_t *widget, player_t *player)
         messages_enabled = show_messages;
     }
 
-    if (widget->duration_left == 0)
+    if (*widget->duration_left == 0)
     {
         overwrite = true;
     }
     else
     {
         ST_AddLine(widget, string);
-        --widget->duration_left;
+        *widget->duration_left -= 1;
     }
 }
 
 static char announce_string[HU_MAXLINELENGTH], author_string[HU_MAXLINELENGTH];
+static int announce_duration_left;
 
 static void UpdateAnnounceMessage(sbe_widget_t *widget, player_t *player)
 {
@@ -154,10 +157,11 @@ static void UpdateAnnounceMessage(sbe_widget_t *widget, player_t *player)
 
     static char string[HU_MAXLINELENGTH];
 
+    widget->duration_left = &announce_duration_left;
     if (announce_string[0])
     {
         state = announce_map;
-        widget->duration_left = widget->duration;
+        *widget->duration_left = widget->duration;
         M_StringCopy(string, announce_string, sizeof(string));
         announce_string[0] = '\0';
     }
@@ -165,20 +169,20 @@ static void UpdateAnnounceMessage(sbe_widget_t *widget, player_t *player)
     {
         author_string[0] = '\0';
         state = announce_secret;
-        widget->duration_left = widget->duration;
+        *widget->duration_left = widget->duration;
         M_snprintf(string, sizeof(string), GOLD_S "%s" ORIG_S,
             player->secretmessage);
         player->secretmessage = NULL;
     }
 
-    if (widget->duration_left > 0)
+    if (*widget->duration_left > 0)
     {
         ST_AddLine(widget, string);
         if (author_string[0])
         {
             ST_AddLine(widget, author_string);
         }
-        --widget->duration_left;
+        *widget->duration_left -= 1;
     }
     else
     {


### PR DESCRIPTION
This fixes the second part of #2651