### PR TITLE
Misc. SBARDEF fixes

### DIFF
--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -1799,7 +1799,7 @@ static void DrawListOfElem(int x1, int y1, int *x2, int *y2, boolean dry,
                            sbarelem_t *elem);
 
 static void DrawElem(int x1, int y1, int *x2, int *y2, boolean dry,
-                     sbarelem_t *elem)
+                     sbarelem_t *elem, boolean is_list_child)
 {
     if (!elem->enabled)
     {
@@ -1809,10 +1809,19 @@ static void DrawElem(int x1, int y1, int *x2, int *y2, boolean dry,
     x1 += elem->x_pos;
     y1 += elem->y_pos;
 
+    // [FG] A list already positions its members, so suppress their own
+    // alignment to avoid applying it twice.
+    sbaralignment_t real_alignment = elem->alignment;
+    if (is_list_child)
+    {
+        elem->alignment = elem->orig_alignment & ~(sbe_h_mask | sbe_v_mask);
+    }
+
     switch (elem->type)
     {
         case sbe_list:
             DrawListOfElem(x1, y1, x2, y2, dry, elem);
+            elem->alignment = real_alignment;
             return;
 
         case sbe_graphic:
@@ -1892,10 +1901,12 @@ static void DrawElem(int x1, int y1, int *x2, int *y2, boolean dry,
             break;
     }
 
+    elem->alignment = real_alignment;
+
     sbarelem_t *child;
     array_foreach(child, elem->children)
     {
-        DrawElem(x1, y1, x2, y2, dry, child);
+        DrawElem(x1, y1, x2, y2, dry, child, false);
     }
 }
 
@@ -1912,7 +1923,7 @@ static void UpdateListOfElem(sbarelem_t *elem, player_t *player)
         int width = 0, height = 0;
         if (child->enabled)
         {
-            DrawElem(0, 0, &width, &height, true, child); // Dry run
+            DrawElem(0, 0, &width, &height, true, child, true); // Dry run
             width -= child->x_pos;
             height -= child->y_pos;
         }
@@ -1927,6 +1938,21 @@ static void UpdateListOfElem(sbarelem_t *elem, player_t *player)
         {
             listheight += (height + list->spacing);
         }
+    }
+
+    // [FG] The loop above adds a trailing list->spacing after the last
+    // contributing child, throwing off a bottom/right-aligned list's
+    // block shift by that amount.
+    if (list->horizontal)
+    {
+        if (listwidth)
+        {
+            listwidth -= list->spacing;
+        }
+    }
+    else if (listheight)
+    {
+        listheight -= list->spacing;
     }
 
     elem->width = listwidth;
@@ -1962,7 +1988,7 @@ static void DrawListOfElem(int x1, int y1, int *x2, int *y2, boolean dry,
             x1adj = AdjustX(x1, child->width, elem->alignment);
         }
 
-        DrawElem(x1adj, y1adj, x2, y2, dry, child);
+        DrawElem(x1adj, y1adj, x2, y2, dry, child, true);
 
         if (list->horizontal && child->width)
         {
@@ -2109,7 +2135,7 @@ static void DrawStatusBar(void)
     int y1 = statusbar->fullscreenrender ? 0 : SCREENHEIGHT - statusbar->height;
     array_foreach(child, statusbar->children)
     {
-        DrawElem(0, y1, NULL, NULL, false, child);
+        DrawElem(0, y1, NULL, NULL, false, child, false);
     }
 
     DrawCenteredMessage();

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -1069,7 +1069,7 @@ static void UpdateNumber(sbarelem_t *elem, player_t *player)
     number->numvalues = numvalues;
 }
 
-// Calculate xoffset/totalwidth for h_right/h_middle
+// Calculate xoffset/totalwidth for h_right/h_middle-aligned strings.
 
 static void UpdateStringLine(sbaralignment_t alignment, hudfont_t *font,
                              stringline_t *line)
@@ -1310,15 +1310,7 @@ static void UpdateElem(sbarelem_t *elem, player_t *player)
                 ST_UpdateWidget(elem, player);
                 UpdateLines(elem);
 
-                // [FG] A non-empty line's height doesn't depend on its
-                // content -- DrawWidget() steps by font->maxheight for
-                // any such line regardless of what's in it -- so compute
-                // it directly instead of via a dry run, which silently
-                // measures 0 height for a line whose only character has
-                // no glyph (e.g. a single space), making list members
-                // above/below it jump around as that line's content
-                // changes. A line with an empty string still counts as
-                // 0, matching DrawWidget()'s own skip below.
+                // Calculate widget's width/height, skip empty lines.
                 int width = 0, height = 0;
                 stringline_t *line;
                 array_foreach(line, widget->lines)
@@ -1771,8 +1763,7 @@ static void DrawWidget(int x1, int y1, int *x2, int *y2, boolean dry,
     {
         DrawStringLine(x1, y1, x2, y2, dry, line, elem, font);
 
-        // [FG] An empty line occupies no vertical space, matching how
-        // UpdateElem() computes elem->height for this widget.
+        // Skip empty lines
         if (!line->string[0])
         {
             continue;
@@ -1851,9 +1842,10 @@ static void DrawElem(int x1, int y1, int *x2, int *y2, boolean dry,
     x1 += elem->x_pos;
     y1 += elem->y_pos;
 
-    // [FG] A list already positions its members, so suppress their own
+    // A list already positions its members, so suppress their own
     // alignment to avoid applying it twice.
-    sbaralignment_t real_alignment = elem->alignment;
+
+    const sbaralignment_t orig_alignment = elem->alignment;
     if (is_list_child)
     {
         elem->alignment = elem->orig_alignment & ~(sbe_h_mask | sbe_v_mask);
@@ -1863,11 +1855,11 @@ static void DrawElem(int x1, int y1, int *x2, int *y2, boolean dry,
     {
         case sbe_list:
             DrawListOfElem(x1, y1, x2, y2, dry, elem);
-            elem->alignment = real_alignment;
+            elem->alignment = orig_alignment;
             return;
 
         case sbe_canvas:
-            // [FG] No visual of its own; just position the anchor for
+            // No visual of its own; just position the anchor for
             // the children loop below.
             x1 = AdjustX(x1, elem->width, elem->alignment);
             x1 = WideShiftX(x1, elem->alignment);
@@ -1951,7 +1943,7 @@ static void DrawElem(int x1, int y1, int *x2, int *y2, boolean dry,
             break;
     }
 
-    elem->alignment = real_alignment;
+    elem->alignment = orig_alignment;
 
     sbarelem_t *child;
     array_foreach(child, elem->children)
@@ -1975,20 +1967,11 @@ static void UpdateListOfElem(sbarelem_t *elem, player_t *player)
         {
             if (child->type == sbe_widget)
             {
-                // [FG] UpdateElem() already computed the widget's true
-                // size directly (line count times font maxheight, not a
-                // per-glyph ink measurement), which the dry run below
-                // cannot reproduce for a line with no visible glyphs.
                 width = child->width;
                 height = child->height;
             }
             else
             {
-                // [FG] Seeding width/height with x_pos/y_pos here
-                // (instead of 0) keeps DrawElem()'s x1/y1 += x_pos/y_pos
-                // from making a large negative offset look smaller than
-                // 0 and getting clamped away by MAX() inside the dry
-                // run.
                 DrawElem(0, 0, &width, &height, true, child, true); // Dry run
                 width -= child->x_pos;
                 height -= child->y_pos;
@@ -2012,15 +1995,13 @@ static void UpdateListOfElem(sbarelem_t *elem, player_t *player)
         }
     }
 
-    // [FG] The loop above adds a trailing list->spacing after the last
+    // The loop above adds a trailing list->spacing after the last
     // contributing child, throwing off a bottom/right-aligned list's
     // block shift by that amount.
-    if (list->horizontal)
+
+    if (list->horizontal && listwidth)
     {
-        if (listwidth)
-        {
-            listwidth -= list->spacing;
-        }
+        listwidth -= list->spacing;
     }
     else if (listheight)
     {
@@ -2031,8 +2012,9 @@ static void UpdateListOfElem(sbarelem_t *elem, player_t *player)
     elem->height = listheight;
 }
 
-// [FG] A canvas positions children at their own x_pos/y_pos instead of
+// A canvas positions children at their own x_pos/y_pos instead of
 // stacking them, so its size is the furthest extent any child reaches.
+
 static void UpdateCanvasOfElem(sbarelem_t *elem, player_t *player)
 {
     int width = 0, height = 0;
@@ -2047,19 +2029,11 @@ static void UpdateCanvasOfElem(sbarelem_t *elem, player_t *player)
             int cw, ch;
             if (child->type == sbe_widget)
             {
-                // [FG] As in UpdateListOfElem(): reuse the widget's
-                // directly-computed size instead of a dry run, which
-                // cannot measure a line with no visible glyphs.
                 cw = child->x_pos + child->width;
                 ch = child->y_pos + child->height;
             }
             else
             {
-                // [FG] Seed the accumulator with x_pos/y_pos, not 0 --
-                // since DrawElem() adds x_pos/y_pos before drawing, a
-                // large enough negative offset would otherwise make the
-                // child's true extent look smaller than 0 and get
-                // clamped away by MAX().
                 cw = child->x_pos;
                 ch = child->y_pos;
                 DrawElem(0, 0, &cw, &ch, true, child, true); // Dry run

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -1069,14 +1069,12 @@ static void UpdateNumber(sbarelem_t *elem, player_t *player)
     number->numvalues = numvalues;
 }
 
-// [FG] Computes xoffset/totalwidth for h_right/h_middle, ignoring any
-// trailing whitespace so a padded, fixed-width string still right-aligns
-// to its visible content rather than to the full padded buffer.
+// Calculate xoffset/totalwidth for h_right/h_middle
+
 static void UpdateStringLine(sbaralignment_t alignment, hudfont_t *font,
                              stringline_t *line)
 {
     int totalwidth = 0;
-    int width_at_last_visible = 0;
 
     const char *str = line->string;
     while (*str)
@@ -1102,23 +1100,18 @@ static void UpdateStringLine(sbaralignment_t alignment, hudfont_t *font,
         }
 
         totalwidth += width;
-
-        if (ch != ' ')
-        {
-            width_at_last_visible = totalwidth;
-        }
     }
 
     line->xoffset = 0;
     if (alignment & sbe_h_middle)
     {
-        line->xoffset -= (width_at_last_visible >> 1);
+        line->xoffset -= (totalwidth >> 1);
     }
     else if (alignment & sbe_h_right)
     {
-        line->xoffset -= width_at_last_visible;
+        line->xoffset -= totalwidth;
     }
-    line->totalwidth = width_at_last_visible;
+    line->totalwidth = totalwidth;
 }
 
 static void UpdateLines(sbarelem_t *elem)

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -1966,12 +1966,21 @@ static void UpdateListOfElem(sbarelem_t *elem, player_t *player)
     {
         UpdateElem(child, player);
 
-        int width = 0, height = 0;
+        int width = child->x_pos, height = child->y_pos;
         if (child->enabled)
         {
+            // [FG] Seeding width/height with x_pos/y_pos here (instead of
+            // 0) keeps DrawElem()'s x1/y1 += x_pos/y_pos from making a
+            // large negative offset look smaller than 0 and getting
+            // clamped away by MAX() inside the dry run below.
             DrawElem(0, 0, &width, &height, true, child, true); // Dry run
             width -= child->x_pos;
             height -= child->y_pos;
+        }
+        else
+        {
+            width = 0;
+            height = 0;
         }
         child->width = width;
         child->height = height;
@@ -2018,13 +2027,12 @@ static void UpdateCanvasOfElem(sbarelem_t *elem, player_t *player)
 
         if (child->enabled)
         {
-            sbaralignment_t real_alignment = child->alignment;
-            child->alignment = child->orig_alignment & ~(sbe_h_mask | sbe_v_mask);
-
-            int cw = 0, ch = 0;
+            // [FG] Seed the accumulator with x_pos/y_pos, not 0 -- since
+            // DrawElem() adds x_pos/y_pos before drawing, a large enough
+            // negative offset would otherwise make the child's true
+            // extent look smaller than 0 and get clamped away by MAX().
+            int cw = child->x_pos, ch = child->y_pos;
             DrawElem(0, 0, &cw, &ch, true, child, true); // Dry run
-
-            child->alignment = real_alignment;
 
             width = MAX(width, cw);
             height = MAX(height, ch);

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -1848,7 +1848,7 @@ static void DrawElem(int x1, int y1, int *x2, int *y2, boolean dry,
     const sbaralignment_t orig_alignment = elem->alignment;
     if (is_list_child)
     {
-        elem->alignment = elem->orig_alignment & ~(sbe_h_mask | sbe_v_mask);
+        elem->alignment &= ~(sbe_h_mask | sbe_v_mask);
     }
 
     switch (elem->type)

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -1312,8 +1312,33 @@ static void UpdateElem(sbarelem_t *elem, player_t *player)
             break;
 
         case sbe_widget:
-            ST_UpdateWidget(elem, player);
-            UpdateLines(elem);
+            {
+                sbe_widget_t *widget = elem->subtype.widget;
+                ST_UpdateWidget(elem, player);
+                UpdateLines(elem);
+
+                // [FG] A non-empty line's height doesn't depend on its
+                // content -- DrawWidget() steps by font->maxheight for
+                // any such line regardless of what's in it -- so compute
+                // it directly instead of via a dry run, which silently
+                // measures 0 height for a line whose only character has
+                // no glyph (e.g. a single space), making list members
+                // above/below it jump around as that line's content
+                // changes. A line with an empty string still counts as
+                // 0, matching DrawWidget()'s own skip below.
+                int width = 0, height = 0;
+                stringline_t *line;
+                array_foreach(line, widget->lines)
+                {
+                    width = MAX(width, line->totalwidth);
+                    if (line->string[0])
+                    {
+                        height += widget->font->maxheight;
+                    }
+                }
+                elem->width = width;
+                elem->height = height;
+            }
             break;
 
         case sbe_carousel:
@@ -1752,6 +1777,14 @@ static void DrawWidget(int x1, int y1, int *x2, int *y2, boolean dry,
     array_foreach(line, widget->lines)
     {
         DrawStringLine(x1, y1, x2, y2, dry, line, elem, font);
+
+        // [FG] An empty line occupies no vertical space, matching how
+        // UpdateElem() computes elem->height for this widget.
+        if (!line->string[0])
+        {
+            continue;
+        }
+
         if (elem->alignment & sbe_v_bottom)
         {
             y1 -= font->maxheight;
@@ -1947,13 +1980,26 @@ static void UpdateListOfElem(sbarelem_t *elem, player_t *player)
         int width = child->x_pos, height = child->y_pos;
         if (child->enabled)
         {
-            // [FG] Seeding width/height with x_pos/y_pos here (instead of
-            // 0) keeps DrawElem()'s x1/y1 += x_pos/y_pos from making a
-            // large negative offset look smaller than 0 and getting
-            // clamped away by MAX() inside the dry run below.
-            DrawElem(0, 0, &width, &height, true, child, true); // Dry run
-            width -= child->x_pos;
-            height -= child->y_pos;
+            if (child->type == sbe_widget)
+            {
+                // [FG] UpdateElem() already computed the widget's true
+                // size directly (line count times font maxheight, not a
+                // per-glyph ink measurement), which the dry run below
+                // cannot reproduce for a line with no visible glyphs.
+                width = child->width;
+                height = child->height;
+            }
+            else
+            {
+                // [FG] Seeding width/height with x_pos/y_pos here
+                // (instead of 0) keeps DrawElem()'s x1/y1 += x_pos/y_pos
+                // from making a large negative offset look smaller than
+                // 0 and getting clamped away by MAX() inside the dry
+                // run.
+                DrawElem(0, 0, &width, &height, true, child, true); // Dry run
+                width -= child->x_pos;
+                height -= child->y_pos;
+            }
         }
         else
         {
@@ -2005,12 +2051,26 @@ static void UpdateCanvasOfElem(sbarelem_t *elem, player_t *player)
 
         if (child->enabled)
         {
-            // [FG] Seed the accumulator with x_pos/y_pos, not 0 -- since
-            // DrawElem() adds x_pos/y_pos before drawing, a large enough
-            // negative offset would otherwise make the child's true
-            // extent look smaller than 0 and get clamped away by MAX().
-            int cw = child->x_pos, ch = child->y_pos;
-            DrawElem(0, 0, &cw, &ch, true, child, true); // Dry run
+            int cw, ch;
+            if (child->type == sbe_widget)
+            {
+                // [FG] As in UpdateListOfElem(): reuse the widget's
+                // directly-computed size instead of a dry run, which
+                // cannot measure a line with no visible glyphs.
+                cw = child->x_pos + child->width;
+                ch = child->y_pos + child->height;
+            }
+            else
+            {
+                // [FG] Seed the accumulator with x_pos/y_pos, not 0 --
+                // since DrawElem() adds x_pos/y_pos before drawing, a
+                // large enough negative offset would otherwise make the
+                // child's true extent look smaller than 0 and get
+                // clamped away by MAX().
+                cw = child->x_pos;
+                ch = child->y_pos;
+                DrawElem(0, 0, &cw, &ch, true, child, true); // Dry run
+            }
 
             width = MAX(width, cw);
             height = MAX(height, ch);

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -1069,6 +1069,58 @@ static void UpdateNumber(sbarelem_t *elem, player_t *player)
     number->numvalues = numvalues;
 }
 
+// [FG] Computes xoffset/totalwidth for h_right/h_middle, ignoring any
+// trailing whitespace so a padded, fixed-width string still right-aligns
+// to its visible content rather than to the full padded buffer.
+static void UpdateStringLine(sbaralignment_t alignment, hudfont_t *font,
+                             stringline_t *line)
+{
+    int totalwidth = 0;
+    int width_at_last_visible = 0;
+
+    const char *str = line->string;
+    while (*str)
+    {
+        int ch = *str++;
+        if (ch == '\x1b' && *str)
+        {
+            ++str;
+            continue;
+        }
+
+        int width;
+        if (font->type == sbf_proportional)
+        {
+            int idx = M_ToUpper(ch) - HU_FONTSTART;
+            patch_t *patch =
+                (idx < 0 || idx >= HU_FONTSIZE) ? NULL : font->characters[idx];
+            width = patch ? SHORT(patch->width) : SPACEWIDTH;
+        }
+        else
+        {
+            width = font->monowidth;
+        }
+
+        totalwidth += width;
+
+        if (ch != ' ')
+        {
+            width_at_last_visible = totalwidth;
+        }
+    }
+
+    line->xoffset = 0;
+    if (alignment & sbe_h_middle)
+    {
+        line->xoffset -= (width_at_last_visible >> 1);
+    }
+    else if (alignment & sbe_h_right)
+    {
+        line->xoffset -= width_at_last_visible;
+    }
+    line->totalwidth = width_at_last_visible;
+}
+
 static void UpdateLines(sbarelem_t *elem)
 {
     sbe_widget_t *widget = elem->subtype.widget;
@@ -1077,50 +1129,7 @@ static void UpdateLines(sbarelem_t *elem)
     stringline_t *line;
     array_foreach(line, widget->lines)
     {
-        int totalwidth = 0;
-
-        const char *str = line->string;
-        while (*str)
-        {
-            int ch = *str++;
-            if (ch == '\x1b' && *str)
-            {
-                ++str;
-                continue;
-            }
-
-            if (font->type == sbf_proportional)
-            {
-                ch = M_ToUpper(ch) - HU_FONTSTART;
-                if (ch < 0 || ch >= HU_FONTSIZE)
-                {
-                    totalwidth += SPACEWIDTH;
-                    continue;
-                }
-                patch_t *patch = font->characters[ch];
-                if (patch == NULL)
-                {
-                    totalwidth += SPACEWIDTH;
-                    continue;
-                }
-                totalwidth += SHORT(patch->width);
-            }
-            else
-            {
-                totalwidth += font->monowidth;
-            }
-        }
-
-        line->xoffset = 0;
-        if (elem->alignment & sbe_h_middle)
-        {
-            line->xoffset -= (totalwidth >> 1);
-        }
-        else if (elem->alignment & sbe_h_right)
-        {
-            line->xoffset -= totalwidth;
-        }
-        line->totalwidth = totalwidth;
+        UpdateStringLine(elem->alignment, font, line);
     }
 }
 
@@ -1263,6 +1272,8 @@ static void UpdateString(sbarelem_t *elem)
         default:
             break;
     }
+
+    UpdateStringLine(elem->alignment, string->font, &string->line);
 }
 
 static void UpdateListOfElem(sbarelem_t *elem, player_t *player);
@@ -1653,21 +1664,6 @@ static void DrawNumber(int x1, int y1, int *x2, int *y2, boolean dry,
                        sbarelem_t *elem)
 {
     sbe_number_t *number = elem->subtype.number;
-    sbaralignment_t real_alignment = elem->alignment;
-
-    if (!dry && (real_alignment & (sbe_h_middle | sbe_h_right)))
-    {
-        // [FG] The per-glyph shift below cancels itself out against
-        // DrawPatch(), so measure the true width via a dry run (widescreen
-        // bits masked too, or WideShiftX() would skew it) and shift once.
-        elem->alignment =
-            real_alignment & ~(sbe_h_mask | sbe_wide_left | sbe_wide_right);
-        int width = 0;
-        DrawNumber(0, y1, &width, NULL, true, elem);
-        x1 -= (real_alignment & sbe_h_middle) ? width / 2 : width;
-    }
-
-    elem->alignment = real_alignment & ~sbe_h_mask;
 
     int value = number->value;
     int base_xoffset = number->xoffset;
@@ -1700,29 +1696,12 @@ static void DrawNumber(int x1, int y1, int *x2, int *y2, boolean dry,
     }
 
     number->xoffset = base_xoffset;
-    elem->alignment = real_alignment;
 }
 
 static void DrawStringLine(int x1, int y1, int *x2, int *y2, boolean dry,
                            stringline_t *line, sbarelem_t *elem,
                            hudfont_t *font)
 {
-    sbaralignment_t real_alignment = elem->alignment;
-
-    if (!dry && (real_alignment & (sbe_h_middle | sbe_h_right)))
-    {
-        // [FG] The per-glyph shift below cancels itself out against
-        // DrawPatch(), so measure the true width via a dry run (widescreen
-        // bits masked too, or WideShiftX() would skew it) and shift once.
-        elem->alignment =
-            real_alignment & ~(sbe_h_mask | sbe_wide_left | sbe_wide_right);
-        int width = 0;
-        DrawStringLine(0, y1, &width, NULL, true, line, elem, font);
-        x1 -= (real_alignment & sbe_h_middle) ? width / 2 : width;
-    }
-
-    elem->alignment = real_alignment & ~sbe_h_mask;
-
     int base_xoffset = line->xoffset;
 
     int cr = elem->cr;
@@ -1761,7 +1740,6 @@ static void DrawStringLine(int x1, int y1, int *x2, int *y2, boolean dry,
     }
 
     line->xoffset = base_xoffset;
-    elem->alignment = real_alignment;
 }
 
 static void DrawWidget(int x1, int y1, int *x2, int *y2, boolean dry,

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -2022,7 +2022,7 @@ static void UpdateCanvasOfElem(sbarelem_t *elem, player_t *player)
             child->alignment = child->orig_alignment & ~(sbe_h_mask | sbe_v_mask);
 
             int cw = 0, ch = 0;
-            DrawElem(0, 0, &cw, &ch, true, child); // Dry run
+            DrawElem(0, 0, &cw, &ch, true, child, true); // Dry run
 
             child->alignment = real_alignment;
 

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -1266,6 +1266,7 @@ static void UpdateString(sbarelem_t *elem)
 }
 
 static void UpdateListOfElem(sbarelem_t *elem, player_t *player);
+static void UpdateCanvasOfElem(sbarelem_t *elem, player_t *player);
 
 static void UpdateElem(sbarelem_t *elem, player_t *player)
 {
@@ -1279,6 +1280,10 @@ static void UpdateElem(sbarelem_t *elem, player_t *player)
     {
         case sbe_list:
             UpdateListOfElem(elem, player);
+            return;
+
+        case sbe_canvas:
+            UpdateCanvasOfElem(elem, player);
             return;
 
         case sbe_face:
@@ -1648,6 +1653,21 @@ static void DrawNumber(int x1, int y1, int *x2, int *y2, boolean dry,
                        sbarelem_t *elem)
 {
     sbe_number_t *number = elem->subtype.number;
+    sbaralignment_t real_alignment = elem->alignment;
+
+    if (!dry && (real_alignment & (sbe_h_middle | sbe_h_right)))
+    {
+        // [FG] The per-glyph shift below cancels itself out against
+        // DrawPatch(), so measure the true width via a dry run (widescreen
+        // bits masked too, or WideShiftX() would skew it) and shift once.
+        elem->alignment =
+            real_alignment & ~(sbe_h_mask | sbe_wide_left | sbe_wide_right);
+        int width = 0;
+        DrawNumber(0, y1, &width, NULL, true, elem);
+        x1 -= (real_alignment & sbe_h_middle) ? width / 2 : width;
+    }
+
+    elem->alignment = real_alignment & ~sbe_h_mask;
 
     int value = number->value;
     int base_xoffset = number->xoffset;
@@ -1680,12 +1700,29 @@ static void DrawNumber(int x1, int y1, int *x2, int *y2, boolean dry,
     }
 
     number->xoffset = base_xoffset;
+    elem->alignment = real_alignment;
 }
 
 static void DrawStringLine(int x1, int y1, int *x2, int *y2, boolean dry,
                            stringline_t *line, sbarelem_t *elem,
                            hudfont_t *font)
 {
+    sbaralignment_t real_alignment = elem->alignment;
+
+    if (!dry && (real_alignment & (sbe_h_middle | sbe_h_right)))
+    {
+        // [FG] The per-glyph shift below cancels itself out against
+        // DrawPatch(), so measure the true width via a dry run (widescreen
+        // bits masked too, or WideShiftX() would skew it) and shift once.
+        elem->alignment =
+            real_alignment & ~(sbe_h_mask | sbe_wide_left | sbe_wide_right);
+        int width = 0;
+        DrawStringLine(0, y1, &width, NULL, true, line, elem, font);
+        x1 -= (real_alignment & sbe_h_middle) ? width / 2 : width;
+    }
+
+    elem->alignment = real_alignment & ~sbe_h_mask;
+
     int base_xoffset = line->xoffset;
 
     int cr = elem->cr;
@@ -1724,6 +1761,7 @@ static void DrawStringLine(int x1, int y1, int *x2, int *y2, boolean dry,
     }
 
     line->xoffset = base_xoffset;
+    elem->alignment = real_alignment;
 }
 
 static void DrawWidget(int x1, int y1, int *x2, int *y2, boolean dry,
@@ -1823,6 +1861,14 @@ static void DrawElem(int x1, int y1, int *x2, int *y2, boolean dry,
             DrawListOfElem(x1, y1, x2, y2, dry, elem);
             elem->alignment = real_alignment;
             return;
+
+        case sbe_canvas:
+            // [FG] No visual of its own; just position the anchor for
+            // the children loop below.
+            x1 = AdjustX(x1, elem->width, elem->alignment);
+            x1 = WideShiftX(x1, elem->alignment);
+            y1 = AdjustY(y1, elem->height, elem->alignment);
+            break;
 
         case sbe_graphic:
             {
@@ -1957,6 +2003,36 @@ static void UpdateListOfElem(sbarelem_t *elem, player_t *player)
 
     elem->width = listwidth;
     elem->height = listheight;
+}
+
+// [FG] A canvas positions children at their own x_pos/y_pos instead of
+// stacking them, so its size is the furthest extent any child reaches.
+static void UpdateCanvasOfElem(sbarelem_t *elem, player_t *player)
+{
+    int width = 0, height = 0;
+
+    sbarelem_t *child;
+    array_foreach(child, elem->children)
+    {
+        UpdateElem(child, player);
+
+        if (child->enabled)
+        {
+            sbaralignment_t real_alignment = child->alignment;
+            child->alignment = child->orig_alignment & ~(sbe_h_mask | sbe_v_mask);
+
+            int cw = 0, ch = 0;
+            DrawElem(0, 0, &cw, &ch, true, child); // Dry run
+
+            child->alignment = real_alignment;
+
+            width = MAX(width, cw);
+            height = MAX(height, ch);
+        }
+    }
+
+    elem->width = width;
+    elem->height = height;
 }
 
 static void DrawListOfElem(int x1, int y1, int *x2, int *y2, boolean dry,

--- a/src/st_widgets.c
+++ b/src/st_widgets.c
@@ -552,11 +552,8 @@ static void UpdateChat(sbe_widget_t *widget)
     if (chat_on)
     {
         M_StringCopy(string, chatline.string, sizeof(string));
-
-        if (leveltime & 16)
-        {
-            M_StringConcat(string, "_", sizeof(string));
-        }
+        // make sure active chat line is at least one char wide
+        M_StringConcat(string, (leveltime & 16) ? "_" : " ", sizeof(string));
         ST_AddLine(widget, string);
     }
 }


### PR DESCRIPTION
- Fix alignments of list elements (Fixes #2765)
- Implement drawing on canvas element
- Fix string line alignments
- Fix height/width calculation
- Fix command history (right-aligned space-padded) drawing
- Fix widget height calculation
- Make sure the active chat line is at least one char wide, so it gets a physical height (this part obsoletes the code change in #2801)
- Obsoletes #2803 and #2805