### PR TITLE
AppImage fixes

### DIFF
--- a/data/io.github.fabiangreffrath.woof-setup.desktop
+++ b/data/io.github.fabiangreffrath.woof-setup.desktop
@@ -6,3 +6,4 @@ Type=Application
 Comment=Setup tool for Woof!
 Categories=Settings;
 Keywords=first;person;shooter;vanilla;doom;boom;mbf;
+StartupWMClass=io.github.fabiangreffrath.woof

--- a/data/io.github.fabiangreffrath.woof.desktop
+++ b/data/io.github.fabiangreffrath.woof.desktop
@@ -8,3 +8,4 @@ Comment=Continuation of the Boom/MBF bloodline of Doom source ports
 Categories=Game;ActionGame;
 MimeType=application/x-doom-wad;
 Keywords=first;person;shooter;vanilla;doom;boom;mbf;
+StartupWMClass=io.github.fabiangreffrath.woof

--- a/data/io.github.fabiangreffrath.woof.desktop
+++ b/data/io.github.fabiangreffrath.woof.desktop
@@ -9,3 +9,8 @@ Categories=Game;ActionGame;
 MimeType=application/x-doom-wad;
 Keywords=first;person;shooter;vanilla;doom;boom;mbf;
 StartupWMClass=io.github.fabiangreffrath.woof
+Actions=launch-setup
+
+[Desktop Action launch-setup]
+Name=Woof! Setup
+Exec=woof -setup

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1627,15 +1627,12 @@ void D_DoomMain(void)
   // Launch woof-setup.
   //
 
-  if (M_getenv("APPIMAGE"))
+  if (M_ParmExists("-setup"))
   {
-    if (M_ParmExists("-setup"))
-    {
-      const char* setup_path = M_StringJoin(D_DoomExeDir(), DIR_SEPARATOR_S, "woof-setup");
-      const char* args[] = { setup_path, NULL };
-      SDL_CreateProcess(args, false);
-      I_SafeExit(0);
-    }
+    const char* setup_path = M_StringJoin(D_DoomExeDir(), DIR_SEPARATOR_S, "woof-setup");
+    const char* args[] = { setup_path, NULL };
+    SDL_CreateProcess(args, false);
+    I_SafeExit(0);
   }
 
   #endif

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1620,6 +1620,26 @@ void D_DoomMain(void)
     I_SafeExit(0);
   }
 
+  #ifdef __linux__
+
+  //!
+  //
+  // Launch woof-setup.
+  //
+
+  if (M_getenv("APPIMAGE"))
+  {
+    if (M_ParmExists("-setup"))
+    {
+      const char* setup_path = M_StringJoin(D_DoomExeDir(), DIR_SEPARATOR_S, "woof-setup");
+      const char* args[] = { setup_path, NULL };
+      SDL_CreateProcess(args, false);
+      I_SafeExit(0);
+    }
+  }
+
+  #endif
+
   // [FG] initialize logging verbosity early to decide
   //      if the following lines will get printed or not
 

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1631,8 +1631,8 @@ void D_DoomMain(void)
   {
     const char* setup_path = M_StringJoin(D_DoomExeDir(), DIR_SEPARATOR_S, "woof-setup");
     const char* args[] = { setup_path, NULL };
-    SDL_CreateProcess(args, false);
-    I_SafeExit(0);
+    SDL_Process* process = SDL_CreateProcess(args, false);
+    I_SafeExit(process ? 0 : 1);
   }
 
   #endif

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg-configuration.schema.json",
-  "overlay-triplets": [ "./cmake/triplets" ]
+  "overlay-triplets": [ "./cmake/triplets" ],
+  "overlay-ports": [ "./vcpkg-overlays" ]
 }

--- a/vcpkg-overlays/sdl3/fix-freebsd.patch
+++ b/vcpkg-overlays/sdl3/fix-freebsd.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9e19336..ff6424b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -4038,7 +4038,7 @@ else()
+ endif()
+ set(SDL_INSTALL_CMAKEDIR_ROOT "${SDL_INSTALL_CMAKEDIR_ROOT_DEFAULT}" CACHE STRING "Root folder where to install SDL3Config.cmake related files (SDL3 subfolder for MSVC projects)")
+ 
+-if(FREEBSD)
++if(0)
+   # FreeBSD uses ${PREFIX}/libdata/pkgconfig
+   set(SDL_PKGCONFIG_INSTALLDIR "libdata/pkgconfig")
+ else()

--- a/vcpkg-overlays/sdl3/fix-freebsd.patch
+++ b/vcpkg-overlays/sdl3/fix-freebsd.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 9e19336..ff6424b 100644
+index 51657f6e4..694571670 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -4038,7 +4038,7 @@ else()
+@@ -4283,7 +4283,7 @@ else()
  endif()
  set(SDL_INSTALL_CMAKEDIR_ROOT "${SDL_INSTALL_CMAKEDIR_ROOT_DEFAULT}" CACHE STRING "Root folder where to install SDL3Config.cmake related files (SDL3 subfolder for MSVC projects)")
  

--- a/vcpkg-overlays/sdl3/portfile.cmake
+++ b/vcpkg-overlays/sdl3/portfile.cmake
@@ -1,0 +1,97 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO libsdl-org/SDL
+    REF "release-${VERSION}"
+    SHA512 d815b28f72d60e4d83e31d878bcf2dd52089353637a4ffd0fd094deaafaaa5b5ee797caad9eeb952f6c28a2bbe26253092c294ce1aefbeb92d85469f35229ed1
+    HEAD_REF main
+    PATCHES
+        fix-freebsd.patch
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" SDL_STATIC)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" SDL_SHARED)
+string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" FORCE_STATIC_VCRT)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        alsa     SDL_ALSA
+        dbus     SDL_DBUS
+        ibus     SDL_IBUS
+        vulkan   SDL_VULKAN
+        wayland  SDL_WAYLAND
+        x11      SDL_X11
+        libusb   SDL_HIDAPI_LIBUSB
+)
+
+if (VCPKG_TARGET_IS_EMSCRIPTEN)
+    vcpkg_check_features(OUT_FEATURE_OPTIONS EMSCRIPTEN_FEATURE_OPTIONS
+        FEATURES
+            emscripten-pthreads     SDL_PTHREADS
+    )
+    vcpkg_list(APPEND FEATURE_OPTIONS "${EMSCRIPTEN_FEATURE_OPTIONS}")
+endif()
+
+if ("x11" IN_LIST FEATURES)
+    message(WARNING "You will need to install Xorg dependencies to use feature x11:\nsudo apt install libx11-dev libxft-dev libxext-dev\n")
+endif()
+if ("wayland" IN_LIST FEATURES)
+    message(WARNING "You will need to install Wayland dependencies to use feature wayland:\nsudo apt install libwayland-dev libxkbcommon-dev libegl1-mesa-dev\n")
+endif()
+if ("ibus" IN_LIST FEATURES)
+    message(WARNING "You will need to install ibus dependencies to use feature ibus:\nsudo apt install libibus-1.0-dev\n")
+endif()
+
+if ("libusb" IN_LIST FEATURES)
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+        vcpkg_list(APPEND FEATURE_OPTIONS "-DSDL_HIDAPI_LIBUSB_SHARED=ON")
+    else()
+        vcpkg_list(APPEND FEATURE_OPTIONS "-DSDL_HIDAPI_LIBUSB_SHARED=OFF")
+    endif()
+endif()
+
+# option for not need to show windows
+list(APPEND FEATURE_OPTIONS -DSDL_UNIX_CONSOLE_BUILD=ON)
+if (VCPKG_TARGET_IS_LINUX AND NOT "x11" IN_LIST FEATURES AND NOT "wayland" IN_LIST FEATURES)
+    message(WARNING "The selected features don't allow sdl3 to create windows, which is usually unintentional. You can get windowing support by installing the x11 and/or wayland features.")
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DSDL_STATIC=${SDL_STATIC}
+        -DSDL_SHARED=${SDL_SHARED}
+        -DSDL_FORCE_STATIC_VCRT=${FORCE_STATIC_VCRT}
+        -DSDL_LIBC=ON
+        -DSDL_TEST_LIBRARY=OFF
+        -DSDL_TESTS=OFF
+        -DSDL_X11_XSCRNSAVER=OFF
+        -DSDL_INSTALL_CMAKEDIR_ROOT=share/${PORT}
+        # Specifying the revision skips the need to use git to determine a version
+        -DSDL_REVISION=vcpkg
+    MAYBE_UNUSED_VARIABLES
+        SDL_FORCE_STATIC_VCRT
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE.txt"
+        "${SOURCE_PATH}/src/hidapi/LICENSE-bsd.txt"
+        "${SOURCE_PATH}/src/video/stb_image.h"
+        "${SOURCE_PATH}/src/video/yuv2rgb/LICENSE"
+        "${SOURCE_PATH}/include/SDL3/SDL_opengles2_gl2.h"
+        "${SOURCE_PATH}/include/SDL3/SDL_opengles2_gl2platform.h"
+    COMMENT "SDL_opengles2_gl2platform.h is licensed under Apache-2.0; see https://www.apache.org/licenses/LICENSE-2.0."
+)

--- a/vcpkg-overlays/sdl3/portfile.cmake
+++ b/vcpkg-overlays/sdl3/portfile.cmake
@@ -84,7 +84,6 @@ file(REMOVE_RECURSE
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 
-file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(
     FILE_LIST
         "${SOURCE_PATH}/LICENSE.txt"

--- a/vcpkg-overlays/sdl3/vcpkg.json
+++ b/vcpkg-overlays/sdl3/vcpkg.json
@@ -1,0 +1,87 @@
+{
+  "name": "sdl3",
+  "version": "3.4.16",
+  "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
+  "homepage": "https://www.libsdl.org",
+  "license": "Zlib AND MIT AND Apache-2.0 AND BSD-3-Clause",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    {
+      "name": "ibus",
+      "platform": "linux"
+    },
+    {
+      "name": "wayland",
+      "platform": "linux"
+    },
+    {
+      "name": "x11",
+      "platform": "linux"
+    }
+  ],
+  "features": {
+    "alsa": {
+      "description": "Support for alsa audio",
+      "dependencies": [
+        {
+          "name": "alsa",
+          "platform": "linux"
+        }
+      ]
+    },
+    "dbus": {
+      "description": "Build with D-Bus support",
+      "dependencies": [
+        {
+          "name": "dbus",
+          "default-features": false,
+          "platform": "linux"
+        }
+      ]
+    },
+    "emscripten-pthreads": {
+      "description": "Build Emscripten pthreads support",
+      "supports": "emscripten"
+    },
+    "ibus": {
+      "description": "Build with ibus IME support",
+      "supports": "linux",
+      "dependencies": [
+        {
+          "name": "sdl3",
+          "default-features": false,
+          "features": [
+            "dbus"
+          ]
+        }
+      ]
+    },
+    "libusb": {
+      "description": "Use libusb for joystick support",
+      "dependencies": [
+        "libusb"
+      ]
+    },
+    "vulkan": {
+      "description": "Vulkan functionality for SDL"
+    },
+    "wayland": {
+      "description": "Build with Wayland support",
+      "supports": "linux"
+    },
+    "x11": {
+      "description": "Build with X11 support",
+      "supports": "!windows"
+    }
+  }
+}


### PR DESCRIPTION
Fixes #2523
Fixes #2827

A few issues with the AppImage are fixed:
1. The .desktop files have StartupWMClass set, without which GNOME will often fail to match the windows to the desktop files.
2. There is now a desktop action to launch woof-setup. Because AppImages are designed to only contain a single executable and have no way to export multiple desktop files or launch anything but the main AppRun, I added a `-setup` cli option to Woof that will launch woof-setup and then immediately exit. The woof-setup window will be matched to the woof desktop file instead of the woof-setup desktop file for 2 reasons: firstly, it seems like a bug both both applications have the same app_id, when woof-setup probably should be `io.github.fabiangreffrath.woof-setup`, secondly we can actually take advantage of this, because it allows the window at least have *an* icon, if not exactly the correct one, because fixing the app_id would result in it not being able to match any desktop file due to the woof-setup one being hidden in the appimage. This should be considered a temporary solution just for until woof-setup is integrated into the main executable.
3. SDL3 is now built with proper support for wayland and x11 features again, by using an overlay port to remove the options that were force-disabling them in upstream vcpkg. This restores proper window decorations:
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/810c2a2d-8b0d-4f3d-8de9-20749de25c96" />
