### PR TITLE
Fix view abruptly jolting up & down when running over tiny sector height variations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## New Features and Improvements
 
-* 
+* **Quality of Life:**
+  - Player view no longer abruptly jolts when running across very shallow floor height changes
 
 ## Bug Fixes
 

--- a/src/p_user.c
+++ b/src/p_user.c
@@ -57,6 +57,8 @@ static fixed_t PlayerSlope(player_t *player)
 #define MAXBOB  0x100000
 
 boolean onground; // whether player is on ground or in air
+int offgroundtics; // how many frames the player has been in the air
+#define AIRBOBFADETICS 4 // how many frames over which to reduce bob to 0 in midair
 
 //
 // P_Thrust
@@ -97,7 +99,7 @@ void P_Bob(player_t *player, angle_t angle, fixed_t move)
 void P_CalcHeight (player_t* player)
 {
   int     angle;
-  fixed_t bob;
+  fixed_t bob, totalviewoffset;
 
   // Regular movement bobbing
   // (needs to be calculated for gun swing
@@ -133,7 +135,9 @@ void P_CalcHeight (player_t* player)
     player->bob = MAXBOB;
   }
 
-  if (!onground || player->cheats & CF_NOMOMENTUM)
+  offgroundtics = onground ? 0 : (offgroundtics+1);
+
+  if (player->cheats & CF_NOMOMENTUM || (!onground && (offgroundtics > AIRBOBFADETICS)) )
     {
       player->viewz = player->mo->z + VIEWHEIGHT;
 
@@ -157,7 +161,7 @@ void P_CalcHeight (player_t* player)
 
   // move viewheight
 
-  if (player->playerstate == PST_LIVE)
+  if (player->playerstate == PST_LIVE && onground)
     {
       player->viewheight += player->deltaviewheight;
 
@@ -182,7 +186,10 @@ void P_CalcHeight (player_t* player)
 	}
     }
 
-  player->viewz = player->mo->z + player->viewheight + bob;
+  totalviewoffset = player->viewheight + bob - VIEWHEIGHT;
+  if (!onground)
+    totalviewoffset = totalviewoffset * (AIRBOBFADETICS-offgroundtics+1) / AIRBOBFADETICS;
+  player->viewz = player->mo->z + VIEWHEIGHT + totalviewoffset;
 
   if (player->viewz > player->mo->ceilingz-4*FRACUNIT)
     player->viewz = player->mo->ceilingz-4*FRACUNIT;


### PR DESCRIPTION
This is a QOL adjustment for a Doom pet peeve of mine. (It goes back as far as vanilla doom, it's not something caused by Woof or interpolation or etc.)

This phenomenon can be seen in wads such as When Them Demons Cry or the immediate left/right rooms of 10x10 MAP01, and many more. When running across very tiny sector height variations, such as rugs or loose tiles that are even 1px high, the view often abruptly jumps up or down by a much greater amount than the actual height difference.

https://github.com/user-attachments/assets/990b36a5-9a0d-42a9-a626-6da57ed7a448

This happens because the running viewbobbing gets instantly set to 0 the moment players enter midair, which they do for a frame when running off of even a 1px tall ledge. Then upon landing the next frame the bobbing immediately returns to its full magnitude. Meaning the view snaps up and down quite a bit when running over floors with tiny 1px details.

To fix this, I track how long the player has been in midair and use that to scale the viewbobbing down to 0 across a few frames rather than immediately zeroing it. This eliminates the sudden view jolts when running around on height variations of a couple units.

https://github.com/user-attachments/assets/677d2a87-dd36-454b-8558-b21ac82f9f20

This component is only used for the view vertical offset, and does not affect the weapon sprite, so demo compatibility should be unaffected.

I haven't put it behind a cfg option because I can't imagine anybody actually wanting the old behavior, but I could do it if you really want it.

UZDoom and Doom Retro are other ports I know of which have also dealt with this issue.
