### PR TITLE
mouse menu: take pixel scaling into account

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -601,8 +601,10 @@ static void UpdateMouseMenu(void)
         ev.data1.i = EV_RESIZE_VIEWPORT;
     }
 
-    x = clampf((x - rect.x) / rect.w, 0.0f, 1.0f) * video.unscaledw;
-    y = clampf((y - rect.y) / rect.h, 0.0f, 1.0f) * SCREENHEIGHT;
+    const float scale = SDL_GetWindowPixelDensity(screen);
+
+    x = clampf((x * scale - rect.x) / rect.w, 0.0f, 1.0f) * video.unscaledw;
+    y = clampf((y * scale - rect.y) / rect.h, 0.0f, 1.0f) * SCREENHEIGHT;
 
     static float oldx, oldy;
     if (x != oldx || y != oldy)


### PR DESCRIPTION
Works on Linux with both X11 and Wayland backends. Formerly, the mouse cursor and the highlighted menu item would not match when using a screen pixel scaling of 125%.