### PR TITLE
Improve palettization of PNGs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * **Quality of Life:**
   - Player view no longer abruptly jolts when running across very shallow floor height changes
 
+* **Rendering:**
+  - Improved palettization of true-color PNG graphics.
+
 ## Bug Fixes
 
 * Fixed setup desktop action exiting immediately when run from the AppImage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   - Player view no longer abruptly jolts when running across very shallow floor height changes
 
 * **Rendering:**
-  - Improved palettization of true-color PNG graphics.
+  - Improved palettization of PNG graphics.
 
 ## Bug Fixes
 

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -52,6 +52,7 @@
 #include "r_draw.h"
 #include "r_main.h"
 #include "r_plane.h"
+#include "r_srgb.h"
 #include "r_voxel.h"
 #include "s_sound.h"
 #include "st_stuff.h"
@@ -1052,7 +1053,7 @@ void I_SetPalette(byte *playpal)
 
 // Taken from Chocolate Doom chocolate-doom/src/i_video.c:L841-867
 
-byte I_GetNearestColor(byte *palette, int r, int g, int b)
+byte I_GetNearestColor(const byte *palette, int r, int g, int b)
 {
     byte best;
     int best_diff, diff;
@@ -1068,6 +1069,60 @@ byte I_GetNearestColor(byte *palette, int r, int g, int b)
         db = b - *palette++;
 
         diff = dr * dr + dg * dg + db * db;
+
+        if (diff < best_diff)
+        {
+            if (!diff)
+            {
+                return i;
+            }
+
+            best = i;
+            best_diff = diff;
+        }
+    }
+
+    return best;
+}
+
+static boolean linear_palette_init = false;
+static double linear_palette[768];
+
+byte I_GetNearestColorLinear(const byte *palette, int red, int green, int blue)
+{
+    if (!linear_palette_init)
+    {
+        linear_palette_init = true;
+
+        // We assume that all calls to this function pass the same palette
+
+        const byte *palette_rover = palette;
+        double *linear_palette_rover = linear_palette;
+
+        for (int i = 0; i < 768; i++)
+        {
+            *linear_palette_rover++ = byte_to_linear(*palette_rover++);
+        }
+    }
+
+    const double
+        linear_red   = byte_to_linear(red),
+        linear_green = byte_to_linear(green),
+        linear_blue  = byte_to_linear(blue);
+
+    byte best = 0;
+    double best_diff = INT_MAX;
+
+    const double *linear_palette_rover = linear_palette;
+
+    for (int i = 0; i < 256; ++i)
+    {
+        const double
+            dr = linear_red   - *linear_palette_rover++,
+            dg = linear_green - *linear_palette_rover++,
+            db = linear_blue  - *linear_palette_rover++;
+
+        const double diff = dr * dr + dg * dg + db * db;
 
         if (diff < best_diff)
         {

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -73,7 +73,8 @@ extern boolean correct_aspect_ratio;
 extern boolean screenvisible;
 
 extern int gamma2;
-byte I_GetNearestColor(byte *palette, int r, int g, int b);
+byte I_GetNearestColor(const byte *palette, int r, int g, int b);
+byte I_GetNearestColorLinear(const byte *palette, int red, int green, int blue);
 
 boolean I_WritePNGfile(char *filename); // [FG] screenshots in PNG format
 

--- a/src/v_patch.c
+++ b/src/v_patch.c
@@ -465,6 +465,8 @@ static boolean DecodePNG(png_t *png)
         const int indexed_size = image_size / 4;
         byte *const indexed_image = malloc(indexed_size);
 
+        InitRGB2Pal();
+
         const byte *roller = image;
 
         static unsigned *alpha_pixels = NULL;

--- a/src/v_patch.c
+++ b/src/v_patch.c
@@ -310,7 +310,7 @@ static void InitRGB2Pal(void)
             {
                 const int sb = b << RGB2PAL_IBPC;
 
-                rgb2pal_g[b] = I_GetNearestColor(playpal, sr, sg, sb);
+                rgb2pal_g[b] = I_GetNearestColorLinear(playpal, sr, sg, sb);
             }
         }
     }
@@ -567,7 +567,7 @@ static boolean DecodePNG(png_t *png)
 
             need_translation = true;
             translate[i] =
-                I_GetNearestColor(playpal, e->red, e->green, e->blue);
+                I_GetNearestColorLinear(playpal, e->red, e->green, e->blue);
         }
 
         if (need_translation)

--- a/src/v_patch.c
+++ b/src/v_patch.c
@@ -493,7 +493,7 @@ static boolean DecodePNG(png_t *png)
                 b = *roller++,
                 a = *roller++;
 
-            if (a < 255)
+            if (a < 128)
             {
                 alpha_pixels[num_alpha_pixels++] = i;
                 continue;

--- a/src/v_patch.c
+++ b/src/v_patch.c
@@ -267,80 +267,58 @@ static void *DummyFlat(int lump, pu_tag tag)
     return lumpcache[lump];
 }
 
-// Uniform Color Quantization
-//
-// Each color component axis (red, green and blue) is divided into a few fixed
-// segments (8-8-4 in 256 colors). Each found color is placed into a
-// corresponding segment slot. After all the colors are added, an average
-// color is calculated for each slot. Those are the colors of the palette.
+// [Alaux] For palettization of true-color PNGs,
+// create a table that uses (quantized) RGB values as indices
+// to obtain the nearest palette color
 
-typedef struct
+#define RGB2PAL_BPC 6 // Bits per channel
+#define RGB2PAL_IBPC (8 - RGB2PAL_BPC) // Inverse bits per channel (i.e. how many missing)
+#define RGB2PAL_SPC (1 << RGB2PAL_BPC) // Shades per channel
+
+#define RGB2PAL_SIZE (RGB2PAL_SPC * RGB2PAL_SPC * RGB2PAL_SPC)
+
+static byte ***rgb2pal = NULL;
+
+static void InitRGB2Pal(void)
 {
-    int value;
-    int pixel_count;
-} color_slot_t;
-
-static void AddValue(color_slot_t *s, int component)
-{
-    s->value += component;
-    s->pixel_count++;
-}
-
-static int GetAverage(color_slot_t *s)
-{
-    int result = 0;
-
-    if (s->pixel_count > 0)
+    if (rgb2pal)
     {
-        result = s->value / s->pixel_count;
+        return;
     }
 
-    return result;
-}
+    byte *const all_rgb2pal_b = malloc(sizeof(***rgb2pal) * RGB2PAL_SIZE);
+    byte **const all_rgb2pal_g = malloc(sizeof(**rgb2pal) * RGB2PAL_SPC * RGB2PAL_SPC);
 
-typedef struct
-{
-    color_slot_t red_slots[8];
-    color_slot_t green_slots[8];
-    color_slot_t blue_slots[8];
+    rgb2pal = malloc(sizeof(*rgb2pal) * RGB2PAL_SPC);
 
-    byte palette[3*512];
-} uniform_quantizer_t;
+    byte *const playpal = W_CacheLumpName("PLAYPAL", PU_CACHE);
 
-static void AddColor(uniform_quantizer_t *q, int r, int g, int b)
-{
-    int red_index = r >> 5;
-    int green_index = g >> 5;
-    int blue_index = b >> 5;
-    AddValue(&q->red_slots[red_index], r);
-    AddValue(&q->green_slots[green_index], g);
-    AddValue(&q->blue_slots[blue_index], b);
-}
-
-static void GetPalette(uniform_quantizer_t *q)
-{
-    byte *roller = q->palette;
-
-    for (int rs = 0; rs < arrlen(q->red_slots); ++rs)
+    for (int r = 0;  r < RGB2PAL_SPC;  r++)
     {
-        for (int gs = 0; gs < arrlen(q->green_slots); ++gs)
+        byte **const rgb2pal_r = rgb2pal[r] = all_rgb2pal_g + (r * RGB2PAL_SPC);
+
+        const int sr = r << RGB2PAL_IBPC;
+
+        for (int g = 0;  g < RGB2PAL_SPC;  g++)
         {
-            for (int bs = 0; bs < arrlen(q->blue_slots); ++bs)
+            byte *const rgb2pal_g =
+                rgb2pal_r[g] = all_rgb2pal_b + ((r * RGB2PAL_SPC + g) * RGB2PAL_SPC);
+
+            const int sg = g << RGB2PAL_IBPC;
+
+            for (int b = 0;  b < RGB2PAL_SPC;  b++)
             {
-                *roller++ = GetAverage(&q->red_slots[rs]);
-                *roller++ = GetAverage(&q->green_slots[gs]);
-                *roller++ = GetAverage(&q->blue_slots[bs]);
+                const int sb = b << RGB2PAL_IBPC;
+
+                rgb2pal_g[b] = I_GetNearestColor(playpal, sr, sg, sb);
             }
         }
     }
 }
 
-static int GetPaletteIndex(int r, int g, int b)
+static inline byte RGBToPalette(const int r, const int g, const int b)
 {
-    int red_index = r >> 5;
-    int green_index = g >> 5;
-    int blue_index = b >> 5;
-    return (red_index << 6) + (green_index << 3) + blue_index;
+  return rgb2pal[r >> RGB2PAL_IBPC][g >> RGB2PAL_IBPC][b >> RGB2PAL_IBPC];
 }
 
 typedef struct
@@ -458,48 +436,23 @@ static boolean DecodePNG(png_t *png)
         return false;
     }
 
-    byte *playpal = W_CacheLumpName("PLAYPAL", PU_CACHE);
-
     if (fmt == SPNG_FMT_RGB8)
     {
-        int indexed_size = image_size / 3;
-        byte *indexed_image = malloc(indexed_size);
+        const int indexed_size = image_size / 3;
+        byte *const indexed_image = malloc(indexed_size);
 
-        uniform_quantizer_t q = {0};
+        InitRGB2Pal();
 
-        byte *roller = image;
+        const byte *roller = image;
 
-        for (int i = 0; i < indexed_size; ++i)
+        for (int i = 0;  i < indexed_size;  i++)
         {
-            int r = *roller++;
-            int g = *roller++;
-            int b = *roller++;
+            const int
+                r = *roller++,
+                g = *roller++,
+                b = *roller++;
 
-            AddColor(&q, r, g, b);
-        }
-
-        GetPalette(&q);
-
-        byte translate[512];
-        byte *palette = q.palette;
-        for (int i = 0; i < 512; ++i)
-        {
-            int r = *palette++;
-            int g = *palette++;
-            int b = *palette++;
-
-            translate[i] = I_GetNearestColor(playpal, r, g, b);
-        }
-
-        roller = image;
-
-        for (int i = 0; i < indexed_size; ++i)
-        {
-            int r = *roller++;
-            int g = *roller++;
-            int b = *roller++;
-
-            indexed_image[i] = translate[GetPaletteIndex(r, g, b)];
+            indexed_image[i] = RGBToPalette(r, g, b);
         }
 
         free(image);
@@ -509,51 +462,54 @@ static boolean DecodePNG(png_t *png)
     }
     else if (fmt == SPNG_FMT_RGBA8)
     {
-        int indexed_size = image_size / 4;
-        byte *indexed_image = malloc(indexed_size);
+        const int indexed_size = image_size / 4;
+        byte *const indexed_image = malloc(indexed_size);
 
-        uniform_quantizer_t q = {0};
+        const byte *roller = image;
 
-        byte *roller = image;
+        static unsigned *alpha_pixels = NULL;
+        static int alpha_pixels_capacity = 0;
 
-        byte used_colors[256] = {0};
-        boolean has_alpha = false;
-
-        for (int i = 0; i < indexed_size; ++i)
+        if (alpha_pixels_capacity < indexed_size)
         {
-            int r = *roller++;
-            int g = *roller++;
-            int b = *roller++;
-            int a = *roller++;
+            alpha_pixels_capacity = indexed_size;
+
+            // Don't use `realloc()`, we don't need to keep the previous contents
+            if (alpha_pixels) { free(alpha_pixels); }
+
+            alpha_pixels = malloc(sizeof(*alpha_pixels) * alpha_pixels_capacity);
+        }
+
+        unsigned num_alpha_pixels = 0;
+        byte used_colors[256] = {0};
+
+        for (int i = 0;  i < indexed_size;  i++)
+        {
+            const int
+                r = *roller++,
+                g = *roller++,
+                b = *roller++,
+                a = *roller++;
+
             if (a < 255)
             {
-                has_alpha = true;
+                alpha_pixels[num_alpha_pixels++] = i;
                 continue;
             }
 
-            AddColor(&q, r, g, b);
-        }
+            const byte c = RGBToPalette(r, g, b);
 
-        GetPalette(&q);
-
-        byte translate[512];
-        byte *palette = q.palette;
-        for (int i = 0; i < 512; ++i)
-        {
-            int r = *palette++;
-            int g = *palette++;
-            int b = *palette++;
-
-            byte c = I_GetNearestColor(playpal, r, g, b);
+            indexed_image[i] = c;
             used_colors[c] = 1;
-            translate[i] = c;
         }
 
-        int color_key = NO_COLOR_KEY;
-
-        if (has_alpha)
+        if (num_alpha_pixels)
         {
-            for (int i = 0; i < 256; ++i)
+            // If all palette colors are used,
+            // fall back to 255 as the color key
+            int color_key = 255;
+
+            for (int i = 0;  i < 256;  i++)
             {
                 if (used_colors[i] == 0)
                 {
@@ -561,24 +517,13 @@ static boolean DecodePNG(png_t *png)
                     break;
                 }
             }
+
             png->color_key = color_key;
-        }
 
-        roller = image;
-
-        for (int i = 0; i < indexed_size; ++i)
-        {
-            int r = *roller++;
-            int g = *roller++;
-            int b = *roller++;
-            int a = *roller++;
-            if (a < 255)
+            for (int i = 0;  i < num_alpha_pixels;  i++)
             {
-                indexed_image[i] = color_key;
-                continue;
+                indexed_image[alpha_pixels[i]] = color_key;
             }
-
-            indexed_image[i] = translate[GetPaletteIndex(r, g, b)];
         }
 
         free(image);
@@ -600,6 +545,8 @@ static boolean DecodePNG(png_t *png)
 
         byte *translate = malloc(plte.n_entries);
         boolean need_translation = false;
+
+        byte *playpal = W_CacheLumpName("PLAYPAL", PU_CACHE);
         byte *palette = playpal;
 
         for (int i = 0; i < plte.n_entries; ++i)


### PR DESCRIPTION
Paraphrasing from the Discord group chat:

This is a new method to palettize true-color PNGs, which consists of generating an RGB-to-palette conversion table and using the RGB values from PNG pixels as indices into it.

The table is generated when we encounter such true-color PNGs, and since `woof.pk3` only contains *paletted* PNGs, this means that the table is only generated when loading WADs with true-color PNGs.

This also makes the conversion process faster: with `vg.wad`, forcing its PNG graphics to be parsed, master takes ~15 seconds in `R_Init()`, whereas in this branch it takes ~13 seconds.

There's a define for the number of bits per channel to use for the table, which can easily be changed. It's currently set to 6 bits, which IMO provides a good balance between table generation time and conversion quality (for reference, the "uniform quantizer" that this replaces seems to be working with only 3 bits).

At said 6 bits, the table takes ~0.2 seconds to generate on my machine, which is barely noticeable, and takes up 0.25 MB.

At 7 bits, it takes ~1.8 seconds, which does make itself noticeable, and it takes up 2 MB, and the quality increase isn't as noticeable as going from the uniform quantizer's 3 bits to this approach's 6 bits. At that point, I would opt to write the table into a file to prevent having to generate it on every program run, but we'd have to write 2 MB *per unique `PLAYPAL` lump*, which might be worth taking into consideration. Either way, like I said, 6 bits seems to be the sweet spot IMO, and it's fast enough to not warrant writing the tables into files.

Here are comparison screenshots taken in Nugget using `vg.wad`, making use of the fact that Nugget can use the high-resolution PNG sprites (in order: the existing uniform quantizer; PR with 6 bits; PR with 7 bits):

<img width="1366" height="768" alt="imagen" src="https://github.com/user-attachments/assets/223a7d2a-fcd1-4b39-9820-6af31c1711dd" />
<img width="1366" height="768" alt="imagen" src="https://github.com/user-attachments/assets/212ac3a1-da7e-4b16-9384-ab8c2fd63f3d" />
<img width="1366" height="768" alt="imagen" src="https://github.com/user-attachments/assets/7f2c8229-56b0-46ac-8b1c-758cb4e2f936" />

Here are other comparison screenshots actually taken in Woof (the PR screenshots use 6 bits):

<details><summary>Details</summary>
<p>

Reference image:
<img width="320" height="200" alt="TITLEPIC" src="https://github.com/user-attachments/assets/94d9fe8a-987c-47b5-9ff3-203f8eee8c20" />

Uniform quantizer:
<img width="1366" height="768" alt="imagen" src="https://github.com/user-attachments/assets/07265ac5-d23e-4c7a-851c-6c2bd071ae78" />

PR:
<img width="1366" height="768" alt="imagen" src="https://github.com/user-attachments/assets/c3e6a5e9-725e-4e5e-adf5-5285cdfa56e5" />

`vg.wad` menu, uniform quantizer:
<img width="1366" height="768" alt="imagen" src="https://github.com/user-attachments/assets/19c9279f-d9aa-43ef-b6c4-bf3f6514cd2b" />

Ditto, PR:
<img width="1366" height="768" alt="imagen" src="https://github.com/user-attachments/assets/e9da160c-c46e-4e71-84e7-d6a4b862b9d3" />


</p>
</details> 