### PR TITLE
Use compgen for gameversion, complevel, and setmem

### DIFF
--- a/man/bash-completion/woof.template
+++ b/man/bash-completion/woof.template
@@ -31,13 +31,13 @@ _@PROJECT_SHORTNAME@()
 
     case $prev in
         -gameversion)
-            COMPREPLY=(1.9 ultimate final hacx chex)
+            COMPREPLY=($(compgen -W "1.9 ultimate final hacx chex" -- "$cur"))
             ;;
         -complevel)
-            COMPREPLY=(vanilla boom mbf mbf21)
+            COMPREPLY=($(compgen -W "vanilla boom mbf mbf21" -- "$cur"))
             ;;
         -setmem)
-            COMPREPLY=(dos622 dos71 dosbox)
+            COMPREPLY=($(compgen -W "dos622 dos71 dosbox" -- "$cur"))
             ;;
     esac
 


### PR DESCRIPTION
This slightly improves the bash completion experience for these 3 options. Currently, even with part of the word typed, COMPREPLY will always be the fully array, and so tab will only ever display the list instead of completing what's being typed.