### PR TITLE
Use execv instead of SDL_CreateProcess for the -setup arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Bug Fixes
 
-* 
+* Fixed setup desktop action exiting immediately when run from the AppImage
 
 ## Miscellaneous
 

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -24,6 +24,10 @@
 #include <ctype.h>
 #endif
 
+#ifdef __linux__
+#include <unistd.h>
+#endif
+
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -1624,10 +1628,10 @@ void D_DoomMain(void)
 
   if (M_ParmExists("-setup"))
   {
-    const char* setup_path = M_StringJoin(D_DoomExeDir(), DIR_SEPARATOR_S, PROJECT_SHORTNAME "-setup");
-    const char* args[] = { setup_path, NULL };
-    SDL_Process* process = SDL_CreateProcess(args, false);
-    I_SafeExit(process ? 0 : 1);
+    char* setup_path = M_StringJoin(D_DoomExeDir(), DIR_SEPARATOR_S, PROJECT_SHORTNAME "-setup");
+    char* args[] = { setup_path, NULL };
+    execv(setup_path, args);
+    I_SafeExit(1);
   }
 
   #endif


### PR DESCRIPTION
This is because the AppImage becomes unmounted as soon as the main process exits, so we need woof-setup to replace the current process
