### PR TITLE
refactor sidedef colormap/music specials

### DIFF
--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -508,12 +508,12 @@ void P_LoadLineDefs2(int lump)
 
 static int32_t GetColormapOrTexture(int32_t *out, const char *texture_name)
 {
-  int texture_index = 0;
-  int32_t colormap_index = -1;
-  if ((colormap_index = R_ColormapNumForName(texture_name)) < 0)
+  int32_t texture_index = R_TextureNumForName(texture_name);
+  int32_t colormap_index = R_ColormapNumForName(texture_name);
+
+  if (colormap_index < 0)
   {
     colormap_index = 0;
-    texture_index = R_TextureNumForName(texture_name);
   }
   else
   {
@@ -526,12 +526,12 @@ static int32_t GetColormapOrTexture(int32_t *out, const char *texture_name)
 
 static int32_t GetMusicOrTexture(int32_t *out, const char *texture_name)
 {
-  int texture_index = 0;
-  int32_t music_index = -1;
-  if ((music_index = W_CheckNumForName(texture_name)) < 0)
+  int32_t texture_index = R_TextureNumForName(texture_name);
+  int32_t music_index = W_CheckNumForName(texture_name);
+
+  if (music_index < 0)
   {
     music_index = 0;
-    texture_index = R_TextureNumForName(texture_name);
   }
   else
   {

--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -506,6 +506,41 @@ void P_LoadLineDefs2(int lump)
 //
 // killough 4/4/98: split into two functions
 
+static int32_t GetColormapOrTexture(int32_t *out, const char *texture_name)
+{
+  int texture_index = 0;
+  int32_t colormap_index = -1;
+  if ((colormap_index = R_ColormapNumForName(texture_name)) < 0)
+  {
+    colormap_index = 0;
+    texture_index = R_TextureNumForName(texture_name);
+  }
+  else
+  {
+    texture_index = 0;
+  }
+
+  *out = colormap_index;
+  return texture_index;
+}
+
+static int32_t GetMusicOrTexture(int32_t *out, const char *texture_name)
+{
+  int texture_index = 0;
+  int32_t music_index = -1;
+  if ((music_index = W_CheckNumForName(texture_name)) < 0)
+  {
+    music_index = 0;
+    texture_index = R_TextureNumForName(texture_name);
+  }
+  else
+  {
+    texture_index = 0;
+  }
+  *out = music_index;
+  return texture_index;
+}
+
 void P_ProcessSideDefs(side_t *side, int i, char *bottomtexture, char *midtexture, char *toptexture)
 {
   sector_t *sec = side->sector;
@@ -515,112 +550,24 @@ void P_ProcessSideDefs(side_t *side, int i, char *bottomtexture, char *midtextur
     case 2063: case 2064: case 2065: case 2066: case 2067: case 2068:
     case 2087: case 2088: case 2089: case 2090: case 2091: case 2092:
     case 2093: case 2094: case 2095: case 2096: case 2097: case 2098:
-    {
-      // All of the W1, WR, S1, SR, G1, GR activations can be triggered from
-      // the back sidedef (reading the front bottom texture) and triggered
-      // from the front sidedef (reading the front upper texture).
-      for (int j = 0; j < numlines; j++)
-      {
-        if (lines[j].sidenum[0] == i)
-        {
-          // Back triggered
-          if ((lines[j].backmusic = W_CheckNumForName(bottomtexture)) < 0)
-          {
-            lines[j].backmusic = 0;
-            side->bottomtexture = R_TextureNumForName(bottomtexture);
-          }
-          else
-          {
-            side->bottomtexture = 0;
-          }
-
-          // Front triggered
-          if ((lines[j].frontmusic = W_CheckNumForName(toptexture)) < 0)
-          {
-            lines[j].frontmusic = 0;
-            side->toptexture = R_TextureNumForName(toptexture);
-          }
-          else
-          {
-            side->toptexture = 0;
-          }
-        }
-      }
+      side->bottomtexture = GetMusicOrTexture(&side->bottomindex, bottomtexture);
+      side->toptexture = GetMusicOrTexture(&side->topindex, toptexture);
       side->midtexture = R_TextureNumForName(midtexture);
       break;
-    }
-
-    case 2075:
-    // Sector tinting
-    {
-      for (int j = 0; j < numlines; j++)
-      {
-        if (lines[j].sidenum[0] == i)
-        {
-          // Front triggered
-          if ((lines[j].fronttint = R_ColormapNumForName(toptexture)) < 0)
-          {
-            lines[j].fronttint = 0;
-            side->toptexture = R_TextureNumForName(toptexture);
-          }
-          else
-          {
-            side->toptexture = 0;
-          }
-        }
-      }
-      side->midtexture = R_TextureNumForName(midtexture);
-      side->bottomtexture = R_TextureNumForName(bottomtexture);
-      break;
-    }
 
     case 2076: case 2077: case 2078: case 2079: case 2080: case 2081:
-    // Sector tinting
-    // All of the W1, WR, S1, SR, G1, GR activations can be triggered from
-    // the back sidedef (reading the front bottom texture) and triggered
-    // from the front sidedef (reading the front upper texture).
-    {
-      for (int j = 0; j < numlines; j++)
-      {
-        if (lines[j].sidenum[0] == i)
-        {
-          // Back triggered
-          if ((lines[j].backtint = R_ColormapNumForName(bottomtexture)) < 0)
-          {
-            lines[j].backtint = 0;
-            side->bottomtexture = R_TextureNumForName(bottomtexture);
-          }
-          else
-          {
-            side->bottomtexture = 0;
-          }
-          // Front triggered
-          if ((lines[j].fronttint = R_ColormapNumForName(toptexture)) < 0)
-          {
-            lines[j].fronttint = 0;
-            side->toptexture = R_TextureNumForName(toptexture);
-          }
-          else
-          {
-            side->toptexture = 0;
-          }
-        }
-      }
+      side->bottomtexture = GetColormapOrTexture(&side->bottomindex, bottomtexture);
+      // fallthrough
+    case 2075:
+      side->toptexture = GetColormapOrTexture(&side->topindex, toptexture);
       side->midtexture = R_TextureNumForName(midtexture);
       break;
-    }
 
     // variable colormap via 242 linedef
     case 242:
-      side->bottomtexture =
-        (sec->bottommap =   R_ColormapNumForName(bottomtexture)) < 0 ?
-        sec->bottommap = 0, R_TextureNumForName(bottomtexture): 0 ;
-      side->midtexture =
-        (sec->midmap =   R_ColormapNumForName(midtexture)) < 0 ?
-        sec->midmap = 0, R_TextureNumForName(midtexture)  : 0 ;
-      side->toptexture =
-        (sec->topmap =   R_ColormapNumForName(toptexture)) < 0 ?
-        sec->topmap = 0, R_TextureNumForName(toptexture)  : 0 ;
+      side->bottomtexture = GetColormapOrTexture(&sec->bottommap, bottomtexture);
+      side->midtexture = GetColormapOrTexture(&sec->midmap, midtexture);
+      side->toptexture = GetColormapOrTexture(&sec->topmap, toptexture);
       break;
 
     // killough 4/11/98: apply translucency to 2s normal texture

--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -537,6 +537,7 @@ static int32_t GetMusicOrTexture(int32_t *out, const char *texture_name)
   {
     texture_index = 0;
   }
+
   *out = music_index;
   return texture_index;
 }

--- a/src/p_spec.c
+++ b/src/p_spec.c
@@ -1142,7 +1142,8 @@ void EV_ChangeMusic(line_t *line, int side)
   boolean loops = false;
   boolean resets = false;
 
-  int music = side ? line->backmusic : line->frontmusic;
+  side_t *sidedef = &sides[line->sidenum[0]];
+  int music = side ? sidedef->bottomindex : sidedef->topindex;
 
   switch (line->special)
   {
@@ -1814,7 +1815,8 @@ void P_CrossSpecialLine(line_t *line, int side, mobj_t *thing, boolean bossactio
 
     case 2077:
     {
-      int colormap_index = side ? line->backtint : line->fronttint;
+      side_t *sidedef = &sides[line->sidenum[0]];
+      int colormap_index = side ? sidedef->bottomindex : sidedef->topindex;
       for (int s = -1; (s = P_FindSectorFromLineTag(line, s)) >= 0;)
       {
         sectors[s].tint = colormap_index;
@@ -2305,7 +2307,8 @@ void P_ShootSpecialLine(mobj_t *thing, line_t *line, int side)
       else
         P_ChangeSwitchTexture(line,1);
 
-      int colormap_index = side ? line->backtint : line->fronttint;
+      side_t *sidedef = &sides[line->sidenum[0]];
+      int colormap_index = side ? sidedef->bottomindex : sidedef->topindex;
       for (int s = -1; (s = P_FindSectorFromLineTag(line, s)) >= 0;)
       {
         sectors[s].tint = colormap_index;
@@ -2942,7 +2945,8 @@ void P_SpawnSpecials (void)
       case 2075:
         for (int s = -1; (s = P_FindSectorFromLineTag(&lines[i], s)) >= 0;)
         {
-          sectors[s].tint = lines[i].fronttint;
+          side_t *side = &sides[lines[i].sidenum[0]];
+          sectors[s].tint = side->topindex;
         }
         break;
       }

--- a/src/p_switch.c
+++ b/src/p_switch.c
@@ -637,7 +637,8 @@ P_UseSpecialLine
       else
         P_ChangeSwitchTexture(line,1);
 
-      int colormap_index = side ? line->backtint : line->fronttint;
+      side_t *sidedef = &sides[line->sidenum[0]];
+      int colormap_index = side ? sidedef->bottomindex : sidedef->topindex;
       for (int s = -1; (s = P_FindSectorFromLineTag(line, s)) >= 0;)
       {
         sectors[s].tint = colormap_index;

--- a/src/r_defs.h
+++ b/src/r_defs.h
@@ -212,6 +212,9 @@ typedef struct side_s
   sector_t* sector;      // Sector the SideDef is facing.
   int32_t tint;          // colormap-based tinting
   sidedef_flags_t flags;
+  int32_t topindex;
+  int32_t bottomindex;
+  int32_t midindex;
 
   // killough 4/4/98, 4/11/98: highest referencing special linedef's type,
   // or lump number of special effect. Allows texture names to be overloaded
@@ -296,10 +299,6 @@ typedef struct line_s
 
   // ID24 line specials
   angle_t angle;
-  int frontmusic; // Front upper texture -- activated from the front side
-  int backmusic; // Front lower texture -- activated from the back side
-  int fronttint; // Front upper texture -- activated from the front side
-  int backtint; // Front lower texture -- activated from the back side
 
   boolean dirty;
 } line_t;


### PR DESCRIPTION
de-duplicates, simplifies some ugly code. tested on id24_test.wad and boomedit.wad, still works the same.