### PR TITLE
Support for translucent translated sprites

### DIFF
--- a/src/r_draw.c
+++ b/src/r_draw.c
@@ -900,6 +900,91 @@ void R_InitTranslationTables(void)
     }
 }
 
+void R_DrawTRTLColumn(void)
+{
+    int count = dc_yh - dc_yl + 1;
+    if (count <= 0)
+    {
+        return;
+    }
+
+#ifdef RANGECHECK
+    if ((unsigned)dc_x >= video.width || dc_yl < 0 || dc_yh >= video.height)
+    {
+        I_Error("%i to %i at %i", dc_yl, dc_yh, dc_x);
+    }
+#endif
+
+    pixel_t *dest = ylookup[dc_yl] + columnofs[dc_x];
+    const fixed_t fracstep = dc_iscale;
+    fixed_t frac = dc_texturemid + (dc_yl - centery) * fracstep;
+
+    const byte *source = dc_source;
+    const byte *translation = dc_translation;
+    const lighttable_t *const *colormap = dc_colormap;
+    const byte *brightmap = dc_brightmap;
+    int heightmask = dc_texheight - 1;
+
+    byte src;
+
+    #define SRCPIXEL \
+      tranmap[(*dest << 8) + colormap[brightmap[src]][translation[src]]]
+
+    if (dc_texheight & heightmask)
+    {
+        heightmask++;
+        heightmask <<= 16;
+        if (frac < 0)
+        {
+            while ((frac += heightmask) < 0)
+                ;
+        }
+        else
+        {
+            while (frac >= heightmask)
+            {
+                frac -= heightmask;
+            }
+        }
+
+        do
+        {
+            src = source[frac >> 16];
+            *dest = SRCPIXEL;
+            dest += linesize;
+            if ((frac += fracstep) >= heightmask)
+            {
+                frac -= heightmask;
+            }
+            if (frac < 0)
+            {
+                frac += heightmask;
+            }
+        } while (--count);
+    }
+    else
+    {
+        while ((count -= 2) >= 0)
+        {
+            src = source[(frac >> FRACBITS) & heightmask];
+            *dest = SRCPIXEL;
+            dest += linesize;
+            frac += fracstep;
+            src = source[(frac >> FRACBITS) & heightmask];
+            *dest = SRCPIXEL;
+            dest += linesize;
+            frac += fracstep;
+        }
+        if (count & 1)
+        {
+            src = source[(frac >> FRACBITS) & heightmask];
+            *dest = SRCPIXEL;
+        }
+    }
+
+    #undef SRCPIXEL
+}
+
 //
 // R_DrawSpan 
 // With DOOM style restrictions on view orientation,

--- a/src/r_draw.h
+++ b/src/r_draw.h
@@ -66,6 +66,7 @@ void R_DrawSkyColumnMasked(void);
 //  Green/Red/Blue/Indigo shirts.
 
 void R_DrawTranslatedColumn(void);
+void R_DrawTRTLColumn(void);
 
 extern const lighttable_t *ds_colormap[2];
 

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -436,30 +436,41 @@ void R_DrawVisSprite(vissprite_t *vis, int x1, int x2)
   // mixed with translucent/non-translucent 2s normals
 
   if (!dc_colormap[0])   // NULL colormap = shadow draw
+  {
     colfunc = R_DrawFuzzColumn;    // killough 3/14/98
+  }
   else
+  {
     // [FG] colored blood and gibs
     if (vis->mobjflags_extra & MFX_COLOREDBLOOD)
-      {
-        colfunc = R_DrawTranslatedColumn;
-        dc_translation = red2col[vis->color];
-      }
-  else
-    if (vis->mobjflags & MF_TRANSLATION)
-      {
-        colfunc = R_DrawTranslatedColumn;
-        dc_translation = translationtables - 256 +
-          ((vis->mobjflags & MF_TRANSLATION) >> (MF_TRANSSHIFT-8) );
-      }
+    {
+      dc_translation = red2col[vis->color];
+    }
+    else if (vis->mobjflags & MF_TRANSLATION)
+    {
+      dc_translation = translationtables - 256 +
+        ((vis->mobjflags & MF_TRANSLATION) >> (MF_TRANSSHIFT-8) );
+    }
     else
-      if (translucency && !(strictmode && demo_compatibility)
-          && vis->tranmap) // phares // ID24
-        {
-          colfunc = R_DrawTLColumn; // killough 4/11/98
-          tranmap = vis->tranmap;   // ID24
-        }
-      else
-        colfunc = R_DrawColumn;         // killough 3/14/98, 4/11/98
+    {
+      dc_translation = NULL;
+    }
+
+    if (translucency && !(strictmode && demo_compatibility)
+        && vis->tranmap) // phares // ID24
+    {
+      tranmap = vis->tranmap;   // ID24
+    }
+    else
+    {
+      tranmap = NULL;
+    }
+
+    colfunc = (dc_translation && tranmap) ? R_DrawTRTLColumn
+            : (dc_translation)            ? R_DrawTranslatedColumn
+            : (tranmap)                   ? R_DrawTLColumn
+            :                               R_DrawColumn;
+  }
 
   dc_iscale = abs(vis->xiscale);
   dc_texturemid = vis->texturemid;


### PR DESCRIPTION
In the current code for drawing sprites, translation and translucency are mutually exclusive, with the former taking precedence over the latter. Notably, this makes translucent colored blood impossible; this is the specific case that was reported to me.

This PR fixes that, adding a column-drawing function which applies translation of either type (colored blood or multiplayer player coloring) and translucency simultaneously. The two translation types are still mutually exclusive with each other, and although the code for that would be trivial, I omitted it because I consider it a very unlikely scenario.