### PR TITLE
Revise lump range checks

### DIFF
--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -960,7 +960,11 @@ boolean P_LoadReject(int lumpnum, int totallines)
         unsigned int padvalue;
 
         rejectmatrix = Z_Malloc(minlength, PU_LEVEL, (void **) &rejectmatrix);
-        W_ReadLumpSize(lumpnum, rejectmatrix, minlength);
+
+        if (W_LumpExists(lumpnum))
+        {
+            W_ReadLumpSize(lumpnum, rejectmatrix, minlength);
+        }
 
         //!
         // @category mod

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -578,7 +578,8 @@ static void R_ProjectSprite(mobj_t* thing, int lightlevel_override)
 
   xscale = FixedDiv(projection, tz);
 
-    // decide which patch to use for sprite relative to player
+  // decide which patch to use for sprite relative to player
+
   if ((unsigned) thing->sprite >= num_sprites)
     I_Error ("invalid sprite number %i", thing->sprite);
 
@@ -856,19 +857,15 @@ void R_DrawPSprite(pspdef_t *psp, int lightlevel_override)
 
   // decide which patch to use
 
-#ifdef RANGECHECK
   if ((unsigned) psp->state->sprite >= num_sprites)
     I_Error ("invalid sprite number %i", psp->state->sprite);
-#endif
 
   sprdef = &sprites[psp->state->sprite];
 
-#ifdef RANGECHECK
   if ((psp->state->frame&FF_FRAMEMASK) >= sprdef->numframes)
     I_Error ("invalid frame %i for sprite %s",
              (int)(psp->state->frame & FF_FRAMEMASK),
              sprnames[psp->state->sprite]);
-#endif
 
   sprframe = &sprdef->spriteframes[psp->state->frame & FF_FRAMEMASK];
 

--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -477,11 +477,19 @@ void W_InitMultipleFiles(void)
 // W_LumpLength
 // Returns the buffer size needed to load the given lump.
 //
+static inline int LumpLength(int lump)
+{
+  return lumpinfo[lump].size;
+}
+
 int W_LumpLength (int lump)
 {
+#ifdef RANGECHECK
   if (lump >= numlumps)
     I_Error ("%i >= numlumps",lump);
-  return lumpinfo[lump].size;
+#endif
+
+  return LumpLength(lump);
 }
 
 //
@@ -490,16 +498,9 @@ int W_LumpLength (int lump)
 //  which must be >= W_LumpLength().
 //
 
-void W_ReadLumpSize(int lump, void *dest, int size)
+static inline void ReadLumpSize(int lump, void *dest, int size)
 {
     lumpinfo_t *info = lumpinfo + lump;
-
-#ifdef RANGECHECK
-    if (lump >= numlumps)
-    {
-        I_Error("%i >= numlumps", lump);
-    }
-#endif
 
     if (!size || !info->size)
     {
@@ -524,6 +525,23 @@ void W_ReadLumpSize(int lump, void *dest, int size)
     I_EndRead();
 }
 
+void W_ReadLumpSize(int lump, void *dest, int size)
+{
+#ifdef RANGECHECK
+    if (lump >= numlumps)
+    {
+        I_Error("%i >= numlumps", lump);
+    }
+#endif
+
+    ReadLumpSize(lump, dest, size);
+}
+
+static void ReadLump(int lump, void *dest)
+{
+    ReadLumpSize(lump, dest, -1);
+}
+
 void W_ReadLump(int lump, void *dest)
 {
     W_ReadLumpSize(lump, dest, -1);
@@ -542,7 +560,7 @@ void *W_CacheLumpNum(int lump, pu_tag tag)
 #endif
 
   if (!lumpcache[lump])      // read the lump in
-    W_ReadLump(lump, Z_Malloc(W_LumpLength(lump), tag, &lumpcache[lump]));
+    ReadLump(lump, Z_Malloc(LumpLength(lump), tag, &lumpcache[lump]));
   else
     Z_ChangeTag(lumpcache[lump],tag);
 
@@ -554,7 +572,7 @@ void *W_CacheLumpNum(int lump, pu_tag tag)
 // [FG] name of the WAD file that contains the lump
 const char *W_WadNameForLump (const int lump)
 {
-  if (lump < 0 || lump >= numlumps)
+  if (!W_LumpExists(lump))
     return "invalid";
   else
   {
@@ -567,21 +585,25 @@ const char *W_WadNameForLump (const int lump)
   }
 }
 
+boolean W_LumpExists(const int lump)
+{
+  return 0 <= lump && lump < numlumps;
+}
+
 boolean W_IsIWADLump (const int lump)
 {
-	return lump >= 0 && lump < numlumps &&
-	       lumpinfo[lump].wad_file == wadfiles[0];
+	return W_LumpExists(lump) && lumpinfo[lump].wad_file == wadfiles[0];
 }
 
 // check if lump is from WAD
 boolean W_IsWADLump (const int lump)
 {
-	return lump >= 0 && lump < numlumps && lumpinfo[lump].wad_file;
+	return W_LumpExists(lump) && lumpinfo[lump].wad_file;
 }
 
 boolean W_LumpExistsWithName(int lump, char *name)
 {
-  if (lump < 0 || lump >= numlumps)
+  if (!W_LumpExists(lump))
     return false;
 
   if (name && strncasecmp(lumpinfo[lump].name, name, 8))
@@ -595,7 +617,7 @@ int W_LumpLengthWithName(int lump, char *name)
   if (!W_LumpExistsWithName(lump, name))
     return 0;
 
-  return W_LumpLength(lump);
+  return LumpLength(lump);
 }
 
 // killough 10/98: support .deh from wads

--- a/src/w_wad.h
+++ b/src/w_wad.h
@@ -155,6 +155,7 @@ void I_BeginRead(unsigned int bytes), I_EndRead(void); // killough 10/98
 
 // [FG] name of the WAD file that contains the lump
 const char *W_WadNameForLump (const int lump);
+boolean W_LumpExists(const int lump);
 boolean W_IsIWADLump (const int lump);
 // check if lump is from WAD
 boolean W_IsWADLump (const int lump);


### PR DESCRIPTION
- Prevented redundant range checks (i.e. functions with range checks calling functions that repeat the checks).
- Added missing `RANGECHECK` flag check to `W_LumpLength()`.
- Removed `RANGECHECK` flag check from `R_DrawPSprite()`, since `R_ProjectSprite()`, which is arguably more of a performance concern, doesn't check the flag and thus always runs the lump range check.
- Added missing check for `REJECT` lump in `P_LoadReject()`.

About the sprite lump checks in `R_ProjectSprite()` and `R_DrawPSprite()`, I'd actually like to get rid of them, but they do provide insight to modders.

I believe that `RANGECHECK` is meant to be an aid for us port devs more than anything, since in most cases it just replaces crashes provoked by faulty code with graceful exits, but the game will ultimately bomb out anyways. However, the error messages seem vague to me, so even if people include them in bug reports, we'd probably have to reproduce the bugs ourselves using debuggers to find out what exactly leads to those graceful exits.

To that effect, I believe we should disable `RANGECHECK` by default in the build system, or even remove it and the code it guards altogether. Otherwise, perhaps we could introduce a second similar flag and guard range checks relevant to modders (such as the sprite lump checks mentioned above) behind it, allowing to toggle modder-oriented checks separately from dev-oriented checks.