### PR TITLE
delay Automap dimensions recalculation by one tic

### DIFF
--- a/src/am_map.c
+++ b/src/am_map.c
@@ -133,6 +133,8 @@ static int m_zoomin_mouse = M2_ZOOMIN;
 static int m_zoomout_mouse = M2_ZOOMOUT;
 static boolean mousewheelzoom;
 
+static boolean am_refresh_background = false;
+
 // translates between frame-buffer and map distances
 // [FG] fix int overflow that causes map and grid lines to disappear
 #define FTOM(x) ((((int64_t)(x)<<16)*scale_ftom)>>16)
@@ -647,6 +649,8 @@ static void AM_initScreenSize(void)
     }
     else
     {
+        ST_SetSTHeight();
+
         f_x = f_y = 0;
         f_w = video.width;
         if (automapoverlay && scaledviewheight == SCREENHEIGHT)
@@ -893,6 +897,7 @@ boolean AM_Responder
       AM_Start ();
       SwapScale();
       viewactive = false;
+      am_refresh_background = true;
       st_refresh_background = true;
       rc = true;
     }
@@ -951,6 +956,7 @@ boolean AM_Responder
       {
         bigstate = 0;
         viewactive = true;
+        am_refresh_background = true;
         st_refresh_background = true;
         AM_Stop ();
       }
@@ -1009,8 +1015,7 @@ boolean AM_Responder
         default: togglemsg("%s", DEH_String(AMSTR_OVERLAYOFF)); break;
       }
 
-      AM_initScreenSize();
-      AM_activateNewScale();
+      am_refresh_background = true;
       st_refresh_background = true;
     }
     else if (M_InputActivated(input_map_rotate))
@@ -1174,6 +1179,14 @@ void AM_Ticker (void)
 
   prev_m_x = m_x;
   prev_m_y = m_y;
+
+  if (am_refresh_background)
+  {
+      AM_initScreenSize();
+      AM_activateNewScale();
+
+      am_refresh_background = false;
+  }
 }
 
 

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -2094,9 +2094,9 @@ static void DrawCenteredMessage(void)
     }
 }
 
-static void DrawStatusBar(void)
+void ST_SetSTHeight(void)
 {
-    if (!statusbar->fullscreenrender)
+    if (statusbar && !statusbar->fullscreenrender)
     {
         st_height = CLAMP(statusbar->height, 0, SCREENHEIGHT) & ~1;
     }
@@ -2104,6 +2104,11 @@ static void DrawStatusBar(void)
     {
         st_height = 0;
     }
+}
+
+static void DrawStatusBar(void)
+{
+    ST_SetSTHeight();
 
     if (st_height && (screenblocks <= 10 || automap_on))
     {

--- a/src/st_stuff.h
+++ b/src/st_stuff.h
@@ -63,6 +63,7 @@ void ST_ResetPalette(void);
 extern boolean st_refresh_background;
 
 void ST_InitRes(void);
+void ST_SetSTHeight(void);
 
 extern int health_red;    // health amount less than which status is red
 extern int health_yellow; // health amount less than which status is yellow


### PR DESCRIPTION
We need to postpone the recalculation of the Automap dimensions in `AM_initScreenSize()` by one tic. This function uses `st_height` to calculate the height of the Automap window `f_h` and thus the vertical position of the player arrow. However, `st_height` is only updated in `ST_Drawer()` via `DrawStatusBar()` based on the current value of `statusbar->height`. The `statusbar` in turn is only updated in `ST_Ticker()` via `UpdateStatusBar()`. So, we need to let one tic pass to let `ST_Ticker()` update `statusbar` and allow to update the value of `st_height` based on that.

Fixes #2651