### PR TITLE
Fix SBARDEF game-mode conditions

### DIFF
--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -59,6 +59,26 @@ static const char *const gamemode_str[] = {
     "Unknown mode"
 };
 
+gameconf_gamemode_t D_ModeToGameconfMode(const GameMode_t mode)
+{
+  switch (mode)
+  {
+    case shareware:
+    case registered:
+      return gc_registered;
+
+    case retail:
+      return gc_retail;
+
+    case commercial:
+      return gc_commercial;
+
+    default:
+      // Fall back to commercial
+      return gc_commercial;
+  }
+}
+
 #define SUB_DIRS(str, ...) (char *[]){str, ##__VA_ARGS__, NULL}
 
 // Array of locations to search for IWAD files

--- a/src/doomdef.h
+++ b/src/doomdef.h
@@ -31,6 +31,15 @@ typedef enum {
   indetermined  // Well, no IWAD found.
 } GameMode_t;
 
+// GAMECONF defines a different ordering for game modes
+typedef enum {
+  gc_registered,
+  gc_retail,
+  gc_commercial
+} gameconf_gamemode_t;
+
+gameconf_gamemode_t D_ModeToGameconfMode(GameMode_t mode);
+
 // Mission packs - might be useful for TC stuff?
 typedef enum {
   doom,          // DOOM 1

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -385,11 +385,11 @@ static boolean CheckConditions(sbarcondition_t *conditions, player_t *player)
                 break;
 
             case sbc_modeeequal:
-                result &= gamemode == (cond->param + 1);
+                result &= D_ModeToGameconfMode(gamemode) == cond->param;
                 break;
 
             case sbc_modenotequal:
-                result &= gamemode != (cond->param + 1);
+                result &= D_ModeToGameconfMode(gamemode) != cond->param;
                 break;
 
             case sbc_hudmodeequal:


### PR DESCRIPTION
SBARDEF uses game modes as listed in GAMECONF, which uses an ordering different to ours.

Alternative to #2807. This should be "safer" since we're only touching the SBARDEF code which has the issue.

The current version of NightFright's SBARDEFs relies on the incorrect behavior that this PR fixes, so this partially breaks those HUDs.