### PR TITLE
Refactor `P_ChangeSwitchTexture`

### DIFF
--- a/src/am_map.c
+++ b/src/am_map.c
@@ -1907,15 +1907,7 @@ static void AM_drawWalls(void)
       }
       if //jff 4/23/98 add exit lines to automap
       (
-        cur_mapcolor_exit &&
-        (
-          lines[i].special==11 ||
-          lines[i].special==52 ||
-          lines[i].special==197 ||
-          lines[i].special==51  ||
-          lines[i].special==124 ||
-          lines[i].special==198
-        )
+        cur_mapcolor_exit && P_IsExitLine(&lines[i])
       )
       {
         AM_drawMline(&l, keyed_door_flash ? cur_mapcolor_grid : cur_mapcolor_exit); // exit line

--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -421,8 +421,7 @@ void P_LinedefInit(line_t * const linedef)
   }
 
   /* calculate sound origin of line to be its midpoint */
-  //e6y: fix sound origin for large levels
-  // no need for comp_sound test, these are only used when comp_sound = 0
+  // Andrey Budko: fix sound origin for large levels
   linedef->soundorg.x = linedef->bbox[BOXLEFT] / 2 + linedef->bbox[BOXRIGHT] / 2;
   linedef->soundorg.y = linedef->bbox[BOXTOP] / 2 + linedef->bbox[BOXBOTTOM] / 2;
 }

--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -419,6 +419,12 @@ void P_LinedefInit(line_t * const linedef)
     linedef->bbox[BOXBOTTOM] = v2.y;
     linedef->bbox[BOXTOP] = v1.y;
   }
+
+  /* calculate sound origin of line to be its midpoint */
+  //e6y: fix sound origin for large levels
+  // no need for comp_sound test, these are only used when comp_sound = 0
+  linedef->soundorg.x = linedef->bbox[BOXLEFT] / 2 + linedef->bbox[BOXRIGHT] / 2;
+  linedef->soundorg.y = linedef->bbox[BOXTOP] / 2 + linedef->bbox[BOXBOTTOM] / 2;
 }
 
 // killough 4/4/98: delay using sidedefs until they are loaded

--- a/src/p_spec.c
+++ b/src/p_spec.c
@@ -1056,6 +1056,15 @@ boolean P_IsDeathExit(sector_t *sector)
   return false;
 }
 
+boolean P_IsExitLine(line_t * line)
+{
+  int special = line->special;
+
+  return special == 11  || special == 51 ||
+         special == 52  || special == 124 ||
+         special == 197 || special == 198;
+}
+
 //
 // P_IsSecret()
 //

--- a/src/p_spec.c
+++ b/src/p_spec.c
@@ -1062,7 +1062,10 @@ boolean P_IsExitLine(line_t * line)
 
   return special == 11  || special == 51 ||
          special == 52  || special == 124 ||
-         special == 197 || special == 198;
+         special == 197 || special == 198 ||
+         special == 2069 || special == 2070 ||
+         special == 2071 || special == 2072 ||
+         special == 2073 || special == 2074;
 }
 
 //
@@ -2620,7 +2623,7 @@ void P_UpdateSpecials (void)
                   buttonlist[i].btexture;
                 break;
               }
-            S_StartSound((mobj_t *)&buttonlist[i].soundorg,sfx_swtchn);
+            S_StartSound((mobj_t *)&buttonlist[i].line->soundorg, sfx_swtchn);
             memset(&buttonlist[i],0,sizeof(button_t));
           }
       }

--- a/src/p_spec.h
+++ b/src/p_spec.h
@@ -534,7 +534,6 @@ typedef struct
   bwhere_e where;
   int   btexture;
   int   btimer;
-  struct degenmobj_s *soundorg;
 } button_t;
 
 void P_StartButton(struct line_s *line, bwhere_e w, int texture, int time);

--- a/src/p_spec.h
+++ b/src/p_spec.h
@@ -534,7 +534,7 @@ typedef struct
   bwhere_e where;
   int   btexture;
   int   btimer;
-  struct mobj_s *soundorg;
+  struct degenmobj_s *soundorg;
 } button_t;
 
 void P_StartButton(struct line_s *line, bwhere_e w, int texture, int time);
@@ -849,6 +849,8 @@ boolean P_CanUnlockGenDoor(struct line_s *line, struct player_s *player);
 int P_SectorActive(special_e t, struct sector_s *s);
 
 boolean P_IsDeathExit(struct sector_s *sec);
+
+boolean P_IsExitLine(struct line_s * line);
 
 boolean P_IsSecret(struct sector_s *sec);
 

--- a/src/p_switch.c
+++ b/src/p_switch.c
@@ -143,7 +143,7 @@ void P_StartButton
       buttonlist[i].where = w;
       buttonlist[i].btexture = texture;
       buttonlist[i].btimer = time;
-      buttonlist[i].soundorg = (mobj_t *)&line->frontsector->soundorg;
+      buttonlist[i].soundorg = &line->frontsector->soundorg;
       return;
     }
     
@@ -160,70 +160,73 @@ void P_StartButton
 //
 // No return value
 //
-void P_ChangeSwitchTexture
-( line_t*       line,
-  int           useAgain )
+void P_ChangeSwitchTexture(line_t *line, int useAgain)
 {
-  int     texTop;
-  int     texMid;
-  int     texBot;
-  int     i;
-  int     sound;
+    /* Rearranged a bit to avoid too much code duplication */
+    sfxenum_t sound = P_IsExitLine(line) ? sfx_swtchx : sfx_swtchn;
+    side_t *s = &sides[line->sidenum[0]];
+    short *texTop = &s->toptexture;
+    short *texMid = &s->midtexture;
+    short *texBot = &s->bottomtexture;
 
-  if (!useAgain)
-    dirty_line(line)->special = 0;
-
-  texTop = sides[line->sidenum[0]].toptexture;
-  texMid = sides[line->sidenum[0]].midtexture;
-  texBot = sides[line->sidenum[0]].bottomtexture;
-
-  sound = sfx_swtchn;
-
-  // EXIT SWITCH?
-  if (line->special == 11)                
-    sound = sfx_swtchx;
-
-  for (i = 0;i < numswitches*2;i++)
-  {
-    if (switchlist[i] == texTop)     // if an upper texture
+    if (!useAgain)
     {
-      S_StartSound(buttonlist->soundorg,sound);     // switch activation sound
-      dirty_side(&sides[line->sidenum[0]])->toptexture = switchlist[i^1];       //chg texture
-
-      if (useAgain)
-        P_StartButton(line,top,switchlist[i],BUTTONTIME);         //start timer
-
-      return;
+        dirty_line(line)->special = 0;
     }
-    else
+
+    /* search for a texture to change */
+    short *texture = NULL;
+    bwhere_e position = 0;
+
+    int i = 0;
+    for (i = 0; i < numswitches * 2; i++)
     {
-      if (switchlist[i] == texMid)   // if a normal texture
-      {
-        S_StartSound(buttonlist->soundorg,sound);   // switch activation sound
-        dirty_side(&sides[line->sidenum[0]])->midtexture = switchlist[i^1];     //chg texture
-
-        if (useAgain)
-          P_StartButton(line, middle,switchlist[i],BUTTONTIME);   //start timer
-
-        return;
-      }
-      else
-      {
-        if (switchlist[i] == texBot) // if a lower texture
+        if (switchlist[i] == *texTop)
         {
-          S_StartSound(buttonlist->soundorg,sound); // switch activation sound
-          dirty_side(&sides[line->sidenum[0]])->bottomtexture = switchlist[i^1];//chg texture
-
-          if (useAgain)
-            P_StartButton(line, bottom,switchlist[i],BUTTONTIME); //start timer
-
-          return;
+            texture = texTop;
+            position = top;
+            break;
         }
-      }
+        else if (switchlist[i] == *texMid)
+        {
+            texture = texMid;
+            position = middle;
+            break;
+        }
+        else if (switchlist[i] == *texBot)
+        {
+            texture = texBot;
+            position = bottom;
+            break;
+        }
     }
-  }
-}
 
+    /* no switch texture was found to change */
+    if (texture == NULL)
+    {
+        return;
+    }
+
+    // Change textures
+    dirty_side(s);
+    *texture = switchlist[i^1];
+
+    degenmobj_t *soundorg =
+        (demo_version >= DV_MBF21)
+            /* use the sound origin of the linedef (its midpoint)
+             * unless in a compatibility mode */
+            ? &line->soundorg
+            /* usually NULL, unless there is another button already pressed in,
+             * in which case it's the sound origin of that button press... */
+            : buttonlist->soundorg;
+
+    S_StartSound((mobj_t *)soundorg, sound);
+
+    if (useAgain)
+    {
+        P_StartButton(line, position, switchlist[i], BUTTONTIME);
+    }
+}
 
 //
 // P_UseSpecialLine

--- a/src/p_switch.c
+++ b/src/p_switch.c
@@ -143,7 +143,6 @@ void P_StartButton
       buttonlist[i].where = w;
       buttonlist[i].btexture = texture;
       buttonlist[i].btimer = time;
-      buttonlist[i].soundorg = &line->frontsector->soundorg;
       return;
     }
     
@@ -211,22 +210,14 @@ void P_ChangeSwitchTexture(line_t *line, int useAgain)
     dirty_side(s);
     *texture = switchlist[i^1];
 
-    degenmobj_t *soundorg =
-        (demo_version >= DV_MBF21)
-            /* use the sound origin of the linedef (its midpoint)
-             * unless in a compatibility mode */
-            ? &line->soundorg
-            /* usually NULL, unless there is another button already pressed in,
-             * in which case it's the sound origin of that button press... */
-            : buttonlist->soundorg;
-
-    S_StartSound((mobj_t *)soundorg, sound);
+    S_StartSound((mobj_t *)&line->soundorg, sound);
 
     if (useAgain)
     {
         P_StartButton(line, position, switchlist[i], BUTTONTIME);
     }
 }
+
 
 //
 // P_UseSpecialLine

--- a/src/r_defs.h
+++ b/src/r_defs.h
@@ -64,7 +64,7 @@ typedef struct vertex_s
 } vertex_t;
 
 // Each sector has a degenmobj_t in its center for sound origin purposes.
-typedef struct
+typedef struct degenmobj_s
 {
   thinker_t thinker;  // not used for anything
   fixed_t x, y, z;
@@ -250,7 +250,6 @@ typedef struct line_s
 {
   vertex_t *v1, *v2;     // Vertices, from v1 to v2.
   fixed_t dx, dy;        // Precalculated v2 - v1 for side checking.
-  // [FG] extended nodes
   uint16_t flags;        // Animation related.
   int16_t special;       // Special action
   int16_t id;            // Tag -> id/arg0 split
@@ -262,6 +261,7 @@ typedef struct line_s
   sector_t *backsector; 
   int validcount;        // if == validcount, already checked
   void *specialdata;     // thinker_t for reversable actions
+  degenmobj_t soundorg;  // sound origin for switches/buttons
   const byte *tranmap;   // better translucency handling
   int firsttag,nexttag;  // killough 4/17/98: improves searches for tags.
 

--- a/src/r_defs.h
+++ b/src/r_defs.h
@@ -64,7 +64,7 @@ typedef struct vertex_s
 } vertex_t;
 
 // Each sector has a degenmobj_t in its center for sound origin purposes.
-typedef struct degenmobj_s
+typedef struct
 {
   thinker_t thinker;  // not used for anything
   fixed_t x, y, z;
@@ -250,6 +250,7 @@ typedef struct line_s
 {
   vertex_t *v1, *v2;     // Vertices, from v1 to v2.
   fixed_t dx, dy;        // Precalculated v2 - v1 for side checking.
+  // [FG] extended nodes
   uint16_t flags;        // Animation related.
   int16_t special;       // Special action
   int16_t id;            // Tag -> id/arg0 split


### PR DESCRIPTION
based on the PrBoom+/DSDA refactor, reduces code duplication.

changes the behavior to always use the linedef's midpoint as the sound origin.

i'm putting this PR up but, strangely, i can't reproduce the issue in my test map.