### PR TITLE
Mute sounds when unfocused

### DIFF
--- a/src/i_3dsound.c
+++ b/src/i_3dsound.c
@@ -235,7 +235,7 @@ static boolean CalcVolumePriority(double dist, sfxparams_t *params)
 static boolean I_3D_AdjustSoundParams(const mobj_t *listener,
                                       const mobj_t *source, sfxparams_t *params)
 {
-    params->volume = snd_SfxVolume * params->volume_scale / 15;
+    params->volume = cur_SfxVolume * params->volume_scale / 15;
 
     if (params->volume < 1)
     {

--- a/src/i_3dsound.c
+++ b/src/i_3dsound.c
@@ -235,7 +235,7 @@ static boolean CalcVolumePriority(double dist, sfxparams_t *params)
 static boolean I_3D_AdjustSoundParams(const mobj_t *listener,
                                       const mobj_t *source, sfxparams_t *params)
 {
-    params->volume = cur_SfxVolume * params->volume_scale / 15;
+    params->volume = snd_SfxVolume * params->volume_scale / 15;
 
     if (params->volume < 1)
     {

--- a/src/i_3dsound.c
+++ b/src/i_3dsound.c
@@ -235,7 +235,7 @@ static boolean CalcVolumePriority(double dist, sfxparams_t *params)
 static boolean I_3D_AdjustSoundParams(const mobj_t *listener,
                                       const mobj_t *source, sfxparams_t *params)
 {
-    params->volume = cur_SfxVolume * params->volume_scale / 15;
+    params->volume = snd_SfxVolume * params->volume_scale / 15;
 
     if (params->volume < 1)
     {
@@ -335,6 +335,8 @@ const sound_module_t sound_3d_module = {
     I_OAL_StopSound,
     I_OAL_PauseSound,
     I_OAL_ResumeSound,
+    I_OAL_MuteSound,
+    I_OAL_UnmuteSound,
     I_OAL_SoundIsPlaying,
     I_OAL_SoundIsPaused,
     I_OAL_ShutdownSound,

--- a/src/i_mbfsound.c
+++ b/src/i_mbfsound.c
@@ -52,7 +52,7 @@ static boolean I_MBF_AdjustSoundParams(const mobj_t *listener,
     angle_t angle;
 
     // haleyjd 05/29/06: allow per-channel volume scaling
-    params->volume = cur_SfxVolume * params->volume_scale / 15;
+    params->volume = snd_SfxVolume * params->volume_scale / 15;
 
     if (params->volume < 1)
     {

--- a/src/i_mbfsound.c
+++ b/src/i_mbfsound.c
@@ -52,7 +52,7 @@ static boolean I_MBF_AdjustSoundParams(const mobj_t *listener,
     angle_t angle;
 
     // haleyjd 05/29/06: allow per-channel volume scaling
-    params->volume = snd_SfxVolume * params->volume_scale / 15;
+    params->volume = cur_SfxVolume * params->volume_scale / 15;
 
     if (params->volume < 1)
     {

--- a/src/i_mbfsound.c
+++ b/src/i_mbfsound.c
@@ -52,7 +52,7 @@ static boolean I_MBF_AdjustSoundParams(const mobj_t *listener,
     angle_t angle;
 
     // haleyjd 05/29/06: allow per-channel volume scaling
-    params->volume = cur_SfxVolume * params->volume_scale / 15;
+    params->volume = snd_SfxVolume * params->volume_scale / 15;
 
     if (params->volume < 1)
     {
@@ -191,6 +191,8 @@ const sound_module_t sound_mbf_module =
     I_OAL_StopSound,
     I_OAL_PauseSound,
     I_OAL_ResumeSound,
+    I_OAL_MuteSound,
+    I_OAL_UnmuteSound,
     I_OAL_SoundIsPlaying,
     I_OAL_SoundIsPaused,
     I_OAL_ShutdownSound,

--- a/src/i_oalsound.c
+++ b/src/i_oalsound.c
@@ -834,6 +834,8 @@ void I_OAL_ResumeSound(int channel)
     }
 }
 
+static ALfloat listener_gain = 1.0f;
+
 void I_OAL_MuteSound(void)
 {
     if (!oal)
@@ -841,6 +843,7 @@ void I_OAL_MuteSound(void)
         return;
     }
 
+    alGetListenerf(AL_GAIN, &listener_gain);
     alListenerf(AL_GAIN, (ALfloat) 0.0f);
 }
 
@@ -851,7 +854,7 @@ void I_OAL_UnmuteSound(void)
         return;
     }
 
-    alListenerf(AL_GAIN, (ALfloat) 1.0f);
+    alListenerf(AL_GAIN, listener_gain);
 }
 
 boolean I_OAL_SoundIsPlaying(int channel)

--- a/src/i_oalsound.c
+++ b/src/i_oalsound.c
@@ -834,6 +834,26 @@ void I_OAL_ResumeSound(int channel)
     }
 }
 
+void I_OAL_MuteSound(void)
+{
+    if (!oal)
+    {
+        return;
+    }
+
+    alListenerf(AL_GAIN, (ALfloat) 0.0f);
+}
+
+void I_OAL_UnmuteSound(void)
+{
+    if (!oal)
+    {
+        return;
+    }
+
+    alListenerf(AL_GAIN, (ALfloat) 1.0f);
+}
+
 boolean I_OAL_SoundIsPlaying(int channel)
 {
     ALint state;

--- a/src/i_oalsound.h
+++ b/src/i_oalsound.h
@@ -71,6 +71,10 @@ void I_OAL_PauseSound(int channel);
 
 void I_OAL_ResumeSound(int channel);
 
+void I_OAL_MuteSound(void);
+
+void I_OAL_UnmuteSound(void);
+
 boolean I_OAL_SoundIsPlaying(int channel);
 
 boolean I_OAL_SoundIsPaused(int channel);

--- a/src/i_pcsound.c
+++ b/src/i_pcsound.c
@@ -434,13 +434,13 @@ static boolean I_PCS_AdjustSoundParams(const mobj_t *listener,
     // volume calculation
     if (approx_dist < S_CLOSE_DIST)
     {
-        params->volume = snd_SfxVolume;
+        params->volume = cur_SfxVolume;
     }
     else
     {
         // distance effect
         params->volume =
-            snd_SfxVolume * (S_CLIPPING_DIST - approx_dist) / S_ATTENUATOR;
+            cur_SfxVolume * (S_CLIPPING_DIST - approx_dist) / S_ATTENUATOR;
     }
 
     return (params->volume > 0);
@@ -449,7 +449,7 @@ static boolean I_PCS_AdjustSoundParams(const mobj_t *listener,
 static void I_PCS_UpdateSoundParams(int channel, const sfxparams_t *params)
 {
     // adjust PC Speaker volume
-    alSourcef(callback_source, AL_GAIN, (float)snd_SfxVolume / 15);
+    alSourcef(callback_source, AL_GAIN, (float)cur_SfxVolume / 15);
 }
 
 static boolean I_PCS_StartSound(int channel, sfxinfo_t *sfx,

--- a/src/i_pcsound.c
+++ b/src/i_pcsound.c
@@ -434,13 +434,13 @@ static boolean I_PCS_AdjustSoundParams(const mobj_t *listener,
     // volume calculation
     if (approx_dist < S_CLOSE_DIST)
     {
-        params->volume = cur_SfxVolume;
+        params->volume = snd_SfxVolume;
     }
     else
     {
         // distance effect
         params->volume =
-            cur_SfxVolume * (S_CLIPPING_DIST - approx_dist) / S_ATTENUATOR;
+            snd_SfxVolume * (S_CLIPPING_DIST - approx_dist) / S_ATTENUATOR;
     }
 
     return (params->volume > 0);
@@ -449,7 +449,7 @@ static boolean I_PCS_AdjustSoundParams(const mobj_t *listener,
 static void I_PCS_UpdateSoundParams(int channel, const sfxparams_t *params)
 {
     // adjust PC Speaker volume
-    alSourcef(callback_source, AL_GAIN, (float)cur_SfxVolume / 15);
+    alSourcef(callback_source, AL_GAIN, (float)snd_SfxVolume / 15);
 }
 
 static boolean I_PCS_StartSound(int channel, sfxinfo_t *sfx,

--- a/src/i_pcsound.c
+++ b/src/i_pcsound.c
@@ -434,13 +434,13 @@ static boolean I_PCS_AdjustSoundParams(const mobj_t *listener,
     // volume calculation
     if (approx_dist < S_CLOSE_DIST)
     {
-        params->volume = cur_SfxVolume;
+        params->volume = snd_SfxVolume;
     }
     else
     {
         // distance effect
         params->volume =
-            cur_SfxVolume * (S_CLIPPING_DIST - approx_dist) / S_ATTENUATOR;
+            snd_SfxVolume * (S_CLIPPING_DIST - approx_dist) / S_ATTENUATOR;
     }
 
     return (params->volume > 0);
@@ -449,7 +449,7 @@ static boolean I_PCS_AdjustSoundParams(const mobj_t *listener,
 static void I_PCS_UpdateSoundParams(int channel, const sfxparams_t *params)
 {
     // adjust PC Speaker volume
-    alSourcef(callback_source, AL_GAIN, (float)cur_SfxVolume / 15);
+    alSourcef(callback_source, AL_GAIN, (float)snd_SfxVolume / 15);
 }
 
 static boolean I_PCS_StartSound(int channel, sfxinfo_t *sfx,
@@ -522,6 +522,8 @@ const sound_module_t sound_pcs_module =
     I_PCS_StopSound,
     NULL,
     NULL,
+    I_OAL_MuteSound,
+    I_OAL_UnmuteSound,
     I_PCS_SoundIsPlaying,
     NULL,
     I_PCS_ShutdownSound,

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -88,8 +88,6 @@ boolean snd_limiter;
 int snd_channels_per_sfx;
 int snd_volume_per_sfx;
 
-int cur_SfxVolume;
-
 //
 // StopChannel
 //
@@ -249,7 +247,7 @@ void I_SetSfxVolume(int volume)
     //  to the state variable used in
     //  the mixing.
 
-    cur_SfxVolume = volume;
+    snd_SfxVolume = volume;
 }
 
 // jff 1/21/98 moved music volume down into MUSIC API with the rest

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -88,6 +88,8 @@ boolean snd_limiter;
 int snd_channels_per_sfx;
 int snd_volume_per_sfx;
 
+int cur_SfxVolume;
+
 //
 // StopChannel
 //
@@ -247,7 +249,7 @@ void I_SetSfxVolume(int volume)
     //  to the state variable used in
     //  the mixing.
 
-    snd_SfxVolume = volume;
+    cur_SfxVolume = volume;
 }
 
 // jff 1/21/98 moved music volume down into MUSIC API with the rest

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -88,8 +88,6 @@ boolean snd_limiter;
 int snd_channels_per_sfx;
 int snd_volume_per_sfx;
 
-int cur_SfxVolume;
-
 //
 // StopChannel
 //
@@ -249,7 +247,7 @@ void I_SetSfxVolume(int volume)
     //  to the state variable used in
     //  the mixing.
 
-    cur_SfxVolume = volume;
+    snd_SfxVolume = volume;
 }
 
 // jff 1/21/98 moved music volume down into MUSIC API with the rest
@@ -399,6 +397,26 @@ void I_ResumeSound(int channel)
     {
         sound_module->ResumeSound(channel);
     }
+}
+
+void I_MuteSound(void)
+{
+    if (!snd_init || !sound_module->MuteSound)
+    {
+        return;
+    }
+
+    sound_module->MuteSound();
+}
+
+void I_UnmuteSound(void)
+{
+    if (!snd_init || !sound_module->UnmuteSound)
+    {
+        return;
+    }
+
+    sound_module->UnmuteSound();
 }
 
 //

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -73,8 +73,6 @@ extern boolean snd_limiter;
 extern int snd_channels_per_sfx;
 extern int snd_volume_per_sfx;
 
-extern int cur_SfxVolume;
-
 typedef struct sound_module_s
 {
     boolean (*InitSound)(void);
@@ -198,7 +196,6 @@ void I_SetMidiPlayer(void);
 
 // Volume.
 void I_SetMusicVolume(int volume);
-void I_SetSfxVolume(int volume);
 
 // PAUSE game handling.
 void I_PauseSong(void *handle);

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -73,6 +73,8 @@ extern boolean snd_limiter;
 extern int snd_channels_per_sfx;
 extern int snd_volume_per_sfx;
 
+extern int cur_SfxVolume;
+
 typedef struct sound_module_s
 {
     boolean (*InitSound)(void);
@@ -196,6 +198,7 @@ void I_SetMidiPlayer(void);
 
 // Volume.
 void I_SetMusicVolume(int volume);
+void I_SetSfxVolume(int volume);
 
 // PAUSE game handling.
 void I_PauseSong(void *handle);

--- a/src/i_sound.h
+++ b/src/i_sound.h
@@ -73,8 +73,6 @@ extern boolean snd_limiter;
 extern int snd_channels_per_sfx;
 extern int snd_volume_per_sfx;
 
-extern int cur_SfxVolume;
-
 typedef struct sound_module_s
 {
     boolean (*InitSound)(void);
@@ -93,6 +91,8 @@ typedef struct sound_module_s
     void (*StopSound)(int channel);
     void (*PauseSound)(int channel);
     void (*ResumeSound)(int channel);
+    void (*MuteSound)(void);
+    void (*UnmuteSound)(void);
     boolean (*SoundIsPlaying)(int channel);
     boolean (*SoundIsPaused)(int channel);
     void (*ShutdownSound)(void);
@@ -133,6 +133,9 @@ void I_StopSound(int handle);
 
 void I_PauseSound(int handle);
 void I_ResumeSound(int handle);
+
+void I_MuteSound(void);
+void I_UnmuteSound(void);
 
 // Called by S_*() functions
 //  to see if a channel is still playing.
@@ -198,7 +201,6 @@ void I_SetMidiPlayer(void);
 
 // Volume.
 void I_SetMusicVolume(int volume);
-void I_SetSfxVolume(int volume);
 
 // PAUSE game handling.
 void I_PauseSong(void *handle);

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -342,7 +342,7 @@ static void HandleWindowEvent(SDL_WindowEvent *event)
             I_UpdatePriority(true);
             if (mute_unfocused)
             {
-                S_ResumeSound();
+                S_UnmuteSound();
                 S_ResumeMusic();
             }
             break;
@@ -352,7 +352,7 @@ static void HandleWindowEvent(SDL_WindowEvent *event)
             I_UpdatePriority(false);
             if (mute_unfocused)
             {
-                S_PauseSound();
+                S_MuteSound();
                 S_PauseMusic();
             }
             break;

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -809,6 +809,31 @@ void S_ResumeSound(void)
     I_ProcessSoundUpdates();
 }
 
+void S_MuteSound(void)
+{
+    if (nosfxparm)
+    {
+        return;
+    }
+
+    for (int cnum = 0; cnum < snd_channels; cnum++)
+    {
+        S_StopChannel(cnum);
+    }
+
+    I_SetSfxVolume(0);
+}
+
+void S_UnmuteSound(void)
+{
+    if (nosfxparm)
+    {
+        return;
+    }
+
+    I_SetSfxVolume(snd_SfxVolume);
+}
+
 //
 // Stop and resume music, during game PAUSE.
 //
@@ -943,6 +968,7 @@ void S_SetSfxVolume(int volume)
     }
 #endif
 
+    I_SetSfxVolume(volume);
     snd_SfxVolume = volume;
 }
 

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -430,6 +430,8 @@ static float GetPitch(pitchrange_t pitch_range)
     }
 }
 
+static boolean mute_sfx_unfocused;
+
 #define StartSound(o, i, p, r) StartSoundEx((o), (i), (p), (r), NULL)
 
 static boolean StartSoundEx(const mobj_t *origin, int sfx_id,
@@ -441,7 +443,7 @@ static boolean StartSoundEx(const mobj_t *origin, int sfx_id,
     sfxinfo_t *sfx;
 
     // jff 1/22/98 return if sound is not enabled
-    if (nosfxparm)
+    if (nosfxparm || mute_sfx_unfocused)
     {
         return false;
     }
@@ -821,7 +823,7 @@ void S_MuteSound(void)
         S_StopChannel(cnum);
     }
 
-    I_SetSfxVolume(0);
+    mute_sfx_unfocused = true;
 }
 
 void S_UnmuteSound(void)
@@ -831,7 +833,7 @@ void S_UnmuteSound(void)
         return;
     }
 
-    I_SetSfxVolume(snd_SfxVolume);
+    mute_sfx_unfocused = false;
 }
 
 //
@@ -968,7 +970,6 @@ void S_SetSfxVolume(int volume)
     }
 #endif
 
-    I_SetSfxVolume(volume);
     snd_SfxVolume = volume;
 }
 

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -816,11 +816,6 @@ void S_MuteSound(void)
         return;
     }
 
-    for (int cnum = 0; cnum < snd_channels; cnum++)
-    {
-        S_StopChannel(cnum);
-    }
-
     I_SetSfxVolume(0);
 }
 

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -430,8 +430,6 @@ static float GetPitch(pitchrange_t pitch_range)
     }
 }
 
-static boolean mute_sfx_unfocused;
-
 #define StartSound(o, i, p, r) StartSoundEx((o), (i), (p), (r), NULL)
 
 static boolean StartSoundEx(const mobj_t *origin, int sfx_id,
@@ -443,7 +441,7 @@ static boolean StartSoundEx(const mobj_t *origin, int sfx_id,
     sfxinfo_t *sfx;
 
     // jff 1/22/98 return if sound is not enabled
-    if (nosfxparm || mute_sfx_unfocused)
+    if (nosfxparm)
     {
         return false;
     }
@@ -823,7 +821,7 @@ void S_MuteSound(void)
         S_StopChannel(cnum);
     }
 
-    mute_sfx_unfocused = true;
+    I_SetSfxVolume(0);
 }
 
 void S_UnmuteSound(void)
@@ -833,7 +831,7 @@ void S_UnmuteSound(void)
         return;
     }
 
-    mute_sfx_unfocused = false;
+    I_SetSfxVolume(snd_SfxVolume);
 }
 
 //
@@ -970,6 +968,7 @@ void S_SetSfxVolume(int volume)
     }
 #endif
 
+    I_SetSfxVolume(volume);
     snd_SfxVolume = volume;
 }
 

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -816,7 +816,7 @@ void S_MuteSound(void)
         return;
     }
 
-    I_SetSfxVolume(0);
+    I_MuteSound();
 }
 
 void S_UnmuteSound(void)
@@ -826,7 +826,7 @@ void S_UnmuteSound(void)
         return;
     }
 
-    I_SetSfxVolume(snd_SfxVolume);
+    I_UnmuteSound();
 }
 
 //
@@ -963,7 +963,6 @@ void S_SetSfxVolume(int volume)
     }
 #endif
 
-    I_SetSfxVolume(volume);
     snd_SfxVolume = volume;
 }
 

--- a/src/s_sound.h
+++ b/src/s_sound.h
@@ -112,6 +112,9 @@ void S_StopMusic(void);
 void S_PauseSound(void);
 void S_ResumeSound(void);
 
+void S_MuteSound(void);
+void S_UnmuteSound(void);
+
 // Stop and resume music, during game PAUSE.
 void S_PauseMusic(void);
 void S_ResumeMusic(void);


### PR DESCRIPTION
We effectively stop sounds and don't allow new ones to play when the game window lost focus.

Fixes #2666 