### PR TITLE
some UDMF doc clean up

### DIFF
--- a/docs/udmf.txt
+++ b/docs/udmf.txt
@@ -1,5 +1,5 @@
 ===============================================================================
-Universal Doom Map Format Specification v1.1 - 03/29/09
+Universal Doom Map Format Specification v1.2 - 2026-05-18
 
 Written by James "Quasar" Haley - haleyjd@hotmail.com
 
@@ -18,7 +18,7 @@ et al.
     under the terms of the GNU Free Documentation License, Version 1.2
     or any later version published by the Free Software Foundation;
     with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.
-    
+
 ===============================================================================
 
 
@@ -26,23 +26,28 @@ et al.
 Preface
 =======================================
 
-The Universal Doom Map Format specification is a collaborative effort to 
+The Universal Doom Map Format specification is a collaborative effort to
 create and maintain a cross-port standardized textual representation for Doom
-engine maps. 
+engine maps.
 
-The basic UDMF standard contains a superset of the features of all commercial 
-Doom engine games, and provides facilities for seamless extension in source 
-ports, allowing in-editor access to custom map data which would otherwise be 
+The basic UDMF standard contains a superset of the features of all commercial
+Doom engine games, and provides facilities for seamless extension in source
+ports, allowing in-editor access to custom map data which would otherwise be
 squirreled away in external lumps.
 
 
 =======================================
-Changes in v1.1
+Changelog
 =======================================
 
-This is version 1.1 of the UDMF specification, superceding the previous version
-1.0 with the following adjustments:
+Changes in version 1.2:
+* Updated changelog format.
+* Removed trailing whitespace.
+* Added missing Strife linedef opacity flag.
+* Made Strife thing opacity flags behavior more explicit.
+* Formalized the requirement of the compiled map data lumps.
 
+Changes in version 1.1:
 * Added Preface.
 * Grammar for identifiers altered to forbid initial numerals.
 * Made use of true/false keywords for boolean-type fields more explicit.
@@ -76,13 +81,13 @@ used as the values of all boolean fields.
 Comments are supported as C-style single and multi-line comments:
 
     // single line comment
-    
+
     /*
        multi
        line
        comment
     */
-    
+
 Multi-line comments may not be nested.
 
 Implementing editors are not required (but are allowed) to maintain syntactic
@@ -94,21 +99,21 @@ entity follows:
 
     linedef { id = 1; }
 
-Compliant parsers will ignore all unknown keywords in global assignments, 
+Compliant parsers will ignore all unknown keywords in global assignments,
 block-level assignments, and block headers. Compliant parsers should attempt
 to preserve as much of such information as is possible by using a flexible
 mapping such as hashing.
 
 For purposes of forward compatibility, user-defined fields are restricted to
 beginning with the string "user_", but are otherwise normal identifiers.
-Implementing editors should not restrict the entry of custom field names to 
-those beginning with "user_", however, in order to avoid problems with 
+Implementing editors should not restrict the entry of custom field names to
+those beginning with "user_", however, in order to avoid problems with
 out-of-date configurations.
 
 Identifiers and keywords are to be treated as case-insensitive.
 
-A field which specifies "boolean" semantics shall accept keyword value 
-true to mean that the field is asserted, and keyword value false to 
+A field which specifies "boolean" semantics shall accept keyword value
+true to mean that the field is asserted, and keyword value false to
 mean that the field is unasserted. Keyword values can only be defined in
 this specification, and not by implementing ports. Use quoted strings
 instead.
@@ -136,7 +141,7 @@ block of memory serving as the implementing port's lines array:
     linedef { id = 2; }
     linedef { id = 3; }
     linedef { id = 4; }
-    
+
 Data types:
 
 For purposes of internal storage:
@@ -148,12 +153,12 @@ Strings have no reasonable length limitations.
 Hard Data Type Limits
 ---------------------
 No limits on number of definitions are defined as part of this specification,
-but implementors may face the need to impose such limitations due to 
+but implementors may face the need to impose such limitations due to
 restrictions on the amount of memory available, or the amount that can be
 allocated through a single pointer on the host machine or in a private heap
 implementation.
 
-In the event that a map exceeds such an internal engine limitation, an 
+In the event that a map exceeds such an internal engine limitation, an
 implementing port or editor should not continue to attempt loading the map, as
 doing so could destabilize the program.
 
@@ -161,17 +166,23 @@ doing so could destabilize the program.
 II.B : Storage Within Archive Files
 -----------------------------------
 
-UDMF maps shall be layed out within the archive directory as follows:
+UDMF maps shall be laid out within the archive directory as follows:
 
     (HEADER)
     TEXTMAP
-    ... 
+    ...
     ENDMAP
 
 (HEADER) = Any lump name from 1 to 8 characters. Serves as the name of the map.
 TEXTMAP  = Single UDMF lump containing all data for the map.
-...      = Blockmap, reject, BSP tree, and port-specific lumps, if any. The
-           format and presence of these resources are not defined by UDMF.
+ZNODES   = BSP tree in any ZDBSP format.
+BLOCKMAP = Linedef collision lookup table, in either vanilla or XBM1 formats.
+REJECT   = Sector visibility matrix.
+BEHAVIOR = Compiled ACS level script. Hexen-only.
+SCRIPTS  = Uncompiled ACS level script. Hexen-only.
+DIALOGUE = Dialogue for NPCs. Strife-only.
+...      = Any port-specific lumps. The format and presence of these additional
+           resources are not defined by UDMF.
 ENDMAP   = Required closing lump.
 
 Implementing editors and source ports may distinguish a UDMF map from a
@@ -184,27 +195,67 @@ interfere with the order or presence of the lumps.
 
 Use of non-implementing resource editors to manipulate UDMF-map-containing WAD
 files is not recommended, however.
-    
-    
+
+Formal descriptions for the following lump formats and algorithms will not be
+provided in this document. Please refer to their own specification.
+
+The ZNODES lump is a required entry in the list of supported UDMF lumps. It is
+expected to come in any valid ZDBSP binary lump format, those being XNOD, XGLN,
+XGL2 and XGL3, or their respective Zlib-compressed variants, those being ZNOD,
+ZGLN, ZGL2 and ZGL3. Implementing ports which require strictly convex subsectors
+for the purposes of hardware rendering may optionally require the ZNODES lump to
+not come in XNOD or ZNOD in their respective namespace (see Section II.C), or
+generate convex polygon data from other algorithmic means, such as ear clippers,
+or always generate convex subsectors from an internal BSP compiler.
+
+The BLOCKMAP lump is an optional entry in the list of supported UDMF lumps. It
+is expected to come in the 16-bit vanilla binary format, or in the extended
+32-bit XBM1 format. If the BLOCKMAP lump is missing, the implementing port is
+expected to generate the block lists internally.
+
+The REJECT lump is an optional entry in the list of supported UDMF lumps. It is
+expected to be a complete visibility matrix for all the sectors in the level.
+While its presence is optional, and implementing ports are expect to generate a
+padded matrix internally, a correctly compiled REJECT lump is highly recommended
+for the performance improvements of skipping unnecessary line-of-sight checks.
+
+The BEHAVIOR lump is an optional entry in the list of supported UDMF lumps.
+It is expected to come in the ACS0 bytecode format, and is comprised of the
+compiled bytecode used for the level's local ACS script. It may only be used in
+the Hexen namespace, and not in Doom, Heretic or Strife. Implementing ports with
+their own namespace may choose to optionally enable it for their use-case. Such
+implementing may choose to optionally allow extended bytecode formats, such as
+ACSe or ACSE.
+
+The SCRIPTS lump is an additional companion to the BEHAVIOR lump. It is
+comprised of the respective uncompiled ACS code. Stored locally for debugging
+and documentation purposes, it is not used at runtime.
+
+The DIALOGUE lump is an optional entry in the list of supported UDMF lumps. It
+is expected to come in USDF (Universal Strife Dialogue Format) and is comprised
+of the level's NPC conversations. It may only be used in the Strife namespace,
+and not in Doom, Heretic or Hexen. Implementing ports with their own namespace
+may choose to optionally enable it for their use-case.
+
 --------------------------------
 II.C : Implementation Dependence
 --------------------------------
 
 A port's list of supported non-standard fields must be provided to implementing
 editors, where they can be provided to the end user as controls, as options
-in a dropbox, or through the ability to input any arbitrary 
+in a dropbox, or through the ability to input any arbitrary
 "identifier = value;" pair in a text box.
 
 Every UDMF map should contain as the first statement in the file the "namespace"
-identifier statement, which declares the source port implementation relative to 
+identifier statement, which declares the source port implementation relative to
 which this map is to be interpreted.
 
 Example:
 
     namespace = "ZDoom";
-    
-Implementing source ports may ignore this information, or they may use it to 
-perform automatic runtime translation of maps they would otherwise be unable to 
+
+Implementing source ports may ignore this information, or they may use it to
+perform automatic runtime translation of maps they would otherwise be unable to
 support.
 
 Implementing source ports should publicly document the value of the "namespace"
@@ -218,15 +269,15 @@ Heretic
 Hexen
 Strife
 
-The use of one of these namespaces indicates that all line specials, sector 
-specials, thing types, and if applicable, thing specials contained in the UDMF 
-map conform to the "vanilla" types for the respective gamemode (with an 
-exception for Doom) and are therefore 100% compatible with all UDMF 
+The use of one of these namespaces indicates that all line specials, sector
+specials, thing types, and if applicable, thing specials contained in the UDMF
+map conform to the "vanilla" types for the respective gamemode (with an
+exception for Doom) and are therefore 100% compatible with all UDMF
 implementors which support the specified gamemode.
 
 An exception is made for the "Doom" translation type. It is considered to
 represent the final fork of the v1.9 Doom engine, and therefore it includes
-all line types added in DOOM II. It is also additionally considered to 
+all line types added in DOOM II. It is also additionally considered to
 include all specials defined in the BOOM and MBF source ports. Implementors
 who support BOOM linedef types can handle these in the normal manner; ports
 which do not support them should zero or otherwise ignore the offending
@@ -244,10 +295,10 @@ independent of any implementing ports' specific namespaces.
 III. Standardized Fields
 =======================================
 
-The UDMF v1.0 specification considers the following fields standard. They must
+The UDMF v1.2 specification considers the following fields standard. They must
 be recognized by all implementing ports and editors (support for the features
 they signify is not necessarily required, such as for ports which do not
-implement Hexen support - all fields unknown to a given port should be 
+implement Hexen support - all fields unknown to a given port should be
 ignored and not treated as an error).
 
 All boolean fields take the keyword values true and false.
@@ -256,12 +307,12 @@ All boolean fields take the keyword values true and false.
    {
       id = <integer>; // ID of line. Interpreted as tag or scripting id.
                       // Default = -1. *** see below.
-      
+
       v1 = <integer>; // Index of first vertex. No valid default.
       v2 = <integer>; // Index of second vertex. No valid default.
-      
+
       // All flags default to false.
-      
+
       blocking      = <bool>; // true = line blocks things.
       blockmonsters = <bool>; // true = line blocks monsters.
       twosided      = <bool>; // true = line is 2S.
@@ -271,24 +322,26 @@ All boolean fields take the keyword values true and false.
       blocksound    = <bool>; // true = blocks sound.
       dontdraw      = <bool>; // true = line never drawn on map.
       mapped        = <bool>; // true = always appears on map.
-      
+
       // BOOM passuse flag not supported in Strife/Heretic/Hexen namespaces.
-      
+
       passuse       = <bool>; // true = passes use action.
 
       // Strife specific flags. Support for other games is not defined by
       // default and these flags should be ignored when reading maps not for
       // the Strife namespace or maps for a port which supports these flags.
 
-      translucent   = <bool>; // true = line is a Strife translucent line.
       jumpover      = <bool>; // true = line is a Strife railing.
       blockfloaters = <bool>; // true = line is a Strife float-blocker.
-      
+      translucent   = <bool>; // true = line is a Strife 75% opacity line.
+      transparent   = <bool>; // true = line is a Strife 25% opacity line.
+                              // transparent has priority over translucent.
+
       // Note: SPAC flags should be set false in Doom/Heretic/Strife
       // namespace maps. Specials in those games do not support this
       // mechanism and instead imply activation parameters through the
       // special number. All flags default to false.
-      
+
       playercross   = <bool>; // true = player can cross.
       playeruse     = <bool>; // true = player can use.
       monstercross  = <bool>; // true = monster can cross.
@@ -298,75 +351,75 @@ All boolean fields take the keyword values true and false.
       monsterpush   = <bool>; // true = monster can push.
       missilecross  = <bool>; // true = projectile can cross.
       repeatspecial = <bool>; // true = repeatable special.
-      
+
       special = <integer>; // Special. Default = 0.
       arg0    = <integer>; // Argument 0. Default = 0.
       arg1    = <integer>; // Argument 1. Default = 0.
       arg2    = <integer>; // Argument 2. Default = 0.
       arg3    = <integer>; // Argument 3. Default = 0.
       arg4    = <integer>; // Argument 4. Default = 0.
-      
+
       sidefront = <integer>; // Sidedef 1 index. No valid default.
       sideback  = <integer>; // Sidedef 2 index. Default = -1.
-      
+
       comment = <string>; // A comment. Implementors should attach no special
                           // semantic meaning to this field.
    }
-   
+
    sidedef
    {
       offsetx = <integer>; // X Offset. Default = 0.
       offsety = <integer>; // Y Offset. Default = 0.
-      
+
       texturetop    = <string>; // Upper texture. Default = "-".
       texturebottom = <string>; // Lower texture. Default = "-".
       texturemiddle = <string>; // Middle texture. Default = "-".
-      
+
       sector = <integer>; // Sector index. No valid default.
 
       comment = <string>; // A comment. Implementors should attach no special
                           // semantic meaning to this field.
    }
-   
+
    vertex
    {
       x = <float>; // X coordinate. No valid default.
       y = <float>; // Y coordinate. No valid default.
    }
-   
+
    sector
    {
       heightfloor   = <integer>; // Floor height. Default = 0.
       heightceiling = <integer>; // Ceiling height. Default = 0.
-      
+
       texturefloor   = <string>; // Floor flat. No valid default.
       textureceiling = <string>; // Ceiling flat. No valid default.
-      
+
       lightlevel = <integer>; // Light level. Default = 160.
-      
+
       special = <integer>; // Sector special. Default = 0.
       id      = <integer>; // Sector tag/id. Default = 0.
 
       comment = <string>; // A comment. Implementors should attach no special
                           // semantic meaning to this field.
    }
-   
+
    thing
    {
       id = <integer>; // Thing ID. Default = 0.
-      
+
       x = <float>; // X coordinate. No valid default.
       y = <float>; // Y coordinate. No valid default.
-      
+
       height = <float>; // Z height relative to floor. Default = 0.
                         // (Relative to ceiling for SPAWNCEILING items).
-                          
+
       angle = <integer>; // Map angle of thing in degrees. Default = 0 (East).
-      
+
       type = <integer>; // DoomedNum. No valid default.
-      
+
       // All flags default to false.
-      
+
       skill1      = <bool>; // true = in skill 1.
       skill2      = <bool>; // true = in skill 2.
       skill3      = <bool>; // true = in skill 3.
@@ -378,31 +431,33 @@ All boolean fields take the keyword values true and false.
       coop        = <bool>; // true = in Coop.
 
       // MBF friend flag not supported in Strife/Heretic/Hexen namespaces.
-      
+
       friend      = <bool>; // true = MBF friend.
-      
+
       // Hexen flags; not supported in Doom/Strife/Heretic namespaces.
-      
+
       dormant     = <bool>; // true = dormant thing.
       class1      = <bool>; // true = Present for pclass 1.
       class2      = <bool>; // true = Present for pclass 2.
       class3      = <bool>; // true = Present for pclass 3.
-      
+
 
       // Strife specific flags. Support for other games is not defined by
       // default and these flags should be ignored when reading maps not for
       // the Strife namespace or maps for a port which supports these flags.
       standing    = <bool>; // true = Strife NPC flag.
       strifeally  = <bool>; // true = Strife ally flag.
-      translucent = <bool>; // true = Strife translucency flag.
+      translucent = <bool>; // true = Strife 25% opacity flag.
       invisible   = <bool>; // true = Strife invisibility flag.
-            
+                            // when combining both translucent and invisible,
+                            // an opacity of 75% is used.
+
       // Note: suggested editor defaults for all skill, gamemode, and player
       // class flags is true rather than the UDMF default of false.
 
       // Thing special semantics are only defined for the Hexen namespace or
       // ports which implement this feature in their own namespace.
-      
+
       special = <integer>; // Scripting special. Default = 0;
       arg0    = <integer>; // Argument 0. Default = 0.
       arg1    = <integer>; // Argument 1. Default = 0.
@@ -413,30 +468,30 @@ All boolean fields take the keyword values true and false.
       comment = <string>; // A comment. Implementors should attach no special
                           // semantic meaning to this field.
    }
-   
+
 
 *** Tag / ID Behavior for Map Conversion:
-   
+
    Unlike traditional Doom maps UDMF makes a clear distinction between a line's
-   ID and the parameter which identifies the object the line's special is 
+   ID and the parameter which identifies the object the line's special is
    supposed to affect.
 
    The id will be used to identify this line, and arg0 will be used to identify
    the line or sector that this line is to affect or otherwise reference, i.e.
    it is effectively a parameter to the line's special.
 
-   Boom used the linedef's tag for both due to lack of other options so in 
-   order to ensure compatibility any map converter converting maps for the 
+   Boom used the linedef's tag for both due to lack of other options so in
+   order to ensure compatibility any map converter converting maps for the
    Doom/Heretic/Strife namespaces must store the linedef's tag field as both
-   the id and as arg0 in each line. The default value of the id field under 
+   the id and as arg0 in each line. The default value of the id field under
    these namespaces is defined as 0 rather than -1.
-   
+
    Since UDMF provides a line id field, the Hexen line special #121
    (Line_SetIdentification) is obsolete. When converting maps to UDMF under
    Hexen namespace, special 121 should be written as zero, and the arg0 of
    the binary linedef should be written as the id field of the UDMF line.
    The arg0 value of the UDMF line should also then be set to zero.
-   
+
 ===============================================================================
 EOF
 ===============================================================================

--- a/docs/udmf_woof.txt
+++ b/docs/udmf_woof.txt
@@ -18,13 +18,15 @@ Preface
 =======================================
 
 This specification defines the "Woof" UDMF namespace for maps which exclusively
-target the eponymous source port.
+target the eponymous source port, and its own derivative "soft forks", such as
+Nugget Doom. It based on the UDMF v1.2 spec, specifically the "Doom" namespace
+and its own definitions. Woof does not support Heretic, Hexen or Strife.
 
 =======================================
 I. Grammar / Syntax
 =======================================
 
-No changes have been made since the v1.1 version of the base specification.
+No changes have been made since the v1.2 version of the base specification.
 
 =======================================
 II. Implementation Semantics
@@ -35,7 +37,7 @@ II.A : Storage and Retrieval of Data
 ------------------------------------
 
 Any TEXTMAP lump in the "Woof" namespace must be encoded in plain ASCII.
-Otherwise, no further changes from the version 1.1 base specification.
+Otherwise, no further changes from the version 1.2 base specification.
 
 -----------------------------------
 II.B : Storage Within Archive Files
@@ -75,60 +77,20 @@ III. Standardized Fields
 =======================================
 
 All boolean fields take the keyword values true and false.
-
-  vertex
-  {
-    x = <float>; // X coordinate. No valid default.
-    y = <float>; // Y coordinate. No valid default.
-  }
+Properties already defined in the base specification are omitted.
 
   linedef
   {
-    id = <integer>; // ID of line. Interpreted as tag or scripting id.
-                    // Default = 0
-
-    v1 = <integer>; // Index of first vertex. No valid default.
-    v2 = <integer>; // Index of second vertex. No valid default.
-
-    // All flags default to false.
-    blocking          = <bool>; // true = line blocks things.
-    blockmonsters     = <bool>; // true = line blocks monsters.
-    twosided          = <bool>; // true = line is 2S.
-    dontpegtop        = <bool>; // true = upper texture unpegged.
-    dontpegbottom     = <bool>; // true = lower texture unpegged.
-    secret            = <bool>; // true = drawn as 1S on map.
-    blocksound        = <bool>; // true = blocks sound.
-    dontdraw          = <bool>; // true = line never drawn on map.
-    mapped            = <bool>; // true = always appears on map.
-    // Boom
-    passuse           = <bool>; // true = passes use action.
     // MBF21
     blocklandmonsters = <bool>; // true = line blocks monsters on the ground.
     blockplayers      = <bool>; // true = line blocks players.
 
-    special = <integer>; // Special. Default = 0.
-    arg0    = <integer>; // Target ID used on action activation. Default = 0.
-
-    sidefront = <integer>; // Sidedef 1 index. No valid default.
-    sideback  = <integer>; // Sidedef 2 index. Default = -1.
-
     alpha   = <float>;  // Opacity percentage. Default = 1.0.
     tranmap = <string>; // Custom translucency map lump. Overrides alpha.
-
-    comment = <string>; // A comment. No special meaning is attached to it.
   }
 
   sidedef
   {
-    offsetx = <integer>; // X Offset. Default = 0.
-    offsety = <integer>; // Y Offset. Default = 0.
-
-    texturetop    = <string>; // Upper texture. Default = "-".
-    texturebottom = <string>; // Lower texture. Default = "-".
-    texturemiddle = <string>; // Middle texture. Default = "-".
-
-    sector = <integer>; // Sector index. No valid default.
-
     offsetx_top    = <float>; // Tiered X/Y textures offsets. Default = 0.0.
     offsety_top    = <float>; // Additive to base offsets.
     offsetx_mid    = <float>; //
@@ -158,30 +120,16 @@ All boolean fields take the keyword values true and false.
     light_bottom = <integer>;      //
     lightabsolute_bottom = <bool>; //
 
-    smoothlighting = <bool>; // Use smooth fake contrast on this sidedef.
     nofakecontrast = <bool>; // Disables use of fake contrast on this sidedef.
                              // The latter takes priority over the former.
 
     clipmidtex = <bool>; // Side's mid textures are clipped to floor and ceiling.
 
     tint = <string>; // View-agnostic custom COLORMAP lump
-
-    comment = <string>; // A comment. No special meaning is attached to it.
   }
 
   sector
   {
-    heightfloor   = <integer>; // Floor height. Default = 0.
-    heightceiling = <integer>; // Ceiling height. Default = 0.
-
-    texturefloor   = <string>; // Floor flat. No valid default.
-    textureceiling = <string>; // Ceiling flat. No valid default.
-
-    lightlevel = <integer>; // Light level. Default = 160.
-
-    special = <integer>; // Sector special. Default = 0.
-    id      = <integer>; // Sector tag/id. Default = 0.
-
     xpanningfloor = <float>;   // Plane texture offsets.
     ypanningfloor = <float>;   // Default = 0.0.
     xpanningceiling = <float>; //
@@ -202,40 +150,15 @@ All boolean fields take the keyword values true and false.
     lightfloorabsolute   = <bool>;    // true = 'light' is considered "absolute",
     lightceilingabsolute = <bool>;    // overriding the sector's light level.
 
-    tint        = <string>; // View-agnostic custom COLORMAP lump
+    tint = <string>; // View-agnostic custom COLORMAP lump for sides, planes and
+                     // things present in said sector. Gets overwritten by the
+                     // more specific tint properties above and below.
     tintfloor   = <string>; // Same as above, but for sector floor
     tintceiling = <string>; // Same as above, but for sector ceiling
-
-    comment = <string>; // A comment. No special meaning is attached to it.
   }
 
   thing
   {
-    id = <integer>; // Thing ID. Default = 0.
-
-    x = <float>; // X coordinate. No valid default.
-    y = <float>; // Y coordinate. No valid default.
-
-    height = <float>; // Z height relative to floor. Default = 0.
-                      // (Relative to ceiling for SPAWNCEILING items).
-
-    angle = <integer>; // Map angle of thing in degrees. Default = 0 (East).
-
-    type = <integer>; // DoomedNum. No valid default.
-
-    // All flags default to false.
-    skill1 = <bool>; // true = in skill 1.
-    skill2 = <bool>; // true = in skill 2.
-    skill3 = <bool>; // true = in skill 3.
-    skill4 = <bool>; // true = in skill 4.
-    skill5 = <bool>; // true = in skill 5.
-    ambush = <bool>; // true = thing is deaf.
-    single = <bool>; // true = in SP mode.
-    dm     = <bool>; // true = in DM mode.
-    coop   = <bool>; // true = in Coop.
-    // MBF
-    friend = <bool>; // true = marine's best friend :)
-
     // MUSINFO Music Changers, and SNDINFO Ambient Sound sources make use of
     // these arguments slots for additional customization.
     arg0 = <integer>; // Argument 0.
@@ -248,19 +171,7 @@ All boolean fields take the keyword values true and false.
     tranmap = <string>; // Custom translucency map lump. Overrides alpha.
     tint    = <string>; // View-agnostic custom COLORMAP lump
 
-    comment = <string>; // A comment. No special meaning is attached to it.
   }
-
-
-*** Tag / ID Behavior for Map Conversion:
-
-  Unlike traditional Doom maps UDMF makes a clear distinction between a line's
-  ID and the parameter which identifies the object the line's special is 
-  supposed to affect.
-
-  The id will be used to identify this line, and arg0 will be used to identify
-  the line or sector that this line is to affect or otherwise reference, i.e.
-  it is effectively a parameter to the line's special.
 
 ===============================================================================
 EOF


### PR DESCRIPTION
Updated copy of base spec UDMF doc from v1.1 to v1.2 _and_ cleaned up our own namespace doc, by mainly removing duplicate definitions from the base spec (UZDoom does this also), .