### PR TITLE
cap HUD font's maxwidth and maxheight at reasonable values

### DIFF
--- a/src/st_sbardef.c
+++ b/src/st_sbardef.c
@@ -475,6 +475,14 @@ static boolean ParseNumberFont(json_t *json, numberfont_t *out)
     return true;
 }
 
+// Some PWADs (e.g. RUST) replace certain HUD font characters with
+// nearly-TITLEPIC-sized graphics with story text.
+//
+// A regular character should not be wider than 8 spaces (32 px)
+#define MAXWIDTH (8 * SPACEWIDTH)
+// A regular character should not be taller than the status bar (32 px)
+#define MAXHEIGHT (ST_HEIGHT)
+
 static void LoadHUDFont(hudfont_t *out)
 {
     char lump[9] = {0};
@@ -494,13 +502,13 @@ static void LoadHUDFont(hudfont_t *out)
         out->characters[i] = V_CachePatchNum(found, PU_STATIC);
 
         const short width = SHORT(out->characters[i]->width);
-        if (width <= 8 * SPACEWIDTH)
+        if (width <= MAXWIDTH)
         {
             maxwidth = MAX(maxwidth, width);
         }
 
         const short height = SHORT(out->characters[i]->height);
-        if (height <= ST_HEIGHT)
+        if (height <= MAXHEIGHT)
         {
             maxheight = MAX(maxheight, height);
         }

--- a/src/st_sbardef.c
+++ b/src/st_sbardef.c
@@ -492,8 +492,18 @@ static void LoadHUDFont(hudfont_t *out)
             continue;
         }
         out->characters[i] = V_CachePatchNum(found, PU_STATIC);
-        maxwidth = MAX(maxwidth, SHORT(out->characters[i]->width));
-        maxheight = MAX(maxheight, SHORT(out->characters[i]->height));
+
+        const short width = SHORT(out->characters[i]->width);
+        if (width <= 8 * SPACEWIDTH)
+        {
+            maxwidth = MAX(maxwidth, width);
+        }
+
+        const short height = SHORT(out->characters[i]->height);
+        if (height <= ST_HEIGHT)
+        {
+            maxheight = MAX(maxheight, height);
+        }
     }
 
     out->maxheight = maxheight;


### PR DESCRIPTION
That is <= 32 px for maxwidth and maxheight.

Fixes #2701