### PR TITLE
fix ghost monster translucency on save/load

### DIFF
--- a/src/p_enemy.c
+++ b/src/p_enemy.c
@@ -1773,7 +1773,7 @@ static boolean P_HealCorpse(mobj_t* actor, int radius, statenum_t healstate, sfx
 		  if (STRICTMODE(ghost_monsters) && corpsehit->height == 0
 		      && corpsehit->radius == 0)
 		  {
-		      corpsehit->tranmap = GetNormalTranMap(default_tranmap_alpha);
+		      corpsehit->intflags |= MIF_GHOST;
 		      I_Printf(VB_WARNING, "A_VileChase: Resurrected ghost monster (%d) at (%d/%d)!",
 		              corpsehit->type, corpsehit->x>>FRACBITS, corpsehit->y>>FRACBITS);
 		  }

--- a/src/p_mobj.h
+++ b/src/p_mobj.h
@@ -245,6 +245,7 @@ typedef enum
   // cosmetic
   MIF_FLIP            = 0x00000010,
   MIF_SPAWNED_BY_ICON = 0x00000020,
+  MIF_GHOST           = 0x00000040,
 } mobjflag_int_t;
 
 // Map Object definition.

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -758,7 +758,7 @@ static void R_ProjectSprite(mobj_t* thing, int lightlevel_override)
   {
     vis->tranmap = main_addimap;
   }
-  else if (thing->flags & MF_TRANSLUCENT)
+  else if ((thing->flags & MF_TRANSLUCENT) || (thing->intflags & MIF_GHOST))
   {
     vis->tranmap = main_tranmap;
   }
@@ -989,7 +989,7 @@ void R_DrawPSprite(pspdef_t *psp, int lightlevel_override)
   {
     vis->tranmap = main_addimap;
   }
-  else if (viewplayer->mo->flags & MF_TRANSLUCENT)
+  else if (viewplayer->mo->flags & MF_TRANSLUCENT /* || (thing->intflags & MIF_GHOST) */)
   {
     vis->tranmap = main_tranmap;
   }


### PR DESCRIPTION
There was no state being stored about vanilla ghost monsters, so upon loading a save file (not rewind) the transparency/translucency would not be restored. By adding a internal flag that is already handled by the save code, this fixes the behavior of vanilla ghosts _not_ keeping their transparency across loads.

Closes #2486