### PR TITLE
SBARDEF: fix proportional string width calculation

### DIFF
--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -1046,7 +1046,7 @@ static void UpdateNumber(sbarelem_t *elem, player_t *player)
         while (tempnum > 0)
         {
             int workingnum = tempnum % 10;
-            totalwidth = SHORT(font->numbers[workingnum]->width);
+            totalwidth += SHORT(font->numbers[workingnum]->width);
             tempnum /= 10;
         }
         if (elem->type == sbe_percent && font->percent != NULL)


### PR DESCRIPTION
Fixes #2752