### PR TITLE
Fix minimap overlapping chat

### DIFF
--- a/base/all-all/sbardef.json
+++ b/base/all-all/sbardef.json
@@ -1028,18 +1028,48 @@
             }
           },
           {
-            "component": {
+            "list": {
               "x": 0,
               "y": -160,
               "alignment": 64,
               "tranmap": null,
-              "translation": "CRGOLD",
+              "translation": null,
               "translucency": false,
               "conditions": [],
-              "children": [],
-              "type": "chat",
-              "font": "Console",
-              "vertical": false
+              "children": [
+                {
+                  "component": {
+                    "x": 0,
+                    "y": 0,
+                    "alignment": 0,
+                    "tranmap": null,
+                    "translation": "CRGOLD",
+                    "translucency": false,
+                    "conditions": [],
+                    "children": [],
+                    "type": "chat",
+                    "font": "Console",
+                    "vertical": false
+                  }
+                },
+                {
+                  "minimap": {
+                    "x": 2,
+                    "y": 1,
+                    "alignment": 0,
+                    "tranmap": null,
+                    "translation": null,
+                    "translucency": false,
+                    "conditions": [],
+                    "children": [],
+                    "width": 72,
+                    "height": 60,
+                    "background": 1
+                  }
+                }
+              ],
+              "horizontal": false,
+              "spacing": 0
             }
           },
           {
@@ -1120,21 +1150,6 @@
               ],
               "horizontal": false,
               "spacing": 0
-            }
-          },
-          {
-            "minimap": {
-              "x": 2,
-              "y": -159,
-              "alignment": 64,
-              "tranmap": null,
-              "translation": null,
-              "translucency": false,
-              "conditions": [],
-              "children": [],
-              "width": 72,
-              "height": 60,
-              "background": 1
             }
           },
           {
@@ -1909,19 +1924,49 @@
                   }
                 },
                 {
-                  "component": {
+                  "list": {
                     "x": 0,
                     "y": 8,
                     "alignment": 64,
                     "tranmap": null,
-                    "translation": "CRGOLD",
+                    "translation": null,
                     "translucency": false,
                     "conditions": [],
-                    "children": [],
-                    "type": "chat",
-                    "font": "Console",
-                    "vertical": false,
-                    "duration": 4.0
+                    "children": [
+                      {
+                        "component": {
+                          "x": 0,
+                          "y": 0,
+                          "alignment": 0,
+                          "tranmap": null,
+                          "translation": "CRGOLD",
+                          "translucency": false,
+                          "conditions": [],
+                          "children": [],
+                          "type": "chat",
+                          "font": "Console",
+                          "vertical": false,
+                          "duration": 4.0
+                        }
+                      },
+                      {
+                        "minimap": {
+                          "x": 2,
+                          "y": 1,
+                          "alignment": 0,
+                          "tranmap": null,
+                          "translation": null,
+                          "translucency": false,
+                          "conditions": [],
+                          "children": [],
+                          "width": 72,
+                          "height": 60,
+                          "background": 1
+                        }
+                      }
+                    ],
+                    "horizontal": false,
+                    "spacing": 0
                   }
                 },
                 {
@@ -2003,21 +2048,6 @@
                     ],
                     "horizontal": false,
                     "spacing": 0
-                  }
-                },
-                {
-                  "minimap": {
-                    "x": 2,
-                    "y": 9,
-                    "alignment": 64,
-                    "tranmap": null,
-                    "translation": null,
-                    "translucency": false,
-                    "conditions": [],
-                    "children": [],
-                    "width": 72,
-                    "height": 60,
-                    "background": 1
                   }
                 },
                 {
@@ -2989,18 +3019,48 @@
             }
           },
           {
-            "component": {
+            "list": {
               "x": 0,
               "y": 8,
               "alignment": 64,
               "tranmap": null,
-              "translation": "CRGOLD",
+              "translation": null,
               "translucency": false,
               "conditions": [],
-              "children": [],
-              "type": "chat",
-              "font": "Console",
-              "vertical": false
+              "children": [
+                {
+                  "component": {
+                    "x": 0,
+                    "y": 0,
+                    "alignment": 0,
+                    "tranmap": null,
+                    "translation": "CRGOLD",
+                    "translucency": false,
+                    "conditions": [],
+                    "children": [],
+                    "type": "chat",
+                    "font": "Console",
+                    "vertical": false
+                  }
+                },
+                {
+                  "minimap": {
+                    "x": 2,
+                    "y": 1,
+                    "alignment": 0,
+                    "tranmap": null,
+                    "translation": null,
+                    "translucency": false,
+                    "conditions": [],
+                    "children": [],
+                    "width": 72,
+                    "height": 60,
+                    "background": 1
+                  }
+                }
+              ],
+              "horizontal": false,
+              "spacing": 0
             }
           },
           {
@@ -3081,21 +3141,6 @@
               ],
               "horizontal": false,
               "spacing": 0
-            }
-          },
-          {
-            "minimap": {
-              "x": 2,
-              "y": 9,
-              "alignment": 64,
-              "tranmap": null,
-              "translation": null,
-              "translucency": false,
-              "conditions": [],
-              "children": [],
-              "width": 72,
-              "height": 60,
-              "background": 1
             }
           },
           {
@@ -3295,18 +3340,48 @@
             }
           },
           {
-            "component": {
+            "list": {
               "x": 0,
               "y": 8,
               "alignment": 64,
               "tranmap": null,
-              "translation": "CRGOLD",
+              "translation": null,
               "translucency": false,
               "conditions": [],
-              "children": [],
-              "type": "chat",
-              "font": "Console",
-              "vertical": false
+              "children": [
+                {
+                  "component": {
+                    "x": 0,
+                    "y": 0,
+                    "alignment": 0,
+                    "tranmap": null,
+                    "translation": "CRGOLD",
+                    "translucency": false,
+                    "conditions": [],
+                    "children": [],
+                    "type": "chat",
+                    "font": "Console",
+                    "vertical": false
+                  }
+                },
+                {
+                  "minimap": {
+                    "x": 2,
+                    "y": 1,
+                    "alignment": 0,
+                    "tranmap": null,
+                    "translation": null,
+                    "translucency": false,
+                    "conditions": [],
+                    "children": [],
+                    "width": 72,
+                    "height": 60,
+                    "background": 1
+                  }
+                }
+              ],
+              "horizontal": false,
+              "spacing": 0
             }
           },
           {
@@ -3387,21 +3462,6 @@
               ],
               "horizontal": false,
               "spacing": 0
-            }
-          },
-          {
-            "minimap": {
-              "x": 2,
-              "y": 9,
-              "alignment": 64,
-              "tranmap": null,
-              "translation": null,
-              "translucency": false,
-              "conditions": [],
-              "children": [],
-              "width": 72,
-              "height": 60,
-              "background": 1
             }
           },
           {

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -1745,13 +1745,6 @@ static void DrawWidget(int x1, int y1, int *x2, int *y2, boolean dry,
             y1 += font->maxheight;
         }
     }
-
-    // If chat is enabled, add spacing even if it has no text
-    if (y2 && widget->type == sbw_chat && chat_on)
-    {
-        y1 = AdjustY(y1, font->maxheight, elem->alignment);
-        *y2 = MAX(*y2, y1);
-    }
 }
 
 static void DrawMiniMap(int x1, int y1, int *x2, int *y2, boolean dry,

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -1745,6 +1745,13 @@ static void DrawWidget(int x1, int y1, int *x2, int *y2, boolean dry,
             y1 += font->maxheight;
         }
     }
+
+    // If chat is enabled, add spacing even if it has no text
+    if (y2 && widget->type == sbw_chat && chat_on)
+    {
+        y1 = AdjustY(y1, font->maxheight, elem->alignment);
+        *y2 = MAX(*y2, y1);
+    }
 }
 
 static void DrawMiniMap(int x1, int y1, int *x2, int *y2, boolean dry,


### PR DESCRIPTION
Fixes #2676.

The chat and minimap have been put together in a list, such that the minimap is shifted downwards when the chat is enabled.

This revealed another issue with the chat, which is that it only contributed towards the spacing of lists if it had visible text; thus, if it were empty, anything after it in a list would jump around as the caret flashed in and out.

That has been changed: the chat now always adds spacing to lists containing it when it is enabled. This should be useful in general, not just for the minimap.