### PR TITLE
savegame system overhaul

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -2447,9 +2447,10 @@ void D_DoomMain(void)
   }
   else if (startloadgame >= 0 && startloadgame <= 77) // Page 0-7, slot 0-7.
   {
+    const int slot = startloadgame % 10, page = startloadgame / 10;
     char *file;
-    file = G_SaveGameName(startloadgame);
-    G_LoadGame(file, startloadgame, true); // killough 5/15/98: add command flag
+    file = G_SaveGameName(slot, page);
+    G_LoadGame(file, slot, page, true); // killough 5/15/98: add command flag
     free(file);
   }
   else

--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -330,8 +330,6 @@ extern  boolean   critical;
 
 #define CRITICAL(x) (critical || strictmode ? 0 : (x))
 
-extern  int       savegameslot;
-
 extern  gamestate_t  gamestate;
 
 //-----------------------------

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -222,7 +222,9 @@ static ticcmd_t basecmd;
 
 boolean joybuttons[NUM_GAMEPAD_BUTTONS];
 
-int   savegameslot = -1;
+static int   savegameslot = -1;
+static int   savegamepage;
+static boolean savegamequick;
 char  savedescription[32];
 
 static boolean save_autosave;
@@ -2368,11 +2370,12 @@ void G_LoadAutoSave(char *name, boolean command)
   command_loadgame = command;
 }
 
-void G_LoadGame(char *name, int slot, boolean command)
+void G_LoadGame(char *name, int slot, int page, boolean command)
 {
   if (savename) free(savename);
   savename = M_StringDuplicate(name);
   savegameslot = slot;
+  savegamepage = page;
   gameaction = ga_loadgame;
   forced_loadgame = false;
   command_loadgame = command;
@@ -2418,11 +2421,23 @@ void G_SaveAutoSave(char *description)
   save_autosave = true;
 }
 
-void G_SaveGame(int slot, char *description)
+void G_SaveGame(int slot, int page, char *description, boolean quicksave)
 {
   savegameslot = slot;
+  savegamepage = page;
+  savegamequick = quicksave;
   strcpy(savedescription, description);
   sendsave = true;
+}
+
+// Cancels a pending save if it was targeting this slot (e.g. the slot's
+// file is about to be deleted from the menu).
+void G_ClearPendingSaveSlot(int slot)
+{
+  if (slot == savegameslot)
+  {
+    savegameslot = -1;
+  }
 }
 
 // killough 3/22/98: form savegame name in one location
@@ -2453,19 +2468,19 @@ char *G_AutoSaveName(void)
   return SaveGameName("autosave.dsg");
 }
 
-char *G_SaveGameName(int slot)
+char *G_SaveGameName(int slot, int page)
 {
   // Ty 05/04/98 - use savegamename variable (see d_deh.c)
   // killough 12/98: add .7 to truncate savegamename
   char buf[16] = {0};
-  sprintf(buf, "%.7s%d.dsg", savegamename, 10 * savepage + slot);
+  sprintf(buf, "%.7s%d.dsg", savegamename, 10 * page + slot);
   return SaveGameName(buf);
 }
 
-char* G_MBFSaveGameName(int slot)
+char* G_MBFSaveGameName(int slot, int page)
 {
   char buf[16] = {0};
-  sprintf(buf, "MBFSAV%d.dsg", 10*savepage+slot);
+  sprintf(buf, "MBFSAV%d.dsg", 10 * page + slot);
 
   char *filepath = M_StringJoin(basesavegame, DIR_SEPARATOR_S, buf);
   char *existing = M_FileCaseExists(filepath);
@@ -2521,7 +2536,7 @@ static uint64_t G_Signature(int sig_epi, int sig_map)
 static json_mut_t *WriteOptionsJSON(json_mut_doc_t * doc);
 static json_mut_t *WriteCustomSkillOptionsJSON(json_mut_doc_t *doc);
 
-static void DoSaveGame(char *name)
+static void DoSaveGame(char *name, const char *success_msg)
 {
     json_mut_doc_t *doc = JS_NewDoc();
     json_mut_t *root_mut = JS_NewObject(doc);
@@ -2683,7 +2698,7 @@ static void DoSaveGame(char *name)
     }
     else
     {
-        displaymsg("%s", DEH_String(GGSAVED));
+        displaymsg("%s", success_msg);
     }
 
     Z_Free(savebuffer); // killough
@@ -2697,16 +2712,28 @@ static void DoSaveGame(char *name)
 
 static void G_DoSaveGame(void)
 {
-  char *name = G_SaveGameName(savegameslot);
-  DoSaveGame(name);
-  MN_SetQuickSaveSlot(savegameslot);
+  char *name = G_SaveGameName(savegameslot, savegamepage);
+  char msg[64];
+
+  if (savegamequick)
+  {
+    M_snprintf(msg, sizeof(msg), "quicksave on page %d slot %d",
+               savegamepage + 1, savegameslot + 1);
+  }
+  else
+  {
+    M_snprintf(msg, sizeof(msg), "%s", DEH_String(GGSAVED));
+  }
+
+  DoSaveGame(name, msg);
+  MN_SetQuickSaveSlot(savegameslot, savegamepage);
   free(name);
 }
 
 static void G_DoSaveAutoSave(void)
 {
   char *name = G_AutoSaveName();
-  DoSaveGame(name);
+  DoSaveGame(name, DEH_String(GGSAVED));
   free(name);
 }
 
@@ -3195,10 +3222,10 @@ static void G_DoLoadGame(void)
 {
   if (DoLoadGame(false))
   {
-    const int slot_num = 10 * savepage + savegameslot;
+    const int slot_num = 10 * savegamepage + savegameslot;
     I_Printf(VB_DEBUG, "G_DoLoadGame: Slot %02d, Time ", slot_num);
     PrintLevelTimes();
-    MN_SetQuickSaveSlot(savegameslot);
+    MN_SetQuickSaveSlot(savegameslot, savegamepage);
   }
 }
 
@@ -3231,7 +3258,7 @@ boolean G_LoadAutoSaveDeathUse(void)
   {
     if (savegameslot >= 0)
     {
-      char *save_path = G_SaveGameName(savegameslot);
+      char *save_path = G_SaveGameName(savegameslot, savegamepage);
       int64_t save_time = M_FileMTime(save_path);
       free(save_path);
       result = (auto_time > save_time);
@@ -3245,6 +3272,24 @@ boolean G_LoadAutoSaveDeathUse(void)
 
   free(auto_path);
   return result;
+}
+
+//
+// G_LoadGameDeathUse
+// Reloads the last manually saved/loaded slot, if any.
+// Returns true if a slot was loaded.
+//
+boolean G_LoadGameDeathUse(void)
+{
+  if (savegameslot < 0)
+  {
+    return false;
+  }
+
+  char *name = G_SaveGameName(savegameslot, savegamepage);
+  G_LoadGame(name, savegameslot, savegamepage, false);
+  free(name);
+  return true;
 }
 
 static void CheckSaveAutoSave(void)

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -49,13 +49,15 @@ void G_SimplifiedInitNew(int episode, int map);
 void G_DeferedInitNew(skill_t skill, int episode, int map);
 void G_DeferedPlayDemo(const char *demo);
 void G_LoadAutoSave(char *name, boolean is_command);
-void G_LoadGame(char *name, int slot, boolean is_command); // killough 5/15/98
+void G_LoadGame(char *name, int slot, int page, boolean is_command); // killough 5/15/98
 void G_ForcedLoadAutoSave(void);
 void G_ForcedLoadGame(void);           // killough 5/15/98: forced loadgames
 void G_SaveAutoSave(char *description);
-void G_SaveGame(int slot, char *description); // Called by M_Responder.
+void G_SaveGame(int slot, int page, char *description, boolean quicksave); // Called by M_Responder.
 boolean G_AutoSaveEnabled(void);
 boolean G_LoadAutoSaveDeathUse(void);
+boolean G_LoadGameDeathUse(void);
+void G_ClearPendingSaveSlot(int slot);
 void G_RecordDemo(const char *name);              // Only called by startup code.
 void G_BeginRecording(void);
 void G_PlayDemo(char *name);
@@ -66,8 +68,8 @@ void G_Ticker(void);
 void G_ScreenShot(void);
 void G_ReloadDefaults(boolean keep_demover); // killough 3/1/98: loads game defaults
 char *G_AutoSaveName(void);
-char *G_SaveGameName(int); // killough 3/22/98: sets savegame filename
-char *G_MBFSaveGameName(int); // MBF savegame filename
+char *G_SaveGameName(int, int); // killough 3/22/98: sets savegame filename
+char *G_MBFSaveGameName(int, int); // MBF savegame filename
 void G_SetFastParms(int);        // killough 4/10/98: sets -fast parameters
 void G_DoNewGame(void);
 void G_DoReborn(int playernum);

--- a/src/mn_menu.c
+++ b/src/mn_menu.c
@@ -901,7 +901,7 @@ static void DeleteAutoSave(void)
 
 static void DeleteSaveGame(int slot)
 {
-    char *name = G_SaveGameName(slot);
+    char *name = G_SaveGameName(slot, savepage);
     M_remove(name);
     free(name);
 
@@ -911,10 +911,7 @@ static void DeleteSaveGame(int slot)
         quickSaveSlot = -1;
     }
 
-    if (slot == savegameslot)
-    {
-        savegameslot = -1;
-    }
+    G_ClearPendingSaveSlot(slot);
 }
 
 static void M_DeleteGame(int choice)
@@ -1049,9 +1046,32 @@ static void M_LoadAutoSaveSelect(int choice)
     //SaveDef.lastOn = choice;
 }
 
+// Loads the savegame at slot/page without relying on the live savepage
+// global, so quickload can target its own page independently of whatever
+// page the save/load menu currently has open.
+static void LoadGameAtSlot(int slot, int page)
+{
+    char *name = G_SaveGameName(slot, page);
+    saveg_compat = saveg_woof510;
+
+    if (!M_FileExistsNotDir(name))
+    {
+        free(name);
+        name = G_MBFSaveGameName(slot, page);
+        saveg_compat = saveg_mbf;
+    }
+
+    G_LoadGame(name, slot, page, false); // killough 3/16/98, 5/15/98: add slot, cmd
+
+    MN_ClearMenus();
+    free(name);
+
+    // [crispy] save the last game you loaded
+    SaveDef.lastOn = slot;
+}
+
 static void M_LoadSelect(int choice)
 {
-    char *name = NULL; // killough 3/22/98
     int slot = choice;
 
     if (menuactive && currentMenu == &LoadAutoSaveDef)
@@ -1059,29 +1079,7 @@ static void M_LoadSelect(int choice)
         slot--;
     }
 
-    name = G_SaveGameName(slot);
-    saveg_compat = saveg_woof510;
-
-    if (!M_FileExistsNotDir(name))
-    {
-        if (name)
-        {
-            free(name);
-        }
-        name = G_MBFSaveGameName(slot);
-        saveg_compat = saveg_mbf;
-    }
-
-    G_LoadGame(name, slot, false); // killough 3/16/98, 5/15/98: add slot, cmd
-
-    MN_ClearMenus();
-    if (name)
-    {
-        free(name);
-    }
-
-    // [crispy] save the last game you loaded
-    SaveDef.lastOn = slot;
+    LoadGameAtSlot(slot, savepage);
 }
 
 //
@@ -1211,29 +1209,26 @@ static void EmptySaveString(char *name, boolean is_autosave)
     }
 }
 
-static void M_ReadSaveString(char *name, int menu_slot, int save_slot,
-                             boolean is_autosave)
+// Parses the already-resolved save file `name` and stores description and
+// (optionally) screenshot at menu index `slot`.
+static void ReadSaveGameContents(char *name, int slot, boolean is_autosave,
+                                  boolean read_screenshot)
 {
-    MN_ReadSavegameTime(menu_slot, name);
-    MN_ResetSnapshot(menu_slot);
+    MN_ReadSavegameTime(slot, name);
+
+    if (read_screenshot)
+    {
+        MN_ResetSnapshot(slot);
+    }
 
     // Check if file exists
 
     if (!M_FileExistsNotDir(name))
     {
-        if (!is_autosave)
-        {
-            free(name);
-            name = G_MBFSaveGameName(save_slot);
-        }
-
-        if (!M_FileExistsNotDir(name))
-        {
-            EmptySaveString(savegamestrings[menu_slot], is_autosave);
-            SetLoadSlotStatus(menu_slot, 0);
-            free(name);
-            return;
-        }
+        EmptySaveString(savegamestrings[slot], is_autosave);
+        SetLoadSlotStatus(slot, 0);
+        free(name);
+        return;
     }
 
     // Open file and read content
@@ -1244,8 +1239,8 @@ static void M_ReadSaveString(char *name, int menu_slot, int save_slot,
 
     if (savegamesize < SAVESTRINGSIZE)
     {
-        EmptySaveString(savegamestrings[menu_slot], is_autosave);
-        SetLoadSlotStatus(menu_slot, 0);
+        EmptySaveString(savegamestrings[slot], is_autosave);
+        SetLoadSlotStatus(slot, 0);
         Z_Free(save_p);
         return;
     }
@@ -1298,26 +1293,29 @@ static void M_ReadSaveString(char *name, int menu_slot, int save_slot,
     if (root)
     {
         const char *savegamestring = JS_GetStringValue(root, "savedescription");
-        const char *snapshot = JS_GetStringValue(root, "snapshot");
 
-        M_snprintf(savegamestrings[menu_slot], SAVESTRINGSIZE, "%s",
+        M_snprintf(savegamestrings[slot], SAVESTRINGSIZE, "%s",
                    savegamestring ? savegamestring : DEH_String(EMPTYSTRING));
 
-        if (!MN_ReadSnapshot(menu_slot, (byte *)snapshot, 0))
+        if (read_screenshot)
         {
-            MN_ResetSnapshot(menu_slot);
+            const char *snapshot = JS_GetStringValue(root, "snapshot");
+            if (!MN_ReadSnapshot(slot, (byte *)snapshot, 0))
+            {
+                MN_ResetSnapshot(slot);
+            }
         }
 
         JS_CloseOptions(NO_INDEX);
     }
     else
     {
-        M_snprintf(savegamestrings[menu_slot], SAVESTRINGSIZE, "%s",
+        M_snprintf(savegamestrings[slot], SAVESTRINGSIZE, "%s",
                    (char *)savebuffer);
 
-        if (!MN_ReadSnapshot(menu_slot, savebuffer, savegamesize))
+        if (read_screenshot && !MN_ReadSnapshot(slot, savebuffer, savegamesize))
         {
-            MN_ResetSnapshot(menu_slot);
+            MN_ResetSnapshot(slot);
         }
     }
 
@@ -1332,7 +1330,31 @@ static void M_ReadSaveString(char *name, int menu_slot, int save_slot,
         savebuffer = save_p = NULL;
     }
 
-    SetLoadSlotStatus(menu_slot, 1);
+    SetLoadSlotStatus(slot, 1);
+}
+
+// Reads name/screenshot for the numbered savegame menu slot `slot` on `page`,
+// applying the same LoadAutoSaveDef slot offset as M_LoadSelect and friends.
+// Used both to refresh a whole page (M_ReadSaveStrings) and to preload a
+// single slot's existing description (e.g. before overwriting a quicksave).
+static void ReadSaveGameInfo(int slot, int page, boolean read_screenshot)
+{
+    int file_slot = slot;
+
+    if (menuactive && currentMenu == &LoadAutoSaveDef)
+    {
+        file_slot--;
+    }
+
+    char *name = G_SaveGameName(file_slot, page);
+
+    if (!M_FileExistsNotDir(name))
+    {
+        free(name);
+        name = G_MBFSaveGameName(file_slot, page);
+    }
+
+    ReadSaveGameContents(name, slot, false, read_screenshot);
 }
 
 static void UpdateRectX(menu_t *menu, int x)
@@ -1367,8 +1389,7 @@ static void M_ReadSaveStrings(void)
 
     if (currentMenu == &LoadAutoSaveDef)
     {
-        char *name = G_AutoSaveName();
-        M_ReadSaveString(name, 0, 0, true);
+        ReadSaveGameContents(G_AutoSaveName(), 0, true, true);
         start_slot = 1;
     }
 
@@ -1376,9 +1397,7 @@ static void M_ReadSaveStrings(void)
 
     for (int menu_slot = start_slot; menu_slot < num_slots; menu_slot++)
     {
-        const int save_slot = menu_slot - start_slot;
-        char *name = G_SaveGameName(save_slot);
-        M_ReadSaveString(name, menu_slot, save_slot, false);
+        ReadSaveGameInfo(menu_slot, savepage, true);
     }
 }
 
@@ -1416,13 +1435,13 @@ static void M_DrawSave(void)
 //
 // M_Responder calls this when user is finished
 //
-static void M_DoSave(int slot)
+static void M_DoSave(int slot, int page, boolean quicksave)
 {
-    G_SaveGame(slot, savegamestrings[slot]);
+    G_SaveGame(slot, page, savegamestrings[slot], quicksave);
     MN_ClearMenus();
 }
 
-void MN_SetQuickSaveSlot(int choice)
+void MN_SetQuickSaveSlot(int choice, int page)
 {
     int slot = choice;
 
@@ -1433,7 +1452,7 @@ void MN_SetQuickSaveSlot(int choice)
 
     if (quickSaveSlot == -2)
     {
-        quickSavePage = savepage;
+        quickSavePage = page;
         quickSaveSlot = slot;
     }
 }
@@ -1518,7 +1537,7 @@ static boolean GamepadSave(int choice)
     {
         // Immediately save game using a default name.
         SetDefaultSaveName(savegamestrings[choice], NULL);
-        M_DoSave(choice);
+        M_DoSave(choice, savepage, false);
         LoadDef.lastOn = choice;
         QuickLoadDef.lastOn = choice;
         LoadAutoSaveDef.lastOn = choice + 1;
@@ -1775,18 +1794,15 @@ static void M_QuickSaveResponse(int ch)
 {
     if (ch == 'y')
     {
-        if (currentMenu != &SaveDef || savepage != quickSavePage)
-        {
-            savepage = quickSavePage;
-            SetNextMenu(&SaveDef);
-            M_ReadSaveStrings();
-        }
+        // load the quicksave slot's current description directly, on
+        // whatever page it lives on, without switching the visible menu page
+        ReadSaveGameInfo(quickSaveSlot, quickSavePage, false);
 
         if (MN_StartsWithMapIdentifier(savegamestrings[quickSaveSlot]))
         {
             SetDefaultSaveName(savegamestrings[quickSaveSlot], NULL);
         }
-        M_DoSave(quickSaveSlot);
+        M_DoSave(quickSaveSlot, quickSavePage, true);
         M_StartSound(sfx_mnucls);
     }
 }
@@ -1824,8 +1840,7 @@ static void M_QuickLoadResponse(int ch)
 {
     if (ch == 'y')
     {
-        savepage = quickSavePage;
-        M_LoadSelect(quickSaveSlot);
+        LoadGameAtSlot(quickSaveSlot, quickSavePage);
         M_StartSound(sfx_mnucls);
     }
 }
@@ -3232,7 +3247,7 @@ boolean M_Responder(event_t *ev)
             saveStringEnter = 0;
             if (savegamestrings[saveSlot][0])
             {
-                M_DoSave(saveSlot);
+                M_DoSave(saveSlot, savepage, quickSaveSlot == -2);
             }
         }
         else if (ev->type == ev_text)

--- a/src/mn_menu.c
+++ b/src/mn_menu.c
@@ -1537,7 +1537,7 @@ static boolean GamepadSave(int choice)
     {
         // Immediately save game using a default name.
         SetDefaultSaveName(savegamestrings[choice], NULL);
-        M_DoSave(choice, savepage, false);
+        M_DoSave(choice, savepage, quickSaveSlot == -2);
         LoadDef.lastOn = choice;
         QuickLoadDef.lastOn = choice;
         LoadAutoSaveDef.lastOn = choice + 1;

--- a/src/mn_menu.h
+++ b/src/mn_menu.h
@@ -92,7 +92,7 @@ extern const char *widescreen_strings[];
 
 void M_ResetAutoSave(void);
 
-void MN_SetQuickSaveSlot(int slot);
+void MN_SetQuickSaveSlot(int slot, int page);
 
 void M_SaveAutoSave(void);
 

--- a/src/p_user.c
+++ b/src/p_user.c
@@ -329,13 +329,7 @@ void P_DeathThink (player_t* player)
 
     if (!G_AutoSaveEnabled() || !G_LoadAutoSaveDeathUse())
     {
-      if (savegameslot >= 0)
-      {
-        char *file = G_SaveGameName(savegameslot);
-        G_LoadGame(file, savegameslot, false);
-        free(file);
-      }
-      else
+      if (!G_LoadGameDeathUse())
       {
         player->playerstate = PST_REBORN;
       }


### PR DESCRIPTION
- turn savegameslot and savegamepage into static variables in g_game.c
- always pass slot and page explicitly as function parameters
- allow to read savegame description from any savegame without having to change the menu page

