### PR TITLE
Replace broken demotest link

### DIFF
--- a/demotest/config.toml
+++ b/demotest/config.toml
@@ -2,7 +2,7 @@
 demo = "judgep1m3018.lmp"
 demo_url = "https://dsdarchive.com/files/demos/judgment/65491/judgep1m3018.zip"
 wad = "Judgment.wad"
-wad_url = "https://www.quaddicted.com/files/idgames/levels/doom2/Ports/megawads/judgment.zip"
+wad_url = "https://dsdarchive.com/files/wads/doom2/3724/judgment.zip"
 levelstat = "judgep1.txt"
 
 [[demo]]


### PR DESCRIPTION
The link for the Judgment WAD in the demo test became broken at some point -- [Quaddicted's idgames mirror shut down](https://discuss.quaddicted.com/t/dropping-the-idgames-doom-and-ftp-3dportal-net-duke-sw-mirrors/8223) -- which caused issues with Nugget's CI, but not with Woof's, presumably because the WAD is cached for the latter. Anyways, I replaced the link with the one available in [the DSDArchive page for Judgment](https://dsdarchive.com/wads/judgment).