### PR TITLE
clear out `thinkers_arena` in `P_SetupLevel()`

### DIFF
--- a/src/m_arena.c
+++ b/src/m_arena.c
@@ -184,6 +184,13 @@ void M_ArenaClear(arena_t *arena)
     arena->hashmap = hashmap_init(1024, sizeof(hashmap_value_t));
 }
 
+void M_ArenaClearZero(arena_t *arena)
+{
+    M_ArenaClear(arena);
+
+    memset(arena->beg, 0, arena->end - arena->beg);
+}
+
 struct arena_copy_s
 {
     char *buffer;

--- a/src/m_arena.h
+++ b/src/m_arena.h
@@ -38,6 +38,7 @@ void arena_free(arena_t *arena, void *ptr);
 
 arena_t *M_ArenaInit(int reserve, int commit);
 void M_ArenaClear(arena_t *arena);
+void M_ArenaClearZero(arena_t *arena);
 
 typedef struct arena_copy_s arena_copy_t;
 

--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -1092,7 +1092,7 @@ void P_SetupLevel(int episode, int map, int playermask, skill_t skill)
 
   Z_FreeTag(PU_LEVEL);
   M_ArenaClear(world_arena);
-  M_ArenaClear(thinkers_arena);
+  M_ArenaClearZero(thinkers_arena);
   M_ArenaClear(msecnodes_arena);
 
   Z_FreeTag(PU_CACHE);


### PR DESCRIPTION
It happens, e.g. all over the place in `p_lights.c`, that we allocate a new thinker and call `P_AddThinker()` for it, before assigning a `thinker.function` to it. In `P_AddThinker()`, however, we call `P_UpdateThinker()` which assigns the thinker to a "thinker class" depending on its thinker function.

Now, if we leave content of the previous map in the `thinkers_arena`, it may happen that there are remains of a previous thinker still around and thus checks based on the thinker pointer will lead to faulty results.

Happened to me on gd.wad MAP09->MAP10.