### PR TITLE
Further work on cropping

### DIFF
--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -1515,10 +1515,6 @@ static void DrawPatch(int x1, int y1, int *x2, int *y2, boolean dry,
     if (alignment & sbe_h_middle)
     {
         x1 += xoffset;
-        if (crop.center)
-        {
-            x1 += width / 2 + crop.left;
-        }
     }
     x1 = WideShiftX(x1, alignment);
 

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -519,10 +519,10 @@ static inline void DrawPatchInternal(int x, int y, int xoffset, int yoffset,
                 : (trans)          ? DrawPatchColumnTL
                                    : DrawPatchColumn;
 
-    const int left_crop = (crop.center && crop.left) ? patch_width / 2 + crop.left : crop.left;
+    const int left_crop = crop.center ? patch_width / 2 + crop.left : crop.left;
     const int final_width = crop.width ? MIN(patch_width, crop.width) : patch_width;
 
-    patchcol.top_crop = (crop.center && crop.top) ? patch_height / 2 + crop.top : crop.top;
+    patchcol.top_crop = crop.center ? patch_height / 2 + crop.top : crop.top;
     patchcol.height = crop.height ? MIN(patch_height, crop.height) : patch_height;
 
     // Adjust for arbitrary resolution


### PR DESCRIPTION
As far as I'm concerned, this fixes #2760.

This brings Woof's cropping in line with Helion/Cacoco's shared behavior, barring any other cases I'm not aware of.

There do exist certain cases where Helion and Cacoco don't match, and until that is resolved, I wouldn't bother trying to fix anything here.

This breaks some HUDs in the current version of NightFright's SBARDEF mod.