### PR TITLE
Fix voxels making voodoo dolls invisible

### DIFF
--- a/src/r_voxel.c
+++ b/src/r_voxel.c
@@ -502,7 +502,7 @@ boolean VX_ProjectVoxel(mobj_t *thing, int lightlevel_override)
 		return false;
 
 	// skip the player thing we are viewing from
-	if (thing->player == viewplayer)
+	if (thing == viewplayer->mo)
 		return true;
 
 	// does the voxel model exist?


### PR DESCRIPTION
If voxels were available at all, player voodoo dolls would become invisible.

The culprit is here:

https://github.com/fabiangreffrath/woof/blob/a88b67effd13c76e244beb9f1629353821abb3b4/src/r_voxel.c#L498-L507

`voxels_rendering` is true if the user has enabled voxels, and at least one voxel model is present, no matter for which sprite. Thus, the `if (thing->player == viewplayer)` check is run.

That condition yields true for all player bodies, since they all point to the same player. Returning `true` makes the normal sprite projection code stop, which is usually done when a voxel is successfully rendered (we don't want to render both the sprite and the voxel), but it also makes sense for the player's body since we don't want to render it either (vanilla doesn't have a guard for this, it just so happens that the body is always close enough to the POV to be culled).

So, I decided to fix this by instead comparing the thing we're projecting against the specific body pointed to by the player.