### PR TITLE
fix RUST finale text off screen issue

### DIFF
--- a/src/f_finale.c
+++ b/src/f_finale.c
@@ -759,8 +759,8 @@ static void F_TextWrite(void)
     {
       continue;
     }
-    // [cispy] prevent text from being drawn off-screen vertically
-    if (cy + SHORT(hu_font[c]->height) > SCREENHEIGHT)
+    // [crispy] prevent text from being drawn off-screen vertically
+    if (cy + SHORT(hu_font[c]->height) - SHORT(hu_font[c]->topoffset) > SCREENHEIGHT)
       break;
     V_DrawPatch(cx, cy, hu_font[c]);
     cx+=w;


### PR DESCRIPTION
Same as https://github.com/fabiangreffrath/crispy-doom/pull/1295