### PR TITLE
Prevent creation of trivial vissprites with negative width

### DIFF
--- a/src/r_things.c
+++ b/src/r_things.c
@@ -625,16 +625,16 @@ static void R_ProjectSprite(mobj_t* thing, int lightlevel_override)
   if (x1 > viewwidth)
     return;
 
+  // [Alaux] Calculate this early
+  // to check if the right edge of the sprite goes past the left one
+  const int vx1 = x1 < 0 ? 0 : x1;
+
   tx +=  spritewidth[lump];
   x2 = ((centerxfrac + FixedMul64(tx,xscale)) >> FRACBITS) - 1;
 
     // off the left side
-  if (x2 < 0)
-    return;
-
-  // [Alaux] x2 can sometimes be less than x1,
-  // creating a vissprite that's ultimately not drawn
-  if (x2 < x1)
+    // [Alaux] Or past the left edge of the sprite
+  if (x2 < vx1)
     return;
 
   gzt = interpz + spritetopoffset[lump];
@@ -681,7 +681,7 @@ static void R_ProjectSprite(mobj_t* thing, int lightlevel_override)
   vis->gz = interpz;
   vis->gzt = gzt;                          // killough 3/27/98
   vis->texturemid = gzt - viewz;
-  vis->x1 = x1 < 0 ? 0 : x1;
+  vis->x1 = vx1;
   vis->x2 = x2 >= viewwidth ? viewwidth-1 : x2;
   iscale = FixedDiv(FRACUNIT, xscale);
   vis->color = thing->bloodcolor;

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -632,6 +632,11 @@ static void R_ProjectSprite(mobj_t* thing, int lightlevel_override)
   if (x2 < 0)
     return;
 
+  // [Alaux] x2 can sometimes be less than x1,
+  // creating a vissprite that's ultimately not drawn
+  if (x2 < x1)
+    return;
+
   gzt = interpz + spritetopoffset[lump];
 
   // killough 4/9/98: clip things which are out of view due to height


### PR DESCRIPTION
It appears that, in `R_ProjectSprite()`, sprites very far away from the camera can somehow yield `x2 < x1`, but this case isn't checked and the vissprites are created anyways.

Later, the loop in `R_DrawVisSprite()` is:

https://github.com/fabiangreffrath/woof/blob/6b95355478b6c674400c3a12ff4a42e3af5365c8/src/r_things.c#L481

With `x2 < x1`, the loop doesn't run at all, so nothing is drawn. However, the mere creation and/or existence of those vissprites can affect performance.

This becomes apparent in MAP07 of [this WAD](https://www.doomworld.com/forum/topic/158448-mbf21-dsdhacked-grey-cat-released-rc-1/) (save attached below); the exit area has rain, comprised of individual drops with tiny sprites, and less of them are ultimately drawn the further away they are from the camera, but the vissprites for them still exist.

So, I added a check for `x2 < x1`; at the spot in that save, running at 300% resolution scale, metrics went from 9344 sprites and 14 FPS to 2805 sprites and 25 FPS, with no apparent visual difference when comparing screenshots.

However, this additional check also incurs a little FPS penalty in Nuts, which has a comparable number of sprites on screen, but most of them aren't small and/or far away enough to not appear on screen (only ~40 of them are omitted at 100% resolution scale, and none are omitted at any higher resolutions). I suggest you try this and see if it's worth it.

[woofsav0.zip](https://github.com/user-attachments/files/28578019/woofsav0.zip)